### PR TITLE
transport ACKs, statuses, simulated delays, tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,5 +103,6 @@ electron/.standalone_output
 .vscode/
 
 src/mesh/examples/integration/integration
+src/mesh2/TODO
 
 .idea/

--- a/src/mesh2/messages/interfaces.go
+++ b/src/mesh2/messages/interfaces.go
@@ -7,6 +7,7 @@ import (
 type NodeInterface interface {
 	GetId() cipher.PubKey
 	InjectTransportMessage(transportId TransportId, msg []byte)
+	SetTransport(TransportId, TransportInterface)
 }
 
 type TransportInterface interface {

--- a/src/mesh2/messages/messages.go
+++ b/src/mesh2/messages/messages.go
@@ -64,6 +64,7 @@ type OutRouteMessage struct {
 //simulates one end of a transport, sending data to other end of the pair
 type TransportDatagramTransfer struct {
 	//put seq number for confirmation/ACK
+	RouteId  RouteId
 	Sequence uint32 //sequential sequence number of ACK
 	Datagram []byte
 }

--- a/src/mesh2/messages/messages_test.go
+++ b/src/mesh2/messages/messages_test.go
@@ -24,11 +24,12 @@ func TestSerialize(t *testing.T) {
 	assert.Equal(t, msg.Datagram, msg1.Datagram)
 
 	sequence := (uint32)(rand.Intn(65536))
-	msg2 := TransportDatagramTransfer{sequence, datagram}
+	msg2 := TransportDatagramTransfer{RandRouteId(), sequence, datagram}
 	serialized = Serialize((uint16)(MsgTransportDatagramTransfer), msg2)
 	msg3 := TransportDatagramTransfer{}
 	err = Deserialize(serialized, &msg3)
 	assert.Nil(t, err)
+	assert.Equal(t, msg2.RouteId, msg3.RouteId)
 	assert.Equal(t, msg2.Sequence, msg3.Sequence)
 	assert.Equal(t, msg2.Datagram, msg3.Datagram)
 

--- a/src/mesh2/node/node_test.go
+++ b/src/mesh2/node/node_test.go
@@ -35,11 +35,9 @@ func TestAddRoute(t *testing.T) {
 	node1.Tick() // run channels consuming
 
 	tf := transport.NewTransportFactory()
-	transport1, transport2 := tf.CreateStubTransportPair()
-	transport1.AttachedNode = node1
-	transport2.AttachedNode = node2
-	tid1 := transport1.Id
-	node1.Transports[tid1] = transport1
+	tf.ConnectNodeToNode(node1, node2)
+	tr1, _ := tf.GetTransports()
+	tid1 := tr1.Id
 
 	routeId := messages.RandRouteId()
 
@@ -65,11 +63,7 @@ func TestRemoveRoute(t *testing.T) {
 	node1.Tick() // run channels consuming
 
 	tf := transport.NewTransportFactory()
-	transport1, transport2 := tf.CreateStubTransportPair()
-	transport1.AttachedNode = node1
-	transport2.AttachedNode = node2
-	tid1 := transport1.Id
-	node1.Transports[tid1] = transport1
+	tf.ConnectNodeToNode(node1, node2)
 
 	routeId := messages.RandRouteId()
 

--- a/src/mesh2/node_manager/node_manager.go
+++ b/src/mesh2/node_manager/node_manager.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/skycoin/skycoin/src/cipher"
-	"github.com/skycoin/skycoin/src/mesh2/messages"
 	"github.com/skycoin/skycoin/src/mesh2/node"
 	"github.com/skycoin/skycoin/src/mesh2/transport"
 )
@@ -56,31 +55,25 @@ func (self *NodeListT) Tick() {
 	}
 }
 
-func (self *NodeManager) ConnectNodeToNode(idA, idB cipher.PubKey) (messages.TransportId, messages.TransportId) {
+func (self *NodeManager) ConnectNodeToNode(idA, idB cipher.PubKey) *transport.TransportFactory {
 	if idA == idB {
 		fmt.Println("Cannot connect node to itself")
-		return (messages.TransportId)(0), (messages.TransportId)(0)
+		return &transport.TransportFactory{}
 	}
 	nodes := self.NodeList.nodes
 	nodeA, found := nodes[idA]
 	if !found {
 		fmt.Println("Cannot find node with ID", idA)
-		return (messages.TransportId)(0), (messages.TransportId)(0)
+		return &transport.TransportFactory{}
 	}
 	nodeB, found := nodes[idB]
 	if !found {
 		fmt.Println("Cannot find node with ID", idB)
-		return (messages.TransportId)(0), (messages.TransportId)(0)
+		return &transport.TransportFactory{}
 	}
 
 	tf := transport.NewTransportFactory()
-	transportA, transportB := tf.CreateStubTransportPair()
-	transportA.AttachedNode = nodeA
-	tidA := transportA.Id
-	transportB.AttachedNode = nodeB
-	tidB := transportB.Id
-	nodeA.Transports[tidA] = transportA
-	nodeB.Transports[tidB] = transportB
+	tf.ConnectNodeToNode(nodeA, nodeB)
 	go tf.Tick()
-	return tidA, tidB
+	return tf
 }

--- a/src/mesh2/transport/transport.go
+++ b/src/mesh2/transport/transport.go
@@ -2,18 +2,21 @@ package transport
 
 import (
 	"fmt"
+	"math/rand"
+	"time"
+
 	"github.com/skycoin/skycoin/src/mesh2/messages"
 )
 
 //Stub Transport
 
 //TODO:
-// - implement simulated "delay" for transport
+// - implement simulated "delay" for transport +
 // - implement simulated out of order packet delivery
 // - implement simulated packet drop
 // - implement real UDP trasport
-// - implement status "connected/disconnected"
-// - implement ACKs
+// - implement status "connected/disconnected" +
+// - implement ACKs +
 
 // TODO:
 // pendingOut channel may need to be on the transport factory itself
@@ -22,24 +25,40 @@ import (
 // - may be more efficient to replace pending out, with an array on TransportFactory
 // - or with array on the transport (who is responsible for processing ACKs?)
 
+const (
+	TIMEOUT   uint32 = 1000 // time for ack waiting
+	CONNECTED        = iota
+	DISCONNECTED
+)
+
 //This is stub transport
 type Transport struct {
 	Id              messages.TransportId
 	IncomingChannel chan ([]byte)
 	PendingOut      chan ([]byte) //messages to send to other end of transport
 	//Note: PendingOut channel may need to be on the transport_factory
+	ackChannels map[string]chan ([]byte)
 
 	AttachedNode messages.NodeInterface //node the transport is attached to
 
-	StubPair *Transport //this is the other transport stub pair
+	StubPair         *Transport //this is the other transport stub pair
+	PacketsSent      uint32
+	PacketsConfirmed uint32 // last confirmed ack
+
+	Status uint8
+
+	MaxSimulatedDelay int // stub for testing
 }
 
 //are created by the factories
 func (self *Transport) NewTransportStub() {
-	fmt.Printf("Created Transport:\n")
 	self.IncomingChannel = make(chan []byte, 1024)
-	//self.PendingOut = make(chan []byte, 1024)
+	self.PendingOut = make(chan []byte, 1024)
+	self.ackChannels = make(map[string]chan []byte)
 	self.Id = messages.RandTransportId()
+	self.Status = DISCONNECTED
+	self.MaxSimulatedDelay = 1000
+	fmt.Printf("Created Transport: %d\n", self.Id)
 }
 
 func (self *Transport) Shutdown() {
@@ -49,38 +68,116 @@ func (self *Transport) Shutdown() {
 //move node forward on tick, process events
 func (self *Transport) Tick() {
 	//process incoming messages
-	fmt.Println("tick")
+	go self.sendFromPending() // for testing purposes
+	go self.receiveIncoming() // receiving messages
+}
+
+func (self *Transport) receiveIncoming() {
+	seed := time.Now().UnixNano()
+	rand.Seed(seed)
 	for msg := range self.IncomingChannel {
+		if self.Status == DISCONNECTED {
+			break
+		}
 		//process our incoming messages
 		fmt.Printf("\ntransport with id %d gets message %d\n\n", self.Id, msg)
 
 		switch messages.GetMessageType(msg) {
 
-		//OutRouteMessage is the only message coming in to node from transports
+		//OutRouteMessage is the only message coming in to transports from node
 		//Node -> Transport message
 		case messages.MsgOutRouteMessage:
 
 			var m1 messages.OutRouteMessage
-			messages.Deserialize(msg, &m1)
-			//get message and put into the queue to be sent out
-			//prime message for transit between the two transport ends
-			var m1b messages.TransportDatagramTransfer
-			m1b.Datagram = m1.Datagram
-			b1 := messages.Serialize(messages.MsgTransportDatagramTransfer, &m1b)
-			self.PendingOut <- b1 //push to queue, to be transferred
+			err := messages.Deserialize(msg, &m1)
+			if err != nil {
+				panic(err)
+			}
+			self.sendTransportDatagramTransfer(&m1)
 
 		//Transport -> Transport messag
 		case messages.MsgTransportDatagramTransfer:
-			var m2 messages.OutRouteMessage
-			messages.Deserialize(msg, m2)
 
+			var m2 messages.TransportDatagramTransfer
+			err := messages.Deserialize(msg, &m2)
+			if err != nil {
+				panic(err)
+			}
+			self.sendAck(&msg, &m2)
+
+		default:
+			fmt.Println("incorrect message type for transport input")
 		}
+	}
+}
+
+func (self *Transport) sendTransportDatagramTransfer(msg *messages.OutRouteMessage) {
+	//get message and put into the queue to be sent out
+	//prime message for transit between the two transport ends
+	self.PacketsSent++
+	var m1b messages.TransportDatagramTransfer
+	m1b.Datagram = msg.Datagram
+	m1b.Sequence = self.PacketsSent
+	m1b.RouteId = msg.RouteId
+
+	b1 := messages.Serialize(messages.MsgTransportDatagramTransfer, m1b)
+	self.PendingOut <- b1 //push to queue, to be transferred
+}
+
+func (self *Transport) sendAck(msg *[]byte, m2 *messages.TransportDatagramTransfer) {
+	routeId := m2.RouteId
+	sequence := m2.Sequence
+	datagram := m2.Datagram
+
+	msgToNode := messages.InRouteMessage{self.Id, routeId, datagram}
+	serialized := messages.Serialize(messages.MsgInRouteMessage, msgToNode)
+	self.InjectNodeMessage(serialized)
+
+	time.Sleep(time.Duration(rand.Intn(self.MaxSimulatedDelay)) * time.Millisecond) // simulating delay, testing purposes!
+
+	ackMsg := messages.TransportDatagramACK{sequence, 0}
+	ackSerialized := messages.Serialize(messages.MsgTransportDatagramACK, ackMsg)
+	ackChannel := self.StubPair.ackChannels[string(*msg)]
+	ackChannel <- ackSerialized
+}
+
+func (self *Transport) receiveAck(msg []byte) {
+	var m3 messages.TransportDatagramACK
+	err := messages.Deserialize(msg, &m3)
+	if err != nil {
+		fmt.Println("incorrect ACK message")
+	} else {
+		lowestSequence := m3.LowestSequence
+		if lowestSequence > self.PacketsConfirmed {
+			self.PacketsConfirmed = lowestSequence
+		}
+		fmt.Printf("transport %d sent %d packets and got %d acks\n", self.Id, self.PacketsSent, self.PacketsConfirmed)
+	}
+}
+
+func (self *Transport) sendFromPending() {
+	for msg := range self.PendingOut {
+		ackChannel := make(chan []byte, 1024)
+		self.ackChannels[string(msg)] = ackChannel
+		self.SendMessageToStubPair(msg)
+		select {
+		case ack := <-ackChannel:
+			self.receiveAck(ack)
+		case <-time.After(time.Duration(TIMEOUT) * time.Millisecond):
+			fmt.Printf("transport %d isn't responding\n", self.StubPair.Id)
+			self.Status, self.StubPair.Status = DISCONNECTED, DISCONNECTED
+			break
+		}
+		close(ackChannel)
+		delete(self.ackChannels, string(msg))
 	}
 }
 
 //inject an incoming message from the transport
 func (self *Transport) InjectNodeMessage(msg []byte) {
-	self.AttachedNode.InjectTransportMessage(self.Id, msg)
+	if self.AttachedNode != nil {
+		self.AttachedNode.InjectTransportMessage(self.Id, msg)
+	}
 }
 
 //message from stub to stub

--- a/src/mesh2/transport/transport_test.go
+++ b/src/mesh2/transport/transport_test.go
@@ -1,0 +1,34 @@
+package transport
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skycoin/src/mesh2/messages"
+)
+
+func TestCreateStubPair(t *testing.T) {
+	tf := NewTransportFactory()
+	assert.Len(t, tf.TransportList, 0, "Should be 0 transports")
+	t1, t2 := tf.CreateStubTransportPair()
+	assert.Len(t, tf.TransportList, 2, "Should be 2 transports")
+	assert.Equal(t, t1.Id, t2.StubPair.Id)
+	assert.Equal(t, t2.Id, t1.StubPair.Id)
+	fmt.Println("====\n")
+}
+
+func TestAck(t *testing.T) {
+	tf := NewTransportFactory()
+	t1, _ := tf.CreateStubTransportPair()
+	go tf.Tick()
+	time.Sleep(1 * time.Second)
+	for i := 0; i < 10; i++ {
+		tdt := messages.OutRouteMessage{messages.RandRouteId(), []byte{'t', 'e', 's', 't'}}
+		t1.sendTransportDatagramTransfer(&tdt)
+	}
+	time.Sleep(10 * time.Second)
+	assert.Equal(t, t1.PacketsSent, t1.PacketsConfirmed)
+
+}


### PR DESCRIPTION
transport ACKS, simulated delays and statuses implemented; to check messages and acks sending and receiving I've simulated closed cycle with 3 nodes in node_manager_test.go (which is forced to be finished in 10 seconds).Transport statuses so far are CONNECTED and DISCONNECTED. transport.go refactored, transport factory got new methods ConnectNodeToNode and GetTransports, transport_test.go is created with 2 tests.
