### PR TITLE
Consensus runs on gnet

### DIFF
--- a/src/consensus/blockstat.go
+++ b/src/consensus/blockstat.go
@@ -1,0 +1,626 @@
+// 20160901 - Initial version by user johnstuartmill,
+// public key 02fb4acf944c84d48341e3c1cb14d707034a68b7f931d6be6d732bec03597d6ff6
+// 20161025 - Code revision by user johnstuartmill.
+package consensus
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+
+	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/cipher/secp256k1-go"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+//
+//
+//
+////////////////////////////////////////////////////////////////////////////////
+// How many (hash,signer_pubkey) pairs to acquire for decision-making.
+// This also limits forwarded traffic, because the messages in excess
+// of this limit are discarded hence not forwarded:
+var Cfg_consensus_max_candidate_messages = 10
+
+//
+////////////////////////////////////////////////////////////////////////////////
+var all_zero_hash = cipher.SHA256{}
+var all_zero_sig = cipher.Sig{}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// BlockStat
+//
+////////////////////////////////////////////////////////////////////////////////
+type BlockStat struct {
+	priority int // Mandatory item for an element of container/heap
+	index    int // Mandatory item for an element of container/heap
+
+	// [JSM:] For a given block sequence number (or 'seqno'), we
+	// want
+	//
+	//     map: hash -> set<pubkey>
+	//
+	// The 'pubkey' is recovered from '(sig,hash)' pair.  Also, we
+	// want the number of unique 'pubkey', which is the number of
+	// independent block-makers. It shows how reliable the averaging
+	// would be.
+	//
+	// [JSM:] We need to put an upper limit to the
+	// ConcensusParticipant's bandwidth requirement in order to
+	// prevent a certain kind of attack on the network.  As an
+	// implementation of that requrement, we stop collecting (hence,
+	// stop propagating) the blocks with the same sequence number
+	// after we have observed a sufficient number of builders.
+	//
+	// [JSM:] The hash that has largest number of unique pubkeys is
+	// selected as the block for the given seqno.
+
+	// [JSM:] This approach is to guard against what can be called an
+	// "amplification attack": A node/pubkey with many subscribers
+	// publishes a block that says "Earth is flat". The above pubkey
+	// is (and has been) trusted by many, but at the moment the pubkey
+	// has been compelled, say, under a threat of burning on a steak,
+	// to publish a clearly-wrong block. You, as a listening pubkey,
+	// have N1 nodes as publisher;
+	// each of them is connected, or have a route, to the
+	// above pubkey that is being coersed. Meanwhile, there are N2
+	// pubkeys that published "Earth is round" block. If you neglect
+	// to check the origin of the block [i.e. who signed it], and if
+	// it happens that N1 >> N2 (e.g. 1000 >> 100), then you would
+	// conclude, quite incorrectly, that the network agrees that
+	// "Earth is flat". If, however, you take into account the origin
+	// of the block, you would see that all N1 blocks are merely
+	// duplicates sent out with the intention to manipulate network
+	// consensus, while all N2 messages came from unique
+	// signers. Therefore you conclude that you have only one block
+	// "Earth is flat" and many blocks "Earth is round", e.g. 1 <<
+	// 100. So you chose "Earth is round" block. The idea of this
+	// approach (or a guard, if you will) can be expressesd as
+	// follows: "Q: Can one billion peasants be all wrong
+	// simultaneously? A: Yes, if they learn what they should think
+	// from the same wall-glued newspaper."
+	//
+	// (Side node: this approach has several useful side-effects
+	// that we shall not discuss here.)
+
+	hash2info map[cipher.SHA256]HashCandidate
+
+	// FOR NOW this is just a label and is used to
+	// set/read. Invariant: all Blocks stored/referenced here have
+	// same seqno.
+	seqno uint64
+
+	// After the class instance was used to select Block for
+	// consensus, we do not update the stats.
+	frozen bool
+
+	// This is to limit traffic due to forwarding. A side-effect is
+	// limited statistics. See'Cfg_consensus_max_candidate_messages'.
+	// Explanation: every node in the network is allowed to make (and
+	// publish) blocks, but we do not wish to receive all of these
+	// messages.
+	accept_count int
+
+	//
+	// BEG debugging/diagnostics
+	//
+	debug_pubkey2count map[cipher.PubKey]int
+	debug_count        int
+
+	// The number of events that would have qualified to be utilized,
+	// but were rejected due to 'frozen == true'
+	debug_reject_count int
+
+	// Ignored due to limitations on how much we want to accept and forward
+	debug_neglect_count int
+
+	debug_usage int
+	//
+	// END debugging/diagnostics
+	//
+
+}
+
+////////////////////////////////////////////////////////////////////////////////
+func (self *BlockStat) is_consistent() bool {
+	for _, info := range self.hash2info {
+		if !info.is_consistent() {
+			return false
+		}
+	}
+	// TODO 1: Need to extract pubkey from 'self.hash2info' and from
+	// 'self.debug_pubkey2count', and make sure they are the same.
+
+	// TODO 2: make sure all debug counters are consistent.
+	return true
+}
+
+////////////////////////////////////////////////////////////////////////////////
+func (self *BlockStat) Init() {
+	self.priority = 0
+	self.index = -1
+
+	self.hash2info = make(map[cipher.SHA256]HashCandidate)
+	self.seqno = 0
+	self.frozen = false
+	self.accept_count = 0
+	//
+	self.debug_pubkey2count = make(map[cipher.PubKey]int)
+	self.debug_count = 0
+	self.debug_reject_count = 0
+	self.debug_neglect_count = 0
+	self.debug_usage = 0
+}
+
+////////////////////////////////////////////////////////////////////////////////
+func (self *BlockStat) GetSeqno() uint64 {
+	return self.seqno
+}
+
+////////////////////////////////////////////////////////////////////////////////
+func (self *BlockStat) Clear() {
+
+	for i, info := range self.hash2info {
+		info.Clear()
+		delete(self.hash2info, i)
+	}
+	self.seqno = 0
+	self.frozen = false
+	self.accept_count = 0
+	//
+	for i, _ := range self.debug_pubkey2count {
+		delete(self.debug_pubkey2count, i)
+	}
+	self.debug_count = 0
+	self.debug_reject_count = 0
+	// NOTE: 'self.debug_usage' is kept as-is
+}
+
+////////////////////////////////////////////////////////////////////////////////
+func (self *BlockStat) try_add_hash_and_sig(
+	hash cipher.SHA256,
+	sig cipher.Sig) int {
+
+	if self.frozen {
+		// To get a more accurate number of rejects, one would need to
+		// do as below, except insertion/updating. However, we do not
+		// want to incurr a calculation in order to get a more
+		// accurate debug numbers. So we simply:
+		self.debug_reject_count += 1
+		return 3
+	}
+
+	// 2016090* ROBUSTNESS: We need to put a limit on the number of
+	// (signer_pubkey,hash) pairs that we process and forward. One
+	// reason is to prevent an attack in which the attacker launches a
+	// large number of nodes each of which make valid blocks, thus
+	// causing large traffic that can potentially degrade the network
+	// performace. Example: when we receive, say 63
+	// (signer_pubkey,hash) pairs for a given seqno, we stop listening
+	// for the updates. Say, the breakdown is: hash H1 from 50
+	// signers, hash H2 from 10, hash H3 from 2 and hash H4 from 1.
+	// We make a local decision to choose H1.
+	if self.accept_count >= Cfg_consensus_max_candidate_messages {
+		self.debug_neglect_count += 1
+		return 1 // same as skip
+	}
+
+	// 20160913 Remember that we move those BlockStat that are old
+	// enought (seqno difference is used as a measure of time
+	// difference) to BlockChain, so that the storage requerement for
+	// each node is now smaller. Yet we keep the limits to avoid
+	// excessive forwarding.
+
+	// At the end of the function, one of them must be 'true'.
+	action_update := false
+	action_skip := false
+	action_insert := false
+
+	var info HashCandidate
+
+	if true {
+		var have bool
+
+		info, have = self.hash2info[hash]
+
+		if !have {
+			info = HashCandidate{}
+			info.Init()
+			action_insert = true
+		} else {
+			if _, saw := info.sig2none[sig]; saw {
+				action_skip = true
+			} else {
+				action_update = true
+			}
+		}
+	}
+
+	if action_insert || action_update {
+
+		if sig == all_zero_sig || hash == all_zero_hash { // Hack
+			return 4 // <<<<<<<<
+		}
+
+		// PERFORMANCE: This is an expensive call:
+		signer_pubkey, err := cipher.PubKeyFromSig(sig, hash)
+		if err != nil {
+			return 4 // <<<<<<<<
+		}
+
+		// Now do the check that we could not do prior to
+		// obtaining 'signer_pubkey':
+		if _, have := info.pubkey2sig[signer_pubkey]; have {
+			// WARNING: ROBUSTNESS: The pubkey 'signer_pubkey' has
+			// already published data with the same hash and same
+			// seqno. This is not a duplicate data: the duplicates
+			// have been intercepted earlier bsaged in (hash,sig)
+			// pair; instead, the pubkey signed the block again and
+			// published the result. So this can be a bug/mistake or
+			// an attempt to artificially increase the traffic on our
+			// network.
+			self.debug_reject_count += 1
+
+			action_update = false
+			action_skip = true
+			action_insert = false
+
+			fmt.Printf("WARNING: %p, Detected malicious publish from"+
+				" pubkey=%s for hash=%s sig=%s\n", &info,
+				signer_pubkey.Hex()[:8], hash.Hex()[:8], sig.Hex()[:8])
+		}
+
+		// These bools could have change, see above:
+		if action_insert || action_update {
+			if false {
+				fmt.Printf("Calling %p->ObserveSigAndPubkey(sig=%s,"+
+					" signer_pubkey=%s), hash=%s\n", &info,
+					sig.Hex()[:8], signer_pubkey.Hex()[:8], hash.Hex()[:8])
+			}
+			info.ObserveSigAndPubkey(sig, signer_pubkey)
+			self.accept_count += 1
+		}
+	}
+
+	if action_insert {
+		self.hash2info[hash] = info
+	}
+
+	self.debug_count += 1
+	self.debug_usage += 1
+
+	if !(action_update || action_skip || action_insert) {
+		panic("Inconsistent BlockStat::try_add_hash_and_sig()")
+		return -1
+	}
+
+	if action_update || action_insert {
+		return 0
+	}
+
+	if action_skip {
+		return 1
+	}
+
+	return -1
+}
+
+////////////////////////////////////////////////////////////////////////////////
+func (self *BlockStat) GetBestHashPubkeySig() (
+	cipher.SHA256,
+	cipher.PubKey,
+	cipher.Sig) {
+
+	var best_n int = -1
+
+	var best_h cipher.SHA256
+
+	for hash, info := range self.hash2info {
+		n := len(info.pubkey2sig)
+
+		if best_n < n {
+			best_n = n
+			best_h = hash
+		} else if best_n == n {
+			// Resolve ties by comparing hashes:
+			if bytes.Compare(best_h[:], hash[:]) < 0 {
+				// Updating 'best_n' is unnecessary, but keep it here
+				// to help avoiding cut-and-paste errors:
+				best_n = n
+				best_h = hash
+			}
+		}
+	}
+
+	if best_n <= 0 {
+		return cipher.SHA256{}, cipher.PubKey{}, cipher.Sig{} // <<<<<<<<
+	}
+
+	var best_p cipher.PubKey
+	var best_s cipher.Sig
+
+	// Resolve ties (if any) by comparing signatures. Do not use
+	// pubkey for this purpose as we do not want, for example, to have
+	// same pubkey sign most of blocks.
+
+	// NOTE 1: We want a deterministic algo here, so that each
+	// ConsensusParticipant across teh network would choose same
+	// (hash,sig) to go to blockchain.
+
+	// NOTE 2: A simplified version of consensus can be imagined, in
+	// which ConsensusParticipant rejects a hash if it saw it already;
+	// this results in local blockchains with same transactions [when
+	// consensus id reached] but *different* signers. Which is not
+	// good from general entropy considerations.
+	initialized := false
+
+	for pubkey, sig := range self.hash2info[best_h].pubkey2sig {
+		if initialized {
+			if bytes.Compare(best_s[:], sig[:]) < 0 {
+				best_p = pubkey
+				best_s = sig
+			}
+		} else {
+			best_p = pubkey
+			best_s = sig
+
+			initialized = true
+		}
+	}
+
+	return best_h, best_p, best_s
+}
+
+////////////////////////////////////////////////////////////////////////////////
+func (self *BlockStat) Print() {
+
+	hash, _, _ := self.GetBestHashPubkeySig()
+	fmt.Printf("BlockStat={count(hash)=%d,count(pubkey)=%d,count(event)=%d"+
+		",accept_count=%d,seqno=%d,debug_usage=%d,frozen=%t,"+
+		"debug_reject_count=%d,debug_neglect_count=%d,best_hash=%s}",
+		len(self.hash2info),
+		len(self.debug_pubkey2count),
+		self.debug_count,
+		self.accept_count,
+		self.seqno,
+		self.debug_usage,
+		self.frozen,
+		self.debug_reject_count,
+		self.debug_neglect_count,
+		hash.Hex()[:8])
+}
+
+////////////////////////////////////////////////////////////////////////////////
+type PriorityQueue []*BlockStat // Contained in BlockStatQueue
+
+// NOTE: a shallow copy (of the slice) is made here
+func (pq PriorityQueue) Len() int {
+	return len(pq)
+}
+
+// NOTE: a shallow copy (of the slice) is made here
+func (pq PriorityQueue) Less(i int, j int) bool {
+	return pq[i].priority < pq[j].priority
+}
+
+// NOTE: a shallow copy (of the slice) is made here
+func (pq PriorityQueue) Swap(i int, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+func (pq *PriorityQueue) Push(x interface{}) {
+	n := len(*pq)
+	item := x.(*BlockStat)
+	item.index = n
+	*pq = append(*pq, item)
+}
+func (pq *PriorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	item.index = -1 // for safety
+	*pq = old[0 : n-1]
+	return item
+}
+
+// update modifies the priority and value of an Item in the queue.
+func (pq *PriorityQueue) update_priority(item *BlockStat, priority int) {
+	item.priority = priority
+	heap.Fix(pq, item.index)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// BlockStatQueue
+//
+////////////////////////////////////////////////////////////////////////////////
+type BlockStatQueue struct {
+	// BlockStatQueue is a wrapper around a priority queue; the latter
+	// is prioretized by Block seqno. The wrapper provides setters and
+	// getters. The setters trim queue size as appropriate.
+	queue PriorityQueue
+}
+
+////////////////////////////////////////////////////////////////////////////////
+func (self *BlockStatQueue) is_consistent() bool {
+	// TODO: implement.
+	return true
+}
+
+////////////////////////////////////////////////////////////////////////////////
+func (self *BlockStatQueue) Len() int {
+	return len(self.queue)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+func (self *BlockStatQueue) Print() {
+	n := len(self.queue)
+	fmt.Printf("BlockStatQueue={n=%d", n)
+
+	for i := 0; i < n; i++ {
+		fmt.Print(",")
+		self.queue[i].Print()
+	}
+
+	fmt.Printf("}")
+}
+
+////////////////////////////////////////////////////////////////////////////////
+func (self *BlockStatQueue) try_append_to_BlockStatQueue(
+	blockPtr *BlockBase) int {
+
+	// Use a superficial, quick test here. A thorough check will be
+	// done later in this function.
+	if secp256k1.VerifySignatureValidity(blockPtr.Sig[:]) != 1 {
+		return 4 // Error
+	}
+
+	if blockPtr.Sig == all_zero_sig || blockPtr.Hash == all_zero_hash { // Hack
+		return 4 // <<<<<<<<
+	}
+
+	// At the end of the function, one of them must be 'true'.
+	action_update := false
+	action_skip := false
+	action_insert := false
+
+	var update_index int = -1
+
+	n := len(self.queue)
+	if n > 0 {
+		f := self.queue[0]
+		l := self.queue[n-1]
+		// ROBUSTNESS Set a max to what 'f - l' can be. For example,
+		// if the limit is 100 and the queue has only one block with
+		// seqno 7, then do not accept blocks with seqno >=
+		// 107. This is to prevent Memory Overflow attack.
+
+		if blockPtr.Seqno < f.seqno {
+			// TODO: Accept, unless 'f.seqno - 1' is already in the
+			// (consented) blockchain; otherwise reject/ignore.  FOR
+			// NOW, accept unless queue length would be too large.
+
+			//
+			//
+			// TODO: evaluae -------------------- URGENT !!!!!
+			//
+			//
+			already_in_blockchain := false
+			//
+			//
+			//
+			//
+			if already_in_blockchain {
+				fmt.Print("DEBUG Already in blockchain. Ignoring block.\n")
+				action_skip = true
+			} else if l.seqno - blockPtr.Seqno >
+				Cfg_consensus_candidate_max_seqno_gap {
+				fmt.Printf("DEBUG proposed=%d, first=%d, last=%d. Too far"+
+					" behind. Ignoring block.\n",
+					blockPtr.Seqno, f.seqno, l.seqno)
+				action_skip = true
+			} else {
+				action_insert = true
+			}
+
+		} else if blockPtr.Seqno > l.seqno {
+			// TODO: Accept, unless 'blockPtr.seqno > l.seqno' is
+			// large, e.g.  the preceived block is way ahead of the
+			// last block in the queue.  FOR NOW, accept unless queue
+			// length would be too large.
+			if blockPtr.Seqno-f.seqno >
+				Cfg_consensus_candidate_max_seqno_gap {
+				fmt.Printf("DEBUG proposed=%d, first=%d, last=%d. Too far"+
+					" ahead. Ignoring block.\n",
+					blockPtr.Seqno, f.seqno, l.seqno)
+				action_skip = true
+			} else {
+				action_insert = true
+			}
+		} else {
+			// The 'blockPtr.seqno' is in between, so we need to insert
+			// a new or find the element with same seqno and update it.
+
+			// PREFORMANCE TODO: Avoid linear search by using a
+			// lookup, or using other properties of Heap object. If
+			// n/a, use Binary Search.
+			S := blockPtr.Seqno
+			found := false
+			for i, _ := range self.queue {
+				s := self.queue[i].seqno
+				if s < S {
+					// keep searching
+				} else if s == S {
+					found = true
+					action_update = true
+					update_index = i
+					break
+				} else if s > S {
+					break
+				}
+			}
+			if !found {
+				action_insert = true
+			}
+		}
+	} else {
+		// The queue is empty, so insert the block.
+		action_insert = true
+	}
+	n = -1 // guard
+
+	if !(action_update || action_skip || action_insert) {
+		panic("Inconsistent")
+		return -1
+	}
+
+	var status_code int = 1
+
+	if !action_skip {
+
+		// TAG Consensus: if we receive 100 copies of a Block (or
+		// Block's hash) that originated from the same block maker,
+		// then the statistical significance of them is not higher
+		// than that of only 1 copy.  The significance is roughly
+		// proportional to sqrt of the number of different [ideally,
+		// independent-thinking] signers for a Block with the same
+		// hash and same seqno.
+
+		should_forward_to_subscribers := false
+
+		if action_update {
+
+			res := self.queue[update_index].
+				try_add_hash_and_sig(blockPtr.Hash, blockPtr.Sig)
+			if res == 0 {
+				should_forward_to_subscribers = true
+			}
+
+		} else if action_insert {
+
+			bs := BlockStat{}
+			bs.Init()
+			bs.seqno = blockPtr.Seqno
+			res := bs.try_add_hash_and_sig(blockPtr.Hash, blockPtr.Sig)
+
+			if res == 0 {
+				// Keep these two together:
+				heap.Push(&self.queue, &bs)
+				self.queue.update_priority(&bs, int(blockPtr.Seqno))
+				// TODO: Above, try to remove the cast.
+
+				should_forward_to_subscribers = true
+			}
+		}
+
+		if should_forward_to_subscribers {
+			status_code = 0
+		}
+
+	}
+
+	return status_code
+}
+////////////////////////////////////////////////////////////////////////////////

--- a/src/consensus/connection_manager.go
+++ b/src/consensus/connection_manager.go
@@ -1,0 +1,24 @@
+// 20160901 - Initial version by user johnstuartmill,
+// public key 02fb4acf944c84d48341e3c1cb14d707034a68b7f931d6be6d732bec03597d6ff6
+// 20161025 - Code revision by user johnstuartmill.
+package consensus
+
+import (
+	//"github.com/skycoin/skycoin/src/cipher"
+)
+////////////////////////////////////////////////////////////////////////////////
+type ConnectionManagerInterface interface {
+	SendBlockToAllMySubscriber(blockPtr *BlockBase)
+
+	Print() // For debugging
+
+	// IMPORTANT: When connection manager (i.e. an implementation of
+	// this interface) receives a message with 'BlockBase', the
+	// manager should call
+	//
+	//    ConsensusParticipant.OnBlockHeaderArrived(blockPtr *BlockBase)
+	//
+	// function. This is not currently enforced, but is required for the
+	// consensus to work properly.
+}
+////////////////////////////////////////////////////////////////////////////////

--- a/src/consensus/consensus.go
+++ b/src/consensus/consensus.go
@@ -1,14 +1,11 @@
 // 20160901 - Initial version by user johnstuartmill,
 // public key 02fb4acf944c84d48341e3c1cb14d707034a68b7f931d6be6d732bec03597d6ff6
+// 20161025 - Code revision by user johnstuartmill.
 package consensus
 
 import (
-	"bytes"
-	"container/heap"
 	"fmt"
-
 	"github.com/skycoin/skycoin/src/cipher"
-	"github.com/skycoin/skycoin/src/cipher/secp256k1-go"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -35,12 +32,12 @@ var Cfg_consensus_waiting_time_as_seqno_diff uint64 = 7
 // How many (hash,signer_pubkey) pairs to acquire for decision-making.
 // This also limits forwarded traffic, because the messages in excess
 // of this limit are discarded hence not forwarded:
-var Cfg_consensus_max_candidate_messages = 10
+//var Cfg_consensus_max_candidate_messages = 10
 
 //
 ////////////////////////////////////////////////////////////////////////////////
-var all_zero_hash = cipher.SHA256{}
-var all_zero_sig = cipher.Sig{}
+//var all_zero_hash = cipher.SHA256{}
+//var all_zero_sig = cipher.Sig{}
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -48,10 +45,13 @@ var all_zero_sig = cipher.Sig{}
 //
 ////////////////////////////////////////////////////////////////////////////////
 type BlockBase struct {
-	sig   cipher.Sig
-	hash  cipher.SHA256
-	seqno uint64
+	Sig   cipher.Sig
+	Hash  cipher.SHA256
+	Seqno uint64
 }
+//func (self *BlockBase) GetSig() cipher.Sig { return self.Sig }
+//func (self *BlockBase) GetHash() cipher.SHA256 { return self.Hash }
+//func (self *BlockBase) GetSeqno() uint64 { return self.Seqno }
 
 ////////////////////////////////////////////////////////////////////////////////
 func (self *BlockBase) Init(
@@ -59,17 +59,20 @@ func (self *BlockBase) Init(
 	hash cipher.SHA256,
 	seqno uint64) {
 
-	self.sig = sig
-	self.hash = hash
-	self.seqno = seqno
+	self.Sig = sig
+	self.Hash = hash
+	self.Seqno = seqno
 }
-
 ////////////////////////////////////////////////////////////////////////////////
 func (self *BlockBase) Print() {
-	fmt.Printf("BlockBase={sig=%s,hash=%s,seqno=%d}",
-		self.sig.Hex()[:8], self.hash.Hex()[:8], self.seqno)
+	fmt.Printf("BlockBase={Sig=%s,Hash=%s,Seqno=%d}",
+		self.Sig.Hex()[:8], self.Hash.Hex()[:8], self.Seqno)
 }
-
+////////////////////////////////////////////////////////////////////////////////
+func (self *BlockBase) String() string {
+	return fmt.Sprintf("BlockBase={Sig=%s,Hash=%s,Seqno=%d}",
+		self.Sig.Hex()[:8], self.Hash.Hex()[:8], self.Seqno)
+}
 ////////////////////////////////////////////////////////////////////////////////
 //
 // BlockchainTail is the most recent part of blockchain that is held in memory
@@ -105,13 +108,13 @@ func (self *BlockchainTail) append_nocheck(blockPtr *BlockBase) {
 	if n+1 > Cfg_blockchain_tail_length {
 		// Trim the size:
 		b0p := self.blockPtr_slice[0]
-		delete(self.hash_to_blockPtr_map, b0p.hash) // pop 1 of 2
+		delete(self.hash_to_blockPtr_map, b0p.Hash) // pop 1 of 2
 		b0p = nil
 		self.blockPtr_slice[0] = nil
 		self.blockPtr_slice = self.blockPtr_slice[1:] // pop 2 of 2
 	}
 	// Append
-	self.hash_to_blockPtr_map[blockPtr.hash] = blockPtr         // push 1 of 2
+	self.hash_to_blockPtr_map[blockPtr.Hash] = blockPtr         // push 1 of 2
 	self.blockPtr_slice = append(self.blockPtr_slice, blockPtr) // push 2 of 2
 }
 
@@ -120,7 +123,7 @@ func (self *BlockchainTail) try_append_to_BlockchainTail(blockPtr *BlockBase) in
 	n := len(self.blockPtr_slice)
 	if n > 0 {
 		// Step 1 of 2: check for presence:
-		_, have := self.hash_to_blockPtr_map[blockPtr.hash]
+		_, have := self.hash_to_blockPtr_map[blockPtr.Hash]
 		if have {
 			if Cfg_debug_block_duplicate {
 				// Duplicate hash detected. Silently ignore it. We
@@ -130,9 +133,9 @@ func (self *BlockchainTail) try_append_to_BlockchainTail(blockPtr *BlockBase) in
 			return 1 // Duplicate hash
 		}
 		// Step 2 of 2: check for sequence numbers:
-		curr := self.blockPtr_slice[n-1].seqno // Most recent
+		curr := self.blockPtr_slice[n-1].Seqno // Most recent
 		next := curr + 1
-		prop := blockPtr.seqno
+		prop := blockPtr.Seqno
 		if prop < next { // uint cmp
 			if Cfg_debug_block_out_of_sequence {
 				fmt.Printf("Block's seqno is too low (%d vs %d), block"+
@@ -159,7 +162,7 @@ func (self *BlockchainTail) try_append_to_BlockchainTail(blockPtr *BlockBase) in
 func (self *BlockchainTail) GetNextSeqNo() uint64 {
 	n := len(self.blockPtr_slice)
 	if n > 0 {
-		return 1 + self.blockPtr_slice[n-1].seqno
+		return 1 + self.blockPtr_slice[n-1].Seqno
 	}
 	return 1
 }
@@ -175,22 +178,6 @@ func (self *BlockchainTail) Print() {
 	}
 	fmt.Printf("}")
 }
-
-////////////////////////////////////////////////////////////////////////////////
-//
-// MeshNetworkInterface interface
-//
-////////////////////////////////////////////////////////////////////////////////
-type MeshNetworkInterface interface {
-	Simulate_send_to_PubKey(
-		from_key cipher.PubKey,
-		to_key cipher.PubKey,
-		blockPtr *BlockBase)
-	Simulate_request_connection_to(
-		to cipher.PubKey,
-		from cipher.PubKey)
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 //
 // HashCandidate
@@ -259,862 +246,4 @@ func (self *HashCandidate) is_consistent() bool {
 
 	return true
 }
-
-////////////////////////////////////////////////////////////////////////////////
-//
-// BlockStat
-//
-////////////////////////////////////////////////////////////////////////////////
-type BlockStat struct {
-	priority int // Mandatory item for an element of container/heap
-	index    int // Mandatory item for an element of container/heap
-
-	// [JSM:] For a given block sequence number (or 'seqno'), we
-	// want
-	//
-	//     map: hash -> set<pubkey>
-	//
-	// The 'pubkey' is recovered from '(sig,hash)' pair.  Also, we
-	// want the number of unique 'pubkey', which is the number of
-	// independent block-makers. It shows how reliable the averaging
-	// would be.
-	//
-	// [JSM:] We need to put an upper limit to the
-	// ConcensusParticipant's bandwidth requirement in order to
-	// prevent a certain kind of attack on the network.  As an
-	// implementation of that requrement, we stop collecting (hence,
-	// stop propagating) the blocks with the same sequence number
-	// after we have observed a sufficient number of builders.
-	//
-	// [JSM:] The hash that has largest number of unique pubkeys is
-	// selected as the block for the given seqno.
-
-	// [JSM:] This approach is to guard against what can be called an
-	// "amplification attack": A node/pubkey with many subscribers
-	// publishes a block that says "Earth is flat". The above pubkey
-	// is (and has been) trusted by many, but at the moment the pubkey
-	// has been compelled, say, under a threat of burning on a steak,
-	// to publish a clearly-wrong block. You, as a listening pubkey,
-	// have N1 nodes as publisher;
-	// each of them is connected, or have a route, to the
-	// above pubkey that is being coersed. Meanwhile, there are N2
-	// pubkeys that published "Earth is round" block. If you neglect
-	// to check the origin of the block [i.e. who signed it], and if
-	// it happens that N1 >> N2 (e.g. 1000 >> 100), then you would
-	// conclude, quite incorrectly, that the network agrees that
-	// "Earth is flat". If, however, you take into account the origin
-	// of the block, you would see that all N1 blocks are merely
-	// duplicates sent out with the intention to manipulate network
-	// consensus, while all N2 messages came from unique
-	// signers. Therefore you conclude that you have only one block
-	// "Earth is flat" and many blocks "Earth is round", e.g. 1 <<
-	// 100. So you chose "Earth is round" block. The idea of this
-	// approach (or a guard, if you will) can be expressesd as
-	// follows: "Q: Can one billion peasants be all wrong
-	// simultaneously? A: Yes, if they learn what they should think
-	// from the same wall-glued newspaper."
-	//
-	// (Side node: this approach has several useful side-effects
-	// that we shall not discuss here.)
-
-	hash2info map[cipher.SHA256]HashCandidate
-
-	// FOR NOW this is just a label and is used to
-	// set/read. Invariant: all Blocks stored/referenced here have
-	// same seqno.
-	seqno uint64
-
-	// After the class instance was used to select Block for
-	// consensus, we do not update the stats.
-	frozen bool
-
-	// This is to limit traffic due to forwarding. A side-effect is
-	// limited statistics. See'Cfg_consensus_max_candidate_messages'.
-	// Explanation: every node in the network is allowed to make (and
-	// publish) blocks, but we do not wish to receive all of these
-	// messages.
-	accept_count int
-
-	//
-	// BEG debugging/diagnostics
-	//
-	debug_pubkey2count map[cipher.PubKey]int
-	debug_count        int
-
-	// The number of events that would have qualified to be utilized,
-	// but were rejected due to 'frozen == true'
-	debug_reject_count int
-
-	// Ignored due to limitations on how much we want to accept and forward
-	debug_neglect_count int
-
-	debug_usage int
-	//
-	// END debugging/diagnostics
-	//
-
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *BlockStat) is_consistent() bool {
-	for _, info := range self.hash2info {
-		if !info.is_consistent() {
-			return false
-		}
-	}
-	// TODO 1: Need to extract pubkey from 'self.hash2info' and from
-	// 'self.debug_pubkey2count', and make sure they are the same.
-
-	// TODO 2: make sure all debug counters are consistent.
-	return true
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *BlockStat) Init() {
-	self.priority = 0
-	self.index = -1
-
-	self.hash2info = make(map[cipher.SHA256]HashCandidate)
-	self.seqno = 0
-	self.frozen = false
-	self.accept_count = 0
-	//
-	self.debug_pubkey2count = make(map[cipher.PubKey]int)
-	self.debug_count = 0
-	self.debug_reject_count = 0
-	self.debug_neglect_count = 0
-	self.debug_usage = 0
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *BlockStat) GetSeqno() uint64 {
-	return self.seqno
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *BlockStat) Clear() {
-
-	for i, info := range self.hash2info {
-		info.Clear()
-		delete(self.hash2info, i)
-	}
-	self.seqno = 0
-	self.frozen = false
-	self.accept_count = 0
-	//
-	for i, _ := range self.debug_pubkey2count {
-		delete(self.debug_pubkey2count, i)
-	}
-	self.debug_count = 0
-	self.debug_reject_count = 0
-	// NOTE: 'self.debug_usage' is kept as-is
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *BlockStat) try_add_hash_and_sig(
-	hash cipher.SHA256,
-	sig cipher.Sig) int {
-
-	if self.frozen {
-		// To get a more accurate number of rejects, one would need to
-		// do as below, except insertion/updating. However, we do not
-		// want to incurr a calculation in order to get a more
-		// accurate debug numbers. So we simply:
-		self.debug_reject_count += 1
-		return 3
-	}
-
-	// 2016090* ROBUSTNESS: We need to put a limit on the number of
-	// (signer_pubkey,hash) pairs that we process and forward. One
-	// reason is to prevent an attack in which the attacker launches a
-	// large number of nodes each of which make valid blocks, thus
-	// causing large traffic that can potentially degrade the network
-	// performace. Example: when we receive, say 63
-	// (signer_pubkey,hash) pairs for a given seqno, we stop listening
-	// for the updates. Say, the breakdown is: hash H1 from 50
-	// signers, hash H2 from 10, hash H3 from 2 and hash H4 from 1.
-	// We make a local decision to choose H1.
-	if self.accept_count >= Cfg_consensus_max_candidate_messages {
-		self.debug_neglect_count += 1
-		return 1 // same as skip
-	}
-
-	// 20160913 Remember that we move those BlockStat that are old
-	// enought (seqno difference is used as a measure of time
-	// difference) to BlockChain, so that the storage requerement for
-	// each node is now smaller. Yet we keep the limits to avoid
-	// excessive forwarding.
-
-	// At the end of the function, one of them must be 'true'.
-	action_update := false
-	action_skip := false
-	action_insert := false
-
-	var info HashCandidate
-
-	if true {
-		var have bool
-
-		info, have = self.hash2info[hash]
-
-		if !have {
-			info = HashCandidate{}
-			info.Init()
-			action_insert = true
-		} else {
-			if _, saw := info.sig2none[sig]; saw {
-				action_skip = true
-			} else {
-				action_update = true
-			}
-		}
-	}
-
-	if action_insert || action_update {
-
-		if sig == all_zero_sig || hash == all_zero_hash { // Hack
-			return 4 // <<<<<<<<
-		}
-
-		// PERFORMANCE: This is an expensive call:
-		signer_pubkey, err := cipher.PubKeyFromSig(sig, hash)
-		if err != nil {
-			return 4 // <<<<<<<<
-		}
-
-		// Now do the check that we could not do prior to
-		// obtaining 'signer_pubkey':
-		if _, have := info.pubkey2sig[signer_pubkey]; have {
-			// WARNING: ROBUSTNESS: The pubkey 'signer_pubkey' has
-			// already published data with the same hash and same
-			// seqno. This is not a duplicate data: the duplicates
-			// have been intercepted earlier bsaged in (hash,sig)
-			// pair; instead, the pubkey signed the block again and
-			// published the result. So this can be a bug/mistake or
-			// an attempt to artificially increase the traffic on our
-			// network.
-			self.debug_reject_count += 1
-
-			action_update = false
-			action_skip = true
-			action_insert = false
-
-			fmt.Printf("WARNING: %p, Detected malicious publish from"+
-				" pubkey=%s for hash=%s sig=%s\n", &info,
-				signer_pubkey.Hex()[:8], hash.Hex()[:8], sig.Hex()[:8])
-		}
-
-		// These bools could have change, see above:
-		if action_insert || action_update {
-			if false {
-				fmt.Printf("Calling %p->ObserveSigAndPubkey(sig=%s,"+
-					" signer_pubkey=%s), hash=%s\n", &info,
-					sig.Hex()[:8], signer_pubkey.Hex()[:8], hash.Hex()[:8])
-			}
-			info.ObserveSigAndPubkey(sig, signer_pubkey)
-			self.accept_count += 1
-		}
-	}
-
-	if action_insert {
-		self.hash2info[hash] = info
-	}
-
-	self.debug_count += 1
-	self.debug_usage += 1
-
-	if !(action_update || action_skip || action_insert) {
-		panic("Inconsistent BlockStat::try_add_hash_and_sig()")
-		return -1
-	}
-
-	if action_update || action_insert {
-		return 0
-	}
-
-	if action_skip {
-		return 1
-	}
-
-	return -1
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *BlockStat) GetBestHashPubkeySig() (
-	cipher.SHA256,
-	cipher.PubKey,
-	cipher.Sig) {
-
-	var best_n int = -1
-
-	var best_h cipher.SHA256
-
-	for hash, info := range self.hash2info {
-		n := len(info.pubkey2sig)
-
-		if best_n < n {
-			best_n = n
-			best_h = hash
-		} else if best_n == n {
-			// Resolve ties by comparing hashes:
-			if bytes.Compare(best_h[:], hash[:]) < 0 {
-				// Updating 'best_n' is unnecessary, but keep it here
-				// to help avoiding cut-and-paste errors:
-				best_n = n
-				best_h = hash
-			}
-		}
-	}
-
-	if best_n <= 0 {
-		return cipher.SHA256{}, cipher.PubKey{}, cipher.Sig{} // <<<<<<<<
-	}
-
-	var best_p cipher.PubKey
-	var best_s cipher.Sig
-
-	// Resolve ties (if any) by comparing signatures. Do not use
-	// pubkey for this purpose as we do not want, for example, to have
-	// same pubkey sign most of blocks.
-
-	// NOTE 1: We want a deterministic algo here, so that each
-	// ConsensusParticipant across teh network would choose same
-	// (hash,sig) to go to blockchain.
-
-	// NOTE 2: A simplified version of consensus can be imagined, in
-	// which ConsensusParticipant rejects a hash if it saw it already;
-	// this results in local blockchains with same transactions [when
-	// consensus id reached] but *different* signers. Which is not
-	// good from general entropy considerations.
-	initialized := false
-
-	for pubkey, sig := range self.hash2info[best_h].pubkey2sig {
-		if initialized {
-			if bytes.Compare(best_s[:], sig[:]) < 0 {
-				best_p = pubkey
-				best_s = sig
-			}
-		} else {
-			best_p = pubkey
-			best_s = sig
-
-			initialized = true
-		}
-	}
-
-	return best_h, best_p, best_s
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *BlockStat) Print() {
-
-	hash, _, _ := self.GetBestHashPubkeySig()
-	fmt.Printf("BlockStat={count(hash)=%d,count(pubkey)=%d,count(event)=%d"+
-		",accept_count=%d,seqno=%d,debug_usage=%d,frozen=%t,"+
-		"debug_reject_count=%d,debug_neglect_count=%d,best_hash=%s}",
-		len(self.hash2info),
-		len(self.debug_pubkey2count),
-		self.debug_count,
-		self.accept_count,
-		self.seqno,
-		self.debug_usage,
-		self.frozen,
-		self.debug_reject_count,
-		self.debug_neglect_count,
-		hash.Hex()[:8])
-}
-
-////////////////////////////////////////////////////////////////////////////////
-type PriorityQueue []*BlockStat // Contained in BlockStatQueue
-
-// NOTE: a shallow copy (of the slice) is made here
-func (pq PriorityQueue) Len() int {
-	return len(pq)
-}
-
-// NOTE: a shallow copy (of the slice) is made here
-func (pq PriorityQueue) Less(i int, j int) bool {
-	return pq[i].priority < pq[j].priority
-}
-
-// NOTE: a shallow copy (of the slice) is made here
-func (pq PriorityQueue) Swap(i int, j int) {
-	pq[i], pq[j] = pq[j], pq[i]
-	pq[i].index = i
-	pq[j].index = j
-}
-func (pq *PriorityQueue) Push(x interface{}) {
-	n := len(*pq)
-	item := x.(*BlockStat)
-	item.index = n
-	*pq = append(*pq, item)
-}
-func (pq *PriorityQueue) Pop() interface{} {
-	old := *pq
-	n := len(old)
-	item := old[n-1]
-	item.index = -1 // for safety
-	*pq = old[0 : n-1]
-	return item
-}
-
-// update modifies the priority and value of an Item in the queue.
-func (pq *PriorityQueue) update_priority(item *BlockStat, priority int) {
-	item.priority = priority
-	heap.Fix(pq, item.index)
-}
-
-////////////////////////////////////////////////////////////////////////////////
-//
-// BlockStatQueue
-//
-////////////////////////////////////////////////////////////////////////////////
-type BlockStatQueue struct {
-	// BlockStatQueue is a wrapper around a priority queue; the latter
-	// is prioretized by Block seqno. The wrapper provides setters and
-	// getters. The setters trim queue size as appropriate.
-	queue PriorityQueue
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *BlockStatQueue) is_consistent() bool {
-	// TODO: implement.
-	return true
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *BlockStatQueue) Len() int {
-	return len(self.queue)
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *BlockStatQueue) Print() {
-	n := len(self.queue)
-	fmt.Printf("BlockStatQueue={n=%d", n)
-
-	for i := 0; i < n; i++ {
-		fmt.Print(",")
-		self.queue[i].Print()
-	}
-
-	fmt.Printf("}")
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *BlockStatQueue) try_append_to_BlockStatQueue(
-	blockPtr *BlockBase) int {
-
-	// Use a superficial, quick test here. A thorough check will be
-	// done later in this function.
-	if secp256k1.VerifySignatureValidity(blockPtr.sig[:]) != 1 {
-		return 4 // Error
-	}
-
-	if blockPtr.sig == all_zero_sig || blockPtr.hash == all_zero_hash { // Hack
-		return 4 // <<<<<<<<
-	}
-
-	// At the end of the function, one of them must be 'true'.
-	action_update := false
-	action_skip := false
-	action_insert := false
-
-	var update_index int = -1
-
-	n := len(self.queue)
-	if n > 0 {
-		f := self.queue[0]
-		l := self.queue[n-1]
-		// ROBUSTNESS Set a max to what 'f - l' can be. For example,
-		// if the limit is 100 and the queue has only one block with
-		// seqno 7, then do not accept blocks with seqno >=
-		// 107. This is to prevent Memory Overflow attack.
-
-		if blockPtr.seqno < f.seqno {
-			// TODO: Accept, unless 'f.seqno - 1' is already in the
-			// (consented) blockchain; otherwise reject/ignore.  FOR
-			// NOW, accept unless queue length would be too large.
-
-			//
-			//
-			// TODO: evaluae -------------------- URGENT !!!!!
-			//
-			//
-			already_in_blockchain := false
-			//
-			//
-			//
-			//
-			if already_in_blockchain {
-				fmt.Print("DEBUG Already in blockchain. Ignoring block.\n")
-				action_skip = true
-			} else if l.seqno-blockPtr.seqno >
-				Cfg_consensus_candidate_max_seqno_gap {
-				fmt.Printf("DEBUG proposed=%d, first=%d, last=%d. Too far"+
-					" behind. Ignoring block.\n",
-					blockPtr.seqno, f.seqno, l.seqno)
-				action_skip = true
-			} else {
-				action_insert = true
-			}
-
-		} else if blockPtr.seqno > l.seqno {
-			// TODO: Accept, unless 'blockPtr.seqno > l.seqno' is
-			// large, e.g.  the preceived block is way ahead of the
-			// last block in the queue.  FOR NOW, accept unless queue
-			// length would be too large.
-			if blockPtr.seqno-f.seqno >
-				Cfg_consensus_candidate_max_seqno_gap {
-				fmt.Printf("DEBUG proposed=%d, first=%d, last=%d. Too far"+
-					" ahead. Ignoring block.\n",
-					blockPtr.seqno, f.seqno, l.seqno)
-				action_skip = true
-			} else {
-				action_insert = true
-			}
-		} else {
-			// The 'blockPtr.seqno' is in between, so we need to insert
-			// a new or find the element with same seqno and update it.
-
-			// PREFORMANCE TODO: Avoid linear search by using a
-			// lookup, or using other properties of Heap object. If
-			// n/a, use Binary Search.
-			S := blockPtr.seqno
-			found := false
-			for i, _ := range self.queue {
-				s := self.queue[i].seqno
-				if s < S {
-					// keep searching
-				} else if s == S {
-					found = true
-					action_update = true
-					update_index = i
-					break
-				} else if s > S {
-					break
-				}
-			}
-			if !found {
-				action_insert = true
-			}
-		}
-	} else {
-		// The queue is empty, so insert the block.
-		action_insert = true
-	}
-	n = -1 // guard
-
-	if !(action_update || action_skip || action_insert) {
-		panic("Inconsistent")
-		return -1
-	}
-
-	var status_code int = 1
-
-	if !action_skip {
-
-		// TAG Consensus: if we receive 100 copies of a Block (or
-		// Block's hash) that originated from the same block maker,
-		// then the statistical significance of them is not higher
-		// than that of only 1 copy.  The significance is roughly
-		// proportional to sqrt of the number of different [ideally,
-		// independent-thinking] signers for a Block with the same
-		// hash and same seqno.
-
-		should_forward_to_subscribers := false
-
-		if action_update {
-
-			res := self.queue[update_index].
-				try_add_hash_and_sig(blockPtr.hash, blockPtr.sig)
-			if res == 0 {
-				should_forward_to_subscribers = true
-			}
-
-		} else if action_insert {
-
-			bs := BlockStat{}
-			bs.Init()
-			bs.seqno = blockPtr.seqno
-			res := bs.try_add_hash_and_sig(blockPtr.hash, blockPtr.sig)
-
-			if res == 0 {
-				// Keep these two together:
-				heap.Push(&self.queue, &bs)
-				self.queue.update_priority(&bs, int(blockPtr.seqno))
-				// TODO: Above, try to remove the cast.
-
-				should_forward_to_subscribers = true
-			}
-		}
-
-		if should_forward_to_subscribers {
-			status_code = 0
-		}
-
-	}
-
-	return status_code
-}
-
-////////////////////////////////////////////////////////////////////////////////
-//
-// Struct ConsensusParticipant is inteneded to extend (or be contained in)
-// github.com/skycoin/skycoin/src/mesh*/node struct Node, so that
-// Node can participate in consensus.
-//
-////////////////////////////////////////////////////////////////////////////////
-type ConsensusParticipant struct {
-	// Source and sink:
-	Network MeshNetworkInterface
-
-	// Who I am:
-	Pubkey cipher.PubKey
-	Seckey cipher.SecKey // For signing
-
-	//
-	//
-	//
-	//
-	//
-
-	// My connections in:
-	publisher_key_list []cipher.PubKey        // To preserve the order.
-	publisher_key_map  map[cipher.PubKey]byte // To avoid duplicates.
-
-	// My connections out:
-	subscriber_key_list []cipher.PubKey        // To preserve the order.
-	subscriber_key_map  map[cipher.PubKey]byte // To avoid duplicates.
-
-	// The tail of Blockchain that I keep.
-	block_queue BlockchainTail
-
-	// Candidates Blocks.
-	block_stat_queue BlockStatQueue
-
-	Incoming_block_count int
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *ConsensusParticipant) GetNextBlockSeqNo() uint64 {
-	return self.block_queue.GetNextSeqNo()
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *ConsensusParticipant) Print() {
-	fmt.Printf("ConsensusParticipant={pubkey=%s,block_msg_count=%d",
-		self.Pubkey.Hex()[:8], self.Incoming_block_count)
-
-	detail := false
-
-	fmt.Printf(",publisher={n=%d", len(self.publisher_key_list))
-	if detail {
-		for _, val := range self.publisher_key_list {
-			fmt.Printf(",%s", val.Hex()[:8])
-		}
-	} else {
-		fmt.Printf(",...")
-	}
-	fmt.Printf("}")
-
-	fmt.Printf(",subscriber={n=%d", len(self.subscriber_key_list))
-	if detail {
-		for _, val := range self.subscriber_key_list {
-			fmt.Printf(",%s", val.Hex()[:8])
-		}
-	} else {
-		fmt.Printf(",...")
-	}
-	fmt.Printf("}")
-
-	fmt.Printf(",block_queue={")
-	self.block_queue.Print()
-	fmt.Printf("}")
-
-	fmt.Printf(",block_stat_queue={")
-	self.block_stat_queue.Print()
-	fmt.Printf("}")
-
-	fmt.Printf("}")
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func NewConsensusParticipantPtr(
-	network MeshNetworkInterface) *ConsensusParticipant {
-
-	node := ConsensusParticipant{
-		publisher_key_map:    make(map[cipher.PubKey]byte),
-		subscriber_key_map:   make(map[cipher.PubKey]byte),
-		block_queue:          BlockchainTail{},
-		Incoming_block_count: 0,
-	}
-	node.block_queue.Init()
-	//node.block_stat_queue.Init()
-	node.Network = network
-
-	// In PROD: each reads/loads the keys. In case the class does not
-	// expect to sign anytging, SecKey should not be stored.
-
-	// In SIMU: generate random keys.
-	node.Pubkey, node.Seckey = cipher.GenerateKeyPair()
-
-	return &node
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Reasons for this function: 1st, we want to minimize exposure of
-// SecKey, even in same process space.  2nd, functions Sign and
-// SignHash already exist, so want keep search/browse/jump-to-tag
-// simple.
-func (self *ConsensusParticipant) SignatureOf(hash cipher.SHA256) cipher.Sig {
-
-	// PERFORMANCE: This is expensive when cipher.DebugLevel2 or
-	// cipher.DebugLevel1 are true:
-	return cipher.SignHash(hash, self.Seckey)
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *ConsensusParticipant) RegisterPublisher(pubkey cipher.PubKey) {
-
-	if pubkey == self.Pubkey {
-		return // Let caller handle his issues.
-	}
-
-	if _, have := self.publisher_key_map[pubkey]; have {
-		return // Let caller handle his issues.
-	}
-
-	if false {
-		fmt.Printf("The %s is calling RegisterPublisher(%s)\n",
-			self.Pubkey.Hex()[:8], pubkey.Hex()[:8])
-	}
-
-	self.publisher_key_list = append(self.publisher_key_list, pubkey)
-	self.publisher_key_map[pubkey] = byte('1')
-
-	if false {
-		fmt.Printf("Now has %d publishers.\n", len(self.publisher_key_list))
-	}
-
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *ConsensusParticipant) OnSubscriberConnectionRequest(
-	pubkey cipher.PubKey) {
-
-	if _, have := self.subscriber_key_map[pubkey]; have {
-		return
-	}
-
-	// FOR NOW accept all connection request. TODO: check for black
-	// list, latency table etc.
-	var acceptable = true
-	if acceptable {
-		self.subscriber_key_list = append(self.subscriber_key_list, pubkey)
-		self.subscriber_key_map[pubkey] = byte('1')
-	}
-
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *ConsensusParticipant) SendBlockToAllMySubscriber(
-	blockPtr *BlockBase) {
-
-	for _, subscriber_key := range self.subscriber_key_list {
-		self.Network.Simulate_send_to_PubKey(self.Pubkey, subscriber_key,
-			blockPtr)
-	}
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *ConsensusParticipant) Get_block_stat_queue_Len() int {
-	return self.block_stat_queue.Len()
-}
-func (self *ConsensusParticipant) Get_block_stat_queue_element_at(
-	j int) *BlockStat {
-
-	return self.block_stat_queue.queue[j] // A pointer, BTW
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *ConsensusParticipant) RequestConnectionToAllMyPublisher() {
-	if false {
-		fmt.Printf("RequestConnectionToAllMyPublisher, %d publishers.\n",
-			len(self.publisher_key_list))
-	}
-
-	for _, publisher_key := range self.publisher_key_list {
-		self.Network.Simulate_request_connection_to(publisher_key, self.Pubkey)
-	}
-	// NOTE: Node does not request connection to subscriber; instead,
-	// the subscriber request connection to Node. This means that Node
-	// does not need to broadcast data.
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *ConsensusParticipant) OnBlockHeaderArrived(
-	from_key cipher.PubKey, blockPtr *BlockBase) {
-
-	self.Incoming_block_count += 1 // TODO: move this to try_add_hash_and_sig
-
-	res1 := self.block_stat_queue.try_append_to_BlockStatQueue(blockPtr)
-	if res1 == 0 {
-		self.harvest_ripe_BlockStat()
-		self.SendBlockToAllMySubscriber(blockPtr)
-	}
-}
-
-////////////////////////////////////////////////////////////////////////////////
-func (self *ConsensusParticipant) harvest_ripe_BlockStat() {
-
-	// POLICY: The BlockStat entries that have much smaller seqno
-	// than the most recent one, 'blockPtr.seqno', are converted
-	// to Blocks and appended to blockchain.
-	n := len(self.block_stat_queue.queue)
-	if n == 0 {
-		return
-	}
-
-	top_seqno := self.block_stat_queue.queue[n-1].seqno
-
-	for i := 0; i < n; i++ {
-		statPtr := self.block_stat_queue.queue[i]
-		if statPtr.seqno+
-			Cfg_consensus_waiting_time_as_seqno_diff <= top_seqno {
-
-			if !statPtr.frozen {
-				//
-				// BEG updating local blockchain
-				//
-
-				hash, _, sig := statPtr.GetBestHashPubkeySig()
-
-				blockPtr := &BlockBase{
-					sig:   sig,
-					hash:  hash,
-					seqno: statPtr.seqno,
-				}
-				res := self.block_queue.try_append_to_BlockchainTail(blockPtr)
-				if res == 0 {
-					// TODO: 'frozen' items should be removed and the 'best'
-					// moved to BlockchainTail.
-					statPtr.frozen = true
-				} else {
-					// Appending did not work. Need to examine 'res'
-					// and log the reason why.
-					blockPtr = nil
-				}
-				//
-				// END updating local blockchain
-				//
-
-			}
-
-		} else {
-			break // The rest are not ripe yet
-		}
-	}
-
-}
-
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/consensus/consensus_test.go
+++ b/src/consensus/consensus_test.go
@@ -1,5 +1,6 @@
 // 20160901 - Initial version by user johnstuartmill,
 // public key 02fb4acf944c84d48341e3c1cb14d707034a68b7f931d6be6d732bec03597d6ff6
+// 20161025 - Code revision by user johnstuartmill.
 package consensus
 
 import (
@@ -33,7 +34,7 @@ func TestBlockchainTail_02(t *testing.T) {
 		x := secp256k1.RandByte(888) // Random data.
 		h := cipher.SumSHA256(x)     // Its hash.
 
-		b := BlockBase{hash: h, seqno: uint64(i)} // OK to leave '.sig' empty
+		b := BlockBase{Hash: h, Seqno: uint64(i)} // OK to leave '.sig' empty
 
 		bq.append_nocheck(&b)
 	}
@@ -56,14 +57,14 @@ func TestBlockchainTail_03(t *testing.T) {
 	bq.Init()
 
 	h1 := cipher.SumSHA256(secp256k1.RandByte(888))
-	b1 := BlockBase{hash: h1, seqno: 1} // OK to leave '.sig' empty
+	b1 := BlockBase{Hash: h1, Seqno: 1} // OK to leave '.sig' empty
 
 	r1 := bq.try_append_to_BlockchainTail(&b1)
 	if r1 != 0 {
 		t.Log("BlockchainTail::try_append_to_BlockchainTail(): initial insert failed.")
 		t.Fail()
 	}
-	if bq.GetNextSeqNo() != b1.seqno+1 {
+	if bq.GetNextSeqNo() != b1.Seqno + 1 {
 		t.Log("BlockchainTail::GetNextSeqNo() failed.")
 		t.Fail()
 	}
@@ -75,20 +76,20 @@ func TestBlockchainTail_03(t *testing.T) {
 	}
 
 	h2 := cipher.SumSHA256(secp256k1.RandByte(888))
-	b2 := BlockBase{hash: h2, seqno: 2} // OK to leave '.sig' empty
+	b2 := BlockBase{Hash: h2, Seqno: 2} // OK to leave '.sig' empty
 
 	r2 := bq.try_append_to_BlockchainTail(&b2)
 	if r2 != 0 {
 		t.Log("BlockchainTail::try_append_to_BlockchainTail(): next insert failed.")
 		t.Fail()
 	}
-	if bq.GetNextSeqNo() != b2.seqno+1 {
+	if bq.GetNextSeqNo() != b2.Seqno + 1 {
 		t.Log("BlockchainTail::GetNextSeqNo() failed.")
 		t.Fail()
 	}
 
 	h3 := cipher.SumSHA256(secp256k1.RandByte(888))
-	b3 := BlockBase{hash: h3, seqno: 0} // OK to leave '.sig' empty
+	b3 := BlockBase{Hash: h3, Seqno: 0} // OK to leave '.sig' empty
 
 	r3 := bq.try_append_to_BlockchainTail(&b3)
 	if r3 != 2 {
@@ -96,7 +97,7 @@ func TestBlockchainTail_03(t *testing.T) {
 		t.Fail()
 	}
 
-	b3.seqno = 4
+	b3.Seqno = 4
 	r4 := bq.try_append_to_BlockchainTail(&b3)
 	if r4 != 3 {
 		t.Log("BlockchainTail::try_append_to_BlockchainTail(): high seqno not detected.")

--- a/src/consensus/example/example_gnet.go
+++ b/src/consensus/example/example_gnet.go
@@ -2,6 +2,7 @@
 // public key 02fb4acf944c84d48341e3c1cb14d707034a68b7f931d6be6d732bec03597d6ff6
 // 20161025 - Code revision by user johnstuartmill.
 package main
+
 //
 // WARNING: WARNING: WARNING: Do NOT use this code for obtaining any
 // research results.  This file is only an illustration. A realistic
@@ -11,128 +12,81 @@ package main
 //
 
 import (
-	"os"
 	"flag"
-	"sort"
 	"fmt"
+	gnet "github.com/skycoin/skycoin/src/aether"
+	"log"
 	mathrand "math/rand"
+	"os"
+	"sort"
+	"time"
 	//
-	"github.com/skycoin/skycoin/src/consensus"
 	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/consensus"
 )
 
-var Cfg_print_config            bool = true
-var Cfg_debug_connect_request   bool = false
-var Cfg_debug_node_final_state  bool = false
-var Cfg_debug_node_summary      bool = false
-var Cfg_debug_show_block_maker  bool = false
+var Cfg_print_config bool = true
+var Cfg_debug_connect_request bool = false
+var Cfg_debug_node_final_state bool = false
+var Cfg_debug_node_summary bool = false
+var Cfg_debug_show_block_maker bool = false
 
 var Cfg_simu_topology_is_random bool = true
 
-var Cfg_simu_num_node            int = 100
-var Cfg_simu_num_blockmaker      int =  10
-var Cfg_simu_prob_malicious  float64 = 0.0
-var Cfg_simu_prob_duplicate  float64 = 0.0
+var Cfg_simu_num_node int = 10
+var Cfg_simu_num_blockmaker int = 2
+var Cfg_simu_prob_malicious float64 = 0.0
+var Cfg_simu_prob_duplicate float64 = 0.0
 
-var Cfg_simu_num_block_round     int =  10
-var Cfg_simu_fanout_per_node     int =   3
+var Cfg_simu_num_block_round int = 10
+var Cfg_simu_fanout_per_node int = 3
 
 // Will be reset later, based on values of other parameters:
-var Cfg_simu_num_iter            int =   0
-////////////////////////////////////////////////////////////////////////////////
-type MinimalConnectionManager struct {
-	theNodePtr *consensus.ConsensusParticipant
-	//
-	publisher_key_list []*MinimalConnectionManager
-	subscriber_key_list []*MinimalConnectionManager
-}
-func (self *MinimalConnectionManager) GetNode() *consensus.ConsensusParticipant {
-	return self.theNodePtr 
-}
-func (self *MinimalConnectionManager) RegisterPublisher(key *MinimalConnectionManager) bool {
+var Cfg_simu_num_iter int = 0
 
-	self.publisher_key_list = append(self.publisher_key_list, key)
-	return true
-}
-func (self *MinimalConnectionManager) SendBlockToAllMySubscriber(blockPtr *consensus.BlockBase) {
-	for _, p := range self.subscriber_key_list {
-		p.GetNode().OnBlockHeaderArrived(blockPtr)
-	}
-}
-func (self *MinimalConnectionManager) RequestConnectionToAllMyPublisher() {
-	for _, p := range self.publisher_key_list {
-		p.OnSubscriberConnectionRequest(self)
-	}
-}
-func (self *MinimalConnectionManager) OnSubscriberConnectionRequest(other *MinimalConnectionManager) {
-	self.subscriber_key_list = append(self.subscriber_key_list, other)
-}
-func (self *MinimalConnectionManager) Print() {
-	detail := false
+var common_channel uint16 = 3
 
-	fmt.Printf("ConnectionManager={publisher={n=%d",
-		len(self.publisher_key_list))
-
-	if detail {
-		for _, val := range self.publisher_key_list {
-			fmt.Printf(",%v", val)
-		}
-	} else {
-		fmt.Printf(",...")
-	}
-	fmt.Printf("}")
-
-	fmt.Printf(",subscriber={n=%d", len(self.subscriber_key_list))
-	if detail {
-		for _, val := range self.subscriber_key_list {
-			fmt.Printf(",%v", val)
-		}
-	} else {
-		fmt.Printf(",...")
-	}
-	fmt.Printf("}")
-}
-////////////////////////////////////////////////////////////////////////////////
-//
-//
-//
 ////////////////////////////////////////////////////////////////////////////////
 func pretty_print_flags(prefix string, detail bool) {
 	if detail {
 
 		max1 := 0
 		max2 := 0
-		
-		flag.VisitAll(func (f *flag.Flag) {
+
+		flag.VisitAll(func(f *flag.Flag) {
 			len1 := len(f.Name)
 			len2 := len(fmt.Sprintf("%v", f.Value))
-			if max1 < len1 { max1 = len1 }
-			if max2 < len2 { max2 = len2 }
+			if max1 < len1 {
+				max1 = len1
+			}
+			if max2 < len2 {
+				max2 = len2
+			}
 		})
-		
+
 		format := fmt.Sprintf("    --%%-%ds %%%dv    %%s\n", max1, max2)
 		format = "%s" + format
-		
-		flag.VisitAll(func (f *flag.Flag) {
+
+		flag.VisitAll(func(f *flag.Flag) {
 			fmt.Printf(format, prefix, f.Name, f.Value, f.Usage)
 		})
 
 	} else {
 
-		flag.VisitAll(func (f *flag.Flag) {
+		flag.VisitAll(func(f *flag.Flag) {
 			fmt.Printf("%s--%s=%v\n", prefix, f.Name, f.Value)
 		})
-		
+
 	}
 }
+
 ////////////////////////////////////////////////////////////////////////////////
 func cmd_line_args_process() {
 
-	var ip *int     = nil
-	var qp *uint64  = nil
+	var ip *int = nil
+	var qp *uint64 = nil
 	var dp *float64 = nil
-	var bp *bool    = nil
-
+	var bp *bool = nil
 
 	//
 	// Simulation parameters
@@ -146,25 +100,24 @@ func cmd_line_args_process() {
 
 	dp = &Cfg_simu_prob_malicious
 	flag.Float64Var(dp, "simu-prob-malicious", *dp,
-		"Probability that a node temporarily joins a malicious group that" +
+		"Probability that a node temporarily joins a malicious group that"+
 			" publishes same block in order to cause a fork of the blockchain.")
 
 	dp = &Cfg_simu_prob_duplicate
 	flag.Float64Var(dp, "simu-prob-duplicate", *dp,
-		"Probability that a node sends a duplicate message with same hash but" +
-			" different signature. (Duplicate (hash,sig) pairs are easily" +
+		"Probability that a node sends a duplicate message with same hash but"+
+			" different signature. (Duplicate (hash,sig) pairs are easily"+
 			" detected and discarded.)")
 
-	ip = &Cfg_simu_num_block_round 
+	ip = &Cfg_simu_num_block_round
 	flag.IntVar(ip, "simu-num-rounds", *ip,
-		"Number of block rounds. When all them are published and the" +
+		"Number of block rounds. When all them are published and the"+
 			" resulting messages propagate, the simulation ends.")
 
 	ip = &Cfg_simu_fanout_per_node
 	flag.IntVar(ip, "simu-fanout-per-node", *ip,
-		"Number of incoming (and outgoing) connections to (and from) each" +
+		"Number of incoming (and outgoing) connections to (and from) each"+
 			" node.")
-
 
 	bp = &Cfg_debug_connect_request
 	flag.BoolVar(bp, "debug-connect-request", *bp, "")
@@ -178,14 +131,12 @@ func cmd_line_args_process() {
 	bp = &Cfg_debug_node_summary
 	flag.BoolVar(bp, "debug-node-summary", *bp, "")
 
-
 	bp = &Cfg_debug_show_block_maker
 	flag.BoolVar(bp, "debug-show-block-maker", *bp, "")
 
 	bp = &Cfg_simu_topology_is_random
 	flag.BoolVar(bp, "simu-topology-is-random", *bp,
 		"Connect nodes randomly or place them in one circle.")
-
 
 	//
 	// Consensus parameters
@@ -209,27 +160,25 @@ func cmd_line_args_process() {
 
 	qp = &consensus.Cfg_consensus_candidate_max_seqno_gap
 	flag.Uint64Var(qp, "consensus-candidate-max-seqno-gap", *qp,
-		"Proposed blocks (or consensus candidates) are ignored if theie seqno" +
-		" is too high or too low w.r.t. what is stored. This limits memory" +
-		" use and helps prevents some mild attacks.")
+		"Proposed blocks (or consensus candidates) are ignored if theie seqno"+
+			" is too high or too low w.r.t. what is stored. This limits memory"+
+			" use and helps prevents some mild attacks.")
 
 	qp = &consensus.Cfg_consensus_waiting_time_as_seqno_diff
 	flag.Uint64Var(qp, "consensus-waiting-time-as-seqno-diff", *qp,
-		"When to decide on selecting the best hash from BlockStat" +
+		"When to decide on selecting the best hash from BlockStat"+
 			" so that it can be moved to blockchain.")
 
 	ip = &consensus.Cfg_consensus_max_candidate_messages
 	flag.IntVar(ip, "consensus-max-candidate-messages", *ip,
-		"How many (hash,signer_pubkey) pairs to acquire for decision-making." +
-		" This also limits forwarded traffic, because the messages in excess" +
-		" of this limit are discarded hence not forwarded.")
-
+		"How many (hash,signer_pubkey) pairs to acquire for decision-making."+
+			" This also limits forwarded traffic, because the messages in excess"+
+			" of this limit are discarded hence not forwarded.")
 
 	//
 	//
 	//
 	show := flag.Bool("show", false, "Show current parameter values and exit.")
-
 
 	//
 	//
@@ -238,24 +187,22 @@ func cmd_line_args_process() {
 	//
 
 	if Cfg_simu_num_node < Cfg_simu_num_blockmaker {
-		fmt.Printf("Invalid input: --simu-num-nodes=%d < --simu-num-blockmaker=" +
+		fmt.Printf("Invalid input: --simu-num-nodes=%d < --simu-num-blockmaker="+
 			"%d. Exiting.\n", Cfg_simu_num_node, Cfg_simu_num_blockmaker)
 		os.Exit(1)
 	}
 
 	if Cfg_simu_prob_malicious < 0. || 1 < Cfg_simu_prob_malicious {
-		fmt.Printf("Invalid input: --simu-prob-malicious=%g is outside" +
+		fmt.Printf("Invalid input: --simu-prob-malicious=%g is outside"+
 			" [0 .. 1] range. Exiting.\n", Cfg_simu_prob_malicious)
 		os.Exit(1)
 	}
 
 	if Cfg_simu_prob_duplicate < 0. || 1 < Cfg_simu_prob_duplicate {
-		fmt.Printf("Invalid input: --simu-prob-duplicate=%g is outside" +
+		fmt.Printf("Invalid input: --simu-prob-duplicate=%g is outside"+
 			" [0 .. 1] range. Exiting.\n", Cfg_simu_prob_malicious)
 		os.Exit(1)
 	}
-
-
 
 	//
 	// Derived parameters
@@ -266,9 +213,9 @@ func cmd_line_args_process() {
 	// by premature exit from the vent loop. Yet we keep it finite to
 	// prevent an infinite run that can be caused by a bug:
 
-	Cfg_simu_num_iter =  10 * // '10' is a heuristic
-	    Cfg_simu_num_node * Cfg_simu_num_blockmaker * 
-        Cfg_simu_num_block_round * Cfg_simu_fanout_per_node
+	Cfg_simu_num_iter = 10 * // '10' is a heuristic
+		Cfg_simu_num_node * Cfg_simu_num_blockmaker *
+		Cfg_simu_num_block_round * Cfg_simu_fanout_per_node
 
 	if *show {
 		pretty_print_flags("", true)
@@ -279,6 +226,7 @@ func cmd_line_args_process() {
 		}
 	}
 }
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 //
@@ -306,7 +254,6 @@ func propagate_hash_from_node(
 	// propagation and to have an event queueu inside the
 	// implementation of MeshNetworkInterface.
 	//
-	
 
 	o := external_seqno // HACK for DEBUGGING
 	if !external_use {
@@ -315,15 +262,220 @@ func propagate_hash_from_node(
 
 	b := consensus.BlockBase{}
 	b.Init(
-		nodePtr.SignatureOf(h),             // Signature of hash.
+		nodePtr.SignatureOf(h), // Signature of hash.
 		h,
 		o)
 
 	nodePtr.OnBlockHeaderArrived(&b)
 }
+
 ////////////////////////////////////////////////////////////////////////////////
-func print_stat(X []*MinimalConnectionManager,
-	iter int) {
+// MESSAGE
+type BlockBaseWrapper struct {
+	consensus.BlockBase
+}
+
+func (self *BlockBaseWrapper) String() string {
+	return fmt.Sprintf("BlockBaseWrapper={Sig=%s,Hash=%s,Seqno=%d}",
+		self.Sig.Hex()[:8], self.Hash.Hex()[:8], self.Seqno)
+}
+func (self *BlockBaseWrapper) Handle(context *gnet.MessageContext, closure interface{}) error {
+
+	if false {
+		fmt.Printf("@@@ consensus.BlockBase Handle: context={%v} closure={%v} data={%v}\n", context, closure, self)
+	}
+
+	arg := closure.(*PoolOwner)
+	arg.DataCallback(context, self)
+	return nil
+}
+
+//array of messages to register
+var messageMap map[string](interface{}) = map[string](interface{}){
+	"id01": BlockBaseWrapper{}, //message id, message type
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+//
+//
+////////////////////////////////////////////////////////////////////////////////
+type PoolOwner struct {
+	pCMan *MinimalConnectionManager
+
+	pDispatcherManager *gnet.DispatcherManager
+	pDispatcher        *gnet.Dispatcher
+	pConnectionPool    *gnet.ConnectionPool
+	//
+	isConnSolicited map[string]bool // Addr -> bool
+	//
+	key_list []string        // To preserve the order.
+	key_map  map[string]byte // To avoid duplicates.
+	//
+	debug_num_id   int
+	debug_nickname string
+}
+
+func (self *PoolOwner) Shutdown() {
+	self.pConnectionPool.Shutdown()
+}
+
+func (self *PoolOwner) Init(pCMan *MinimalConnectionManager, listen_port uint16, num_id int, nickname string) {
+
+	config := gnet.NewConfig()
+	config.Port = uint16(listen_port)
+
+	cp := gnet.NewConnectionPool(config)
+
+	dm := gnet.NewDispatcherManager()
+
+	self.isConnSolicited = make(map[string]bool)
+
+	cp.Config.MessageCallback = dm.OnMessage
+	cp.Config.ConnectCallback = self.OnConnect
+	cp.Config.DisconnectCallback = self.OnDisconnect
+
+	d := dm.NewDispatcher(cp, common_channel, self)
+	d.RegisterMessages(messageMap)
+
+	self.pCMan = pCMan
+	self.pDispatcherManager = dm
+	self.pDispatcher = d
+	self.key_map = make(map[string]byte)
+	self.pConnectionPool = cp
+
+	self.debug_num_id = num_id
+	self.debug_nickname = nickname
+}
+
+func (self *PoolOwner) Run() {
+
+	cp := self.pConnectionPool // alias
+
+	if cp.Config.Port != 0 {
+		if err := cp.StartListen(); err != nil {
+			log.Panic(err)
+		}
+		go cp.AcceptConnections()
+	}
+
+	go func() {
+		for true {
+			// [JSM] 20161025 The 'Sleep' below is a workaround of
+			// unresolve concurrency issues in file gnet/pool.go
+			// class ConnectionPool.
+			time.Sleep(time.Millisecond * 1)
+			cp.HandleMessages()
+		}
+	}()
+
+}
+func (self *PoolOwner) DataCallback(context *gnet.MessageContext, xxx *BlockBaseWrapper) {
+
+	if self.isConnSolicited[context.Conn.Addr()] {
+
+		var msg consensus.BlockBase
+		msg.Sig = xxx.Sig
+		msg.Hash = xxx.Hash
+		msg.Seqno = xxx.Seqno
+
+		self.pCMan.GetNode().OnBlockHeaderArrived(&msg)
+
+	} else {
+		// Ignoring
+	}
+}
+func (self *PoolOwner) OnConnect(c *gnet.Connection, is_solicited bool) {
+	self.isConnSolicited[c.Addr()] = is_solicited
+
+	if false {
+		for channel, pDispatcher := range self.pDispatcherManager.Dispatchers {
+			// (BTW, pDispatcher.ReceivingObject is '&PoolOwner')
+
+			// Each channel (or subscription subject) might require
+			// specific action to be taken on connect, such as request
+			// initial values from solicited, authenticate the client
+			// from unsolicited one etc.
+			_ = channel
+			_ = pDispatcher
+		}
+	}
+}
+func (self *PoolOwner) OnDisconnect(c *gnet.Connection, reason gnet.DisconnectReason) {
+
+	if false {
+		for channel, pDispatcher := range self.pDispatcherManager.Dispatchers {
+			// (BTW, pDispatcher.ReceivingObject is '&PoolOwner')
+
+			// Each channel (or subscription subject) might require
+			// specific action to be taken on disconnect, such as
+			// reconnect, clean up etc.
+			_ = channel
+			_ = pDispatcher
+		}
+	}
+
+	delete(self.isConnSolicited, c.Addr())
+}
+
+////////////////////////////////////////////////////////////////////////////////
+func (self *PoolOwner) RequestConnectionToKeys() {
+	for _, key := range self.key_list {
+		go func(arg string) {
+			_, err := self.BlockingConnectToUrl(arg)
+			if err != nil {
+				log.Panic(err)
+			}
+		}(key)
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+func (self *PoolOwner) RegisterKey(key string) bool {
+
+	if _, have := self.key_map[key]; have {
+		return false // Let caller handle his issues.
+	}
+
+	self.key_list = append(self.key_list, key)
+	self.key_map[key] = byte('1')
+
+	return true
+
+}
+func (self *PoolOwner) GetListenPort() uint16 {
+	return self.pDispatcher.Pool.Config.Port
+}
+func (self *PoolOwner) BlockingConnectTo(IPAddress string, port uint16) (*gnet.Connection, error) {
+	url := fmt.Sprintf("%s:%d", IPAddress, port)
+	conn, err := self.pDispatcher.Pool.Connect(url)
+	return conn, err
+}
+func (self *PoolOwner) BlockingConnectToUrl(url string) (*gnet.Connection, error) {
+	conn, err := self.pDispatcher.Pool.Connect(url)
+	return conn, err
+}
+func (self *PoolOwner) BroadcastMessage(msg gnet.Message) error {
+	return self.pDispatcher.BroadcastMessage(common_channel, msg)
+}
+func (self *PoolOwner) Print() {
+	detail := true
+
+	fmt.Printf("PoolOwner={%d,%s,keys={n=%d",
+		self.debug_num_id, self.debug_nickname, len(self.key_list))
+
+	if detail {
+		for _, val := range self.key_list {
+			fmt.Printf(",%s", val)
+		}
+	} else {
+		fmt.Printf(",...")
+	}
+	fmt.Printf("}}")
+}
+
+////////////////////////////////////////////////////////////////////////////////
+func print_stat(X []*MinimalConnectionManager, iter int) {
 
 	n := 0
 	for i, _ := range X {
@@ -331,7 +483,7 @@ func print_stat(X []*MinimalConnectionManager,
 	}
 
 	msg_per_node_per_round :=
-		float64(n)/float64(Cfg_simu_num_node*Cfg_simu_num_block_round)
+		float64(n) / float64(Cfg_simu_num_node*Cfg_simu_num_block_round)
 
 	msg_per_node_per_round_per_link := msg_per_node_per_round /
 		float64(Cfg_simu_fanout_per_node)
@@ -341,17 +493,17 @@ func print_stat(X []*MinimalConnectionManager,
 
 	// Print for viewing:
 	fmt.Printf(
-		"MSG_STAT iter                     %d\n"   +
-		"MSG_STAT msg_count_all            %d\n"   +
-		"MSG_STAT num_node                 %d\n"   +
-		"MSG_STAT num_blockmaker           %d\n"   +
-		"MSG_STAT num_block_round          %d\n"   +
-		"MSG_STAT fanout_per_node          %d\n"   +
-		"MSG_STAT max_candidate_messages   %d (This limits the effect of" +
-" having large num_blockmaker)\n" +
-		"MSG_STAT msg_per_node_per_round                %.3f\n" +
-		"MSG_STAT msg_per_node_per_round_per_link       %.3f\n" +
-		"MSG_STAT msg_per_node_per_round_per_blockmaker %.3f\n",
+		"MSG_STAT iter                     %d\n"+
+			"MSG_STAT msg_count_all            %d\n"+
+			"MSG_STAT num_node                 %d\n"+
+			"MSG_STAT num_blockmaker           %d\n"+
+			"MSG_STAT num_block_round          %d\n"+
+			"MSG_STAT fanout_per_node          %d\n"+
+			"MSG_STAT max_candidate_messages   %d (This limits the effect of"+
+			" having large num_blockmaker)\n"+
+			"MSG_STAT msg_per_node_per_round                %.3f\n"+
+			"MSG_STAT msg_per_node_per_round_per_link       %.3f\n"+
+			"MSG_STAT msg_per_node_per_round_per_blockmaker %.3f\n",
 		iter, n, Cfg_simu_num_node, Cfg_simu_num_blockmaker,
 		Cfg_simu_num_block_round, Cfg_simu_fanout_per_node,
 		consensus.Cfg_consensus_max_candidate_messages,
@@ -359,13 +511,13 @@ func print_stat(X []*MinimalConnectionManager,
 		msg_per_node_per_round_per_link,
 		msg_per_node_per_round_per_blockmaker)
 
-
 }
+
 ////////////////////////////////////////////////////////////////////////////////
 func Simulate_compare_node_StateQueue(
 	X []*MinimalConnectionManager,
-	global_seqno2h map[uint64] cipher.SHA256,
-	global_seqno2h_alt map[uint64] cipher.SHA256,
+	global_seqno2h map[uint64]cipher.SHA256,
+	global_seqno2h_alt map[uint64]cipher.SHA256,
 ) {
 	//
 	// Step 1 of 3: for each observed seqno, find the histogram of
@@ -373,7 +525,7 @@ func Simulate_compare_node_StateQueue(
 	//
 	type QQQ map[uint64]map[cipher.SHA256]int
 	xxx := make(QQQ) // Access:       [seqno][hash]=count
-	type ZZZ [] QQQ  // Access: [node][seqno][hash]=count
+	type ZZZ []QQQ   // Access: [node][seqno][hash]=count
 
 	ni := len(X)
 
@@ -385,7 +537,7 @@ func Simulate_compare_node_StateQueue(
 		zzz[i] = make(map[uint64]map[cipher.SHA256]int)
 
 		for j := 0; j < nj; j++ { // Elements in node's BlockStatQueue
-			
+
 			// 'bs' a pointer:
 			bs := X[i].GetNode().Get_block_stat_queue_element_at(j)
 			seqno := bs.GetSeqno()
@@ -423,26 +575,25 @@ func Simulate_compare_node_StateQueue(
 			if initialized {
 				if best_count < count {
 					best_count = count
-					best_hash  = hash
+					best_hash = hash
 				}
 			} else {
 				initialized = true
-				
+
 				best_count = count
-				best_hash  = hash
+				best_hash = hash
 			}
 			sum_count += count
 		}
-		
+
 		if initialized {
 			yyy[seqno] = best_hash
-			
+
 			// Here all 'seqno' contribute equally:
 			accept_count += best_count
 			total_count += sum_count
 		}
 	}
-
 
 	if true {
 		keys := []int{}
@@ -459,30 +610,29 @@ func Simulate_compare_node_StateQueue(
 			best_hash := yyy[seqno]
 
 			prescribed := best_hash == global_seqno2h[seqno]
-			malicious  := best_hash == global_seqno2h_alt[seqno]
+			malicious := best_hash == global_seqno2h_alt[seqno]
 
-			fmt.Printf("CONSENSUS: seqno=%d best_hash=%s prescribed=%t" +
+			fmt.Printf("CONSENSUS: seqno=%d best_hash=%s prescribed=%t"+
 				" malicious=%t\n", seqno, best_hash.Hex()[:8], prescribed,
 				malicious)
 		}
-		
+
 	}
 	fmt.Printf("CONSENSUS: total_count=%d accept_count=%d, accept_ratio=%f\n",
 		total_count, accept_count, float32(accept_count)/float32(total_count))
 
-
 	for i, zzz_i := range zzz {
-		join_count       := 0 // How many have selected the most popular hash.
-		other_count      := 0 // How many have selected NOT the most popular.
+		join_count := 0       // How many have selected the most popular hash.
+		other_count := 0      // How many have selected NOT the most popular.
 		prescribed_count := 0 // How many have selected the intented hash.
-		malicious_count  := 0 // How many have selected the malicious hash.
+		malicious_count := 0  // How many have selected the malicious hash.
 
 		for seqno, hash2count := range zzz_i {
 
 			// Most-frequently accepted (across nodes) for the given seqno:
-			best_hash  := yyy[seqno]
+			best_hash := yyy[seqno]
 			prescribed := global_seqno2h[seqno]
-			malicious  := global_seqno2h_alt[seqno]
+			malicious := global_seqno2h_alt[seqno]
 
 			for hash, count := range hash2count {
 				if hash == best_hash {
@@ -499,21 +649,103 @@ func Simulate_compare_node_StateQueue(
 				}
 			}
 		}
-	
-		fmt.Printf("NODE i=%d join_count=%d other_count=%d prescribed_count=" +
+
+		fmt.Printf("NODE i=%d join_count=%d other_count=%d prescribed_count="+
 			"%d  malicious_count=%d\n",
 			i, join_count, other_count, prescribed_count, malicious_count)
 	}
 }
+
+////////////////////////////////////////////////////////////////////////////////
+type MinimalConnectionManager struct {
+	theNodePtr *consensus.ConsensusParticipant
+
+	// MinimalConnectionManager solicit a conn to them; receive data
+	// from them but do not send anything
+	publishers  PoolOwner
+
+	// MinimalConnectionManager accept
+	// connections. MinimalConnectionManager send data to them; does
+	// not receive anything; ignores all incoming data
+	subscribers PoolOwner
+}
+
+func (self *MinimalConnectionManager) Init(listen_port uint16, num_id int, nickname string) {
+	self.publishers.Init(self, 0, num_id, nickname+";recv_from_pub")
+	self.subscribers.Init(self, listen_port, num_id, nickname+";send_to_sub")
+}
+func (self *MinimalConnectionManager) Run() {
+	self.publishers.Run()
+	self.subscribers.Run()
+}
+func (self *MinimalConnectionManager) ShutdownPublishing() {
+	self.subscribers.Shutdown()
+}
+func (self *MinimalConnectionManager) ShutdownSubscribing() {
+	self.publishers.Shutdown()
+}
+func (self *MinimalConnectionManager) GetListenPort() uint16 {
+	return self.subscribers.pDispatcher.Pool.Config.Port
+}
+
+////////////////////////////////////////////////////////////////////////////////
+func (self *MinimalConnectionManager) GetNode() *consensus.ConsensusParticipant {
+	return self.theNodePtr
+}
+func (self *MinimalConnectionManager) RegisterPublisher(key string) bool {
+	return self.publishers.RegisterKey(key)
+}
+func (self *MinimalConnectionManager) SendBlockToAllMySubscriber(xxx *consensus.BlockBase) {
+	var msg BlockBaseWrapper
+	msg.Sig = xxx.Sig
+	msg.Hash = xxx.Hash
+	msg.Seqno = xxx.Seqno
+
+	self.subscribers.pDispatcher.BroadcastMessage(common_channel, &msg)
+}
+func (self *MinimalConnectionManager) RequestConnectionToAllMyPublisher() {
+	self.publishers.RequestConnectionToKeys()
+
+	// NOTE: The node does not request connection to subscriber;
+	// instead, the subscriber request connection to Node.
+}
+func (self *MinimalConnectionManager) OnSubscriberConnectionRequest(key string) {
+	fmt.Printf(">>>>>>>>>>>>>>>> GOT HERE. Please cooment this line out >>>>>>>>>>>>>>>>>>>>>>>>>\n")
+
+	// FOR NOW accept all connection request. TODO: check for black
+	// list, latency table etc.
+	var acceptable = true
+	if acceptable {
+		self.subscribers.RegisterKey(key)
+	}
+}
+func (self *MinimalConnectionManager) Print() {
+	fmt.Printf("ConnectionManager={Pub={")
+	self.publishers.Print()
+	fmt.Printf("},Sub={")
+	self.subscribers.Print()
+	fmt.Printf("}}")
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+//
+//
+////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 func get_random_index_subset(N int, S int) []int {
 	// N - population size
 	// S - subset size
 
-	if N < 0 { N = 0 }
-	if S < 0 { S = 0 }
-	if S > N { S = N }
-
+	if N < 0 {
+		N = 0
+	}
+	if S < 0 {
+		S = 0
+	}
+	if S > N {
+		S = N
+	}
 
 	index_map := make(map[int]int, S)
 	if 2*S < N {
@@ -523,7 +755,7 @@ func get_random_index_subset(N int, S int) []int {
 				break
 			}
 			index_map[mathrand.Intn(N)] = 1
-		}			
+		}
 	} else {
 		// Fill up
 		for i := 0; i < N; i++ {
@@ -565,14 +797,14 @@ func main() {
 
 	var hack_global_seqno uint64 = 0
 
-
 	seed := "hdhdhdkjashfy7273"
 	_, SecKeyArray :=
 		cipher.GenerateDeterministicKeyPairsSeed([]byte(seed), Cfg_simu_num_node)
 
-
 	for i := 0; i < Cfg_simu_num_node; i++ {
-		cm := MinimalConnectionManager{}
+		var cm MinimalConnectionManager
+		cm.Init(6060+uint16(i), i, "fox")
+
 		// Reason for mutual registration: (1) when conn man receives
 		// messages, it needs to notify the node; (2) when node has
 		// processed a mesage, it might need to use conn man to send
@@ -582,7 +814,7 @@ func main() {
 		nodePtr.SetPubkeySeckey(cipher.PubKeyFromSecKey(s), s)
 
 		cm.theNodePtr = nodePtr
-		
+
 		X = append(X, &cm)
 	}
 	if false {
@@ -591,49 +823,63 @@ func main() {
 
 	if Cfg_simu_topology_is_random {
 
-		fmt.Printf("CONFIG Topology: connecting %d nodes randomly with approx" +
-			" %d  nearest-neighbors in and approx %d nearest-neighbors out.\n",
+		fmt.Printf("CONFIG Topology: connecting %d nodes randomly with approx"+
+			" %d nearest-neighbors in and approx %d nearest-neighbors out.\n",
 			Cfg_simu_num_node, Cfg_simu_fanout_per_node,
 			Cfg_simu_fanout_per_node)
 
+		n := len(X)
 
-		
-		for i, _ := range X {
+		for i := 0; i < n; i++ {
+
 			cm := X[i]
-			for g := 0; g < Cfg_simu_fanout_per_node; g++ {
-				j := mathrand.Intn(Cfg_simu_num_node)
+
+			indices :=
+				get_random_index_subset(Cfg_simu_num_node, Cfg_simu_fanout_per_node)
+			for _, j := range indices {
 				if i != j {
-					cm.RegisterPublisher(X[j])
+					cm.RegisterPublisher(fmt.Sprintf("127.0.0.1:%d", X[j].GetListenPort()))
+					fmt.Printf("TOPOLOGY: port %d solicits conn to port %d\n", cm.GetListenPort(), X[j].GetListenPort())
+
 				}
 			}
 		}
 	} else {
 
-		fmt.Printf("CONFIG Topology: connecting %d nodes via one (thick)" +
-			" circle with approx %d  nearest-neighbors in and approx %d " +
+		fmt.Printf("CONFIG Topology: connecting %d nodes via one (thick)"+
+			" circle with approx %d  nearest-neighbors in and approx %d "+
 			"nearest-neighbors out.\n",
 			Cfg_simu_num_node, Cfg_simu_fanout_per_node,
 			Cfg_simu_fanout_per_node)
 
 		n := len(X)
+
 		for i := 0; i < n; i++ {
 
 			cm := X[i]
 
-			c_left := int(Cfg_simu_fanout_per_node/2)
+			c_left := int(Cfg_simu_fanout_per_node / 2)
 			c_right := Cfg_simu_fanout_per_node - c_left
 
 			for c := 0; c < c_left; c++ {
 				j := (i - 1 - c + n) % n
-				cm.RegisterPublisher(X[j])
+				cm.RegisterPublisher(fmt.Sprintf("127.0.0.1:%d", X[j].GetListenPort()))
 			}
-		
+
 			for c := 0; c < c_right; c++ {
 				j := (i + 1 + c) % n
-				cm.RegisterPublisher(X[j])
+				cm.RegisterPublisher(fmt.Sprintf("127.0.0.1:%d", X[j].GetListenPort()))
 			}
 		}
 	}
+
+	// Start GoRoutines related to connectivity
+	for i, _ := range X {
+		X[i].Run()
+	}
+
+	fmt.Printf("Waiting for start ...\n")
+	time.Sleep(time.Millisecond * 10)
 
 	// Connect. PROD: This should request connections. The
 	// connections can be accepted, rejected or never answered. Such
@@ -642,17 +888,33 @@ func main() {
 		X[i].RequestConnectionToAllMyPublisher()
 	}
 
+	fmt.Printf("Waiting for connections ...\n")
+	time.Sleep(time.Second * 1)
 
-	global_seqno2h := make(map[uint64] cipher.SHA256)
-	global_seqno2h_alt := make(map[uint64] cipher.SHA256)
+	global_seqno2h := make(map[uint64]cipher.SHA256)
+	global_seqno2h_alt := make(map[uint64]cipher.SHA256)
 
 	iter := 0
 	block_round := 0
 	done_processing_messages := false
 	for ; iter < Cfg_simu_num_iter; iter++ {
-		
+
+		if false {
+			fmt.Printf("Iteration %d\n", iter)
+		}
+
+		//fmt.Printf("Waiting for messages to propagate ...\n")
+		time.Sleep(time.Millisecond * 100)
+
 		if true {
 			if block_round < Cfg_simu_num_block_round {
+
+				if true {
+					t := time.Now()
+					fmt.Printf("wall_time=%02d:%02d:%02d"+
+						" block_round=%d\n", t.Hour(), t.Minute(), t.Second(),
+						block_round)
+				}
 
 				// NOTE: Propagating blocks from here is a
 				// simplification/HACK: it implies that we have
@@ -662,29 +924,28 @@ func main() {
 				// debugging and testing only.
 
 				//x := secp256k1.RandByte(888) // Random data in SIMU.
-				x := make([]byte, 888); mathrand.Read(x)
+				x := make([]byte, 888)
+				mathrand.Read(x)
 
-
-				h := cipher.SumSHA256(x)     // Its hash.
+				h := cipher.SumSHA256(x) // Its hash.
 
 				//x_alt := secp256k1.RandByte(888) // Random data in SIMU.
-				x_alt := make([]byte, 888); mathrand.Read(x)
+				x_alt := make([]byte, 888)
+				mathrand.Read(x)
 				h_alt := cipher.SumSHA256(x_alt) // Its hash.
 
 				global_seqno2h[hack_global_seqno] = h
 				global_seqno2h_alt[hack_global_seqno] = h_alt
 
-
 				indices := get_random_index_subset(Cfg_simu_num_node,
 					Cfg_simu_num_blockmaker)
 
 				if Cfg_debug_show_block_maker {
-					fmt.Printf("block_round=%d, Random indices of block-" +
-						"makers: %v\n",	block_round, indices)
+					fmt.Printf("block_round=%d, Random indices of block-"+
+						"makers: %v\n", block_round, indices)
 				}
 
-				n_forkers := int(Cfg_simu_prob_malicious*float64(len(indices)))
-
+				n_forkers := int(Cfg_simu_prob_malicious * float64(len(indices)))
 
 				for i := 0; i < len(indices); i++ {
 					// TODO: Have many nodes send same block, and a few nodes
@@ -706,7 +967,6 @@ func main() {
 					if duplicate {
 						rep = 2
 					}
-					
 
 					//
 					// WARNING: In a reslistic simulation, one would
@@ -714,7 +974,7 @@ func main() {
 					// properties such as 'hack_global_seqno'
 					//
 					if malicious {
-						fmt.Printf(">>>>>> NODE (index,pubkey)=(%d,%s) is" +
+						fmt.Printf(">>>>>> NODE (index,pubkey)=(%d,%s) is"+
 							" publishing ALTERNATIVE block\n", index,
 							nodePtr.Pubkey.Hex()[:8])
 					}
@@ -738,19 +998,29 @@ func main() {
 		}
 	}
 
-
-
+	fmt.Printf("Waiting to finish ...\n")
+	time.Sleep(time.Millisecond * 500)
 
 	zzz := "done"
 	if !done_processing_messages {
 		zzz = "***NOT done***"
 	}
 
-	fmt.Printf("Done (i) making Blocks, %s (ii) processing responses." +
-		" See stats on the next few lines. Used iterations=%d, unused" +
-		" iterations=%d. Exiting the event loop now.\n",
-		zzz, iter, Cfg_simu_num_iter - iter)
+	if false {
+		// [JSM] Do not call these FOR NOW: ConnectionPool does not
+		// implement shutdown correctly.
+		for i, _ := range X {
+			X[i].ShutdownPublishing()
+		}
+		for i, _ := range X {
+			X[i].ShutdownSubscribing()
+		}
+	}
 
+	fmt.Printf("Done (i) making Blocks, %s (ii) processing responses."+
+		" See stats on the next few lines. Used iterations=%d, unused"+
+		" iterations=%d. Exiting the event loop now.\n",
+		zzz, iter, Cfg_simu_num_iter-iter)
 
 	print_stat(X, iter)
 
@@ -761,9 +1031,10 @@ func main() {
 			fmt.Printf("\n")
 		}
 	}
-	
+
 	if Cfg_debug_node_summary {
 		Simulate_compare_node_StateQueue(X, global_seqno2h, global_seqno2h_alt)
 	}
 }
+
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/consensus/participant.go
+++ b/src/consensus/participant.go
@@ -1,0 +1,170 @@
+// 20160901 - Initial version by user johnstuartmill,
+// public key 02fb4acf944c84d48341e3c1cb14d707034a68b7f931d6be6d732bec03597d6ff6
+// 20161025 - Code revision by user johnstuartmill.
+package consensus
+
+import (
+	"fmt"
+	"github.com/skycoin/skycoin/src/cipher"
+)
+////////////////////////////////////////////////////////////////////////////////
+//
+// Struct ConsensusParticipant is inteneded to extend (or be contained in)
+// github.com/skycoin/skycoin/src/mesh*/node struct Node, so that
+// Node can participate in consensus.
+//
+////////////////////////////////////////////////////////////////////////////////
+type ConsensusParticipant struct {
+	Pubkey cipher.PubKey // Who we are
+	Seckey cipher.SecKey // For signing
+
+	pConnectionManager ConnectionManagerInterface
+
+	// The tail of Blockchain that I keep.
+	block_queue BlockchainTail
+
+	// Candidates Blocks.
+	block_stat_queue BlockStatQueue
+
+	Incoming_block_count int
+}
+func (self *ConsensusParticipant) GetConnectionManager() ConnectionManagerInterface {
+	return self.pConnectionManager
+}
+////////////////////////////////////////////////////////////////////////////////
+func (self *ConsensusParticipant) GetNextBlockSeqNo() uint64 {
+	return self.block_queue.GetNextSeqNo()
+}
+////////////////////////////////////////////////////////////////////////////////
+func (self *ConsensusParticipant) SetPubkeySeckey(
+	pubkey cipher.PubKey,
+	seckey cipher.SecKey) {
+
+	self.Pubkey, self.Seckey = pubkey, seckey
+	//self.pConnectionManager.SetPubkey(pubkey)
+}
+////////////////////////////////////////////////////////////////////////////////
+func (self *ConsensusParticipant) Print() {
+	fmt.Printf("ConsensusParticipant={pubkey=%s,block_msg_count=%d,",
+		self.Pubkey.Hex()[:8], self.Incoming_block_count)
+
+	self.pConnectionManager.Print()
+
+	fmt.Printf(",block_queue={")
+	self.block_queue.Print()
+	fmt.Printf("}")
+
+	fmt.Printf(",block_stat_queue={")
+	self.block_stat_queue.Print()
+	fmt.Printf("}")
+
+	fmt.Printf("}")
+}
+
+////////////////////////////////////////////////////////////////////////////////
+func NewConsensusParticipantPtr(pMan ConnectionManagerInterface) *ConsensusParticipant {
+
+	node := ConsensusParticipant{
+		pConnectionManager : pMan,
+		block_queue :  BlockchainTail{},
+		Incoming_block_count: 0,
+	}
+	node.block_queue.Init()
+	//node.block_stat_queue.Init()
+
+	// In PROD: each reads/loads the keys. In case the class does not
+	// expect to sign anything, SecKey should not be stored.
+
+	// In SIMU: generate random keys.
+	node.SetPubkeySeckey(cipher.GenerateKeyPair())
+
+	return &node
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Reasons for this function: 1st, we want to minimize exposure of
+// SecKey, even in same process space.  2nd, functions Sign and
+// SignHash already exist, so want keep search/browse/jump-to-tag
+// unambiguous.
+func (self *ConsensusParticipant) SignatureOf(hash cipher.SHA256) cipher.Sig {
+
+	// PERFORMANCE: This is expensive when cipher.DebugLevel2 or
+	// cipher.DebugLevel1 are true:
+	return cipher.SignHash(hash, self.Seckey)
+}
+////////////////////////////////////////////////////////////////////////////////
+func (self *ConsensusParticipant) Get_block_stat_queue_Len() int {
+	return self.block_stat_queue.Len()
+}
+////////////////////////////////////////////////////////////////////////////////
+func (self *ConsensusParticipant) Get_block_stat_queue_element_at(
+	j int) *BlockStat {
+
+	return self.block_stat_queue.queue[j] // A pointer, BTW
+}
+
+////////////////////////////////////////////////////////////////////////////////
+func (self *ConsensusParticipant) OnBlockHeaderArrived(blockPtr *BlockBase) {
+
+	self.Incoming_block_count += 1 // TODO: move this to try_add_hash_and_sig
+
+	res1 := self.block_stat_queue.try_append_to_BlockStatQueue(blockPtr)
+	if res1 == 0 {
+		self.harvest_ripe_BlockStat()
+		self.pConnectionManager.SendBlockToAllMySubscriber(blockPtr)
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+func (self *ConsensusParticipant) harvest_ripe_BlockStat() {
+
+	// POLICY: The BlockStat entries that have much smaller seqno
+	// than the most recent one, 'blockPtr.seqno', are converted
+	// to Blocks and appended to blockchain.
+	n := len(self.block_stat_queue.queue)
+	if n == 0 {
+		return
+	}
+
+	top_seqno := self.block_stat_queue.queue[n-1].seqno
+
+	for i := 0; i < n; i++ {
+		statPtr := self.block_stat_queue.queue[i]
+		if statPtr.seqno+
+			Cfg_consensus_waiting_time_as_seqno_diff <= top_seqno {
+
+			if !statPtr.frozen {
+				//
+				// BEG updating local blockchain
+				//
+
+				hash, _, sig := statPtr.GetBestHashPubkeySig()
+
+				blockPtr := &BlockBase{
+					Sig:   sig,
+					Hash:  hash,
+					Seqno: statPtr.seqno,
+				}
+				res := self.block_queue.try_append_to_BlockchainTail(blockPtr)
+				if res == 0 {
+					// TODO: 'frozen' items should be removed and the 'best'
+					// moved to BlockchainTail.
+					statPtr.frozen = true
+				} else {
+					// Appending did not work. Need to examine 'res'
+					// and log the reason why.
+					blockPtr = nil
+				}
+				//
+				// END updating local blockchain
+				//
+
+			}
+
+		} else {
+			break // The rest are not ripe yet
+		}
+	}
+
+}
+////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
1. Done splitting file consensus.go into several files and re-factoring. Main algorithm for consensus is unchanged.
2. Revised consensus-related interfaces, and simplified them.
3. New functionality: file consensus/example*/example_gnet.go. This is a runnable file. It shows how to connect  ConsesusParticipant nodes via TPC/IP transport.
4. The nodes generate hashes (of blocks), propagate them over the mesh network, and negotiate the consensus. Malicious nodes can be optionally introduces, and the convergence of the consensus algorithm can be examined. This was available since about 2016/10/22 with function calls as transport; this version intruduces TCP/IP as transport.

John Stuart Mill.
