### PR TITLE
refactoring of node and transport packets for improving code readability

### DIFF
--- a/src/mesh/domain/config.go
+++ b/src/mesh/domain/config.go
@@ -3,14 +3,8 @@ package domain
 import (
 	"time"
 
-	"github.com/satori/go.uuid"
 	"github.com/skycoin/skycoin/src/cipher"
 )
-
-type RouteConfig struct {
-	ID    uuid.UUID
-	Peers []cipher.PubKey
-}
 
 type NodeConfig struct {
 	PubKey                        cipher.PubKey
@@ -21,8 +15,4 @@ type NodeConfig struct {
 	TimeToAssembleMessage         time.Duration
 	TransportMessageChannelLength int
 	//ChaCha20Key                   [32]byte
-}
-
-type TransportConfig struct {
-	SendChannelLength uint32
 }

--- a/src/mesh/domain/message.go
+++ b/src/mesh/domain/message.go
@@ -17,8 +17,8 @@ type MessageBase struct {
 	SendRouteID RouteID
 	SendBack    bool
 	// For sending the reply from the last node in a route
-	FromPeer cipher.PubKey
-	Nonce    [4]byte
+	FromPeerID cipher.PubKey
+	Nonce      [4]byte
 }
 
 type UserMessage struct {
@@ -33,9 +33,9 @@ type SetRouteMessage struct {
 	MessageBase
 	SetRouteID                 RouteID
 	ConfirmRouteID             RouteID
-	ForwardToPeer              cipher.PubKey
+	ForwardToPeerID            cipher.PubKey
 	ForwardRewriteSendRouteID  RouteID
-	BackwardToPeer             cipher.PubKey
+	BackwardToPeerID           cipher.PubKey
 	BackwardRewriteSendRouteID RouteID
 	DurationHint               time.Duration
 }
@@ -63,36 +63,6 @@ type DeleteRouteMessage struct {
 type AddNodeMessage struct {
 	MessageBase
 	Content []byte
-}
-
-// Get a node from the network
-//type GetNodeMessage struct {
-//	MessageBase
-//}
-
-// Set up a node from the network
-//type SetUpNodeMessage struct {
-//	MessageBase
-//}
-
-// Delete a node from the network
-//type DeleteNodeMessage struct {
-//	MessageBase
-//}
-
-// Get a route between two nodes from the node manager
-//type GetNodeRouteMessage struct {
-//	MessageBase
-//}
-
-type MessageToSend struct {
-	ThruRoute uuid.UUID
-	Contents  []byte
-}
-
-type MessageToReceive struct {
-	Contents []byte
-	Reply    []byte
 }
 
 type MessageUnderAssembly struct {

--- a/src/mesh/domain/peer.go
+++ b/src/mesh/domain/peer.go
@@ -1,8 +1,0 @@
-package domain
-
-import "github.com/skycoin/skycoin/src/cipher"
-
-type Peer struct {
-	Peer cipher.PubKey
-	Info string
-}

--- a/src/mesh/domain/route.go
+++ b/src/mesh/domain/route.go
@@ -8,10 +8,10 @@ import (
 
 type Route struct {
 	// Forward should never be cipher.PubKey{}
-	ForwardToPeer             cipher.PubKey
+	ForwardToPeerID           cipher.PubKey
 	ForwardRewriteSendRouteID RouteID
 
-	BackwardToPeer             cipher.PubKey
+	BackwardToPeerID           cipher.PubKey
 	BackwardRewriteSendRouteID RouteID
 
 	// time.Unix(0,0) means it lives forever
@@ -19,10 +19,10 @@ type Route struct {
 }
 
 type LocalRoute struct {
-	LastForwardingPeer cipher.PubKey
-	TerminatingPeer    cipher.PubKey
-	LastHopRouteID     RouteID
-	LastConfirmed      time.Time
+	LastForwardingPeerID cipher.PubKey
+	TerminatingPeerID    cipher.PubKey
+	LastHopRouteID       RouteID
+	LastConfirmed        time.Time
 }
 
 type ReplyTo struct {

--- a/src/mesh/node/node.go
+++ b/src/mesh/node/node.go
@@ -1,32 +1,19 @@
 package mesh
 
 import (
-	"crypto/rand"
-	"errors"
 	"fmt"
 	"os"
-	"reflect"
-	"runtime/debug"
 	"sync"
 	"time"
 
-	"github.com/satori/go.uuid"
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/mesh/domain"
-	"github.com/skycoin/skycoin/src/mesh/node/connection"
 	"github.com/skycoin/skycoin/src/mesh/serialize"
 	"github.com/skycoin/skycoin/src/mesh/transport"
-	"gopkg.in/op/go-logging.v1"
+	//"gopkg.in/op/go-logging.v1"
 )
 
-type TimeoutError struct {
-}
-
-var NilRouteID domain.RouteID = (domain.RouteID)(uuid.Nil)
-
-type rewritableMessage interface {
-	Rewrite(newSendRouteID domain.RouteID) rewritableMessage
-}
+//var logger = logging.MustGetLogger("node")
 
 type Node struct {
 	config                     domain.NodeConfig
@@ -47,14 +34,8 @@ type Node struct {
 	messagesBeingAssembled         map[domain.MessageID]*domain.MessageUnderAssembly
 }
 
-func (self *TimeoutError) Error() string {
-	return "Timeout"
-}
-
-var logger = logging.MustGetLogger("node")
-
 func NewNode(config domain.NodeConfig) (*Node, error) {
-	ret := &Node{
+	node := &Node{
 		config:                     config,
 		outputMessagesReceived:     nil,                                                     // received
 		transportsMessagesReceived: make(chan []byte, config.TransportMessageChannelLength), // received
@@ -70,18 +51,97 @@ func NewNode(config domain.NodeConfig) (*Node, error) {
 		routeExtensionsAwaitingConfirm: make(map[domain.RouteID]chan bool),
 		//myCrypto:                   &ChaChaCrypto{config.ChaCha20Key},
 	}
-	ret.serializer.RegisterMessageForSerialization(serialize.MessagePrefix{1}, domain.UserMessage{})
-	ret.serializer.RegisterMessageForSerialization(serialize.MessagePrefix{2}, domain.SetRouteMessage{})
-	ret.serializer.RegisterMessageForSerialization(serialize.MessagePrefix{3}, domain.RefreshRouteMessage{})
-	ret.serializer.RegisterMessageForSerialization(serialize.MessagePrefix{4}, domain.DeleteRouteMessage{})
-	ret.serializer.RegisterMessageForSerialization(serialize.MessagePrefix{5}, domain.SetRouteReply{})
+	node.serializer.RegisterMessageForSerialization(serialize.MessagePrefix{1}, domain.UserMessage{})
+	node.serializer.RegisterMessageForSerialization(serialize.MessagePrefix{2}, domain.SetRouteMessage{})
+	node.serializer.RegisterMessageForSerialization(serialize.MessagePrefix{3}, domain.RefreshRouteMessage{})
+	node.serializer.RegisterMessageForSerialization(serialize.MessagePrefix{4}, domain.DeleteRouteMessage{})
+	node.serializer.RegisterMessageForSerialization(serialize.MessagePrefix{5}, domain.SetRouteReply{})
 
-	go ret.processIncomingMessagesLoop()
-	go ret.expireOldRoutesLoop()
-	go ret.expireOldMessagesLoop()
-	go ret.refreshRoutesLoop()
+	go node.processIncomingMessagesLoop()
+	go node.expireOldRoutesLoop()
+	go node.expireOldMessagesLoop()
+	go node.refreshRoutesLoop()
 
-	return ret, nil
+	return node, nil
+}
+
+func (self *Node) GetConfig() domain.NodeConfig {
+	return self.config
+}
+
+func (self *Node) GetConnectedPeers() []cipher.PubKey {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	ret := []cipher.PubKey{}
+	for nodeTransport := range self.transports {
+		peers := nodeTransport.GetConnectedPeers()
+		ret = append(ret, peers...)
+	}
+	return ret
+}
+
+func (self *Node) ConnectedToPeer(peer cipher.PubKey) bool {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	for nodeTransport := range self.transports {
+		if nodeTransport.ConnectedToPeer(peer) {
+			return true
+		}
+	}
+	return false
+}
+
+// Waits for transports to close
+func (self *Node) Close() error {
+	for i := 0; i < 10; i++ {
+		self.closing <- true
+	}
+	close(self.transportsMessagesReceived)
+	self.closeGroup.Wait()
+	return nil
+}
+
+// Node takes ownership of the transport, and will call Close() when it is closed
+func (self *Node) AddTransport(transportNode transport.ITransport) {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	//chaCha20Key := &transport.ChaChaCrypto{}
+	//chaCha20Key.SetKey(chaChaKey)
+	//transportNode.SetCrypto(chaCha20Key)
+	transportNode.SetReceiveChannel(self.transportsMessagesReceived)
+	self.transports[transportNode] = true
+}
+
+func (self *Node) RemoveTransport(transport transport.ITransport) {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	delete(self.transports, transport)
+}
+
+func (self *Node) GetTransports() []transport.ITransport {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	ret := []transport.ITransport{}
+	for nodeTransport := range self.transports {
+		ret = append(ret, nodeTransport)
+	}
+	return ret
+}
+
+func (self *Node) unsafelyGetTransportToPeer(peerKey cipher.PubKey) transport.ITransport {
+	for transportToPeer := range self.transports {
+		// TODO: Choose transport more intelligently
+		if transportToPeer.ConnectedToPeer(peerKey) {
+			return transportToPeer
+		}
+	}
+	return nil
+}
+
+func (self *Node) safelyGetTransportToPeer(peerKey cipher.PubKey) transport.ITransport {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	return self.unsafelyGetTransportToPeer(peerKey)
 }
 
 // Returns nil if reassembly didn't happen (incomplete message)
@@ -143,819 +203,4 @@ func (self *Node) reassembleUserMessage(msgIn domain.UserMessage) []byte {
 	}
 
 	return nil
-}
-
-func generateNonce() [4]byte {
-	ret := make([]byte, 4)
-	n, err := rand.Read(ret)
-	if n != 4 {
-		panic("rand.Read() failed")
-	}
-	if err != nil {
-		panic(err)
-	}
-	ret_b := [4]byte{0, 0, 0, 0}
-	copy(ret_b[:], ret[:])
-	return ret_b
-}
-
-func getMessageBase(msg interface{}) domain.MessageBase {
-	msg_type := reflect.TypeOf(msg)
-
-	if msg_type == reflect.TypeOf(domain.UserMessage{}) {
-		return (msg.(domain.UserMessage)).MessageBase
-	} else if msg_type == reflect.TypeOf(domain.SetRouteMessage{}) {
-		return (msg.(domain.SetRouteMessage)).MessageBase
-	} else if msg_type == reflect.TypeOf(domain.RefreshRouteMessage{}) {
-		return (msg.(domain.RefreshRouteMessage)).MessageBase
-	} else if msg_type == reflect.TypeOf(domain.DeleteRouteMessage{}) {
-		return (msg.(domain.DeleteRouteMessage)).MessageBase
-	} else if msg_type == reflect.TypeOf(domain.SetRouteReply{}) {
-		return (msg.(domain.SetRouteReply)).MessageBase
-	}
-	debug.PrintStack()
-	panic(fmt.Sprintf("Internal error: getMessageBase incomplete (%v)", msg_type))
-}
-
-func rewriteMessage(msg interface{}, newBase domain.MessageBase) interface{} {
-	msg_type := reflect.TypeOf(msg)
-	newBase.Nonce = generateNonce()
-
-	if msg_type == reflect.TypeOf(domain.UserMessage{}) {
-		ret := (msg.(domain.UserMessage))
-		ret.MessageBase = newBase
-		return ret
-	} else if msg_type == reflect.TypeOf(domain.SetRouteMessage{}) {
-		ret := (msg.(domain.SetRouteMessage))
-		ret.MessageBase = newBase
-		return ret
-	} else if msg_type == reflect.TypeOf(domain.RefreshRouteMessage{}) {
-		ret := (msg.(domain.RefreshRouteMessage))
-		ret.MessageBase = newBase
-		return ret
-	} else if msg_type == reflect.TypeOf(domain.DeleteRouteMessage{}) {
-		ret := (msg.(domain.DeleteRouteMessage))
-		ret.MessageBase = newBase
-		return ret
-	} else if msg_type == reflect.TypeOf(domain.SetRouteReply{}) {
-		ret := (msg.(domain.SetRouteReply))
-		ret.MessageBase = newBase
-		return ret
-	}
-	panic("Internal error: rewriteMessage incomplete")
-}
-
-func (self *Node) safelyGetForwarding(msg interface{}) (SendBack bool, route domain.Route, doForward bool) {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-
-	messageBase := getMessageBase(msg)
-	routeFound, foundRoute := self.routes[messageBase.SendRouteID]
-
-	doForward = foundRoute
-
-	if messageBase.SendBack {
-		if routeFound.BackwardToPeer == (cipher.PubKey{}) {
-			doForward = false
-		}
-	} else {
-		if routeFound.ForwardToPeer == (cipher.PubKey{}) {
-			doForward = false
-		}
-	}
-
-	if doForward {
-		return messageBase.SendBack, routeFound, doForward
-	} else {
-		return false, domain.Route{}, doForward
-	}
-}
-
-func (self *Node) safelyGetRoute(routeID domain.RouteID) (route domain.Route, exists bool) {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-
-	route, exists = self.routes[routeID]
-	return
-}
-
-func (self *Node) safelyGetRewriteBase(msg interface{}) (forwardTo cipher.PubKey, base domain.MessageBase, doForward bool) {
-	// sendBack
-	sendBack, route, foundRoute := self.safelyGetForwarding(msg)
-	if !foundRoute {
-		return cipher.PubKey{}, domain.MessageBase{}, false
-	}
-	forwardTo = route.ForwardToPeer
-	rewriteTo := route.ForwardRewriteSendRouteID
-	if sendBack {
-		forwardTo = route.BackwardToPeer
-		rewriteTo = route.BackwardRewriteSendRouteID
-	}
-	if forwardTo == (cipher.PubKey{}) {
-		return cipher.PubKey{}, domain.MessageBase{}, false
-	}
-	newBase :=
-		domain.MessageBase{
-			SendRouteID: rewriteTo,
-			SendBack:    sendBack,
-			FromPeer:    self.config.PubKey,
-			Nonce:       generateNonce(),
-		}
-	return forwardTo, newBase, true
-}
-
-func (self *Node) forwardMessage(msg interface{}) bool {
-	forwardTo, newBase, doForward := self.safelyGetRewriteBase(msg)
-	if !doForward {
-		return false
-	}
-	// Rewrite
-	rewritten := rewriteMessage(msg, newBase)
-	transportToPeer := self.safelyGetTransportToPeer(forwardTo)
-	if transportToPeer == nil {
-		fmt.Fprintf(os.Stderr, "No transport found for forwarded message from %v to %v, dropping\n", self.config.PubKey, forwardTo)
-		return true
-	}
-
-	serialized := self.serializer.SerializeMessage(rewritten)
-	err := transportToPeer.SendMessage(forwardTo, serialized)
-	if err != nil {
-		fmt.Fprint(os.Stderr, "Failed to send forwarded message, dropping\n")
-		return true
-	}
-
-	// Forward, not receive
-	return true
-}
-
-func (self *Node) processUserMessage(msgIn domain.UserMessage) {
-	reassembled := self.reassembleUserMessage(msgIn)
-	// Not finished reassembling yet
-	if reassembled == nil {
-		return
-	}
-	directPeer, forwardBase, doForward := self.safelyGetRewriteBase(msgIn)
-	if doForward {
-		transportToPeer := self.safelyGetTransportToPeer(directPeer)
-		if transportToPeer == nil {
-			fmt.Fprintf(os.Stderr, "No transport to peer %v from %v, dropping\n", directPeer, self.config.PubKey)
-			return
-		}
-		// Forward reassembled message, not individual pieces. This is done because of the need for refragmentation
-		fragments := connection.ConnectionManager.FragmentMessage(reassembled, directPeer, transportToPeer, forwardBase)
-		for _, fragment := range fragments {
-			serialized := self.serializer.SerializeMessage(fragment)
-			err := transportToPeer.SendMessage(directPeer, serialized)
-			if err != nil {
-				fmt.Fprint(os.Stderr, "Failed to send forwarded message, dropping\n")
-				return
-			}
-		}
-	} else {
-		self.outputMessagesReceived <- domain.MeshMessage{domain.ReplyTo{msgIn.SendRouteID, msgIn.FromPeer}, reassembled}
-	}
-}
-
-func (self *Node) sendSetRouteReply(base domain.MessageBase, confirmId domain.RouteID) {
-	reply := domain.SetRouteReply{
-		MessageBase: domain.MessageBase{
-			SendRouteID: base.SendRouteID,
-			SendBack:    true,
-			FromPeer:    self.config.PubKey,
-			Nonce:       generateNonce(),
-		},
-		ConfirmRouteID: confirmId,
-	}
-	transportToPeer := self.safelyGetTransportToPeer(base.FromPeer)
-	if transportToPeer == nil {
-		fmt.Fprintf(os.Stderr, "No transport to peer %v from %v\n", base.FromPeer, self.config.PubKey)
-		return
-	}
-	serialized := self.serializer.SerializeMessage(reply)
-	err := transportToPeer.SendMessage(base.FromPeer, serialized)
-	if err != nil {
-		return
-	}
-}
-
-func (self *Node) processSetRouteMessage(msg domain.SetRouteMessage) {
-	if msg.SendBack {
-		fmt.Fprintf(os.Stderr, "Invalid SetRouteMessage received, dropping: %v\n", msg)
-		return
-	}
-	self.lock.Lock()
-	defer self.lock.Unlock()
-
-	if msg.SetRouteID == NilRouteID {
-		fmt.Fprintf(os.Stderr, "Invalid SetRouteMessage received, dropping: %v\n", msg)
-		return
-	}
-	self.routes[msg.SetRouteID] =
-		domain.Route{
-			ForwardToPeer:              msg.ForwardToPeer,
-			ForwardRewriteSendRouteID:  msg.ForwardRewriteSendRouteID,
-			BackwardToPeer:             msg.BackwardToPeer,
-			BackwardRewriteSendRouteID: msg.BackwardRewriteSendRouteID,
-			ExpiryTime:                 self.clipExpiryTime(time.Now().Add(msg.DurationHint)),
-		}
-
-	// Don't block to send reply
-	go self.sendSetRouteReply(msg.MessageBase, msg.ConfirmRouteID)
-}
-
-func (self *Node) processSetRouteReplyMessage(msg domain.SetRouteReply) {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-	confirmChan, foundChan := self.routeExtensionsAwaitingConfirm[msg.ConfirmRouteID]
-	if foundChan {
-		confirmChan <- true
-	}
-	localRoute, foundLocal := self.localRoutes[msg.ConfirmRouteID]
-	if foundLocal {
-		localRoute.LastConfirmed = time.Now()
-		self.localRoutes[msg.ConfirmRouteID] = localRoute
-	}
-}
-
-func (self *Node) clipExpiryTime(hint time.Time) time.Time {
-	maxTime := time.Now().Add(self.config.MaximumForwardingDuration)
-	if hint.Unix() > maxTime.Unix() {
-		return maxTime
-	}
-	return hint
-}
-
-func (self *Node) processRefreshRouteMessage(msg domain.RefreshRouteMessage, forwarded bool) {
-	if forwarded {
-		self.lock.Lock()
-		defer self.lock.Unlock()
-		route, exists := self.routes[msg.SendRouteID]
-		if !exists {
-			fmt.Fprintf(os.Stderr, "Refresh sent for unknown route: %v\n", msg.SendRouteID)
-			return
-		}
-		route.ExpiryTime = self.clipExpiryTime(time.Now().Add(msg.DurationHint))
-		self.routes[msg.SendRouteID] = route
-	} else {
-		// Don't block to send reply
-		go self.sendSetRouteReply(msg.MessageBase, msg.ConfirmRoutedID)
-	}
-}
-
-func (self *Node) processDeleteRouteMessage(msg domain.DeleteRouteMessage) {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-	delete(self.routes, msg.SendRouteID)
-}
-
-func (self *Node) processMessage(serialized []byte) {
-	msg, deserialize_error := self.serializer.UnserializeMessage(serialized)
-	if deserialize_error != nil {
-		fmt.Fprintf(os.Stderr, "Deserialization error %v\n", deserialize_error)
-		return
-	}
-
-	msg_type := reflect.TypeOf(msg)
-	// User messages have fragmentation to deal with
-	if msg_type == reflect.TypeOf(domain.UserMessage{}) {
-		self.processUserMessage(msg.(domain.UserMessage))
-	} else {
-		forwardedMessage := self.forwardMessage(msg)
-		if !forwardedMessage {
-			// Receive or forward. Refragment on forward!
-			if msg_type == reflect.TypeOf(domain.SetRouteMessage{}) {
-				self.processSetRouteMessage(msg.(domain.SetRouteMessage))
-			} else if msg_type == reflect.TypeOf(domain.SetRouteReply{}) {
-				self.processSetRouteReplyMessage(msg.(domain.SetRouteReply))
-			}
-		} else {
-			if msg_type == reflect.TypeOf(domain.DeleteRouteMessage{}) {
-				self.processDeleteRouteMessage(msg.(domain.DeleteRouteMessage))
-			}
-		}
-
-		if msg_type == reflect.TypeOf(domain.RefreshRouteMessage{}) {
-			self.processRefreshRouteMessage(msg.(domain.RefreshRouteMessage), forwardedMessage)
-		}
-	}
-}
-
-func (self *Node) expireOldMessages() {
-	time_now := time.Now()
-	self.lock.Lock()
-	defer self.lock.Unlock()
-
-	lastMessages := self.messagesBeingAssembled
-	self.messagesBeingAssembled = make(map[domain.MessageID]*domain.MessageUnderAssembly)
-	for id, msg := range lastMessages {
-		if time_now.Before(msg.ExpiryTime) {
-			self.messagesBeingAssembled[id] = msg
-		}
-	}
-}
-
-func (self *Node) expireOldRoutes() {
-	time_now := time.Now()
-	self.lock.Lock()
-	defer self.lock.Unlock()
-
-	lastMessages := self.routes
-	self.routes = make(map[domain.RouteID]domain.Route)
-	// Last refresh of time.Unix(0,0) means it lives forever
-	for id, route := range lastMessages {
-		if (route.ExpiryTime == time.Unix(0, 0)) || time_now.Before(route.ExpiryTime) {
-			self.routes[id] = route
-		}
-	}
-}
-
-func (self *Node) refreshRoute(routeId domain.RouteID) {
-	route, routeFound := self.safelyGetRoute(routeId)
-	if !routeFound {
-		fmt.Fprintf(os.Stderr, "Cannot refresh unknown route: %v\n", routeId)
-		return
-	}
-	base := domain.MessageBase{
-		SendRouteID: route.ForwardRewriteSendRouteID,
-		SendBack:    false,
-		FromPeer:    self.config.PubKey,
-		Nonce:       generateNonce(),
-	}
-	directPeer := route.ForwardToPeer
-	transportToPeer := self.safelyGetTransportToPeer(directPeer)
-	if transportToPeer == nil {
-		fmt.Fprintf(os.Stderr, "No transport to peer %v\n", directPeer)
-		return
-	}
-	message := domain.RefreshRouteMessage{
-		MessageBase:     base,
-		DurationHint:    3 * self.config.RefreshRouteDuration,
-		ConfirmRoutedID: routeId,
-	}
-	serialized := self.serializer.SerializeMessage(message)
-	err := transportToPeer.SendMessage(directPeer, serialized)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Serialization error %v\n", err)
-		return
-	}
-}
-
-func (self *Node) refreshRoutes() {
-	self.lock.Lock()
-	localRoutes := self.localRoutes
-	self.lock.Unlock()
-
-	for routeID := range localRoutes {
-		self.refreshRoute(routeID)
-	}
-}
-
-func (self *Node) expireOldMessagesLoop() {
-	self.closeGroup.Add(1)
-	defer self.closeGroup.Done()
-	for len(self.closing) == 0 {
-		select {
-		case <-time.After(self.config.ExpireMessagesInterval):
-			{
-				self.expireOldMessages()
-			}
-		case <-self.closing:
-			{
-				return
-			}
-		}
-	}
-}
-
-func (self *Node) processIncomingMessagesLoop() {
-	self.closeGroup.Add(1)
-	defer self.closeGroup.Done()
-	for len(self.closing) == 0 {
-		select {
-		case msg, ok := <-self.transportsMessagesReceived:
-			{
-				if ok {
-					self.processMessage(msg)
-				}
-			}
-		case <-self.closing:
-			{
-				return
-			}
-		}
-	}
-}
-
-func (self *Node) expireOldRoutesLoop() {
-	self.closeGroup.Add(1)
-	defer self.closeGroup.Done()
-	for len(self.closing) == 0 {
-		select {
-		case <-time.After(self.config.ExpireRoutesInterval):
-			{
-				self.expireOldRoutes()
-			}
-		case <-self.closing:
-			{
-				return
-			}
-		}
-	}
-}
-
-func (self *Node) refreshRoutesLoop() {
-	self.closeGroup.Add(1)
-	defer self.closeGroup.Done()
-	for len(self.closing) == 0 {
-		select {
-		case <-time.After(self.config.RefreshRouteDuration):
-			{
-				self.refreshRoutes()
-			}
-		case <-self.closing:
-			{
-				return
-			}
-		}
-	}
-}
-
-// Waits for transports to close
-func (self *Node) Close() error {
-	for i := 0; i < 10; i++ {
-		self.closing <- true
-	}
-	close(self.transportsMessagesReceived)
-	self.closeGroup.Wait()
-	return nil
-}
-
-func (self *Node) GetConfig() domain.NodeConfig {
-	return self.config
-}
-
-// Node takes ownership of the transport, and will call Close() when it is closed
-func (self *Node) AddTransport(transportNode transport.ITransport) {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-	//chaCha20Key := &transport.ChaChaCrypto{}
-	//chaCha20Key.SetKey(chaChaKey)
-	//transportNode.SetCrypto(chaCha20Key)
-	transportNode.SetReceiveChannel(self.transportsMessagesReceived)
-	self.transports[transportNode] = true
-}
-
-func (self *Node) RemoveTransport(transport transport.ITransport) {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-	delete(self.transports, transport)
-}
-
-func (self *Node) GetTransports() []transport.ITransport {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-	ret := []transport.ITransport{}
-	for nodeTransport := range self.transports {
-		ret = append(ret, nodeTransport)
-	}
-	return ret
-}
-
-func (self *Node) GetConnectedPeers() []cipher.PubKey {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-	ret := []cipher.PubKey{}
-	for nodeTransport := range self.transports {
-		peers := nodeTransport.GetConnectedPeers()
-		ret = append(ret, peers...)
-	}
-	return ret
-}
-
-func (self *Node) ConnectedToPeer(peer cipher.PubKey) bool {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-	for nodeTransport := range self.transports {
-		if nodeTransport.ConnectedToPeer(peer) {
-			return true
-		}
-	}
-	return false
-}
-
-// Message order is not preserved
-func (self *Node) SetReceiveChannel(received chan domain.MeshMessage) {
-	self.outputMessagesReceived = received
-}
-
-// toPeer must be the public key of a connected peer
-func (self *Node) AddRoute(routeID domain.RouteID, toPeer cipher.PubKey) error {
-	_, routeExists := self.safelyGetRoute(routeID)
-	if routeExists {
-		return errors.New(fmt.Sprintf("Route %v already exists\n", routeID))
-	}
-
-	transportToPeer := self.safelyGetTransportToPeer(toPeer)
-	if transportToPeer == nil {
-		return errors.New(fmt.Sprintf("No transport to peer %v\n", toPeer))
-	}
-
-	// Add locally to routesById for backward termination
-	self.lock.Lock()
-	defer self.lock.Unlock()
-	self.routes[routeID] =
-		domain.Route{
-			ForwardToPeer:              toPeer,
-			ForwardRewriteSendRouteID:  routeID,
-			BackwardToPeer:             cipher.PubKey{},
-			BackwardRewriteSendRouteID: NilRouteID,
-			// Route lifetime: never dies until route is removed
-			ExpiryTime: time.Unix(0, 0),
-		}
-
-	self.localRoutesByTerminatingPeer[toPeer] = routeID
-	self.localRoutes[routeID] = domain.LocalRoute{
-		LastForwardingPeer: self.config.PubKey,
-		TerminatingPeer:    toPeer,
-		LastHopRouteID:     NilRouteID,
-		LastConfirmed:      time.Unix(0, 0),
-	}
-	return nil
-}
-
-func (self *Node) sendDeleteRoute(routeID domain.RouteID, route domain.Route) error {
-	sendBase := domain.MessageBase{
-		SendRouteID: route.ForwardRewriteSendRouteID,
-		SendBack:    false,
-		FromPeer:    self.config.PubKey,
-		Nonce:       generateNonce(),
-	}
-	message := domain.DeleteRouteMessage{
-		MessageBase: sendBase,
-	}
-
-	directPeer := route.ForwardToPeer
-	transportToPeer := self.safelyGetTransportToPeer(directPeer)
-	if transportToPeer == nil {
-		return errors.New(fmt.Sprintf("No transport to peer %v from %v\n", directPeer, self.config.PubKey))
-	}
-	serialized := self.serializer.SerializeMessage(message)
-	err := transportToPeer.SendMessage(directPeer, serialized)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (self *Node) DeleteRoute(routeID domain.RouteID) (err error) {
-	route, routeExists := self.safelyGetRoute(routeID)
-	if !routeExists {
-		return errors.New(fmt.Sprintf("Cannot delete route %v, doesn't exist\n", routeID))
-	}
-
-	err = self.sendDeleteRoute(routeID, route)
-
-	self.lock.Lock()
-	defer self.lock.Unlock()
-	localRoute, localExists := self.localRoutes[routeID]
-
-	delete(self.routes, routeID)
-	delete(self.routeExtensionsAwaitingConfirm, routeID)
-
-	if localExists {
-		delete(self.localRoutes, routeID)
-		delete(self.localRoutesByTerminatingPeer, localRoute.TerminatingPeer)
-	}
-	return err
-}
-
-func (self *Node) extendRouteWithoutSending(routeID domain.RouteID, toPeer cipher.PubKey) (message domain.SetRouteMessage, directPeer cipher.PubKey, waitConfirm chan bool, err error) {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-
-	_, alreadyExtending := self.routeExtensionsAwaitingConfirm[routeID]
-	if alreadyExtending {
-		return domain.SetRouteMessage{}, cipher.PubKey{}, nil, errors.New("Cannot extend route more than once at the same time")
-	}
-
-	newHopId := routeID
-
-	localRoute, localRouteExists := self.localRoutes[routeID]
-	if !localRouteExists {
-		return domain.SetRouteMessage{}, cipher.PubKey{}, nil, errors.New(fmt.Sprintf("ExtendRoute called on unknown route: %v", routeID))
-	}
-
-	route, routeExists := self.routes[routeID]
-	if !routeExists {
-		panic("Internal consistency error 8JUL2016544")
-	}
-
-	directPeer = route.ForwardToPeer
-
-	sendBase := domain.MessageBase{
-		SendRouteID: route.ForwardRewriteSendRouteID,
-		SendBack:    false,
-		FromPeer:    self.config.PubKey,
-		Nonce:       generateNonce(),
-	}
-
-	newTermMessage := domain.SetRouteMessage{
-		MessageBase:                sendBase,
-		SetRouteID:                 routeID,
-		ConfirmRouteID:             routeID,
-		ForwardToPeer:              toPeer,
-		ForwardRewriteSendRouteID:  routeID,
-		BackwardToPeer:             localRoute.LastForwardingPeer,
-		BackwardRewriteSendRouteID: localRoute.LastHopRouteID,
-		DurationHint:               3 * self.config.RefreshRouteDuration,
-	}
-	delete(self.localRoutesByTerminatingPeer, localRoute.TerminatingPeer)
-	self.localRoutes[routeID] = domain.LocalRoute{
-		LastForwardingPeer: localRoute.TerminatingPeer,
-		TerminatingPeer:    toPeer,
-		LastHopRouteID:     newHopId,
-		LastConfirmed:      localRoute.LastConfirmed,
-	}
-	self.localRoutesByTerminatingPeer[toPeer] = routeID
-
-	updatedRoute := route
-	updatedRoute.ForwardRewriteSendRouteID = newHopId
-	self.routes[routeID] = updatedRoute
-	confirmChan := make(chan bool, 1)
-	self.routeExtensionsAwaitingConfirm[routeID] = confirmChan
-
-	return newTermMessage, directPeer, confirmChan, nil
-}
-
-// toPeer must be the public key of a peer connected to the current last node in this route
-// Blocks until the set route reply is received or the timeout is reached
-func (self *Node) ExtendRoute(routeID domain.RouteID, toPeer cipher.PubKey, timeout time.Duration) (err error) {
-	message, directPeer, confirm, extendError := self.extendRouteWithoutSending(routeID, toPeer)
-	if extendError != nil {
-		return extendError
-	}
-	transportToPeer := self.safelyGetTransportToPeer(directPeer)
-	if transportToPeer == nil {
-		return errors.New(fmt.Sprintf("No transport to peer %v from %v\n", directPeer, self.config.PubKey))
-	}
-	serialized := self.serializer.SerializeMessage(message)
-	err = transportToPeer.SendMessage(directPeer, serialized)
-	if err != nil {
-		return err
-	}
-	select {
-	case <-confirm:
-		{
-			break
-		}
-	case <-time.After(timeout):
-		{
-			// Still need to remove from confirm map
-			err = &TimeoutError{}
-		}
-	}
-	self.lock.Lock()
-	defer self.lock.Unlock()
-
-	delete(self.routeExtensionsAwaitingConfirm, routeID)
-	return
-}
-
-func (self *Node) GetRouteLastConfirmed(routeID domain.RouteID) (time.Time, error) {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-	localRoute, found := self.localRoutes[routeID]
-	if !found {
-		return time.Unix(0, 0), errors.New(fmt.Sprintf("Unknown route id: %v", routeID))
-	}
-	return localRoute.LastConfirmed, nil
-}
-
-func (self *Node) unsafelyGetTransportToPeer(peerKey cipher.PubKey) transport.ITransport {
-	for transportToPeer := range self.transports {
-		// TODO: Choose transport more intelligently
-		if transportToPeer.ConnectedToPeer(peerKey) {
-			return transportToPeer
-		}
-	}
-	return nil
-}
-
-func (self *Node) safelyGetTransportToPeer(peerKey cipher.PubKey) transport.ITransport {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-	return self.unsafelyGetTransportToPeer(peerKey)
-}
-
-func (self *Node) findRouteToPeer(toPeer cipher.PubKey) (directPeer cipher.PubKey, localId, sendId domain.RouteID, transport transport.ITransport, err error) {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-	localRouteId, localRouteExists := self.localRoutesByTerminatingPeer[toPeer]
-	if localRouteExists {
-		route, routeStructExists := self.routes[localRouteId]
-		if !routeStructExists {
-			panic("Local route struct does not exists")
-		}
-		directPeer = route.ForwardToPeer
-		localId = localRouteId
-		sendId = route.ForwardRewriteSendRouteID
-	} else {
-		return cipher.PubKey{}, NilRouteID, NilRouteID, nil, errors.New(fmt.Sprintf("No route to peer: %v", toPeer))
-	}
-	transport = self.unsafelyGetTransportToPeer(directPeer)
-	if transport == nil {
-		return cipher.PubKey{}, NilRouteID, NilRouteID, nil,
-			errors.New(fmt.Sprintf("No route or transport to peer %v\n", toPeer))
-	}
-	return
-}
-
-// Chooses a route automatically. Sends directly without a route if connected to that peer
-func (self *Node) SendMessageToPeer(toPeer cipher.PubKey, contents []byte) (err error, routeId domain.RouteID) {
-	directPeer, localRouteId, sendId, transportToPeer, err := self.findRouteToPeer(toPeer)
-	if err != nil {
-		return err, NilRouteID
-	}
-	base := domain.MessageBase{
-		SendRouteID: sendId,
-		SendBack:    false,
-		FromPeer:    self.config.PubKey,
-		Nonce:       generateNonce(),
-	}
-	messages := connection.ConnectionManager.FragmentMessage(contents, directPeer, transportToPeer, base)
-	for _, message := range messages {
-		serialized := self.serializer.SerializeMessage(message)
-		err := transportToPeer.SendMessage(directPeer, serialized)
-		if err != nil {
-			return err, NilRouteID
-		}
-	}
-	return nil, localRouteId
-}
-
-// Blocks until message is confirmed received
-func (self *Node) SendMessageThruRoute(routeId domain.RouteID, contents []byte) error {
-	route, routeFound := self.safelyGetRoute(routeId)
-	if !routeFound {
-		return errors.New("Route not found")
-	}
-
-	base := domain.MessageBase{
-		SendRouteID: route.ForwardRewriteSendRouteID,
-		SendBack:    false,
-		FromPeer:    self.config.PubKey,
-		Nonce:       generateNonce(),
-	}
-	directPeer := route.ForwardToPeer
-	transportToPeer := self.safelyGetTransportToPeer(directPeer)
-	if transportToPeer == nil {
-		return errors.New(fmt.Sprintf("No transport to peer %v\n", directPeer))
-	}
-	messages := connection.ConnectionManager.FragmentMessage(contents, directPeer, transportToPeer, base)
-	for _, message := range messages {
-		serialized := self.serializer.SerializeMessage(message)
-		fmt.Fprintln(os.Stdout, "Send Message")
-		err := transportToPeer.SendMessage(directPeer, serialized)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// Blocks until message is confirmed received
-func (self *Node) SendMessageBackThruRoute(replyTo domain.ReplyTo, contents []byte) error {
-	directPeer := replyTo.FromPeer
-	transportToPeer := self.safelyGetTransportToPeer(directPeer)
-	if transportToPeer == nil {
-		return errors.New(fmt.Sprintf("No route or transport to peer %v\n", directPeer))
-	}
-	base := domain.MessageBase{
-		SendRouteID: replyTo.RouteID,
-		SendBack:    true,
-		FromPeer:    self.config.PubKey,
-		Nonce:       generateNonce(),
-	}
-	messages := connection.ConnectionManager.FragmentMessage(contents, directPeer, transportToPeer, base)
-	for _, message := range messages {
-		serialized := self.serializer.SerializeMessage(message)
-		err := transportToPeer.SendMessage(directPeer, serialized)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (self *Node) debug_countRoutes() int {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-	return len(self.routes)
-}
-
-func (self *Node) debug_countMessages() int {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-	return len(self.messagesBeingAssembled)
 }

--- a/src/mesh/node/node_message_processing.go
+++ b/src/mesh/node/node_message_processing.go
@@ -1,0 +1,157 @@
+package mesh
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"time"
+
+	"github.com/skycoin/skycoin/src/mesh/domain"
+	"github.com/skycoin/skycoin/src/mesh/node/connection"
+)
+
+// Message order is not preserved
+func (self *Node) SetReceiveChannel(received chan domain.MeshMessage) {
+	self.outputMessagesReceived = received
+}
+
+func (self *Node) processIncomingMessagesLoop() {
+	self.closeGroup.Add(1)
+	defer self.closeGroup.Done()
+	for len(self.closing) == 0 {
+		select {
+		case msg, ok := <-self.transportsMessagesReceived:
+			{
+				if ok {
+					self.processMessage(msg)
+				}
+			}
+		case <-self.closing:
+			{
+				return
+			}
+		}
+	}
+}
+
+func (self *Node) processMessage(serialized []byte) {
+	message, err := self.serializer.UnserializeMessage(serialized)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Deserialization error %v\n", err)
+		return
+	}
+
+	messageType := reflect.TypeOf(message)
+	// User messages have fragmentation to deal with
+	if messageType == reflect.TypeOf(domain.UserMessage{}) {
+		self.processUserMessage(message.(domain.UserMessage))
+	} else {
+		forwardedMessage := self.forwardMessage(message)
+		if !forwardedMessage {
+			// Receive or forward. Refragment on forward!
+			if messageType == reflect.TypeOf(domain.SetRouteMessage{}) {
+				self.processSetRouteMessage(message.(domain.SetRouteMessage))
+			} else if messageType == reflect.TypeOf(domain.SetRouteReply{}) {
+				self.processSetRouteReplyMessage(message.(domain.SetRouteReply))
+			}
+		} else {
+			if messageType == reflect.TypeOf(domain.DeleteRouteMessage{}) {
+				self.processDeleteRouteMessage(message.(domain.DeleteRouteMessage))
+			}
+		}
+
+		if messageType == reflect.TypeOf(domain.RefreshRouteMessage{}) {
+			self.processRefreshRouteMessage(message.(domain.RefreshRouteMessage), forwardedMessage)
+		}
+	}
+}
+
+func (self *Node) processUserMessage(msgIn domain.UserMessage) {
+	reassembled := self.reassembleUserMessage(msgIn)
+	// Not finished reassembling yet
+	if reassembled == nil {
+		return
+	}
+	directPeer, forwardBase, doForward := self.safelyGetRewriteBase(msgIn)
+	if doForward {
+		transportToPeer := self.safelyGetTransportToPeer(directPeer)
+		if transportToPeer == nil {
+			fmt.Fprintf(os.Stderr, "No transport to peer %v from %v, dropping\n", directPeer, self.config.PubKey)
+			return
+		}
+		// Forward reassembled message, not individual pieces. This is done because of the need for refragmentation
+		fragments := connection.ConnectionManager.FragmentMessage(reassembled, directPeer, transportToPeer, forwardBase)
+		for _, fragment := range fragments {
+			serialized := self.serializer.SerializeMessage(fragment)
+			err := transportToPeer.SendMessage(directPeer, serialized)
+			if err != nil {
+				fmt.Fprint(os.Stderr, "Failed to send forwarded message, dropping\n")
+				return
+			}
+		}
+	} else {
+		self.outputMessagesReceived <- domain.MeshMessage{domain.ReplyTo{msgIn.SendRouteID, msgIn.FromPeerID}, reassembled}
+	}
+}
+
+func (self *Node) processSetRouteMessage(msg domain.SetRouteMessage) {
+	if msg.SendBack {
+		fmt.Fprintf(os.Stderr, "Invalid SetRouteMessage received, dropping: %v\n", msg)
+		return
+	}
+	self.lock.Lock()
+	defer self.lock.Unlock()
+
+	if msg.SetRouteID == NilRouteID {
+		fmt.Fprintf(os.Stderr, "Invalid SetRouteMessage received, dropping: %v\n", msg)
+		return
+	}
+	self.routes[msg.SetRouteID] =
+		domain.Route{
+			ForwardToPeerID:            msg.ForwardToPeerID,
+			ForwardRewriteSendRouteID:  msg.ForwardRewriteSendRouteID,
+			BackwardToPeerID:           msg.BackwardToPeerID,
+			BackwardRewriteSendRouteID: msg.BackwardRewriteSendRouteID,
+			ExpiryTime:                 self.clipExpiryTime(time.Now().Add(msg.DurationHint)),
+		}
+
+	// Don't block to send reply
+	go self.sendSetRouteReply(msg.MessageBase, msg.ConfirmRouteID)
+}
+
+func (self *Node) processSetRouteReplyMessage(msg domain.SetRouteReply) {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	confirmChan, foundChan := self.routeExtensionsAwaitingConfirm[msg.ConfirmRouteID]
+	if foundChan {
+		confirmChan <- true
+	}
+	localRoute, foundLocal := self.localRoutes[msg.ConfirmRouteID]
+	if foundLocal {
+		localRoute.LastConfirmed = time.Now()
+		self.localRoutes[msg.ConfirmRouteID] = localRoute
+	}
+}
+
+func (self *Node) processRefreshRouteMessage(msg domain.RefreshRouteMessage, forwarded bool) {
+	if forwarded {
+		self.lock.Lock()
+		defer self.lock.Unlock()
+		route, exists := self.routes[msg.SendRouteID]
+		if !exists {
+			fmt.Fprintf(os.Stderr, "Refresh sent for unknown route: %v\n", msg.SendRouteID)
+			return
+		}
+		route.ExpiryTime = self.clipExpiryTime(time.Now().Add(msg.DurationHint))
+		self.routes[msg.SendRouteID] = route
+	} else {
+		// Don't block to send reply
+		go self.sendSetRouteReply(msg.MessageBase, msg.ConfirmRoutedID)
+	}
+}
+
+func (self *Node) processDeleteRouteMessage(msg domain.DeleteRouteMessage) {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	delete(self.routes, msg.SendRouteID)
+}

--- a/src/mesh/node/node_message_sending.go
+++ b/src/mesh/node/node_message_sending.go
@@ -1,0 +1,247 @@
+package mesh
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"time"
+
+	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/mesh/domain"
+	"github.com/skycoin/skycoin/src/mesh/node/connection"
+)
+
+// Chooses a route automatically. Sends directly without a route if connected to that peer
+func (self *Node) SendMessageToPeer(toPeer cipher.PubKey, contents []byte) (error, domain.RouteID) {
+	directPeer, localRouteID, sendRoutID, transportToPeer, err := self.findRouteToPeer(toPeer)
+	if err != nil {
+		return err, NilRouteID
+	}
+	messageBase := domain.MessageBase{
+		SendRouteID: sendRoutID,
+		SendBack:    false,
+		FromPeerID:  self.config.PubKey,
+		Nonce:       generateNonce(),
+	}
+	messages := connection.ConnectionManager.FragmentMessage(contents, directPeer, transportToPeer, messageBase)
+	for _, message := range messages {
+		serialized := self.serializer.SerializeMessage(message)
+		err := transportToPeer.SendMessage(directPeer, serialized)
+		if err != nil {
+			return err, NilRouteID
+		}
+	}
+	return nil, localRouteID
+}
+
+// Blocks until message is confirmed received
+func (self *Node) SendMessageThruRoute(routeId domain.RouteID, contents []byte) error {
+	route, routeFound := self.safelyGetRoute(routeId)
+	if !routeFound {
+		return errors.New("Route not found")
+	}
+
+	base := domain.MessageBase{
+		SendRouteID: route.ForwardRewriteSendRouteID,
+		SendBack:    false,
+		FromPeerID:  self.config.PubKey,
+		Nonce:       generateNonce(),
+	}
+	directPeer := route.ForwardToPeerID
+	transportToPeer := self.safelyGetTransportToPeer(directPeer)
+	if transportToPeer == nil {
+		return errors.New(fmt.Sprintf("No transport to peer %v\n", directPeer))
+	}
+	messages := connection.ConnectionManager.FragmentMessage(contents, directPeer, transportToPeer, base)
+	for _, message := range messages {
+		serialized := self.serializer.SerializeMessage(message)
+		fmt.Fprintln(os.Stdout, "Send Message")
+		err := transportToPeer.SendMessage(directPeer, serialized)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Blocks until message is confirmed received
+func (self *Node) SendMessageBackThruRoute(replyTo domain.ReplyTo, contents []byte) error {
+	directPeer := replyTo.FromPeer
+	transportToPeer := self.safelyGetTransportToPeer(directPeer)
+	if transportToPeer == nil {
+		return errors.New(fmt.Sprintf("No route or transport to peer %v\n", directPeer))
+	}
+	base := domain.MessageBase{
+		SendRouteID: replyTo.RouteID,
+		SendBack:    true,
+		FromPeerID:  self.config.PubKey,
+		Nonce:       generateNonce(),
+	}
+	messages := connection.ConnectionManager.FragmentMessage(contents, directPeer, transportToPeer, base)
+	for _, message := range messages {
+		serialized := self.serializer.SerializeMessage(message)
+		err := transportToPeer.SendMessage(directPeer, serialized)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (self *Node) expireOldMessages() {
+	time_now := time.Now()
+	self.lock.Lock()
+	defer self.lock.Unlock()
+
+	lastMessages := self.messagesBeingAssembled
+	self.messagesBeingAssembled = make(map[domain.MessageID]*domain.MessageUnderAssembly)
+	for id, msg := range lastMessages {
+		if time_now.Before(msg.ExpiryTime) {
+			self.messagesBeingAssembled[id] = msg
+		}
+	}
+}
+
+func (self *Node) expireOldMessagesLoop() {
+	self.closeGroup.Add(1)
+	defer self.closeGroup.Done()
+	for len(self.closing) == 0 {
+		select {
+		case <-time.After(self.config.ExpireMessagesInterval):
+			{
+				self.expireOldMessages()
+			}
+		case <-self.closing:
+			{
+				return
+			}
+		}
+	}
+}
+
+func (self *Node) sendSetRouteReply(base domain.MessageBase, confirmId domain.RouteID) {
+	replyMessage := domain.SetRouteReply{
+		MessageBase: domain.MessageBase{
+			SendRouteID: base.SendRouteID,
+			SendBack:    true,
+			FromPeerID:  self.config.PubKey,
+			Nonce:       generateNonce(),
+		},
+		ConfirmRouteID: confirmId,
+	}
+	transportToPeer := self.safelyGetTransportToPeer(base.FromPeerID)
+	if transportToPeer == nil {
+		fmt.Fprintf(os.Stderr, "No transport to peer %v from %v\n", base.FromPeerID, self.config.PubKey)
+		return
+	}
+	serialized := self.serializer.SerializeMessage(replyMessage)
+	err := transportToPeer.SendMessage(base.FromPeerID, serialized)
+	if err != nil {
+		return
+	}
+}
+
+func (self *Node) forwardMessage(msg interface{}) bool {
+	forwardTo, newBase, doForward := self.safelyGetRewriteBase(msg)
+	if !doForward {
+		return false
+	}
+	// Rewrite
+	rewritten := rewriteMessage(msg, newBase)
+	transportToPeer := self.safelyGetTransportToPeer(forwardTo)
+	if transportToPeer == nil {
+		fmt.Fprintf(os.Stderr, "No transport found for forwarded message from %v to %v, dropping\n", self.config.PubKey, forwardTo)
+		return true
+	}
+
+	serialized := self.serializer.SerializeMessage(rewritten)
+	err := transportToPeer.SendMessage(forwardTo, serialized)
+	if err != nil {
+		fmt.Fprint(os.Stderr, "Failed to send forwarded message, dropping\n")
+		return true
+	}
+
+	// Forward, not receive
+	return true
+}
+
+func (self *Node) safelyGetRewriteBase(msg interface{}) (forwardTo cipher.PubKey, base domain.MessageBase, doForward bool) {
+	// sendBack
+	sendBack, route, foundRoute := self.safelyGetForwarding(msg)
+	if !foundRoute {
+		return cipher.PubKey{}, domain.MessageBase{}, false
+	}
+	forwardTo = route.ForwardToPeerID
+	rewriteTo := route.ForwardRewriteSendRouteID
+	if sendBack {
+		forwardTo = route.BackwardToPeerID
+		rewriteTo = route.BackwardRewriteSendRouteID
+	}
+	if forwardTo == (cipher.PubKey{}) {
+		return cipher.PubKey{}, domain.MessageBase{}, false
+	}
+	newBase :=
+		domain.MessageBase{
+			SendRouteID: rewriteTo,
+			SendBack:    sendBack,
+			FromPeerID:  self.config.PubKey,
+			Nonce:       generateNonce(),
+		}
+	return forwardTo, newBase, true
+}
+
+func rewriteMessage(message interface{}, newBase domain.MessageBase) interface{} {
+	messageType := reflect.TypeOf(message)
+	newBase.Nonce = generateNonce()
+
+	switch messageType {
+	case reflect.TypeOf(domain.UserMessage{}):
+		newMessage := (message.(domain.UserMessage))
+		newMessage.MessageBase = newBase
+		return newMessage
+
+	case reflect.TypeOf(domain.SetRouteMessage{}):
+		newMessage := (message.(domain.SetRouteMessage))
+		newMessage.MessageBase = newBase
+		return newMessage
+
+	case reflect.TypeOf(domain.RefreshRouteMessage{}):
+		newMessage := (message.(domain.RefreshRouteMessage))
+		newMessage.MessageBase = newBase
+		return newMessage
+
+	case reflect.TypeOf(domain.DeleteRouteMessage{}):
+		newMessage := (message.(domain.DeleteRouteMessage))
+		newMessage.MessageBase = newBase
+		return newMessage
+
+	case reflect.TypeOf(domain.SetRouteReply{}):
+		newMessage := (message.(domain.SetRouteReply))
+		newMessage.MessageBase = newBase
+		return newMessage
+	}
+
+	panic("Internal error: rewriteMessage incomplete")
+}
+
+func (self *Node) debug_countMessages() int {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	return len(self.messagesBeingAssembled)
+}
+
+func generateNonce() [4]byte {
+	ret := make([]byte, 4)
+	n, err := rand.Read(ret)
+	if n != 4 {
+		panic("rand.Read() failed")
+	}
+	if err != nil {
+		panic(err)
+	}
+	ret_b := [4]byte{0, 0, 0, 0}
+	copy(ret_b[:], ret[:])
+	return ret_b
+}

--- a/src/mesh/node/node_routing.go
+++ b/src/mesh/node/node_routing.go
@@ -1,0 +1,393 @@
+package mesh
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"runtime/debug"
+	"time"
+
+	"github.com/satori/go.uuid"
+	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/mesh/domain"
+	"github.com/skycoin/skycoin/src/mesh/transport"
+)
+
+var NilRouteID domain.RouteID = (domain.RouteID)(uuid.Nil)
+
+// toPeer must be the public key of a connected peer
+func (self *Node) AddRoute(routeID domain.RouteID, toPeer cipher.PubKey) error {
+	_, routeExists := self.safelyGetRoute(routeID)
+	if routeExists {
+		return errors.New(fmt.Sprintf("Route %v already exists\n", routeID))
+	}
+
+	transportToPeer := self.safelyGetTransportToPeer(toPeer)
+	if transportToPeer == nil {
+		return errors.New(fmt.Sprintf("No transport to peer %v\n", toPeer))
+	}
+
+	// Add locally to routes for backward termination
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	self.routes[routeID] =
+		domain.Route{
+			ForwardToPeerID:            toPeer,
+			ForwardRewriteSendRouteID:  routeID,
+			BackwardToPeerID:           cipher.PubKey{},
+			BackwardRewriteSendRouteID: NilRouteID,
+			// Route lifetime: never dies until route is removed
+			ExpiryTime: time.Unix(0, 0),
+		}
+
+	self.localRoutesByTerminatingPeer[toPeer] = routeID
+	self.localRoutes[routeID] = domain.LocalRoute{
+		LastForwardingPeerID: self.config.PubKey,
+		TerminatingPeerID:    toPeer,
+		LastHopRouteID:       NilRouteID,
+		LastConfirmed:        time.Unix(0, 0),
+	}
+	return nil
+}
+
+func (self *Node) DeleteRoute(routeID domain.RouteID) (err error) {
+	route, routeExists := self.safelyGetRoute(routeID)
+	if !routeExists {
+		return errors.New(fmt.Sprintf("Cannot delete route %v, doesn't exist\n", routeID))
+	}
+
+	err = self.sendDeleteRoute(routeID, route)
+
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	localRoute, localExists := self.localRoutes[routeID]
+
+	delete(self.routes, routeID)
+	delete(self.routeExtensionsAwaitingConfirm, routeID)
+
+	if localExists {
+		delete(self.localRoutes, routeID)
+		delete(self.localRoutesByTerminatingPeer, localRoute.TerminatingPeerID)
+	}
+	return err
+}
+
+// toPeer must be the public key of a peer connected to the current last node in this route
+// Blocks until the set route reply is received or the timeout is reached
+func (self *Node) ExtendRoute(routeID domain.RouteID, toPeer cipher.PubKey, timeout time.Duration) (err error) {
+	message, directPeer, confirm, extendError := self.extendRouteWithoutSending(routeID, toPeer)
+	if extendError != nil {
+		return extendError
+	}
+	transportToPeer := self.safelyGetTransportToPeer(directPeer)
+	if transportToPeer == nil {
+		return errors.New(fmt.Sprintf("No transport to peer %v from %v\n", directPeer, self.config.PubKey))
+	}
+	serialized := self.serializer.SerializeMessage(message)
+	err = transportToPeer.SendMessage(directPeer, serialized)
+	if err != nil {
+		return err
+	}
+	select {
+	case <-confirm:
+		{
+			break
+		}
+	case <-time.After(timeout):
+		{
+			// Still need to remove from confirm map
+			err = &TimeoutError{}
+		}
+	}
+	self.lock.Lock()
+	defer self.lock.Unlock()
+
+	delete(self.routeExtensionsAwaitingConfirm, routeID)
+	return
+}
+
+func (self *Node) GetRouteLastConfirmed(routeID domain.RouteID) (time.Time, error) {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	localRoute, found := self.localRoutes[routeID]
+	if !found {
+		return time.Unix(0, 0), errors.New(fmt.Sprintf("Unknown route id: %v", routeID))
+	}
+	return localRoute.LastConfirmed, nil
+}
+
+func (self *Node) findRouteToPeer(toPeer cipher.PubKey) (directPeer cipher.PubKey, localId, sendId domain.RouteID, transport transport.ITransport, err error) {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	localRouteId, localRouteExists := self.localRoutesByTerminatingPeer[toPeer]
+	if localRouteExists {
+		route, routeStructExists := self.routes[localRouteId]
+		if !routeStructExists {
+			panic("Local route struct does not exists")
+		}
+		directPeer = route.ForwardToPeerID
+		localId = localRouteId
+		sendId = route.ForwardRewriteSendRouteID
+	} else {
+		return cipher.PubKey{}, NilRouteID, NilRouteID, nil, errors.New(fmt.Sprintf("No route to peer: %v", toPeer))
+	}
+	transport = self.unsafelyGetTransportToPeer(directPeer)
+	if transport == nil {
+		return cipher.PubKey{}, NilRouteID, NilRouteID, nil,
+			errors.New(fmt.Sprintf("No route or transport to peer %v\n", toPeer))
+	}
+	return
+}
+
+func (self *Node) extendRouteWithoutSending(routeID domain.RouteID, toPeer cipher.PubKey) (message domain.SetRouteMessage, directPeer cipher.PubKey, waitConfirm chan bool, err error) {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+
+	_, alreadyExtending := self.routeExtensionsAwaitingConfirm[routeID]
+	if alreadyExtending {
+		return domain.SetRouteMessage{}, cipher.PubKey{}, nil, errors.New("Cannot extend route more than once at the same time")
+	}
+
+	newHopId := routeID
+
+	localRoute, localRouteExists := self.localRoutes[routeID]
+	if !localRouteExists {
+		return domain.SetRouteMessage{}, cipher.PubKey{}, nil, errors.New(fmt.Sprintf("ExtendRoute called on unknown route: %v", routeID))
+	}
+
+	route, routeExists := self.routes[routeID]
+	if !routeExists {
+		panic("Internal consistency error 8JUL2016544")
+	}
+
+	directPeer = route.ForwardToPeerID
+
+	sendBase := domain.MessageBase{
+		SendRouteID: route.ForwardRewriteSendRouteID,
+		SendBack:    false,
+		FromPeerID:  self.config.PubKey,
+		Nonce:       generateNonce(),
+	}
+
+	newTermMessage := domain.SetRouteMessage{
+		MessageBase:                sendBase,
+		SetRouteID:                 routeID,
+		ConfirmRouteID:             routeID,
+		ForwardToPeerID:            toPeer,
+		ForwardRewriteSendRouteID:  routeID,
+		BackwardToPeerID:           localRoute.LastForwardingPeerID,
+		BackwardRewriteSendRouteID: localRoute.LastHopRouteID,
+		DurationHint:               3 * self.config.RefreshRouteDuration,
+	}
+	delete(self.localRoutesByTerminatingPeer, localRoute.TerminatingPeerID)
+	self.localRoutes[routeID] = domain.LocalRoute{
+		LastForwardingPeerID: localRoute.TerminatingPeerID,
+		TerminatingPeerID:    toPeer,
+		LastHopRouteID:       newHopId,
+		LastConfirmed:        localRoute.LastConfirmed,
+	}
+	self.localRoutesByTerminatingPeer[toPeer] = routeID
+
+	updatedRoute := route
+	updatedRoute.ForwardRewriteSendRouteID = newHopId
+	self.routes[routeID] = updatedRoute
+	confirmChan := make(chan bool, 1)
+	self.routeExtensionsAwaitingConfirm[routeID] = confirmChan
+
+	return newTermMessage, directPeer, confirmChan, nil
+}
+
+func (self *Node) sendDeleteRoute(routeID domain.RouteID, route domain.Route) error {
+	sendBase := domain.MessageBase{
+		SendRouteID: route.ForwardRewriteSendRouteID,
+		SendBack:    false,
+		FromPeerID:  self.config.PubKey,
+		Nonce:       generateNonce(),
+	}
+	message := domain.DeleteRouteMessage{
+		MessageBase: sendBase,
+	}
+
+	directPeer := route.ForwardToPeerID
+	transportToPeer := self.safelyGetTransportToPeer(directPeer)
+	if transportToPeer == nil {
+		return errors.New(fmt.Sprintf("No transport to peer %v from %v\n", directPeer, self.config.PubKey))
+	}
+	serialized := self.serializer.SerializeMessage(message)
+	err := transportToPeer.SendMessage(directPeer, serialized)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (self *Node) expireOldRoutesLoop() {
+	self.closeGroup.Add(1)
+	defer self.closeGroup.Done()
+	for len(self.closing) == 0 {
+		select {
+		case <-time.After(self.config.ExpireRoutesInterval):
+			{
+				self.expireOldRoutes()
+			}
+		case <-self.closing:
+			{
+				return
+			}
+		}
+	}
+}
+
+func (self *Node) refreshRoutesLoop() {
+	self.closeGroup.Add(1)
+	defer self.closeGroup.Done()
+	for len(self.closing) == 0 {
+		select {
+		case <-time.After(self.config.RefreshRouteDuration):
+			{
+				self.refreshRoutes()
+			}
+		case <-self.closing:
+			{
+				return
+			}
+		}
+	}
+}
+
+func (self *Node) safelyGetForwarding(msg interface{}) (SendBack bool, route domain.Route, doForward bool) {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+
+	messageBase := getMessageBase(msg)
+	routeFound, foundRoute := self.routes[messageBase.SendRouteID]
+
+	doForward = foundRoute
+
+	if messageBase.SendBack {
+		if routeFound.BackwardToPeerID == (cipher.PubKey{}) {
+			doForward = false
+		}
+	} else {
+		if routeFound.ForwardToPeerID == (cipher.PubKey{}) {
+			doForward = false
+		}
+	}
+
+	if doForward {
+		return messageBase.SendBack, routeFound, doForward
+	} else {
+		return false, domain.Route{}, doForward
+	}
+}
+
+func (self *Node) safelyGetRoute(routeID domain.RouteID) (route domain.Route, exists bool) {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+
+	route, exists = self.routes[routeID]
+	return
+}
+
+func (self *Node) expireOldRoutes() {
+	time_now := time.Now()
+	self.lock.Lock()
+	defer self.lock.Unlock()
+
+	lastMessages := self.routes
+	self.routes = make(map[domain.RouteID]domain.Route)
+	// Last refresh of time.Unix(0,0) means it lives forever
+	for id, route := range lastMessages {
+		if (route.ExpiryTime == time.Unix(0, 0)) || time_now.Before(route.ExpiryTime) {
+			self.routes[id] = route
+		}
+	}
+}
+
+func (self *Node) refreshRoute(routeId domain.RouteID) {
+	route, routeFound := self.safelyGetRoute(routeId)
+	if !routeFound {
+		fmt.Fprintf(os.Stderr, "Cannot refresh unknown route: %v\n", routeId)
+		return
+	}
+	base := domain.MessageBase{
+		SendRouteID: route.ForwardRewriteSendRouteID,
+		SendBack:    false,
+		FromPeerID:  self.config.PubKey,
+		Nonce:       generateNonce(),
+	}
+	directPeer := route.ForwardToPeerID
+	transportToPeer := self.safelyGetTransportToPeer(directPeer)
+	if transportToPeer == nil {
+		fmt.Fprintf(os.Stderr, "No transport to peer %v\n", directPeer)
+		return
+	}
+	message := domain.RefreshRouteMessage{
+		MessageBase:     base,
+		DurationHint:    3 * self.config.RefreshRouteDuration,
+		ConfirmRoutedID: routeId,
+	}
+	serialized := self.serializer.SerializeMessage(message)
+	err := transportToPeer.SendMessage(directPeer, serialized)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Serialization error %v\n", err)
+		return
+	}
+}
+
+func (self *Node) refreshRoutes() {
+	self.lock.Lock()
+	localRoutes := self.localRoutes
+	self.lock.Unlock()
+
+	for routeID := range localRoutes {
+		self.refreshRoute(routeID)
+	}
+}
+
+func (self *Node) clipExpiryTime(hint time.Time) time.Time {
+	maxTime := time.Now().Add(self.config.MaximumForwardingDuration)
+	if hint.Unix() > maxTime.Unix() {
+		return maxTime
+	}
+	return hint
+}
+
+func getMessageBase(msg interface{}) domain.MessageBase {
+	messageType := reflect.TypeOf(msg)
+
+	switch messageType {
+	case reflect.TypeOf(domain.UserMessage{}):
+		return (msg.(domain.UserMessage)).MessageBase
+
+	case reflect.TypeOf(domain.SetRouteMessage{}):
+		return (msg.(domain.SetRouteMessage)).MessageBase
+
+	case reflect.TypeOf(domain.RefreshRouteMessage{}):
+		return (msg.(domain.RefreshRouteMessage)).MessageBase
+
+	case reflect.TypeOf(domain.DeleteRouteMessage{}):
+		return (msg.(domain.DeleteRouteMessage)).MessageBase
+
+	case reflect.TypeOf(domain.SetRouteReply{}):
+		return (msg.(domain.SetRouteReply)).MessageBase
+	}
+
+	debug.PrintStack()
+	panic(fmt.Sprintf("Internal error: getMessageBase incomplete (%v)", messageType))
+}
+
+func (self *Node) debug_countRoutes() int {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	return len(self.routes)
+}
+
+type TimeoutError struct {
+}
+
+func (self *TimeoutError) Error() string {
+	return "Timeout"
+}

--- a/src/mesh/nodemanager/nodemanager.go
+++ b/src/mesh/nodemanager/nodemanager.go
@@ -184,7 +184,7 @@ func ConnectNodeToNode(config1, config2 *TestConfig) {
 }
 
 // Add Routes to Node
-func AddRoutesToEstablish(node *mesh.Node, routesConfigs []domain.RouteConfig) {
+func AddRoutesToEstablish(node *mesh.Node, routesConfigs []RouteConfig) {
 	// Setup route
 	for _, routeConfig := range routesConfigs {
 		if len(routeConfig.Peers) == 0 {

--- a/src/mesh/nodemanager/testconfig.go
+++ b/src/mesh/nodemanager/testconfig.go
@@ -2,6 +2,7 @@ package nodemanager
 
 import (
 	"github.com/satori/go.uuid"
+	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/mesh/domain"
 	"github.com/skycoin/skycoin/src/mesh/transport"
 	"github.com/skycoin/skycoin/src/mesh/transport/physical"
@@ -12,21 +13,41 @@ type TestConfig struct {
 	UDPConfig       physical.UDPConfig
 	NodeConfig      domain.NodeConfig
 
-	PeersToConnect           []domain.Peer
-	RoutesConfigsToEstablish []domain.RouteConfig
-	MessagesToSend           []domain.MessageToSend
-	MessagesToReceive        []domain.MessageToReceive
+	PeersToConnect           []Peer
+	RoutesConfigsToEstablish []RouteConfig
+	MessagesToSend           []MessageToSend
+	MessagesToReceive        []MessageToReceive
+}
+
+type RouteConfig struct {
+	ID    uuid.UUID
+	Peers []cipher.PubKey
+}
+
+type Peer struct {
+	Peer cipher.PubKey
+	Info string
+}
+
+type MessageToSend struct {
+	ThruRoute uuid.UUID
+	Contents  []byte
+}
+
+type MessageToReceive struct {
+	Contents []byte
+	Reply    []byte
 }
 
 func (self *TestConfig) AddPeerToConnect(addr string, config *TestConfig) {
-	peerToConnect := domain.Peer{}
+	peerToConnect := Peer{}
 	peerToConnect.Peer = config.NodeConfig.PubKey
 	peerToConnect.Info = physical.CreateUDPCommConfig(addr, nil)
 	self.PeersToConnect = append(self.PeersToConnect, peerToConnect)
 }
 
 func (self *TestConfig) AddRouteToEstablish(config *TestConfig) {
-	routeConfigToEstablish := domain.RouteConfig{}
+	routeConfigToEstablish := RouteConfig{}
 	routeConfigToEstablish.ID = uuid.NewV4()
 	routeConfigToEstablish.Peers = append(routeConfigToEstablish.Peers, config.NodeConfig.PubKey)
 	self.RoutesConfigsToEstablish = append(self.RoutesConfigsToEstablish, routeConfigToEstablish)
@@ -37,14 +58,14 @@ func (self *TestConfig) AddPeerToRoute(indexRoute int, config *TestConfig) {
 }
 
 func (self *TestConfig) AddMessageToSend(thruRoute uuid.UUID, message string) {
-	messageToSend := domain.MessageToSend{}
+	messageToSend := MessageToSend{}
 	messageToSend.ThruRoute = thruRoute
 	messageToSend.Contents = []byte(message)
 	self.MessagesToSend = append(self.MessagesToSend, messageToSend)
 }
 
 func (self *TestConfig) AddMessageToReceive(messageReceive, messageReply string) {
-	messageToReceive := domain.MessageToReceive{}
+	messageToReceive := MessageToReceive{}
 	messageToReceive.Contents = []byte(messageReceive)
 	messageToReceive.Reply = []byte(messageReply)
 	self.MessagesToReceive = append(self.MessagesToReceive, messageToReceive)

--- a/src/mesh/serialize/serialize.go
+++ b/src/mesh/serialize/serialize.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
-)
 
-import (
 	"github.com/skycoin/skycoin/src/cipher/encoder"
 )
 
@@ -17,99 +15,97 @@ const messagePrefixLength = 1
 type MessagePrefix [messagePrefixLength]byte
 
 type Serializer struct {
-	messageIdMap        map[reflect.Type]MessagePrefix
-	messageIdReverseMap map[MessagePrefix]reflect.Type
+	messageTypeToPrefix map[reflect.Type]MessagePrefix
+	messagePrefixToType map[MessagePrefix]reflect.Type
 }
 
 func NewSerializer() *Serializer {
-	ret := &Serializer{}
-	ret.messageIdMap = make(map[reflect.Type]MessagePrefix)
-	ret.messageIdReverseMap = make(map[MessagePrefix]reflect.Type)
-	return ret
+	serializer := &Serializer{}
+	serializer.messageTypeToPrefix = make(map[reflect.Type]MessagePrefix)
+	serializer.messagePrefixToType = make(map[MessagePrefix]reflect.Type)
+	return serializer
 }
 
 // Register a message struct for recognition by the message handlers.
-func (self *Serializer) RegisterMessageForSerialization(prefix MessagePrefix, msg interface{}) {
-	t := reflect.TypeOf(msg)
-	id := MessagePrefix{}
-	copy(id[:], prefix[:])
-	_, exists := self.messageIdReverseMap[id]
+func (self *Serializer) RegisterMessageForSerialization(messagePrefix MessagePrefix, message interface{}) {
+	messageType := reflect.TypeOf(message)
+	messagePrefixBuf := MessagePrefix{}
+	copy(messagePrefixBuf[:], messagePrefix[:])
+	_, exists := self.messagePrefixToType[messagePrefixBuf]
 	if exists {
 		log.Panicf("Attempted to register message prefix %s twice",
-			string(id[:]))
+			string(messagePrefixBuf[:]))
 	}
-	_, exists = self.messageIdMap[t]
+	_, exists = self.messageTypeToPrefix[messageType]
 	if exists {
-		log.Panicf("Attempts to register message type %v twice", t)
+		log.Panicf("Attempts to register message type %v twice", messageType)
 	}
-	self.messageIdMap[t] = id
-	self.messageIdReverseMap[id] = t
+	self.messageTypeToPrefix[messageType] = messagePrefixBuf
+	self.messagePrefixToType[messagePrefixBuf] = messageType
 }
 
-func (self *Serializer) UnserializeMessage(msg []byte) (interface{}, error) {
-	msgId := [1]byte{}
-	if len(msg) < len(msgId) {
-		return nil, errors.New("Not enough data to read msg id")
+func (self *Serializer) UnserializeMessage(messageData []byte) (interface{}, error) {
+	messagePrefix := [1]byte{}
+	if len(messageData) < len(messagePrefix) {
+		return nil, errors.New("Not enough data to read message prefix")
 	}
-	copy(msgId[:], msg[:len(msgId)])
-	msg = msg[len(msgId):]
+	copy(messagePrefix[:], messageData[:len(messagePrefix)])
+	messageData = messageData[len(messagePrefix):]
 
-	t, succ := self.messageIdReverseMap[msgId]
-	if !succ {
-		return nil, fmt.Errorf("Unknown message %s received", string(msgId[:]))
+	messageType, exists := self.messagePrefixToType[messagePrefix]
+	if !exists {
+		return nil, fmt.Errorf("Unknown message %s received", string(messagePrefix[:]))
 	}
-	var m interface{}
-	var v reflect.Value = reflect.New(t)
+	var reflectValue reflect.Value = reflect.New(messageType)
 	//logger.Debug("Giving %d bytes to the decoder", len(msg))
-	used, err := self.deserializeMessage(msg, v)
+	usedBytesCount, err := self.deserializeMessage(messageData, reflectValue)
 	if err != nil {
 		return nil, err
 	}
-	if used != len(msg) {
+	if usedBytesCount != len(messageData) {
 		return nil, errors.New("Data buffer was not completely decoded")
 	}
-	m, succ = (v.Elem().Interface()).(interface{})
-	if !succ {
+	message, exists := (reflectValue.Elem().Interface()).(interface{})
+	if !exists {
 		// This occurs only when the user registers an interface that does
 		// match the interface{} interface.  They should have known about this
 		// earlier via a call to VerifyMessages
 		log.Panic("interface{} obtained from map does not match interface{} interface")
-		return nil, errors.New("MessageIdMaps contain non-interface{}")
+		return nil, errors.New("messagePrefixToType contain non-interface{}")
 	}
-	return m, nil
+	return message, nil
 }
 
 // Wraps encoder.DeserializeRawToValue and traps panics as an error
-func (self *Serializer) deserializeMessage(msg []byte, v reflect.Value) (n int, e error) {
+func (self *Serializer) deserializeMessage(messageData []byte, reflectValue reflect.Value) (usedBytesCount int, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			switch x := r.(type) {
 			case string:
-				e = errors.New(x)
+				err = errors.New(x)
 			case error:
-				e = x
+				err = x
 			default:
-				e = errors.New("interface{} deserialization failed")
+				err = errors.New("interface{} deserialization failed")
 			}
 		}
 	}()
-	n, e = encoder.DeserializeRawToValue(msg, v)
+	usedBytesCount, err = encoder.DeserializeRawToValue(messageData, reflectValue)
 	return
 }
 
-// Packgs a interface{} into []byte containing length, id and data
-func (self *Serializer) SerializeMessage(msg interface{}) []byte {
-	t := reflect.TypeOf(msg)
-	msgId, succ := self.messageIdMap[t]
-	if !succ {
-		txt := "Attempted to serialize message type not in MessageIdMap: %v"
-		log.Panicf(txt, t)
+// Packs a interface{} into []byte containing length, id and data
+func (self *Serializer) SerializeMessage(message interface{}) []byte {
+	messageType := reflect.TypeOf(message)
+	messagePrefix, exists := self.messageTypeToPrefix[messageType]
+	if !exists {
+		log.Panicf("Attempted to serialize message with unknown type: %v", messageType)
 	}
-	bMsg := encoder.Serialize(msg)
+	serializedMessageData := encoder.Serialize(message)
 
 	// message length
-	m := make([]byte, 0)
-	m = append(m, msgId[:]...) // message id
-	m = append(m, bMsg...)     // message bytes
-	return m
+	finalMessage := make([]byte, 0)
+	finalMessage = append(finalMessage, messagePrefix[:]...)      // message prefix
+	finalMessage = append(finalMessage, serializedMessageData...) // message bytes
+	return finalMessage
 }

--- a/src/mesh/transport/physical/udp.go
+++ b/src/mesh/transport/physical/udp.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ccding/go-stun/stun"
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/cipher/encoder"
-	"github.com/skycoin/skycoin/src/mesh/domain"
 	"github.com/skycoin/skycoin/src/mesh/transport"
 )
 
@@ -28,13 +27,17 @@ type ListenPort struct {
 }
 
 type UDPConfig struct {
-	domain.TransportConfig
+	TransportConfig
 	DatagramLength  uint16
 	LocalAddress    string // "" for default
 	NumListenPorts  uint16
 	ListenPortMin   uint16   // If 0, STUN is used
 	ExternalAddress string   // External address to use if STUN is not
 	StunEndpoints   []string // STUN servers to try for NAT traversal
+}
+
+type TransportConfig struct {
+	SendChannelLength uint32
 }
 
 type UDPCommConfig struct {

--- a/src/mesh/transport/physical/udp_test.go
+++ b/src/mesh/transport/physical/udp_test.go
@@ -5,12 +5,11 @@ import (
 	"time"
 
 	"github.com/skycoin/skycoin/src/cipher"
-	"github.com/skycoin/skycoin/src/mesh/domain"
 	"github.com/stretchr/testify/assert"
 )
 
 var staticTestConfig UDPConfig = UDPConfig{
-	TransportConfig: domain.TransportConfig{
+	TransportConfig: TransportConfig{
 		SendChannelLength: 8,
 	},
 	DatagramLength:  512,
@@ -38,7 +37,7 @@ func TestClose(t *testing.T) {
 
 func TestBindSTUNPorts(t *testing.T) {
 	config := UDPConfig{
-		TransportConfig: domain.TransportConfig{
+		TransportConfig: TransportConfig{
 			SendChannelLength: 8,
 		},
 		DatagramLength:  512,

--- a/src/mesh/transport/transport_message_processing.go
+++ b/src/mesh/transport/transport_message_processing.go
@@ -1,0 +1,80 @@
+package transport
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"time"
+)
+
+func (self *Transport) SetReceiveChannel(received chan []byte) {
+	self.outputChannel = received
+}
+
+func (self *Transport) processReceivedLoop() {
+	self.closeWait.Add(1)
+	defer self.closeWait.Done()
+
+	for len(self.closing) == 0 {
+		select {
+		case physicalMsg, ok := <-self.physicalReceived:
+			{
+				if ok {
+					self.processPhysicalMessage(physicalMsg)
+				}
+			}
+		case <-self.closing:
+			{
+				return
+			}
+		}
+	}
+}
+
+func (self *Transport) processSend(message SendMessage) {
+	self.sendAck(message)
+
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	_, alreadyReceived := self.messagesReceived[message.MessageID]
+	if !alreadyReceived {
+		self.outputChannel <- message.Contents
+		self.messagesReceived[message.MessageID] = time.Now().Add(self.config.RememberMessageReceivedDuration)
+	}
+}
+
+func (self *Transport) processReply(message ReplyMessage) {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	state, exists := self.messagesSent[message.MessageID]
+	if !exists {
+		fmt.Fprintf(os.Stderr, "Received ack for unknown sent message %v\n", message.MessageID)
+		return
+	}
+	state.receivedAck = true
+	self.messagesSent[message.MessageID] = state
+
+	// Test
+	if !self.messagesSent[message.MessageID].receivedAck {
+		panic("Test error")
+	}
+}
+
+func (self *Transport) processPhysicalMessage(physicalMessage []byte) {
+	message, err := self.serializer.UnserializeMessage(physicalMessage)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Deserialization error %v\n", err)
+		return
+	}
+	messageType := reflect.TypeOf(message)
+
+	if messageType == reflect.TypeOf(SendMessage{}) {
+		send := message.(SendMessage)
+		self.processSend(send)
+	} else if messageType == reflect.TypeOf(ReplyMessage{}) {
+		reply := message.(ReplyMessage)
+		self.processReply(reply)
+	} else {
+		panic("Internal error: unknown message type")
+	}
+}

--- a/src/mesh/transport/transport_message_sending.go
+++ b/src/mesh/transport/transport_message_sending.go
@@ -1,0 +1,67 @@
+package transport
+
+import (
+	"time"
+
+	"github.com/satori/go.uuid"
+	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/mesh/domain"
+)
+
+func (self *Transport) SendMessage(toPeer cipher.PubKey, contents []byte) error {
+	messageID := self.newMessageID()
+	sendMessage := SendMessage{messageID, self.config.MyPeerID, contents}
+	sendSerialized := self.serializer.SerializeMessage(sendMessage)
+	state := messageSentState{toPeer,
+		sendSerialized,
+		time.Now().Add(self.config.RetransmitDuration),
+		false}
+	err := self.physicalTransport.SendMessage(toPeer, sendSerialized)
+	if err == nil {
+		self.lock.Lock()
+		defer self.lock.Unlock()
+		self.messagesSent[messageID] = state
+	}
+	return err
+}
+
+func (self *Transport) SetCrypto(crypto ITransportCrypto) {
+	self.physicalTransport.SetCrypto(crypto)
+}
+
+func (self *Transport) doRetransmits() {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	for _, state := range self.messagesSent {
+		if !state.receivedAck {
+			go self.physicalTransport.SendMessage(state.toPeer, state.serialized)
+		}
+	}
+}
+
+func (self *Transport) retransmitLoop() {
+	self.closeWait.Add(1)
+	defer self.closeWait.Done()
+	for len(self.closing) == 0 {
+		select {
+		case <-time.After(self.config.RetransmitDuration):
+			{
+				self.doRetransmits()
+			}
+		case <-self.closing:
+			{
+				return
+			}
+		}
+	}
+}
+
+func (self *Transport) sendAck(message SendMessage) {
+	reply := ReplyMessage{message.MessageID}
+	serialized := self.serializer.SerializeMessage(reply)
+	go self.physicalTransport.SendMessage(message.FromPeerID, serialized)
+}
+
+func (self *Transport) newMessageID() domain.MessageID {
+	return (domain.MessageID)(uuid.NewV4())
+}


### PR DESCRIPTION
I've split god-like structures into few files:

- node.go
- node_message_processing.go
- node_message_sending.go
- node_message_routing.go

- transport.go
- transport_message_processing.go
- transport_message_sending.go

I sure that it could decrease complicity of code.

Also I've moved some structures from domain package into specific packages.
Many variables have become more readable names.
Some unused code removed

**all tests passed**