### PR TITLE
Some bug fixes about electron wallet and CLI

### DIFF
--- a/electron/README.md
+++ b/electron/README.md
@@ -54,18 +54,6 @@ npm install
 
 A folder `node_modules/` should now exist.
 
-Manually download electron release 1.2.2
------
-
- The gulp-electron now can't download the electron release of version 1.2.2
- automatically. We need to download them manually from the following links:
-
- * [electron-v1.2.2-darwin-x64.zip](https://github.com/electron/electron/releases/download/v1.2.2/electron-v1.2.2-darwin-x64.zip)
- * [electron-v1.2.2-linux-x64.zip](https://github.com/electron/electron/releases/download/v1.2.2/electron-v1.2.2-linux-x64.zip)
- * [electron-v1.2.2-win32-x64.zip](https://github.com/electron/electron/releases/download/v1.2.2/electron-v1.2.2-win32-x64.zip)
-
-Copy the downloaded zip files into `electron/.electron_cache` folder.
-
 Building
 --------
 

--- a/electron/build-conf.sh
+++ b/electron/build-conf.sh
@@ -3,12 +3,13 @@ set -e -o pipefail
 
 # These values are also in gulpfile.js and package.json and must be equal
 SKY_VERSION="0.8.1"
-ELN_VERSION="v1.2.2"
+ELN_VERSION="v1.4.13"
 ELN_OUTPUT_BASE=".electron_output"
 ELN_OUTPUT="${ELN_OUTPUT_BASE}/${ELN_VERSION}"
 
 GOX_OSARCH="linux/amd64 windows/amd64 darwin/amd64"
 # GOX_OSARCH="darwin/amd64"
+# GOX_OSARCH="windows/amd64"
 GOX_OUTPUT=".gox_output"
 
 STL_OUTPUT=".standalone_output"

--- a/electron/package-electron-release.sh
+++ b/electron/package-electron-release.sh
@@ -43,7 +43,7 @@ function copy_if_exists {
     if [  -f "$BIN" ]; then
         # Copy binary to electron app
         echo "Copying $BIN to $DESTBIN"
-        mkdir -p $DESTBIN
+        # mkdir -p $DESTBIN
         cp "$BIN" "$DESTBIN"
 
         # Copy static resources to electron app

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,11 +1,11 @@
 {
-  "devDependencies": {
-    "electron": "^1.4.13",
-    "electron-packager": "^7.0.2",
-    "gulp": "^3.9.1"
-  },
-  "dependencies": {
-    "electron-log": "^1.2.2",
-    "electron-prebuilt": "^1.2.0"
-  }
+    "devDependencies": {
+        "electron-packager": "^7.0.2",
+        "gulp": "^3.9.1",
+        "gulp-electron": "^0.1.3"
+    },
+    "dependencies": {
+        "electron-log": "^1.2.2",
+        "electron-prebuilt": "^1.2.0"
+    }
 }

--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -72,7 +72,6 @@ function startSkycoin() {
         // '-web-interface-https=true',
     ]
 
-
     skycoin = childProcess.spawn(exe, args);
 
     skycoin.on('error', (e) => {
@@ -100,6 +99,7 @@ function startSkycoin() {
             throw new Error('web interface url log line incomplete');
         }
         var url = data.slice(i + marker.length, j);
+        currentURL = url.toString();
         app.emit('skycoin-ready', { url: currentURL });
     });
 

--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -92,14 +92,15 @@ function startSkycoin() {
         if (i === -1) {
             return
         }
-        var j = data.indexOf('\n', i);
+        // var j = data.indexOf('\n', i);
 
-        // dialog.showErrorBox('index of newline: ', j);
-        if (j === -1) {
-            throw new Error('web interface url log line incomplete');
-        }
-        var url = data.slice(i + marker.length, j);
-        currentURL = url.toString();
+        // // dialog.showErrorBox('index of newline: ', j);
+        // if (j === -1) {
+        //     throw new Error('web interface url log line incomplete');
+        // }
+        // var url = data.slice(i + marker.length, j);
+        // currentURL = url.toString();
+        currentURL = defaultURL;
         app.emit('skycoin-ready', { url: currentURL });
     });
 

--- a/src/api/cli/wallet_history.go
+++ b/src/api/cli/wallet_history.go
@@ -98,7 +98,7 @@ func walletHistoryAction(c *gcli.Context) error {
 		return err
 	}
 
-	// transmute the uxout to addrHistory, and also sort the items by time in ascend order.
+	// transmute the uxout to addrHistory, and sort the items by time in ascend order.
 	totalAddrHis := []addrHistory{}
 	for _, ux := range uxouts {
 		addrHis, err := makeAddrHisArray(ux)
@@ -158,17 +158,17 @@ func makeAddrHisArray(ux webrpc.AddrUxoutResult) ([]addrHistory, error) {
 		spentBlkSeq = append(spentBlkSeq, seq)
 	}
 
-	getBlkTime, err := createBlkTimeFinder(spentBlkSeq)
-	if err != nil {
-		return []addrHistory{}, err
-	}
+	if len(spentBlkSeq) > 0 {
+		getBlkTime, err := createBlkTimeFinder(spentBlkSeq)
+		if err != nil {
+			return []addrHistory{}, err
+		}
 
-	for i, his := range spentHis {
-		spentHis[i].Timestamp = time.Unix(getBlkTime(his.BlockSeq), 0).UTC()
+		for i, his := range spentHis {
+			spentHis[i].Timestamp = time.Unix(getBlkTime(his.BlockSeq), 0).UTC()
+		}
+		addrHis = append(addrHis, spentHis...)
 	}
-	addrHis = append(addrHis, spentHis...)
-
-	// sort.Sort(byTime(addrHis))
 
 	// merge history in the same transaction.
 	hisMap := map[string][]addrHistory{}

--- a/src/util/file.go
+++ b/src/util/file.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 
 	logging "github.com/op/go-logging"
 )
@@ -189,27 +188,27 @@ func ResolveResourceDirectory(path string) string {
 func DetermineResourcePath(staticDir string, resourceDir string, devDir string) (string, error) {
 	//check "dev" directory first
 	appLoc := filepath.Join(staticDir, devDir)
-	if !strings.HasPrefix(appLoc, "/") {
-		// Prepend the binary's directory path if appLoc is relative
-		dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
-		if err != nil {
-			return "", err
-		}
+	// if !strings.HasPrefix(appLoc, "/") {
+	// 	// Prepend the binary's directory path if appLoc is relative
+	// 	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	// 	if err != nil {
+	// 		return "", err
+	// 	}
 
-		appLoc = filepath.Join(dir, appLoc)
-	}
+	// 	appLoc = filepath.Join(dir, appLoc)
+	// }
 	if _, err := os.Stat(appLoc); os.IsNotExist(err) {
 		//check dist directory
 		appLoc = filepath.Join(staticDir, resourceDir)
-		if !strings.HasPrefix(appLoc, "/") {
-			// Prepend the binary's directory path if appLoc is relative
-			dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
-			if err != nil {
-				return "", err
-			}
+		// if !strings.HasPrefix(appLoc, "/") {
+		// 	// Prepend the binary's directory path if appLoc is relative
+		// 	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+		// 	if err != nil {
+		// 		return "", err
+		// 	}
 
-			appLoc = filepath.Join(dir, appLoc)
-		}
+		// 	appLoc = filepath.Join(dir, appLoc)
+		// }
 
 		if _, err := os.Stat(appLoc); os.IsNotExist(err) {
 			return "", err

--- a/src/visor/unconfirmed.go
+++ b/src/visor/unconfirmed.go
@@ -247,7 +247,7 @@ func (utp *UnconfirmedTxnPool) SpendsForAddress(bcUnspent *coin.UnspentPool,
 
 // AllSpendsOutputs returns all spending outputs in unconfirmed tx pool.
 func (utp *UnconfirmedTxnPool) AllSpendsOutputs(bcUnspent *coin.UnspentPool) []ReadableOutput {
-	var outs []ReadableOutput
+	outs := []ReadableOutput{}
 	for _, tx := range utp.Txns {
 		for _, in := range tx.Txn.In {
 			if ux, ok := bcUnspent.Get(in); ok {
@@ -260,7 +260,7 @@ func (utp *UnconfirmedTxnPool) AllSpendsOutputs(bcUnspent *coin.UnspentPool) []R
 
 // AllIncommingOutputs returns all predicted incomming outputs.
 func (utp *UnconfirmedTxnPool) AllIncommingOutputs(bh coin.BlockHeader) []ReadableOutput {
-	var outs []ReadableOutput
+	outs := []ReadableOutput{}
 	for _, tx := range utp.Txns {
 		uxOuts := coin.CreateUnspents(bh, tx.Txn)
 		for _, ux := range uxOuts {

--- a/src/wallet/deterministic.go
+++ b/src/wallet/deterministic.go
@@ -257,6 +257,7 @@ func (wlt *Wallet) Load(dir string) error {
 	if err := r.Load(filepath.Join(dir, wlt.GetFilename())); err != nil {
 		return err
 	}
+	r.Meta["filename"] = wlt.GetFilename()
 	*wlt = NewWalletFromReadable(r)
 	return nil
 }


### PR DESCRIPTION
- Fix the bug in electron build script
- Fix the bug that wallet doesn't work in windows
- Fix the bug of walletHistory command
- Remove the doc about manually download electron release, since gulp-electron can download 1.4.13 automatically.
- Fix bug in loading wallet file, CLI generateAddresses command will fail if someone rename the wallet file manually.
- Update the outputs api's result when no filters are set. The outgoing_outputs and incomming_outputs filed will be 'null' if they're not exist, while, it should be empty array: '[]'. 
