### PR TITLE
Update outputs api result and avoid double spending in CLI send command

### DIFF
--- a/src/api/cli/check_balance.go
+++ b/src/api/cli/check_balance.go
@@ -9,16 +9,17 @@ import (
 	"strings"
 
 	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/visor"
 	"github.com/skycoin/skycoin/src/wallet"
 	gcli "github.com/urfave/cli"
 )
 
 type unspentOut struct {
-	Hash              string `json:"txid"` //hash uniquely identifies transaction
-	SourceTransaction string `json:"src_tx"`
-	Address           string `json:"address"`
-	Coins             string `json:"coins"`
-	Hours             uint64 `json:"hours"`
+	visor.ReadableOutput
+}
+
+type unspentOutSet struct {
+	visor.ReadableOutputSet
 }
 
 type balance struct {
@@ -149,7 +150,7 @@ func getAddrsBalance(addrs []string) (balanceResult, error) {
 		return -1, errors.New("not exist")
 	}
 
-	for _, o := range outs {
+	for _, o := range outs.HeadOutputs {
 		amt, err := strconv.ParseUint(o.Coins, 10, 64)
 		if err != nil {
 			return balanceResult{}, errors.New("error coins string")

--- a/src/api/cli/create_rawtx.go
+++ b/src/api/cli/create_rawtx.go
@@ -305,7 +305,13 @@ func makeTx(inAddrs []string, chgAddr string, toAddr string, amt uint64, wlt *wa
 		return "", err
 	}
 
-	outs, err := getSufficientUnspents(unspents, amt)
+	spdouts := unspents.SpendableOutputs()
+	spendableOuts := make([]unspentOut, len(spdouts))
+	for i := range spdouts {
+		spendableOuts[i] = unspentOut{spdouts[i]}
+	}
+
+	outs, err := getSufficientUnspents(spendableOuts, amt)
 	if err != nil {
 		return "", err
 	}

--- a/src/api/webrpc/gateway.go
+++ b/src/api/webrpc/gateway.go
@@ -15,7 +15,7 @@ type Gatewayer interface {
 	GetLastBlocks(num uint64) *visor.ReadableBlocks
 	GetBlocks(start, end uint64) *visor.ReadableBlocks
 	GetBlocksInDepth(vs []uint64) *visor.ReadableBlocks
-	GetUnspentOutputs(filters ...daemon.OutputsFilter) []visor.ReadableOutput
+	GetUnspentOutputs(filters ...daemon.OutputsFilter) visor.ReadableOutputSet
 	GetTransaction(txid cipher.SHA256) (*visor.TransactionResult, error)
 	InjectTransaction(tx coin.Transaction) (coin.Transaction, error)
 	GetAddrUxOuts(addr cipher.Address) ([]*historydb.UxOutJSON, error)

--- a/src/api/webrpc/gateway.go
+++ b/src/api/webrpc/gateway.go
@@ -3,6 +3,7 @@ package webrpc
 import (
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/coin"
+	"github.com/skycoin/skycoin/src/daemon"
 	"github.com/skycoin/skycoin/src/visor"
 	"github.com/skycoin/skycoin/src/visor/historydb"
 )
@@ -14,8 +15,7 @@ type Gatewayer interface {
 	GetLastBlocks(num uint64) *visor.ReadableBlocks
 	GetBlocks(start, end uint64) *visor.ReadableBlocks
 	GetBlocksInDepth(vs []uint64) *visor.ReadableBlocks
-	GetUnspentByAddrs(addrs []string) []visor.ReadableOutput
-	GetUnspentByHashes(hashes []string) []visor.ReadableOutput
+	GetUnspentOutputs(filters ...daemon.OutputsFilter) []visor.ReadableOutput
 	GetTransaction(txid cipher.SHA256) (*visor.TransactionResult, error)
 	InjectTransaction(tx coin.Transaction) (coin.Transaction, error)
 	GetAddrUxOuts(addr cipher.Address) ([]*historydb.UxOutJSON, error)

--- a/src/api/webrpc/gatewayer_mock_test.go
+++ b/src/api/webrpc/gatewayer_mock_test.go
@@ -11,6 +11,7 @@ import (
 
 	cipher "github.com/skycoin/skycoin/src/cipher"
 	coin "github.com/skycoin/skycoin/src/coin"
+	daemon "github.com/skycoin/skycoin/src/daemon"
 	visor "github.com/skycoin/skycoin/src/visor"
 	historydb "github.com/skycoin/skycoin/src/visor/historydb"
 )
@@ -150,33 +151,15 @@ func (m *GatewayerMock) GetTransaction(p0 cipher.SHA256) (*visor.TransactionResu
 
 }
 
-// GetUnspentByAddrs mocked method
-func (m *GatewayerMock) GetUnspentByAddrs(p0 []string) []visor.ReadableOutput {
+// GetUnspentOutputs mocked method
+func (m *GatewayerMock) GetUnspentOutputs(p0 ...daemon.OutputsFilter) visor.ReadableOutputSet {
 
 	ret := m.Called(p0)
 
-	var r0 []visor.ReadableOutput
+	var r0 visor.ReadableOutputSet
 	switch res := ret.Get(0).(type) {
 	case nil:
-	case []visor.ReadableOutput:
-		r0 = res
-	default:
-		panic(fmt.Sprintf("unexpected type: %v", res))
-	}
-
-	return r0
-
-}
-
-// GetUnspentByHashes mocked method
-func (m *GatewayerMock) GetUnspentByHashes(p0 []string) []visor.ReadableOutput {
-
-	ret := m.Called(p0)
-
-	var r0 []visor.ReadableOutput
-	switch res := ret.Get(0).(type) {
-	case nil:
-	case []visor.ReadableOutput:
+	case visor.ReadableOutputSet:
 		r0 = res
 	default:
 		panic(fmt.Sprintf("unexpected type: %v", res))

--- a/src/api/webrpc/outputs.go
+++ b/src/api/webrpc/outputs.go
@@ -10,7 +10,7 @@ import (
 )
 
 type OutputsResult struct {
-	Outputs []visor.ReadableOutput `json:"outputs"`
+	Outputs visor.ReadableOutputSet `json:"outputs"`
 }
 
 func getOutputsHandler(req Request, gateway Gatewayer) Response {

--- a/src/api/webrpc/outputs.go
+++ b/src/api/webrpc/outputs.go
@@ -1,9 +1,13 @@
 package webrpc
 
-import "strings"
-import "github.com/skycoin/skycoin/src/cipher"
-import "fmt"
-import "github.com/skycoin/skycoin/src/visor"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/daemon"
+	"github.com/skycoin/skycoin/src/visor"
+)
 
 type OutputsResult struct {
 	Outputs []visor.ReadableOutput `json:"outputs"`
@@ -30,6 +34,6 @@ func getOutputsHandler(req Request, gateway Gatewayer) Response {
 		}
 	}
 
-	outs := gateway.GetUnspentByAddrs(addrs)
+	outs := gateway.GetUnspentOutputs(daemon.FbyAddresses(addrs))
 	return makeSuccessResponse(req.ID, OutputsResult{outs})
 }

--- a/src/api/webrpc/outputs_test.go
+++ b/src/api/webrpc/outputs_test.go
@@ -10,32 +10,44 @@ import (
 )
 
 var outputStr = `{
-       "outputs": [
-            {
-                "txid": "0ccc33d0f771b60c95e660745a1b1a92f9dc29f50bdf28d81755cdd3466caf41",
-                "src_tx": "5d4f0397d0f7278d70a81623cc5e3899e65a8b9063d61e15a908657189855082",
-                "address": "cBnu9sUvv12dovBmjQKTtfE4rbjMmf3fzW",
-                "coins": "6",
-                "hours": 430
-            },
-            {
-                "txid": "574d7e5afaefe4ee7e0adf6ce1971d979f038adc8ebbd35771b2c19b0bad7e3d",
-                "src_tx": "662835cc081e037561e1fe05860fdc4b426f6be562565bfaa8ec91be5675064a",
-                "address": "cBnu9sUvv12dovBmjQKTtfE4rbjMmf3fzW",
-                "coins": "1",
-                "hours": 3455
-            },
-            {
-                "txid": "6d8a9c89177ce5e9d3b4b59fff67c00f0471fdebdfbb368377841b03fc7d688b",
-                "src_tx": "662835cc081e037561e1fe05860fdc4b426f6be562565bfaa8ec91be5675064a",
-                "address": "fyqX5YuwXMUs4GEUE3LjLyhrqvNztFHQ4B",
-                "coins": "5",
-                "hours": 3455
-            }
-        ]
+       "outputs": 
+			{
+				"head_outputs": [
+					{
+						"hash": "ca02361ef6d658cac5b5aadcb502b4b6046d1403e0f4b1f16b35c06a3f27e3df",
+						"src_tx": "e00196267e879c76215ccb93d046bd248e2bc5accad93d246ba43c71c42ff44a",
+						"address": "cBnu9sUvv12dovBmjQKTtfE4rbjMmf3fzW",
+						"coins": "4",
+						"hours": 0
+					},
+					{
+						"hash": "22f489be1a2f87ed826c183b516bd10f1703c6591643796f48630ba97db3b16c",
+						"src_tx": "fe50714012b29b3ffe5bc2f8e12a95af35004513d61e329e33b9b2a964ae2924",
+						"address": "cBnu9sUvv12dovBmjQKTtfE4rbjMmf3fzW",
+						"coins": "1",
+						"hours": 0
+					},
+					{
+						"hash": "f34f2f08c0a9bab56920b4ef946c0cb3ce31bbd641e44b23c5c1c39a14c86c86",
+						"src_tx": "059197c06b3a236c550bec377e26401c50ee6480b51206b6f3899ece55209b50",
+						"address": "fyqX5YuwXMUs4GEUE3LjLyhrqvNztFHQ4B",
+						"coins": "53",
+						"hours": 1
+					},
+					{
+						"hash": "86c43aeaa420e17843fee51ec28275726c6422f6bb0f844e70c552d65dd63df8",
+						"src_tx": "bb35c6b277f432c6cf13d4a6b36d64f75cc405bc2b864aad718e53a6cbbd9105",
+						"address": "cBnu9sUvv12dovBmjQKTtfE4rbjMmf3fzW",
+						"coins": "1",
+						"hours": 0
+					}
+				],
+				"outgoing_outputs": [],
+				"incoming_outputs": []
+			}
     }`
 
-func decodeOutputStr(str string) []visor.ReadableOutput {
+func decodeOutputStr(str string) visor.ReadableOutputSet {
 	outs := OutputsResult{}
 	if err := json.NewDecoder(strings.NewReader(outputStr)).Decode(&outs); err != nil {
 		panic(err)
@@ -43,14 +55,34 @@ func decodeOutputStr(str string) []visor.ReadableOutput {
 	return outs.Outputs
 }
 
-func filterOut(outs []visor.ReadableOutput, f func(out visor.ReadableOutput) bool) []visor.ReadableOutput {
-	ret := []visor.ReadableOutput{}
-	for _, o := range outs {
+func filterOut(outs visor.ReadableOutputSet, f func(out visor.ReadableOutput) bool) visor.ReadableOutputSet {
+	headOuts := []visor.ReadableOutput{}
+	outgoingOuts := []visor.ReadableOutput{}
+	incommingOuts := []visor.ReadableOutput{}
+
+	for _, o := range outs.HeadOutputs {
 		if f(o) {
-			ret = append(ret, o)
+			headOuts = append(headOuts, o)
 		}
 	}
-	return ret
+
+	for _, o := range outs.OutgoingOutputs {
+		if f(o) {
+			outgoingOuts = append(outgoingOuts, o)
+		}
+	}
+
+	for _, o := range outs.IncommingOutputs {
+		if f(o) {
+			incommingOuts = append(incommingOuts, o)
+		}
+	}
+
+	return visor.ReadableOutputSet{
+		HeadOutputs:      headOuts,
+		OutgoingOutputs:  outgoingOuts,
+		IncommingOutputs: incommingOuts,
+	}
 }
 
 func Test_getOutputsHandler(t *testing.T) {

--- a/src/api/webrpc/webrpc_test.go
+++ b/src/api/webrpc/webrpc_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/coin"
+	"github.com/skycoin/skycoin/src/daemon"
 	"github.com/skycoin/skycoin/src/visor"
 	"github.com/skycoin/skycoin/src/visor/historydb"
 )
@@ -55,21 +56,31 @@ func (fg fakeGateway) GetBlocksInDepth(vs []uint64) *visor.ReadableBlocks {
 	return nil
 }
 
-func (fg fakeGateway) GetUnspentByAddrs(addrs []string) []visor.ReadableOutput {
-	addrMap := make(map[string]bool)
-	for _, a := range addrs {
-		addrMap[a] = true
+func (fg fakeGateway) GetUnspentOutputs(filters ...daemon.OutputsFilter) visor.ReadableOutputSet {
+	v := decodeOutputStr(outputStr)
+	for _, f := range filters {
+		v.HeadOutputs = f(v.HeadOutputs)
+		v.OutgoingOutputs = f(v.OutgoingOutputs)
+		v.IncommingOutputs = f(v.IncommingOutputs)
 	}
-
-	return filterOut(decodeOutputStr(outputStr), func(out visor.ReadableOutput) bool {
-		_, ok := addrMap[out.Address]
-		return ok
-	})
+	return v
 }
 
-func (fg fakeGateway) GetUnspentByHashes(hashes []string) []visor.ReadableOutput {
-	return []visor.ReadableOutput{}
-}
+// func (fg fakeGateway) GetUnspentByAddrs(addrs []string) []visor.ReadableOutput {
+// 	addrMap := make(map[string]bool)
+// 	for _, a := range addrs {
+// 		addrMap[a] = true
+// 	}
+
+// 	return filterOut(decodeOutputStr(outputStr), func(out visor.ReadableOutput) bool {
+// 		_, ok := addrMap[out.Address]
+// 		return ok
+// 	})
+// }
+
+// func (fg fakeGateway) GetUnspentByHashes(hashes []string) []visor.ReadableOutput {
+// 	return []visor.ReadableOutput{}
+// }
 
 func (fg fakeGateway) GetTransaction(txid cipher.SHA256) (*visor.TransactionResult, error) {
 	str, ok := fg.transactions[txid.Hex()]

--- a/src/daemon/daemon_test.go
+++ b/src/daemon/daemon_test.go
@@ -253,8 +253,14 @@ func TestDaemonLoopApiRequest(t *testing.T) {
 	d, quit := setupDaemonLoop()
 	defer closeDaemon(d, quit)
 	go d.Start(quit)
-	rsp := d.Gateway.doRequest(func() interface{} { return &Connection{Id: 7} })
-	resp := <-rsp
+
+	conn := make(chan interface{})
+	d.Gateway.Requests <- func() {
+		conn <- &Connection{Id: 7}
+	}
+
+	resp := <-conn
+
 	assert.Equal(t, resp.(*Connection).Id, 7)
 }
 

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -150,47 +150,57 @@ func (gw *Gateway) GetLastBlocks(num uint64) *visor.ReadableBlocks {
 	return <-blocks
 }
 
-// GetUnspentByAddrs gets unspent of specific addresses
-func (gw *Gateway) GetUnspentByAddrs(addrs []string) []visor.ReadableOutput {
+// OutputsFilter used as optional arguments in GetUnspentOutputs method
+type OutputsFilter func(outputs []visor.ReadableOutput) []visor.ReadableOutput
+
+// GetUnspentOutputs gets unspent outputs and returns the filtered results,
+// Note: all filters will be executed as the pending sequence in 'AND' mode.
+func (gw *Gateway) GetUnspentOutputs(filters ...OutputsFilter) []visor.ReadableOutput {
 	outputs := make(chan []visor.ReadableOutput)
 	gw.Requests <- func() {
-		outs := gw.V.GetUnspentOutputReadables()
+		outputs <- gw.V.GetUnspentOutputReadables()
+	}
+	outs := <-outputs
+	for _, flt := range filters {
+		outs = flt(outs)
+	}
+	return outs
+}
+
+// FbyAddresses filters the unspent outputs that owned by the addresses
+func FbyAddresses(addrs []string) OutputsFilter {
+	return func(outputs []visor.ReadableOutput) []visor.ReadableOutput {
 		addrMatch := []visor.ReadableOutput{}
 		addrMap := make(map[string]bool)
 		for _, addr := range addrs {
 			addrMap[addr] = true
 		}
 
-		for _, u := range outs {
+		for _, u := range outputs {
 			if _, ok := addrMap[u.Address]; ok {
 				addrMatch = append(addrMatch, u)
 			}
 		}
-		outputs <- addrMatch
+		return addrMatch
 	}
-	return <-outputs
 }
 
-// GetUnspentByHashes gets unspent of specific unspent hashes.
-func (gw *Gateway) GetUnspentByHashes(hashes []string) []visor.ReadableOutput {
-	outputs := make(chan []visor.ReadableOutput)
-	gw.Requests <- func() {
-		outs := gw.V.GetUnspentOutputReadables()
-
+// FbyHashes filters the unspent outputs that have hashes matched.
+func FbyHashes(hashes []string) OutputsFilter {
+	return func(outputs []visor.ReadableOutput) []visor.ReadableOutput {
 		hsMatch := []visor.ReadableOutput{}
 		hsMap := make(map[string]bool)
 		for _, h := range hashes {
 			hsMap[h] = true
 		}
 
-		for _, u := range outs {
+		for _, u := range outputs {
 			if _, ok := hsMap[u.Hash]; ok {
 				hsMatch = append(hsMatch, u)
 			}
 		}
-		outputs <- hsMatch
+		return hsMatch
 	}
-	return <-outputs
 }
 
 // GetTransaction gets transaction by txid.
@@ -260,6 +270,7 @@ func (gw *Gateway) GetAddrUxOuts(addr cipher.Address) ([]*historydb.UxOutJSON, e
 	return uxs, err
 }
 
+// GetTimeNow returns the current Unix time
 func (gw *Gateway) GetTimeNow() uint64 {
 	return uint64(time.Now().Unix())
 }

--- a/src/daemon/gateway_test.go
+++ b/src/daemon/gateway_test.go
@@ -1,0 +1,125 @@
+package daemon
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/skycoin/skycoin/src/visor"
+)
+
+func TestFbyAddresses(t *testing.T) {
+	tests := []struct {
+		name    string
+		addrs   []string
+		outputs []visor.ReadableOutput
+		want    []visor.ReadableOutput
+	}{
+		// TODO: Add test cases.
+		{
+			"filter with one address",
+			[]string{"abc"},
+			[]visor.ReadableOutput{
+				{
+					Address: "abc",
+				},
+				{
+					Address: "cde",
+				},
+			},
+			[]visor.ReadableOutput{
+				{
+					Address: "abc",
+				},
+			},
+		},
+		{
+			"filter with multiple addresses",
+			[]string{"abc", "cde"},
+			[]visor.ReadableOutput{
+				{
+					Address: "abc",
+				},
+				{
+					Address: "cde",
+				},
+				{
+					Address: "efg",
+				},
+			},
+			[]visor.ReadableOutput{
+				{
+					Address: "abc",
+				},
+				{
+					Address: "cde",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		outs := FbyAddresses(tt.addrs)(tt.outputs)
+		if !reflect.DeepEqual(outs, tt.want) {
+			t.Errorf("%q. FbyAddresses() = %v, want %v", tt.name, outs, tt.want)
+		}
+	}
+}
+
+func TestFbyHashes(t *testing.T) {
+	type args struct {
+		hashes []string
+	}
+	tests := []struct {
+		name    string
+		hashes  []string
+		outputs []visor.ReadableOutput
+		want    []visor.ReadableOutput
+	}{
+		// TODO: Add test cases.
+		{
+			"filter with one hash",
+			[]string{"abc"},
+			[]visor.ReadableOutput{
+				{
+					Hash: "abc",
+				},
+				{
+					Hash: "cde",
+				},
+			},
+			[]visor.ReadableOutput{
+				{
+					Hash: "abc",
+				},
+			},
+		},
+		{
+			"filter with multiple hash",
+			[]string{"abc", "cde"},
+			[]visor.ReadableOutput{
+				{
+					Hash: "abc",
+				},
+				{
+					Hash: "cde",
+				},
+				{
+					Hash: "efg",
+				},
+			},
+			[]visor.ReadableOutput{
+				{
+					Hash: "abc",
+				},
+				{
+					Hash: "cde",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		outs := FbyHashes(tt.hashes)(tt.outputs)
+		if !reflect.DeepEqual(outs, tt.want) {
+			t.Errorf("%q. FbyHashes() = %v, want %v", tt.name, outs, tt.want)
+		}
+	}
+}

--- a/src/gui/wallet.go
+++ b/src/gui/wallet.go
@@ -563,7 +563,6 @@ func walletsReloadHandler(gateway *daemon.Gateway) http.HandlerFunc {
 func getOutputsHandler(gateway *daemon.Gateway) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "GET" {
-			var outs []visor.ReadableOutput
 			var addrs []string
 			var hashes []string
 
@@ -593,7 +592,8 @@ func getOutputsHandler(gateway *daemon.Gateway) http.HandlerFunc {
 				filters = append(filters, daemon.FbyHashes(hashes))
 			}
 
-			outs = gateway.GetUnspentOutputs(filters...)
+			outs := gateway.GetUnspentOutputs(filters...)
+
 			wh.SendOr404(w, outs)
 		}
 	}

--- a/src/visor/blockchain_parser.go
+++ b/src/visor/blockchain_parser.go
@@ -79,6 +79,7 @@ func (bcp *BlockchainParser) Stop() {
 
 func (bcp *BlockchainParser) parseTo(bcHeight uint64) error {
 	if bcp.parsedHeight == 0 {
+		logger.Critical("historydb parse %d/%d", bcp.parsedHeight, bcHeight)
 		for i := uint64(0); i <= bcHeight-bcp.parsedHeight; i++ {
 			b := bcp.bc.GetBlockInDepth(bcp.parsedHeight + i)
 			if b == nil {
@@ -88,9 +89,10 @@ func (bcp *BlockchainParser) parseTo(bcHeight uint64) error {
 			if err := bcp.historyDB.ProcessBlock(b); err != nil {
 				return err
 			}
-			logger.Critical("historydb parse %d/%d", bcp.parsedHeight+i, bcHeight)
 		}
+		logger.Critical("historydb parse %d/%d", bcHeight, bcHeight)
 	} else {
+		logger.Critical("historydb parse %d/%d", bcp.parsedHeight, bcHeight)
 		for i := uint64(0); i < bcHeight-bcp.parsedHeight; i++ {
 			b := bcp.bc.GetBlockInDepth(bcp.parsedHeight + i + 1)
 			if b == nil {
@@ -100,8 +102,8 @@ func (bcp *BlockchainParser) parseTo(bcHeight uint64) error {
 			if err := bcp.historyDB.ProcessBlock(b); err != nil {
 				return err
 			}
-			logger.Critical("historydb parse %d/%d", bcp.parsedHeight+i+1, bcHeight)
 		}
+		logger.Critical("historydb parse %d/%d", bcHeight, bcHeight)
 	}
 	bcp.parsedHeight = bcHeight
 	return nil

--- a/src/visor/readable.go
+++ b/src/visor/readable.go
@@ -166,6 +166,13 @@ type ReadableOutput struct {
 	Hours             uint64 `json:"hours"`
 }
 
+// ReadableOutputSet records unspent outputs in different status.
+type ReadableOutputSet struct {
+	HeadOutputs      []ReadableOutput `json:"head_outputs"`
+	OutgoingOutputs  []ReadableOutput `json:"outgoing_outputs"`
+	IncommingOutputs []ReadableOutput `json:"incoming_outputs"`
+}
+
 func NewReadableOutput(t coin.UxOut) ReadableOutput {
 	return ReadableOutput{
 		Hash:              t.Hash().Hex(),

--- a/src/visor/readable.go
+++ b/src/visor/readable.go
@@ -179,12 +179,15 @@ func (os ReadableOutputSet) SpendableOutputs() []ReadableOutput {
 		return os.HeadOutputs
 	}
 
+	spending := make(map[string]bool)
+	for _, u := range os.OutgoingOutputs {
+		spending[u.Hash] = true
+	}
+
 	var outs []ReadableOutput
 	for i := range os.HeadOutputs {
-		for _, o := range os.OutgoingOutputs {
-			if os.HeadOutputs[i].Hash != o.Hash {
-				outs = append(outs, os.HeadOutputs[i])
-			}
+		if _, ok := spending[os.HeadOutputs[i].Hash]; !ok {
+			outs = append(outs, os.HeadOutputs[i])
 		}
 	}
 	return outs

--- a/src/visor/readable.go
+++ b/src/visor/readable.go
@@ -159,7 +159,7 @@ func NewReadableTransactionOutput(t *coin.TransactionOutput, txid cipher.SHA256)
 	Add a verbose version
 */
 type ReadableOutput struct {
-	Hash              string `json:"txid"` //hash uniquely identifies transaction
+	Hash              string `json:"hash"`
 	SourceTransaction string `json:"src_tx"`
 	Address           string `json:"address"`
 	Coins             string `json:"coins"`

--- a/src/visor/readable.go
+++ b/src/visor/readable.go
@@ -173,6 +173,23 @@ type ReadableOutputSet struct {
 	IncommingOutputs []ReadableOutput `json:"incoming_outputs"`
 }
 
+// SpendableOutputs caculates the spendable unspent outputs
+func (os ReadableOutputSet) SpendableOutputs() []ReadableOutput {
+	if len(os.OutgoingOutputs) == 0 {
+		return os.HeadOutputs
+	}
+
+	var outs []ReadableOutput
+	for i := range os.HeadOutputs {
+		for _, o := range os.OutgoingOutputs {
+			if os.HeadOutputs[i].Hash != o.Hash {
+				outs = append(outs, os.HeadOutputs[i])
+			}
+		}
+	}
+	return outs
+}
+
 func NewReadableOutput(t coin.UxOut) ReadableOutput {
 	return ReadableOutput{
 		Hash:              t.Hash().Hex(),

--- a/src/visor/unconfirmed.go
+++ b/src/visor/unconfirmed.go
@@ -244,3 +244,28 @@ func (utp *UnconfirmedTxnPool) SpendsForAddress(bcUnspent *coin.UnspentPool,
 	auxs := utp.SpendsForAddresses(bcUnspent, ma)
 	return auxs[a]
 }
+
+// AllSpendsOutputs returns all spending outputs in unconfirmed tx pool.
+func (utp *UnconfirmedTxnPool) AllSpendsOutputs(bcUnspent *coin.UnspentPool) []ReadableOutput {
+	var outs []ReadableOutput
+	for _, tx := range utp.Txns {
+		for _, in := range tx.Txn.In {
+			if ux, ok := bcUnspent.Get(in); ok {
+				outs = append(outs, NewReadableOutput(ux))
+			}
+		}
+	}
+	return outs
+}
+
+// AllIncommingOutputs returns all predicted incomming outputs.
+func (utp *UnconfirmedTxnPool) AllIncommingOutputs(bh coin.BlockHeader) []ReadableOutput {
+	var outs []ReadableOutput
+	for _, tx := range utp.Txns {
+		uxOuts := coin.CreateUnspents(bh, tx.Txn)
+		for _, ux := range uxOuts {
+			outs = append(outs, NewReadableOutput(ux))
+		}
+	}
+	return outs
+}

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -312,6 +312,16 @@ func (vs *Visor) GetUnspentOutputReadables() []ReadableOutput {
 	return rxReadables
 }
 
+// AllSpendsOutputs returns all spending outputs in unconfirmed tx pool
+func (vs *Visor) AllSpendsOutputs() []ReadableOutput {
+	return vs.Unconfirmed.AllSpendsOutputs(vs.Blockchain.GetUnspent())
+}
+
+// AllIncommingOutputs returns all predicted outputs that are in pending tx pool
+func (vs *Visor) AllIncommingOutputs() []ReadableOutput {
+	return vs.Unconfirmed.AllIncommingOutputs(vs.Blockchain.Head().Head)
+}
+
 // GetSignedBlocksSince returns N signed blocks more recent than Seq. Does not return nil.
 func (vs *Visor) GetSignedBlocksSince(seq, ct uint64) []coin.SignedBlock {
 	avail := uint64(0)


### PR DESCRIPTION
- Change /outputs api's result set, now it have three output parts, head_outputs, outgoing_outputs and incomming_outputs. The head_outputs means unspent outputs that are executed base on the current head block; outgoing_outputs means the outputs that have been spent in pending transaction pool but not executed in block yet; the incomming_outputs means outputs from pending transactions, that are either change or else someone sending you money.
- Avoid the double spending in CLI send command.