### PR TITLE
Reenable peer exchange

### DIFF
--- a/electron/build-conf.sh
+++ b/electron/build-conf.sh
@@ -6,6 +6,7 @@ set -e -o pipefail
 # Get skycoin build version from package.json
 APP_VERSION=`grep version package.json | sed  's/[,\", ]//g'| awk '{split($0,a,":");print a[2]}'`
 
+
 # package name
 PKG_NAME=`grep name package.json | sed 's/[,\", ]//g' | awk '{split($0,s,":");print s[2]}'`
 

--- a/electron/package.json
+++ b/electron/package.json
@@ -3,7 +3,7 @@
     "productName": "Skycoin",
     "author": "skycoin",
     "main": "src/electron-main.js",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "description": "skycoin wallet",
     "build": {
         "appId": "org.skycoin.skycoin",

--- a/electron/skycoin/current-skycoin.json
+++ b/electron/skycoin/current-skycoin.json
@@ -1,1 +1,1 @@
-versionData='{     "version": "1.13.1" }';
+versionData='{     "version": "0.13.0" }';

--- a/electron/version-control.sh
+++ b/electron/version-control.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 
 echo "$VERSION_FILE ---- version file"
 
-APP_VERSION=`grep version package.json | sed  's/[,]//g'`
+versionData=`grep version package.json | sed  's/[,]//g'`
 # versionData='{ "version":"0.12.1" }';
 
-echo "versionData='{ $APP_VERSION }';" > skycoin/current-skycoin.json
+echo "versionData='{ $versionData }';" > skycoin/current-skycoin.json

--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -316,6 +316,11 @@ func (self *Daemon) Start(quit chan int) {
 	clearStaleConnectionsTicker := time.Tick(self.Pool.Config.ClearStaleRate)
 	idleCheckTicker := time.Tick(self.Pool.Config.IdleCheckRate)
 
+	// connecto to trusted peers
+	if !self.Config.DisableOutgoingConnections {
+		self.connectToTrustPeer()
+	}
+
 main:
 	for {
 		select {
@@ -496,6 +501,21 @@ func (self *Daemon) makePrivateConnections() {
 			if err := self.connectToPeer(p); err != nil {
 				logger.Debug("Did not connect to private peer: %v", err)
 			}
+		}
+	}
+}
+
+func (self *Daemon) connectToTrustPeer() {
+	if self.Config.DisableIncomingConnections {
+		return
+	}
+
+	logger.Info("connect to trusted peers")
+	// make connections to all trusted peers
+	peers := self.Peers.Peers.Peerlist.GetPublicTrustPeers()
+	for _, p := range peers {
+		if self.connectToPeer(p) == nil {
+			break
 		}
 	}
 }

--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -354,8 +354,9 @@ main:
 			}
 		// Fill up our outgoing connections
 		case <-outgoingConnectionsTicker:
+			trustPeerNum := len(self.Peers.Peers.Peerlist.GetAllTrustedPeers())
 			if !self.Config.DisableOutgoingConnections &&
-				len(self.OutgoingConnections) < self.Config.OutgoingMax &&
+				len(self.OutgoingConnections) < (self.Config.OutgoingMax+trustPeerNum) &&
 				len(self.pendingConnections) < self.Config.PendingMax {
 				self.connectToRandomPeer()
 			}

--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -168,7 +168,7 @@ func NewDaemonConfig() DaemonConfig {
 		Port:                       6677,
 		OutgoingRate:               time.Second * 5,
 		PrivateRate:                time.Second * 5,
-		OutgoingMax:                32,
+		OutgoingMax:                16,
 		PendingMax:                 16,
 		IntroductionWait:           time.Second * 30,
 		CullInvalidRate:            time.Second * 3,

--- a/src/daemon/messages.go
+++ b/src/daemon/messages.go
@@ -282,7 +282,7 @@ func (self *IntroductionMessage) Process(d *Daemon) {
 	}
 	// Add the remote peer with their chosen listening port
 	a := self.c.Conn.Addr()
-	ip, pt, err := SplitAddr(a)
+	_, pt, err := SplitAddr(a)
 	if err != nil {
 		// This should never happen, but the program should still work if it
 		// does.
@@ -306,12 +306,13 @@ func (self *IntroductionMessage) Process(d *Daemon) {
 		if err := d.Peers.Peers.SetPeerHasInPort(a, true); err != nil {
 			logger.Error("Failed to set peer hasInPort statue, %v", err)
 		}
-	} else {
-		_, err = d.Peers.Peers.AddPeer(fmt.Sprintf("%s:%d", ip, self.Port))
-		if err != nil {
-			logger.Error("Failed to add peer: %v", err)
-		}
 	}
+	// else {
+	// 	_, err = d.Peers.Peers.AddPeer(fmt.Sprintf("%s:%d", ip, self.Port))
+	// 	if err != nil {
+	// 		logger.Error("Failed to add peer: %v", err)
+	// 	}
+	// }
 
 	// Request blocks immediately after they're confirmed
 	err = d.Visor.RequestBlocksFromAddr(d.Pool, self.c.Conn.Addr())

--- a/src/daemon/messages.go
+++ b/src/daemon/messages.go
@@ -282,7 +282,7 @@ func (self *IntroductionMessage) Process(d *Daemon) {
 	}
 	// Add the remote peer with their chosen listening port
 	a := self.c.Conn.Addr()
-	_, pt, err := SplitAddr(a)
+	ip, pt, err := SplitAddr(a)
 	if err != nil {
 		// This should never happen, but the program should still work if it
 		// does.
@@ -306,13 +306,12 @@ func (self *IntroductionMessage) Process(d *Daemon) {
 		if err := d.Peers.Peers.SetPeerHasInPort(a, true); err != nil {
 			logger.Error("Failed to set peer hasInPort statue, %v", err)
 		}
+	} else {
+		_, err = d.Peers.Peers.AddPeer(fmt.Sprintf("%s:%d", ip, self.Port))
+		if err != nil {
+			logger.Error("Failed to add peer: %v", err)
+		}
 	}
-	// else {
-	// 	_, err = d.Peers.Peers.AddPeer(fmt.Sprintf("%s:%d", ip, self.Port))
-	// 	if err != nil {
-	// 		logger.Error("Failed to add peer: %v", err)
-	// 	}
-	// }
 
 	// Request blocks immediately after they're confirmed
 	err = d.Visor.RequestBlocksFromAddr(d.Pool, self.c.Conn.Addr())

--- a/src/daemon/peers.go
+++ b/src/daemon/peers.go
@@ -78,7 +78,9 @@ func (self *Peers) Init() {
 
 	//Boot strap peers
 	for _, addr := range DefaultConnections {
+		// default peers will mark as trusted peers.
 		peers.AddPeer(addr)
+		peers.SetTrustState(addr, true)
 	}
 
 	self.Peers = peers

--- a/src/daemon/pex/pex.go
+++ b/src/daemon/pex/pex.go
@@ -83,7 +83,6 @@ type Peer struct {
 // Returns a *Peer initialised by an address string of the form ip:port
 func NewPeer(address string) *Peer {
 	p := &Peer{Addr: address, Private: false, Trusted: false}
-	logger.Critical(fmt.Sprintf("New peer:%+v", p))
 	p.Seen()
 	return p
 }

--- a/src/daemon/pex/pex.go
+++ b/src/daemon/pex/pex.go
@@ -82,7 +82,8 @@ type Peer struct {
 
 // Returns a *Peer initialised by an address string of the form ip:port
 func NewPeer(address string) *Peer {
-	p := &Peer{Addr: address, Private: false}
+	p := &Peer{Addr: address, Private: false, Trusted: false}
+	logger.Critical(fmt.Sprintf("New peer:%+v", p))
 	p.Seen()
 	return p
 }
@@ -478,6 +479,23 @@ func (self *Pex) AddPeer(addr string) (*Peer, error) {
 		self.Peerlist[peer.Addr] = peer
 		return peer, nil
 	}
+}
+
+// SetTrustState updates the peer's Trusted statue
+func (self *Pex) SetTrustState(addr string, trusted bool) error {
+	if !ValidateAddress(addr, self.AllowLocalhost) {
+		return InvalidAddressError
+	}
+	if self.IsBlacklisted(addr) {
+		return BlacklistedAddressError
+	}
+
+	if p, ok := self.Peerlist[addr]; ok {
+		p.Trusted = trusted
+		return nil
+	}
+
+	return fmt.Errorf("%s does not exist in peel list", addr)
 }
 
 // SetPeerHasInPort update whether the peer has incomming port.

--- a/src/gui/static/src/current-skycoin.json
+++ b/src/gui/static/src/current-skycoin.json
@@ -1,1 +1,1 @@
-versionData='{ "version":"0.12.1" }';
+versionData='{ "version":"0.13.0" }';


### PR DESCRIPTION
- Reenable peer exchange, limit the max outgoing connections number to 16, and the trusted peers will not count toward the ougtoing connection pool. 
- Add apis for querying trusted peers, exchangeable peers
- Fix bug in electron build version control