### PR TITLE
adding build job in gulp

### DIFF
--- a/src/gui/static/gulpfile.ts
+++ b/src/gui/static/gulpfile.ts
@@ -14,6 +14,10 @@ gulp.task('clean', (cb) => {
     return del(["dist"], cb);
 });
 
+gulp.task('clean_dev', (cb) => {
+    return del(["dev"], cb);
+});
+
 /**
  * Lint all custom TypeScript files.
  */
@@ -35,12 +39,26 @@ gulp.task("compile", ["tslint"], () => {
         .pipe(gulp.dest("dist"));
 });
 
+gulp.task("compile_dev", ["tslint"], () => {
+    let tsResult = gulp.src("src/**/*.ts")
+        .pipe(sourcemaps.init())
+        .pipe(tsc(tsProject));
+    return tsResult.js
+        .pipe(sourcemaps.write("."))
+        .pipe(gulp.dest("dev"));
+});
+
 /**
  * Copy all resources that are not TypeScript files into build directory.
  */
 gulp.task("resources", () => {
     return gulp.src(["src/**/*", "!**/*.ts"])
         .pipe(gulp.dest("dist"));
+});
+
+gulp.task("resources_dev", () => {
+    return gulp.src(["src/**/*", "!**/*.ts"])
+        .pipe(gulp.dest("dev"));
 });
 
 /**
@@ -59,6 +77,19 @@ gulp.task("libs", () => {
         .pipe(gulp.dest("dist/lib"));
 });
 
+gulp.task("libs_dev", () => {
+    return gulp.src([
+        'es6-shim/es6-shim.min.js',
+        'systemjs/dist/system-polyfills.js',
+        'systemjs/dist/system.src.js',
+        'reflect-metadata/Reflect.js',
+        'rxjs/**',
+        'zone.js/dist/**',
+        '@angular/**'
+    ], {cwd: "node_modules/**"}) /* Glob required here. */
+        .pipe(gulp.dest("dev/lib"));
+});
+
 /**
  * Watch for changes in TypeScript, HTML and CSS files.
  */
@@ -75,5 +106,9 @@ gulp.task('watch', function () {
  * Build the project.
  */
 gulp.task("dist", ['compile', 'resources', 'libs'], () => {
+    console.log("Building the project ...");
+});
+
+gulp.task("build", ['clean_dev', 'compile_dev', 'resources_dev', 'libs_dev'], () => {
     console.log("Building the project ...");
 });


### PR DESCRIPTION
added the missing "build job" in the current gulp tasks.
now the gulp --tasks has.
├── clean
├── clean_dev
├── tslint
├─┬ compile
│ └── tslint
├─┬ compile_dev
│ └── tslint
├── resources
├── resources_dev
├── libs
├── libs_dev
├── watch
├─┬ dist
│ ├── compile
│ ├── resources
│ └── libs
└─┬ build
       ├── clean_dev
       ├── compile_dev
       ├── resources_dev
       └── libs_dev
