### PR TITLE
src/daemon/gnet add ability to use raw connections before starting internal read/write loop

### DIFF
--- a/src/daemon/gnet/dispatcher_test.go
+++ b/src/daemon/gnet/dispatcher_test.go
@@ -3,21 +3,13 @@ package gnet
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"net"
 	"reflect"
 	"testing"
 	"time"
 
-	logging "github.com/op/go-logging"
 	"github.com/stretchr/testify/assert"
 )
-
-func init() {
-	if silenceLogger {
-		logging.SetBackend(logging.NewLogBackend(ioutil.Discard, "", 0))
-	}
-}
 
 var (
 	_sendByteMessage = sendByteMessage

--- a/src/daemon/gnet/message_test.go
+++ b/src/daemon/gnet/message_test.go
@@ -2,19 +2,11 @@ package gnet
 
 import (
 	"errors"
-	"io/ioutil"
 	"reflect"
 	"testing"
 
-	logging "github.com/op/go-logging"
 	"github.com/stretchr/testify/assert"
 )
-
-func init() {
-	if silenceLogger {
-		logging.SetBackend(logging.NewLogBackend(ioutil.Discard, "", 0))
-	}
-}
 
 func TestNewMessageContext(t *testing.T) {
 	c := &Connection{}


### PR DESCRIPTION
The ability to use raw connections is good for handshakes. When I need to send-receive some messages with known size and known timeout, I uses messages. But, it's very hard and can be replaced with two functions that works on raw connections.

+ add Acquire/Release methods to be able to use raw incoming connections asynchronously
+ add tests to Acquire and Release methods
+ add documentation to the methods
+ change test behavior to use '-v' flag to show debug logs
