### PR TITLE
src/daemon/gnet: move DebugPrint from global variable to Config

### DIFF
--- a/src/daemon/gnet/dispatcher.go
+++ b/src/daemon/gnet/dispatcher.go
@@ -33,7 +33,7 @@ func sendMessage(conn net.Conn, msg Message, timeout time.Duration) error {
 }
 
 // Event handler that is called after a Connection sends a complete message
-func convertToMessage(id int, msg []byte) (Message, error) {
+func convertToMessage(id int, msg []byte, debugPrint bool) (Message, error) {
 	msgId := [4]byte{}
 	if len(msg) < len(msgId) {
 		return nil, errors.New("Not enough data to read msg id")
@@ -45,7 +45,7 @@ func convertToMessage(id int, msg []byte) (Message, error) {
 		return nil, fmt.Errorf("Unknown message %s received", string(msgId[:]))
 	}
 
-	if DebugPrint {
+	if debugPrint {
 		logger.Debug("Convert, Message type %v", t)
 	}
 

--- a/src/daemon/gnet/dispatcher_test.go
+++ b/src/daemon/gnet/dispatcher_test.go
@@ -38,7 +38,7 @@ func TestConvertToMessage(t *testing.T) {
 	b := make([]byte, 0)
 	b = append(b, BytePrefix[:]...)
 	b = append(b, byte(7))
-	m, err := convertToMessage(c.Id, b)
+	m, err := convertToMessage(c.Id, b, testing.Verbose())
 	assert.Nil(t, err)
 	assert.NotNil(t, m)
 	if m == nil {
@@ -53,7 +53,7 @@ func TestConvertToMessageNoMessageId(t *testing.T) {
 	resetHandler()
 	c := &Connection{}
 	b := []byte{}
-	m, err := convertToMessage(c.Id, b)
+	m, err := convertToMessage(c.Id, b, testing.Verbose())
 	assert.Nil(t, m)
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "Not enough data to read msg id")
@@ -64,7 +64,7 @@ func TestConvertToMessageUnknownMessage(t *testing.T) {
 	resetHandler()
 	c := &Connection{}
 	b := MessagePrefix{'C', 'C', 'C', 'C'}
-	m, err := convertToMessage(c.Id, b[:])
+	m, err := convertToMessage(c.Id, b[:], testing.Verbose())
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "Unknown message CCCC received")
 	assert.Nil(t, m)
@@ -79,14 +79,14 @@ func TestConvertToMessageBadDeserialize(t *testing.T) {
 	c := &Connection{}
 	// Test with too many bytes
 	b := append(DummyPrefix[:], []byte{0, 1, 1, 1}...)
-	m, err := convertToMessage(c.Id, b)
+	m, err := convertToMessage(c.Id, b, testing.Verbose())
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "Data buffer was not completely decoded")
 	assert.Nil(t, m)
 
 	// Test with not enough bytes
 	b = append([]byte{}, BytePrefix[:]...)
-	m, err = convertToMessage(c.Id, b)
+	m, err = convertToMessage(c.Id, b, testing.Verbose())
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "Deserialization failed")
 	assert.Nil(t, m)
@@ -98,7 +98,9 @@ func TestConvertToMessageNotMessage(t *testing.T) {
 	RegisterMessage(NothingPrefix, Nothing{})
 	// don't verify messages
 	c := &Connection{}
-	assert.Panics(t, func() { convertToMessage(c.Id, NothingPrefix[:]) })
+	assert.Panics(t, func() {
+		convertToMessage(c.Id, NothingPrefix[:], testing.Verbose())
+	})
 }
 
 func TestDeserializeMessageTrapsPanic(t *testing.T) {

--- a/src/daemon/gnet/pool.go
+++ b/src/daemon/gnet/pool.go
@@ -16,10 +16,6 @@ import (
 	"github.com/skycoin/skycoin/src/util"
 )
 
-var DebugPrint bool = true //disable to disable printing
-
-// TODO -- parameterize configuration per pool
-
 // DisconnectReason is passed to ConnectionPool's DisconnectCallback
 type DisconnectReason error
 
@@ -73,6 +69,8 @@ type Config struct {
 	DisconnectCallback DisconnectCallback
 	// Triggered on client connect
 	ConnectCallback ConnectCallback
+	// Print debug logs
+	DebugPrint bool
 }
 
 // NewConfig returns a Config with defaults set
@@ -90,6 +88,7 @@ func NewConfig() Config {
 		ConnectionWriteQueueSize: 32,
 		DisconnectCallback:       nil,
 		ConnectCallback:          nil,
+		DebugPrint:               false,
 	}
 }
 
@@ -557,7 +556,7 @@ func (pool *ConnectionPool) Size() int {
 // SendMessage sends a Message to a Connection and pushes the result onto the
 // SendResults channel.
 func (pool *ConnectionPool) SendMessage(addr string, msg Message) error {
-	if DebugPrint {
+	if pool.Config.DebugPrint {
 		logger.Debug("Send, Msg Type: %s", reflect.TypeOf(msg))
 	}
 	var msgQueueFull bool
@@ -580,7 +579,7 @@ func (pool *ConnectionPool) SendMessage(addr string, msg Message) error {
 
 // BroadcastMessage sends a Message to all connections in the Pool.
 func (pool *ConnectionPool) BroadcastMessage(msg Message) {
-	if DebugPrint {
+	if pool.Config.DebugPrint {
 		logger.Debug("Broadcast, Msg Type: %s", reflect.TypeOf(msg))
 	}
 	fullWriteQueue := []string{}
@@ -604,7 +603,7 @@ func (pool *ConnectionPool) BroadcastMessage(msg Message) {
 // first return value.  Otherwise, error will be nil and DisconnectReason will
 // be the value returned from the message handler.
 func (pool *ConnectionPool) receiveMessage(c *Connection, msg []byte) (DisconnectReason, error) {
-	m, err := convertToMessage(c.Id, msg)
+	m, err := convertToMessage(c.Id, msg, pool.Config.DebugPrint)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The `src/daemon/gnet` used `DebugPrint` global variable. The PR move it to `Config` allowing to configure every instance of `Pool`.

There aren't changes in related packages. May be `src/daemon` should be fixed