### PR TITLE
src/daemon/gnet add (*ConnectionPool).ListeningAddress method

### DIFF
--- a/src/daemon/gnet/pool.go
+++ b/src/daemon/gnet/pool.go
@@ -266,6 +266,16 @@ func (self *ConnectionPool) AcceptConnections() {
 	}
 }
 
+// ListeningAddress returns address, on which the ConnectionPool
+// listening on. It returns nil, and error if the ConnectionPool
+// is not listening
+func (self *ConnectionPool) ListeningAddress() (net.Addr, error) {
+	if self.listener == nil {
+		return nil, errors.New("Not listening, call StartListen first")
+	}
+	return self.listener.Addr(), nil
+}
+
 // Begin listening on the port the ConnectionPool is configured for.
 // Calling StartListen() twice with no intermediate StopListen() will panic.
 func (self *ConnectionPool) StartListen() error {

--- a/src/daemon/gnet/pool_test.go
+++ b/src/daemon/gnet/pool_test.go
@@ -184,6 +184,31 @@ func TestAcceptConnections(t *testing.T) {
 	assert.True(t, called)
 }
 
+func TestListeningAddress(t *testing.T) {
+	t.Run("not listening", func(t *testing.T) {
+		cleanupNet()
+		cfg := NewConfig()
+		p := NewConnectionPool(cfg, nil)
+		addr, err := p.ListeningAddress()
+		assert.Nil(t, addr)
+		assert.NotNil(t, err)
+	})
+	t.Run("listening", func(t *testing.T) {
+		cleanupNet()
+		cfg := NewConfig()
+		cfg.Address = ""
+		cfg.Port = 0
+		p := NewConnectionPool(cfg, nil)
+		defer p.StopListen()
+		assert.Nil(t, p.StartListen())
+		wait()
+		addr, err := p.ListeningAddress()
+		assert.Nil(t, err)
+		assert.NotNil(t, addr)
+		t.Log("ListeningAddress: ", addr)
+	})
+}
+
 func TestStartListen(t *testing.T) {
 	cleanupNet()
 	cfg := NewConfig()


### PR DESCRIPTION
Add `ListeningAddress() (net.Addr, error)` method to `ConnectionPoool`. This way we can obtain listening address even if we pass empty address and 0-port to configurations.