### PR TITLE
Fixed the wallet grid as suggested.

### DIFF
--- a/src/gui/static/src/app/templates/wallet.html
+++ b/src/gui/static/src/app/templates/wallet.html
@@ -56,38 +56,40 @@
                     <button class="btn btn-default" type="button" (click)="openLoadWallet()"><i class="fa fa-circle-o"></i> Load Wallet From Seed</button>
                 </div>
                   <table id="overview-wallet" class="outline" >
-                      <thead>
-                      <tr class="dark-row">
-                        <td style="width:30px;"></td>
-                        <td>Label</td>
-                        <td>Address</td>
-                        <td>Address Balance</td>
-                        <td>Wallet Balance</td>
-                        <td class="text-right">Addresses</td>
-                      </tr>
-                    </thead>
+                        <thead>
+                        <tr class="dark-row">
+                            <td style="width:30px;"></td>
+                            <td>Label</td>
+                            <td>Address</td>
+                            <td class="text-center" colspan="2">Balance</td>
+                            <td class="text-center" colspan="2">Addresses</td>
+                        </tr>
+                        </thead>
                         <tbody *ngFor="let wallet of wallets">
-                          <tr>
+                        <tr>
                             <td>
-                              <a href="#" (click)="toggleShowChild(wallet)" *ngIf="!wallet.showChild"><i class="fa fa-angle-right"></i></a>
-                              <a href="#" (click)="toggleShowChild(wallet)" *ngIf="wallet.showChild"><i class="fa fa-angle-down"></i></a>
+                                <a href="#" (click)="toggleShowChild(wallet)" *ngIf="!wallet.showChild"><i class="fa fa-angle-right"></i></a>
+                                <a href="#" (click)="toggleShowChild(wallet)" *ngIf="wallet.showChild"><i class="fa fa-angle-down"></i></a>
                             </td>
                             <td><a href="#" (click)="editWallet(wallet)"><i class="fa fa-edit"></i></a>&nbsp;{{wallet.meta.label?wallet.meta.label:'Undefined'}}</td>
-                            <td><a href="#" (click)="showQR(wallet)">&nbsp;<i class="fa fa-qrcode"></i></a>&nbsp;{{wallet.entries[0].address}}</td>
-                            <td><a href="#" (click)="switchTab(displayModeEnum.second, wallet)" ><i class="fa fa-cloud-upload"></i></a>&nbsp;{{wallet.entries[0].balance}} SKY</td>
-                            <td><a href="#" (click)="switchTab(displayModeEnum.second, wallet)" ><i class="fa fa-cloud-upload"></i></a>&nbsp;{{wallet.balance}} SKY</td>
-                            <td class="text-right">{{wallet.entries.length}}&nbsp;<a href="#" (click)="addNewAddress(wallet)"><i class="fa fa-plus"></i></a></td>
-                          </tr>
-                          <tr *ngFor="let entry of wallet.entries; let idx=index" [hidden]="!wallet.showChild||idx==0">
                             <td></td>
-                            <td><a href="#" (click)="editWallet(wallet)"><i class="fa fa-edit"></i></a>&nbsp;{{wallet.meta.label?wallet.meta.label:'Undefined'}}({{idx}})</td>
-                            <td><a href="#" (click)="showQR(wallet)">&nbsp;<i class="fa fa-qrcode"></i></a>&nbsp;{{entry.address}}</td>
+                            <td class="text-right"><a href="#" (click)="switchTab(displayModeEnum.second, wallet)" ><i class="fa fa-cloud-upload"></i></a>&nbsp;</td>
+                            <td class="text-left">{{wallet.entries[0].balance}} SKY</td>
+                            <td class="text-right">{{wallet.entries.length}}&nbsp;</td>
+                            <td class="text-right">
+                                <a href="#" (click)="addNewAddress(wallet)"><i class="fa fa-plus add-address"></i></a></td>
+                        </tr>
+                        <tr *ngFor="let entry of wallet.entries; let idx=index" [hidden]="!wallet.showChild" style="background-color: #f4f5f6">
+                            <td></td>
+                            <td class="text-center">  {{idx+1}}</td>
+                            <td><a href="#" (click)="showQR(wallet)"><i class="fa " aria-hidden="true"></i>&nbsp;<i class="fa fa-qrcode"></i></a>&nbsp;{{entry.address}}</td>
+                            <td></td>
                             <td><a href="#" (click)="switchTab(displayModeEnum.second, wallet)" ><i class="fa fa-cloud-upload"></i></a>&nbsp;{{entry.balance?entry.balance:0}} SKY</td>
                             <td></td>
-                            <td class="text-right"></td>
-                          </tr>
-                      </tbody>
-                  </table>
+                            <td></td>
+                        </tr>
+                        </tbody>
+                    </table>
                   <!-- historyPager -->
               </div>
             </div>


### PR DESCRIPTION
The PR contains following.

- Every wallet has its own row now.
- Each address resides inside a wallet now and would appear when the user expands the wallet.
- Removed the address label from wallet.
- Removed the redundant column and changed the label of the new.
- Each address now has index starting from 1.
- Each row has balance which is slightly indented to right.
- Each address row now has a different color to stand out.
- The (+) button is now placed at the end of the row and has enough spacing.
- When a new wallet is added that has 1 address, a set is inserted at the bottom upon click of which the address gets revealed.

Will work on other details in next PR.


