### PR TITLE
Apply color-log command line arg

### DIFF
--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -468,6 +468,7 @@ func Run(c *Config) {
 
 	logCfg := util.DevLogConfig(logModules)
 	logCfg.Format = logFormat
+	logCfg.Colors = c.ColorLog
 	logCfg.InitLogger()
 
 	// initLogging(c.LogLevel, c.ColorLog)


### PR DESCRIPTION
Apply the color-log command line argument in the skycoin cmd