### PR TITLE
Add options for creating wallet

### DIFF
--- a/src/api/cli/generate_wallet.go
+++ b/src/api/cli/generate_wallet.go
@@ -113,7 +113,7 @@ func generateWallet(c *gcli.Context) error {
 	if err != nil {
 		return err
 	}
-	wlt := wallet.NewWallet(sd, wltName, label)
+	wlt := wallet.NewWallet(wltName, wallet.OptLabel(label), wallet.OptSeed(sd))
 	wlt.GenerateAddresses(int(num))
 
 	// check if the wallet dir does exist.

--- a/src/gui/wallet.go
+++ b/src/gui/wallet.go
@@ -41,11 +41,13 @@ type WalletRPC struct {
 //use a global for now
 var Wg *WalletRPC
 
-func InitWalletRPC(walletDir string) {
-	Wg = NewWalletRPC(walletDir)
+// InitWalletRPC init wallet rpc
+func InitWalletRPC(walletDir string, options ...wallet.Option) {
+	Wg = NewWalletRPC(walletDir, options...)
 }
 
-func NewWalletRPC(walletDir string) *WalletRPC {
+// NewWalletRPC new wallet rpc
+func NewWalletRPC(walletDir string, options ...wallet.Option) *WalletRPC {
 	rpc := &WalletRPC{}
 
 	if err := os.MkdirAll(walletDir, os.FileMode(0700)); err != nil {
@@ -62,7 +64,7 @@ func NewWalletRPC(walletDir string) *WalletRPC {
 
 	if len(rpc.Wallets) == 0 {
 		wltName := wallet.NewWalletFilename()
-		rpc.CreateWallet("", wltName, "")
+		rpc.CreateWallet("", wltName, "", options...)
 
 		if err := rpc.SaveWallet(wltName); err != nil {
 			log.Panicf("Failed to save wallets to %s: %v", rpc.WalletDirectory, err)
@@ -100,8 +102,8 @@ func (self *WalletRPC) SaveWallets() map[string]error {
 	return self.Wallets.Save(self.WalletDirectory)
 }
 
-func (self *WalletRPC) CreateWallet(seed, wltName, label string) (wallet.Wallet, error) {
-	w := wallet.NewWallet(seed, wltName, label)
+func (self *WalletRPC) CreateWallet(seed, wltName, label string, options ...wallet.Option) (wallet.Wallet, error) {
+	w := wallet.NewWallet(seed, wltName, label, options...)
 	// generate a default address
 	w.GenerateAddresses(1)
 

--- a/src/wallet/deterministic.go
+++ b/src/wallet/deterministic.go
@@ -31,20 +31,15 @@ type Option func(w *Wallet)
 
 // NewWallet generates Deterministic Wallet
 // generates a random seed if seed is ""
-func NewWallet(seed, wltName, label string, opts ...Option) Wallet {
-	//if seed is blank, generate a new seed
-	if seed == "" {
-		seedRaw := cipher.SumSHA256(secp256k1.RandByte(64))
-		seed = hex.EncodeToString(seedRaw[:])
-	}
+func NewWallet(wltName string, opts ...Option) Wallet {
+	seedRaw := cipher.SumSHA256(secp256k1.RandByte(64))
+	seed := hex.EncodeToString(seedRaw[:])
 
-	// generate the first address.
-	// pub, sec := cipher.GenerateDeterministicKeyPair([]byte(seed[:]))
 	w := Wallet{
 		Meta: map[string]string{
 			"filename": wltName,
 			"version":  version,
-			"label":    label,
+			"label":    "",
 			"seed":     seed,
 			"lastSeed": seed,
 			"tm":       fmt.Sprintf("%v", time.Now().Unix()),
@@ -59,10 +54,27 @@ func NewWallet(seed, wltName, label string, opts ...Option) Wallet {
 	return w
 }
 
-// Coin NewWallet function's optional argument
-func Coin(coin string) Option {
+// OptCoin NewWallet function's optional argument
+func OptCoin(coin string) Option {
 	return func(w *Wallet) {
 		w.Meta["coin"] = coin
+	}
+}
+
+// OptLabel NewWallet function's optional argument
+func OptLabel(label string) Option {
+	return func(w *Wallet) {
+		w.Meta["label"] = label
+	}
+}
+
+// OptSeed NewWallet function's optional argument
+func OptSeed(sd string) Option {
+	return func(w *Wallet) {
+		if sd != "" {
+			w.Meta["seed"] = sd
+			w.Meta["lastSeed"] = sd
+		}
 	}
 }
 

--- a/src/wallet/deterministic.go
+++ b/src/wallet/deterministic.go
@@ -26,9 +26,12 @@ type Wallet struct {
 
 var version = "0.1"
 
+// Option NewWallet optional arguments type
+type Option func(w *Wallet)
+
 // NewWallet generates Deterministic Wallet
 // generates a random seed if seed is ""
-func NewWallet(seed, wltName, label string) Wallet {
+func NewWallet(seed, wltName, label string, opts ...Option) Wallet {
 	//if seed is blank, generate a new seed
 	if seed == "" {
 		seedRaw := cipher.SumSHA256(secp256k1.RandByte(64))
@@ -37,7 +40,7 @@ func NewWallet(seed, wltName, label string) Wallet {
 
 	// generate the first address.
 	// pub, sec := cipher.GenerateDeterministicKeyPair([]byte(seed[:]))
-	return Wallet{
+	w := Wallet{
 		Meta: map[string]string{
 			"filename": wltName,
 			"version":  version,
@@ -47,6 +50,19 @@ func NewWallet(seed, wltName, label string) Wallet {
 			"tm":       fmt.Sprintf("%v", time.Now().Unix()),
 			"type":     "deterministic",
 			"coin":     "sky"},
+	}
+
+	for _, opt := range opts {
+		opt(&w)
+	}
+
+	return w
+}
+
+// Coin NewWallet function's optional argument
+func Coin(coin string) Option {
+	return func(w *Wallet) {
+		w.Meta["coin"] = coin
 	}
 }
 

--- a/src/wallet/deterministic.go
+++ b/src/wallet/deterministic.go
@@ -130,13 +130,13 @@ func (wlt Wallet) Validate() error {
 		return errors.New("wallet type invalid")
 	}
 
-	coinType, ok := wlt.Meta["coin"]
-	if !ok {
+	// coinType, ok := wlt.Meta["coin"]
+	if _, ok := wlt.Meta["coin"]; !ok {
 		return errors.New("coin field not set")
 	}
-	if coinType != "sky" {
-		return errors.New("coin type invalid")
-	}
+	// if coinType != "sky" {
+	// 	return errors.New("coin type invalid")
+	// }
 
 	return nil
 


### PR DESCRIPTION
When creating wallet, the default wallet meta data and settings will be used if no options are set, otherwise the settings may be changed by the option.