### PR TITLE
Persist unconfirmed transactions and add txn exchange on connect

### DIFF
--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/boltdb/bolt"
 	logging "github.com/op/go-logging"
 	"github.com/skycoin/skycoin/src/api/webrpc"
 	"github.com/skycoin/skycoin/src/cipher"
@@ -139,6 +140,8 @@ type Config struct {
 	// Will force it to connect to this ip:port, instead of waiting for it
 	// to show up as a peer
 	ConnectTo string
+
+	DB *bolt.DB
 }
 
 func (c *Config) register() {
@@ -441,6 +444,7 @@ func configureDaemon(c *Config) daemon.Config {
 	dc.Visor.Config.GenesisSignature = c.GenesisSignature
 	dc.Visor.Config.GenesisTimestamp = c.GenesisTimestamp
 	dc.Visor.Config.GenesisCoinVolume = GenesisCoinVolume
+	dc.Visor.Config.DB = c.DB
 	return dc
 }
 
@@ -471,8 +475,10 @@ func Run(c *Config) {
 	// initLogging(c.LogLevel, c.ColorLog)
 
 	// start the block db.
-	blockdb.Start()
-	defer blockdb.Stop()
+	db, stop := blockdb.Open()
+	defer stop()
+
+	c.DB = db
 
 	// start the transaction db.
 	// transactiondb.Start()

--- a/electron/package-standalone-release.sh
+++ b/electron/package-standalone-release.sh
@@ -49,8 +49,9 @@ function copy_if_exists_with_builder {
         cp "$BIN" "$DESTDIR"
 
         # Copy static resources to electron app
-        echo "Copying $GUI_DIST_DIR to $DESTDIR"
-        cp -R "$GUI_DIST_DIR" "$DESTDIR"
+        echo "Copying $GUI_DIST_DIR to ${DESTDIR}/src/gui/static"
+        mkdir -p "${DESTDIR}/src/gui/static"
+        cp -R "$GUI_DIST_DIR" "${DESTDIR}/src/gui/static"
 
         echo "Adding $DESTSRC to package-source.sh list"
         DESTSRCS+=("$DESTSRC")
@@ -81,8 +82,10 @@ function copy_if_exists {
         cp "$BIN" "$DESTBIN"
 
         # Copy static resources to electron app
-        echo "Copying $GUI_DIST_DIR to $DESTDIR"
-        cp -R "$GUI_DIST_DIR" "$DESTDIR"
+        echo "Copying $GUI_DIST_DIR to ${DESTDIR}/src/gui/static"
+
+        mkdir -p "${DESTDIR}/src/gui/static"
+        cp -R "$GUI_DIST_DIR" "${DESTDIR}/src/gui/static"
 
         echo "Adding $DESTSRC to package-source.sh list"
         DESTSRCS+=("$DESTSRC")

--- a/electron/package.json
+++ b/electron/package.json
@@ -3,7 +3,7 @@
     "productName": "Skycoin",
     "author": "skycoin",
     "main": "src/electron-main.js",
-    "version": "0.14.0",
+    "version": "0.15.0",
     "description": "skycoin wallet",
     "build": {
         "appId": "org.skycoin.skycoin",

--- a/electron/skycoin/current-skycoin.json
+++ b/electron/skycoin/current-skycoin.json
@@ -1,1 +1,1 @@
-versionData='{     "version": "0.14.0" }';
+versionData='{     "version": "0.15.0" }';

--- a/src/api/cli/create_rawtx.go
+++ b/src/api/cli/create_rawtx.go
@@ -443,10 +443,10 @@ func getSufficientUnspents(unspents []unspentOut, amt uint64) ([]unspentOut, err
 			us[i].Coins = strconv.FormatUint(tmpAmt, 10)
 			totalAmt += coins
 			outs = append(outs, us[i])
-		}
 
-		if totalAmt >= amt {
-			return outs, nil
+			if totalAmt >= amt {
+				return outs, nil
+			}
 		}
 	}
 

--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -310,6 +310,7 @@ func (dm *Daemon) Start(quit chan int) {
 	}
 
 	unconfirmedRefreshTicker := time.Tick(dm.Visor.Config.Config.UnconfirmedRefreshRate)
+	resendUnconfirmedTicker := time.Tick(dm.Visor.Config.Config.UnconfirmedResendPeriod)
 	blocksRequestTicker := time.Tick(dm.Visor.Config.BlocksRequestRate)
 	blocksAnnounceTicker := time.Tick(dm.Visor.Config.BlocksAnnounceRate)
 
@@ -421,6 +422,8 @@ main:
 			}
 		case <-unconfirmedRefreshTicker:
 			dm.Visor.RefreshUnconfirmed()
+		case <-resendUnconfirmedTicker:
+			dm.Visor.ResendUnconfirmedTxns(dm.Pool)
 		case <-blocksRequestTicker:
 			dm.Visor.RequestBlocks(dm.Pool)
 		case <-blocksAnnounceTicker:

--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -313,6 +313,7 @@ func (dm *Daemon) Start(quit chan int) {
 	resendUnconfirmedTicker := time.Tick(dm.Visor.Config.Config.UnconfirmedResendPeriod)
 	blocksRequestTicker := time.Tick(dm.Visor.Config.BlocksRequestRate)
 	blocksAnnounceTicker := time.Tick(dm.Visor.Config.BlocksAnnounceRate)
+	txnsAnnounceTicker := time.Tick(dm.Visor.Config.TxnsAnnounceRate)
 
 	privateConnectionsTicker := time.Tick(dm.Config.PrivateRate)
 	cullInvalidTicker := time.Tick(dm.Config.CullInvalidRate)
@@ -428,6 +429,8 @@ main:
 			dm.Visor.RequestBlocks(dm.Pool)
 		case <-blocksAnnounceTicker:
 			dm.Visor.AnnounceBlocks(dm.Pool)
+		case <-txnsAnnounceTicker:
+			dm.Visor.AnnounceTxns(dm.Pool)
 		case f := <-dm.memChannel:
 			f()
 		case <-quit:

--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -486,10 +486,10 @@ func (dm *Daemon) connectToPeer(p *pex.Peer) error {
 	if _, ok := dm.pendingConnections.Get(p.Addr); ok {
 		return errors.New("Connection is pending")
 	}
-	// cnt, ok := dm.ipCounts.Get(a)
-	// if !dm.Config.LocalhostOnly && ok && cnt != 0 {
-	// 	return errors.New("Already connected to a peer with this base IP")
-	// }
+	cnt, ok := dm.ipCounts.Get(a)
+	if !dm.Config.LocalhostOnly && ok && cnt != 0 {
+		return errors.New("Already connected to a peer with this base IP")
+	}
 	logger.Debug("Trying to connect to %s", p.Addr)
 	dm.pendingConnections.Add(p.Addr, p)
 	go func() {

--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -310,10 +310,10 @@ func (dm *Daemon) Start(quit chan int) {
 	}
 
 	unconfirmedRefreshTicker := time.Tick(dm.Visor.Config.Config.UnconfirmedRefreshRate)
-	resendUnconfirmedTicker := time.Tick(dm.Visor.Config.Config.UnconfirmedResendPeriod)
+	// resendUnconfirmedTicker := time.Tick(dm.Visor.Config.Config.UnconfirmedResendPeriod)
 	blocksRequestTicker := time.Tick(dm.Visor.Config.BlocksRequestRate)
 	blocksAnnounceTicker := time.Tick(dm.Visor.Config.BlocksAnnounceRate)
-	txnsAnnounceTicker := time.Tick(dm.Visor.Config.TxnsAnnounceRate)
+	// txnsAnnounceTicker := time.Tick(dm.Visor.Config.TxnsAnnounceRate)
 
 	privateConnectionsTicker := time.Tick(dm.Config.PrivateRate)
 	cullInvalidTicker := time.Tick(dm.Config.CullInvalidRate)
@@ -422,15 +422,18 @@ main:
 				}
 			}
 		case <-unconfirmedRefreshTicker:
-			dm.Visor.RefreshUnconfirmed()
-		case <-resendUnconfirmedTicker:
-			// dm.Visor.ResendUnconfirmedTxns(dm.Pool)
+			// get the transactions that turn to valid
+			validTxns := dm.Visor.RefreshUnconfirmed()
+			// announce this transactions
+			dm.Visor.AnnounceTxns(dm.Pool, validTxns)
+		// case <-resendUnconfirmedTicker:
+		// dm.Visor.ResendUnconfirmedTxns(dm.Pool)
 		case <-blocksRequestTicker:
 			dm.Visor.RequestBlocks(dm.Pool)
 		case <-blocksAnnounceTicker:
 			dm.Visor.AnnounceBlocks(dm.Pool)
-		case <-txnsAnnounceTicker:
-			dm.Visor.AnnounceTxns(dm.Pool)
+		// case <-txnsAnnounceTicker:
+		// dm.Visor.AnnounceTxns(dm.Pool)
 		case f := <-dm.memChannel:
 			f()
 		case <-quit:

--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -423,7 +423,7 @@ main:
 		case <-unconfirmedRefreshTicker:
 			dm.Visor.RefreshUnconfirmed()
 		case <-resendUnconfirmedTicker:
-			dm.Visor.ResendUnconfirmedTxns(dm.Pool)
+			// dm.Visor.ResendUnconfirmedTxns(dm.Pool)
 		case <-blocksRequestTicker:
 			dm.Visor.RequestBlocks(dm.Pool)
 		case <-blocksAnnounceTicker:

--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -486,10 +486,10 @@ func (dm *Daemon) connectToPeer(p *pex.Peer) error {
 	if _, ok := dm.pendingConnections.Get(p.Addr); ok {
 		return errors.New("Connection is pending")
 	}
-	cnt, ok := dm.ipCounts.Get(a)
-	if !dm.Config.LocalhostOnly && ok && cnt != 0 {
-		return errors.New("Already connected to a peer with this base IP")
-	}
+	// cnt, ok := dm.ipCounts.Get(a)
+	// if !dm.Config.LocalhostOnly && ok && cnt != 0 {
+	// 	return errors.New("Already connected to a peer with this base IP")
+	// }
 	logger.Debug("Trying to connect to %s", p.Addr)
 	dm.pendingConnections.Add(p.Addr, p)
 	go func() {
@@ -626,7 +626,7 @@ func (dm *Daemon) onConnect(e ConnectEvent) {
 	if e.Solicited {
 		logger.Info("Connected to %s as we requested", a)
 	} else {
-		logger.Info("Received unsolicited connection to %s", a)
+		logger.Info("Received unsolicited connection from %s", a)
 	}
 
 	dm.pendingConnections.Remove(a)
@@ -657,7 +657,7 @@ func (dm *Daemon) onConnect(e ConnectEvent) {
 	}
 
 	dm.expectingIntroductions.Add(a, util.Now())
-	logger.Debug("Sending introduction message to %s", a)
+	logger.Debug("Sending introduction message to %s, mirror:%d", a, dm.Messages.Mirror)
 	m := NewIntroductionMessage(dm.Messages.Mirror, dm.Config.Version,
 		dm.Pool.Pool.Config.Port)
 	dm.Pool.Pool.SendMessage(a, m)

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -384,7 +384,7 @@ func (gw *Gateway) GetAllUnconfirmedTxns() (txns []visor.UnconfirmedTxn) {
 // GetUnconfirmedTxns returns addresses related unconfirmed transactions
 func (gw *Gateway) GetUnconfirmedTxns(addrs []cipher.Address) (txns []visor.UnconfirmedTxn) {
 	gw.strand(func() {
-		txns = gw.v.GetUnconfirmedTxns(addrs)
+		txns = gw.v.GetUnconfirmedTxns(visor.ToAddresses(addrs))
 	})
 	return
 }

--- a/src/daemon/gnet/pool.go
+++ b/src/daemon/gnet/pool.go
@@ -113,10 +113,11 @@ type Connection struct {
 	LastSent time.Time
 	// Message send queue.
 	WriteQueue chan Message
+	Solicited  bool
 }
 
 // NewConnection creates a new Connection tied to a ConnectionPool
-func NewConnection(pool *ConnectionPool, id int, conn net.Conn, writeQueueSize int) *Connection {
+func NewConnection(pool *ConnectionPool, id int, conn net.Conn, writeQueueSize int, solicited bool) *Connection {
 	return &Connection{
 		Id:             id,
 		Conn:           conn,
@@ -125,6 +126,7 @@ func NewConnection(pool *ConnectionPool, id int, conn net.Conn, writeQueueSize i
 		LastReceived:   Now(),
 		LastSent:       Now(),
 		WriteQueue:     make(chan Message, writeQueueSize),
+		Solicited:      solicited,
 	}
 }
 
@@ -254,7 +256,7 @@ func (pool *ConnectionPool) strand(f func()) {
 
 // NewConnection creates a new Connection around a net.Conn.  Trying to make a connection
 // to an address that is already connected will panic.
-func (pool *ConnectionPool) NewConnection(conn net.Conn) (*Connection, error) {
+func (pool *ConnectionPool) NewConnection(conn net.Conn, solicited bool) (*Connection, error) {
 	a := conn.RemoteAddr().String()
 	var nc *Connection
 	var err error
@@ -265,7 +267,7 @@ func (pool *ConnectionPool) NewConnection(conn net.Conn) (*Connection, error) {
 		}
 		pool.connId++
 		nc = NewConnection(pool, pool.connId, conn,
-			pool.Config.ConnectionWriteQueueSize)
+			pool.Config.ConnectionWriteQueueSize, solicited)
 
 		pool.pool[nc.Id] = nc
 		pool.addresses[a] = nc
@@ -301,7 +303,7 @@ func (pool *ConnectionPool) handleConnection(conn net.Conn, solicited bool) {
 		}
 	}()
 
-	c, err := pool.NewConnection(conn)
+	c, err := pool.NewConnection(conn, solicited)
 	if err != nil {
 		log.Panic(err)
 	}

--- a/src/daemon/messages.go
+++ b/src/daemon/messages.go
@@ -326,6 +326,9 @@ func (self *IntroductionMessage) Process(d *Daemon) {
 	} else {
 		logger.Warning("%v", err)
 	}
+
+	// Anounce unconfirmed know txns
+	d.Visor.AnnounceTxns(d.Pool)
 }
 
 // Sent to keep a connection alive. A PongMessage is sent in reply.

--- a/src/daemon/messages.go
+++ b/src/daemon/messages.go
@@ -328,7 +328,7 @@ func (self *IntroductionMessage) Process(d *Daemon) {
 	}
 
 	// Anounce unconfirmed know txns
-	d.Visor.AnnounceTxns(d.Pool)
+	d.Visor.AnnounceAllTxns(d.Pool)
 }
 
 // Sent to keep a connection alive. A PongMessage is sent in reply.

--- a/src/daemon/messages.go
+++ b/src/daemon/messages.go
@@ -156,7 +156,7 @@ func (self *GetPeersMessage) Process(d *Daemon) {
 		return
 	}
 
-	logger.Info(fmt.Sprintf("give exchange peers:%+v", peers))
+	// logger.Info(fmt.Sprintf("give exchange peers:%+v", peers))
 
 	m := NewGivePeersMessage(peers)
 	d.Pool.Pool.SendMessage(self.addr, m)

--- a/src/daemon/pex/pex.go
+++ b/src/daemon/pex/pex.go
@@ -154,6 +154,7 @@ type Peerlist struct {
 func (pl *Peerlist) strand(f func(), arg ...interface{}) {
 	pl.lock.Lock()
 	defer pl.lock.Unlock()
+	// logger.Critical("%v", arg)
 	f()
 }
 
@@ -317,7 +318,7 @@ func (self *Peerlist) random(count int, includePrivate bool) []*Peer {
 func (self *Peerlist) getExchgAddr(private bool) []string {
 	keys := []string{}
 	for a, p := range self.peers {
-		if p.HasIncomePort && p.Private {
+		if p.HasIncomePort && p.Private == private {
 			keys = append(keys, a)
 		}
 	}

--- a/src/daemon/rpc.go
+++ b/src/daemon/rpc.go
@@ -73,9 +73,11 @@ func (self RPC) GetConnections(d *Daemon) *Connections {
 	}
 	conns := make([]*Connection, 0, d.Pool.Pool.Size())
 	for _, c := range d.Pool.Pool.GetConnections() {
-		conn := self.GetConnection(d, c.Addr())
-		if conn != nil {
-			conns = append(conns, conn)
+		if c.Solicited {
+			conn := self.GetConnection(d, c.Addr())
+			if conn != nil {
+				conns = append(conns, conn)
+			}
 		}
 	}
 	return &Connections{Connections: conns}

--- a/src/daemon/visor.go
+++ b/src/daemon/visor.go
@@ -503,7 +503,7 @@ func (self *GiveBlocksMessage) Process(d *Daemon) {
 		}
 		err := d.Visor.ExecuteSignedBlock(b)
 		if err == nil {
-			// logger.Critical("Added new block %d", b.Block.Head.BkSeq)
+			logger.Critical("Added new block %d", b.Block.Head.BkSeq)
 			processed++
 		} else {
 			logger.Critical("Failed to execute received block: %v", err)
@@ -512,7 +512,6 @@ func (self *GiveBlocksMessage) Process(d *Daemon) {
 			break
 		}
 	}
-	logger.Critical("Processed %d/%d blocks", int(maxSeq)+processed, int(maxSeq)+len(self.Blocks))
 	if processed == 0 {
 		return
 	}

--- a/src/daemon/visor.go
+++ b/src/daemon/visor.go
@@ -232,7 +232,7 @@ func (vs *Visor) ResendTransaction(h cipher.SHA256, pool *Pool) {
 		return
 	}
 	vs.strand(func() {
-		if ut, ok := vs.v.Unconfirmed.Txns[h]; ok {
+		if ut, ok := vs.v.Unconfirmed.Get(h); ok {
 			vs.BroadcastTransaction(ut.Txn, pool)
 		}
 	})
@@ -246,10 +246,13 @@ func (vs *Visor) ResendUnconfirmedTxns(pool *Pool) []cipher.SHA256 {
 		return txids
 	}
 	vs.strand(func() {
-		var txns []visor.UnconfirmedTxn
-		for _, unconfirmTxn := range vs.v.Unconfirmed.Txns {
-			txns = append(txns, unconfirmTxn)
-		}
+		// var txns []visor.UnconfirmedTxn
+
+		// for _, unconfirmTxn := range vs.v.Unconfirmed.Txns {
+		// 	txns = append(txns, unconfirmTxn)
+		// }
+
+		txns := vs.v.Unconfirmed.GetAllUnconfirmedTxns()
 
 		// sort the txns by receive time
 		sort.Sort(byTxnRecvTime(txns))
@@ -662,5 +665,5 @@ func (txs byTxnRecvTime) Swap(i, j int) {
 }
 
 func (txs byTxnRecvTime) Less(i, j int) bool {
-	return txs[i].Received.Nanosecond() < txs[j].Received.Nanosecond()
+	return txs[i].Received < txs[j].Received
 }

--- a/src/daemon/visor.go
+++ b/src/daemon/visor.go
@@ -165,8 +165,9 @@ func (vs *Visor) AnnounceAllTxns(pool *Pool) {
 		return
 	}
 	vs.strand(func() {
-		// get local unconfired transaction hashes.
-		hashes := vs.v.GetAllUnconfirmedHashes()
+		// get local unconfirmed transaction hashes.
+		hashes := vs.v.GetAllValidUnconfirmedTxHashes()
+		// filter all thoses invalid txns
 		hashesSet := divideHashes(hashes, vs.Config.MaxTxnAnnounceNum)
 		for _, hs := range hashesSet {
 			m := NewAnnounceTxnsMessage(hs)
@@ -306,7 +307,7 @@ func (vs *Visor) ResendUnconfirmedTxns(pool *Pool) []cipher.SHA256 {
 		return txids
 	}
 	vs.strand(func() {
-		txns := vs.v.Unconfirmed.GetAllUnconfirmedTxns()
+		txns := vs.v.GetAllUnconfirmedTxns()
 
 		for i := range txns {
 			logger.Debugf("Rebroadcast tx %s", txns[i].Hash().Hex())

--- a/src/daemon/visor.go
+++ b/src/daemon/visor.go
@@ -519,6 +519,7 @@ func (self *GiveBlocksMessage) Process(d *Daemon) {
 		if err == nil {
 			logger.Critical("Added new block %d", b.Block.Head.BkSeq)
 			processed++
+			logger.Critical("Processed %d blocks", int(maxSeq)+processed)
 		} else {
 			logger.Critical("Failed to execute received block: %v", err)
 			// Blocks must be received in order, so if one fails its assumed

--- a/src/daemon/visor.go
+++ b/src/daemon/visor.go
@@ -246,12 +246,6 @@ func (vs *Visor) ResendUnconfirmedTxns(pool *Pool) []cipher.SHA256 {
 		return txids
 	}
 	vs.strand(func() {
-		// var txns []visor.UnconfirmedTxn
-
-		// for _, unconfirmTxn := range vs.v.Unconfirmed.Txns {
-		// 	txns = append(txns, unconfirmTxn)
-		// }
-
 		txns := vs.v.Unconfirmed.GetAllUnconfirmedTxns()
 
 		// sort the txns by receive time

--- a/src/daemon/visor_test.go
+++ b/src/daemon/visor_test.go
@@ -1,5 +1,12 @@
 package daemon
 
+import (
+	"testing"
+
+	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/stretchr/testify/assert"
+)
+
 /*
 import (
 	"crypto/rand"
@@ -16,6 +23,7 @@ import (
 	"github.com/skycoin/skycoin/src/util"
 	"github.com/skycoin/skycoin/src/visor"
 	"github.com/skycoin/skycoin/src/wallet"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/assert"
 )
 */
@@ -1412,3 +1420,99 @@ func TestBlockchainLengths(t *testing.T) {
 }
 
 */
+
+func TestSplitHashes(t *testing.T) {
+	hashes := make([]cipher.SHA256, 10)
+	for i := 0; i < 10; i++ {
+		hashes[i] = cipher.SumSHA256(cipher.RandByte(512))
+	}
+
+	testCasts := []struct {
+		name  string
+		init  []cipher.SHA256
+		n     int
+		array [][]cipher.SHA256
+	}{
+		{
+			"has one odd",
+			hashes[:],
+			3,
+			[][]cipher.SHA256{
+				[]cipher.SHA256{
+					hashes[0],
+					hashes[1],
+					hashes[2],
+				},
+				[]cipher.SHA256{
+					hashes[3],
+					hashes[4],
+					hashes[5],
+				},
+				[]cipher.SHA256{
+					hashes[6],
+					hashes[7],
+					hashes[8],
+				},
+				[]cipher.SHA256{
+					hashes[9],
+				},
+			},
+		},
+		{
+			"only one value",
+			hashes[:1],
+			1,
+			[][]cipher.SHA256{
+				[]cipher.SHA256{
+					hashes[0],
+				},
+			},
+		},
+		{
+			"empty value",
+			hashes[:0],
+			0,
+			[][]cipher.SHA256{},
+		},
+		{
+			"with 3 value",
+			hashes[:3],
+			3,
+			[][]cipher.SHA256{
+				[]cipher.SHA256{
+					hashes[0],
+					hashes[1],
+					hashes[2],
+				},
+			},
+		},
+		{
+			"with 8 value",
+			hashes[:8],
+			3,
+			[][]cipher.SHA256{
+				[]cipher.SHA256{
+					hashes[0],
+					hashes[1],
+					hashes[2],
+				},
+				[]cipher.SHA256{
+					hashes[3],
+					hashes[4],
+					hashes[5],
+				},
+				[]cipher.SHA256{
+					hashes[6],
+					hashes[7],
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCasts {
+		t.Run(tc.name, func(t *testing.T) {
+			rlt := divideHashes(tc.init, tc.n)
+			assert.Equal(t, tc.array, rlt)
+		})
+	}
+}

--- a/src/gui/static/dist/current-skycoin.json
+++ b/src/gui/static/dist/current-skycoin.json
@@ -1,1 +1,1 @@
-versionData='{ "version":"0.13.0" }';
+versionData='{ "version":"0.15.0" }';

--- a/src/gui/static/src/current-skycoin.json
+++ b/src/gui/static/src/current-skycoin.json
@@ -1,1 +1,1 @@
-versionData='{ "version":"0.13.0" }';
+versionData='{ "version":"0.15.0" }';

--- a/src/visor/blockchain.go
+++ b/src/visor/blockchain.go
@@ -17,6 +17,9 @@ var (
 	DebugLevel1 = true
 	// DebugLevel2 enable checks for impossible conditions
 	DebugLevel2 = true
+
+	// ErrUnspentNotExist represents the error of unspent output in a tx does not exist
+	ErrUnspentNotExist = errors.New("Unspent output does not exist")
 )
 
 //Warning: 10e6 is 10 million, 1e6 is 1 million
@@ -537,7 +540,7 @@ func (bc Blockchain) TransactionFee(t *coin.Transaction) (uint64, error) {
 	for i := range t.In {
 		in, ok := bc.unspent.Get(t.In[i])
 		if !ok {
-			return 0, errors.New("Unspent output does not exist")
+			return 0, ErrUnspentNotExist
 		}
 		inHours += in.CoinHours(headTime)
 	}

--- a/src/visor/blockchain_parser.go
+++ b/src/visor/blockchain_parser.go
@@ -79,7 +79,7 @@ func (bcp *BlockchainParser) Stop() {
 
 func (bcp *BlockchainParser) parseTo(bcHeight uint64) error {
 	if bcp.parsedHeight == 0 {
-		logger.Critical("historydb parse %d/%d", bcp.parsedHeight, bcHeight)
+		// logger.Critical("historydb parse %d/%d", bcp.parsedHeight, bcHeight)
 		for i := uint64(0); i <= bcHeight-bcp.parsedHeight; i++ {
 			b := bcp.bc.GetBlockInDepth(bcp.parsedHeight + i)
 			if b == nil {
@@ -90,9 +90,9 @@ func (bcp *BlockchainParser) parseTo(bcHeight uint64) error {
 				return err
 			}
 		}
-		logger.Critical("historydb parse %d/%d", bcHeight, bcHeight)
+		// logger.Critical("historydb parse %d/%d", bcHeight, bcHeight)
 	} else {
-		logger.Critical("historydb parse %d/%d", bcp.parsedHeight, bcHeight)
+		// logger.Critical("historydb parse %d/%d", bcp.parsedHeight, bcHeight)
 		for i := uint64(0); i < bcHeight-bcp.parsedHeight; i++ {
 			b := bcp.bc.GetBlockInDepth(bcp.parsedHeight + i + 1)
 			if b == nil {
@@ -103,7 +103,7 @@ func (bcp *BlockchainParser) parseTo(bcHeight uint64) error {
 				return err
 			}
 		}
-		logger.Critical("historydb parse %d/%d", bcHeight, bcHeight)
+		// logger.Critical("historydb parse %d/%d", bcHeight, bcHeight)
 	}
 	bcp.parsedHeight = bcHeight
 	return nil

--- a/src/visor/blockchain_test.go
+++ b/src/visor/blockchain_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/skycoin/skycoin/src/aether/encoder"
 	"github.com/skycoin/skycoin/src/cipher"
-	"github.com/skycoin/skycoin/src/cipher/encoder"
 	"github.com/skycoin/skycoin/src/coin"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,12 +25,6 @@ var _incTime uint64 = 3600 * 1000
 var _genCoins uint64 = 1000e6
 var _genCoinHours uint64 = 1000 * 1000
 
-/*
-
-
-
- */
-
 func tNow() uint64 {
 	return uint64(time.Now().UTC().Unix())
 }
@@ -45,7 +39,7 @@ func _makeFeeCalc(fee uint64) coin.FeeCalculator {
 	}
 }
 
-/* Helpers */
+// /* Helpers */
 
 type FakeTree struct {
 	blocks []*coin.Block
@@ -134,7 +128,7 @@ func makeTransactionForChainWithFee(t *testing.T, bc *Blockchain,
 	ux := coin.UxOut{}
 	hrs := uint64(100)
 	for _, u := range bc.GetUnspent().Array() {
-		if ux.CoinHours(bc.Time()) > hrs {
+		if u.CoinHours(bc.Time()) > hrs {
 			ux = u
 			break
 		}
@@ -146,7 +140,7 @@ func makeTransactionForChainWithFee(t *testing.T, bc *Blockchain,
 }
 
 func makeTransactionForChain(t *testing.T, bc *Blockchain) coin.Transaction {
-	return makeTransactionForChainWithFee(t, bc, 100)
+	return makeTransactionForChainWithFee(t, bc, 500000001)
 }
 
 func addTransactionToBlock(t *testing.T, b *coin.Block) coin.Transaction {

--- a/src/visor/blockdb/blocksigs.go
+++ b/src/visor/blockdb/blocksigs.go
@@ -3,6 +3,7 @@ package blockdb
 import (
 	"fmt"
 
+	"github.com/boltdb/bolt"
 	"github.com/skycoin/skycoin/src/aether/encoder"
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/coin"
@@ -23,7 +24,7 @@ type BlockSigs struct {
 	Sigs *bucket.Bucket
 }
 
-func NewBlockSigs() *BlockSigs {
+func NewBlockSigs(db *bolt.DB) *BlockSigs {
 	sigs, err := bucket.New([]byte("block_sigs"), db)
 	if err != nil {
 		panic(err)

--- a/src/visor/bucket/bucket.go
+++ b/src/visor/bucket/bucket.go
@@ -1,7 +1,7 @@
 package bucket
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/boltdb/bolt"
 )
@@ -42,11 +42,10 @@ func (b *Bucket) GetAll() map[interface{}][]byte {
 	values := map[interface{}][]byte{}
 	b.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(b.Name)
-		c := bkt.Cursor()
-
-		for k, v := c.First(); k != nil; k, v = c.Next() {
+		bkt.ForEach(func(k, v []byte) error {
 			values[string(k)] = v
-		}
+			return nil
+		})
 		return nil
 	})
 	return values
@@ -106,7 +105,7 @@ func (b *Bucket) Update(key []byte, f func([]byte) ([]byte, error)) error {
 			}
 			return bkt.Put(key, v)
 		}
-		return errors.New("not exist in bucket")
+		return fmt.Errorf("%s not exist in bucket %s", string(key), string(b.Name))
 	})
 }
 

--- a/src/visor/bucket/bucket.go
+++ b/src/visor/bucket/bucket.go
@@ -9,7 +9,7 @@ type Bucket struct {
 	db   *bolt.DB
 }
 
-// NewBucket create bucket of specific name.
+// New create bucket of specific name.
 func New(name []byte, db *bolt.DB) (*Bucket, error) {
 	err := db.Update(func(tx *bolt.Tx) error {
 		if _, err := tx.CreateBucketIfNotExists(name); err != nil {
@@ -47,7 +47,6 @@ func (b Bucket) Find(filter func(key, value []byte) bool) []byte {
 		bt := tx.Bucket(b.Name)
 
 		c := bt.Cursor()
-
 		for k, v := c.First(); k != nil; k, v = c.Next() {
 			if filter(k, v) {
 				value = v
@@ -59,15 +58,91 @@ func (b Bucket) Find(filter func(key, value []byte) bool) []byte {
 	return value
 }
 
-// Count return the number of key/value pairs
-// func (b Bucket) Count() uint64 {
-// 	var count uint64
-// 	b.db.View(func(tx *bolt.Tx) error {
-// 		bt := tx.Bucket(b.Name)
-// 		return bt.ForEach(func(k, v []byte) error {
-// 			count++
-// 			return nil
-// 		})
-// 	})
-// 	return count
-// }
+// Update use callback func to update the value of given key
+func (b *Bucket) Update(key []byte, f func([]byte) ([]byte, error)) error {
+	return b.db.Update(func(tx *bolt.Tx) error {
+		// get the value of given key
+		bkt := tx.Bucket(b.Name)
+		v := bkt.Get(key)
+		var err error
+		v, err = f(v)
+		if err != nil {
+			return err
+		}
+
+		return bkt.Put(key, v)
+	})
+}
+
+// Delete removes value of given key
+func (b *Bucket) Delete(key []byte) error {
+	return b.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(b.Name).Delete(key)
+	})
+}
+
+// GetAll returns all values
+func (b *Bucket) GetAll() map[interface{}][]byte {
+	values := map[interface{}][]byte{}
+	b.db.View(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(b.Name)
+		c := bkt.Cursor()
+
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			values[string(k)] = v
+		}
+		return nil
+	})
+	return values
+}
+
+// RangeUpdate updates range of the values
+func (b *Bucket) RangeUpdate(f func(k, v []byte) ([]byte, error)) error {
+	return b.db.Update(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(b.Name)
+		c := bkt.Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			v, err := f(k, v)
+			if err != nil {
+				return err
+			}
+
+			if err := bkt.Put(k, v); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// IsExist check if the value exist of the given key
+func (b *Bucket) IsExist(k []byte) bool {
+	var exist bool
+	b.db.View(func(tx *bolt.Tx) error {
+		v := tx.Bucket(b.Name).Get(k)
+		if v != nil {
+			exist = true
+		}
+		return nil
+	})
+	return exist
+}
+
+// ForEach iterate the whole bucket
+func (b *Bucket) ForEach(f func(k, v []byte) error) error {
+	return b.db.View(func(tx *bolt.Tx) error {
+		return tx.Bucket(b.Name).ForEach(f)
+	})
+}
+
+// Len returns the number of key value pairs
+func (b *Bucket) Len() (len int) {
+	b.db.View(func(tx *bolt.Tx) error {
+		c := tx.Bucket(b.Name).Cursor()
+		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+			len++
+		}
+		return nil
+	})
+	return
+}

--- a/src/visor/bucket/bucket_test.go
+++ b/src/visor/bucket/bucket_test.go
@@ -1,0 +1,332 @@
+package bucket
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+
+	"encoding/json"
+
+	"bytes"
+
+	"github.com/boltdb/bolt"
+	"github.com/stretchr/testify/assert"
+)
+
+type person struct {
+	Name string
+	Age  int
+}
+
+func prepareDB(t *testing.T) (*bolt.DB, func()) {
+	f := fmt.Sprintf("test%d.db", rand.Intn(1024))
+	db, err := bolt.Open(f, 0700, nil)
+	assert.Nil(t, err)
+	return db, func() {
+		db.Close()
+		os.Remove(f)
+	}
+}
+
+func TestBktUpdate(t *testing.T) {
+	testCases := []struct {
+		Init      map[string]person
+		UpdateAge map[string]int
+	}{
+		{
+			map[string]person{
+				"1": person{"XiaoHei", 10},
+				"2": person{"XiaoHuang", 11},
+			},
+			map[string]int{
+				"1": 20,
+				"2": 21,
+			},
+		},
+	}
+
+	db, cancel := prepareDB(t)
+	defer cancel()
+
+	for _, tc := range testCases {
+		bkt, err := New([]byte(fmt.Sprintf("bkt%d", rand.Int31n(1024))), db)
+		assert.Nil(t, err)
+		// init value
+		for k, v := range tc.Init {
+			d, err := json.Marshal(v)
+			assert.Nil(t, err)
+			bkt.Put([]byte(k), d)
+		}
+
+		// update value
+		for k, v := range tc.UpdateAge {
+			err := bkt.Update([]byte(k), func(val []byte) ([]byte, error) {
+				var p person
+				if err := json.NewDecoder(bytes.NewReader(val)).Decode(&p); err != nil {
+					return nil, err
+				}
+				p.Age = v
+				d, err := json.Marshal(p)
+				if err != nil {
+					return nil, err
+				}
+				return d, nil
+			})
+			assert.Nil(t, err)
+		}
+
+		// check the updated value
+		for k, v := range tc.UpdateAge {
+			val := bkt.Get([]byte(k))
+			var p person
+			err := json.NewDecoder(bytes.NewReader(val)).Decode(&p)
+			assert.Nil(t, err)
+			assert.Equal(t, v, p.Age)
+		}
+	}
+}
+
+func TestDelete(t *testing.T) {
+	testCases := []struct {
+		Name string
+		Init map[string]string
+		Del  string
+		Err  error
+	}{
+		{
+			"Delete exist",
+			map[string]string{
+				"a": "1",
+				"b": "2",
+			},
+			"a",
+			nil,
+		},
+		{
+			"Delete none exist",
+			map[string]string{
+				"a": "1",
+			},
+			"b",
+			nil,
+		},
+	}
+	db, cancel := prepareDB(t)
+	defer cancel()
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			bkt, err := New([]byte(fmt.Sprintf("abc%d", rand.Int31n(1024))), db)
+			assert.Nil(t, err)
+			for k, v := range tc.Init {
+				err := bkt.Put([]byte(k), []byte(v))
+				assert.Nil(t, err)
+			}
+
+			err = bkt.Delete([]byte(tc.Del))
+			assert.Equal(t, tc.Err, err)
+
+			// check if this value is deleted
+			v := bkt.Get([]byte(tc.Del))
+			assert.Nil(t, v)
+		})
+	}
+}
+
+func TestGetAll(t *testing.T) {
+	testCases := []struct {
+		init map[string]string
+	}{
+		{
+			map[string]string{
+				"a": "1",
+				"b": "2",
+				"c": "3",
+			},
+		},
+	}
+	db, cancel := prepareDB(t)
+	defer cancel()
+
+	for _, tc := range testCases {
+		bkt, err := New([]byte(fmt.Sprintf("abc%d", rand.Int31n(1024))), db)
+		assert.Nil(t, err)
+		// init bkt
+		for k, v := range tc.init {
+			bkt.Put([]byte(k), []byte(v))
+		}
+
+		// get all
+		vs := bkt.GetAll()
+		for k, v := range vs {
+			assert.Equal(t, string(v), tc.init[k.(string)])
+		}
+	}
+}
+
+func TestRangeUpdate(t *testing.T) {
+	testCases := []struct {
+		init map[string]string
+		up   map[string]string
+	}{
+		{
+			map[string]string{
+				"a": "1",
+				"b": "2",
+				"c": "3",
+			},
+			map[string]string{
+				"a": "10",
+				"b": "20",
+				"c": "30",
+			},
+		},
+	}
+	db, cancel := prepareDB(t)
+	defer cancel()
+
+	for _, tc := range testCases {
+		bkt, err := New([]byte(fmt.Sprintf("asd%d", rand.Int31n(1024))), db)
+		assert.Nil(t, err)
+		for k, v := range tc.init {
+			bkt.Put([]byte(k), []byte(v))
+		}
+
+		// range update
+		bkt.RangeUpdate(func(k, v []byte) ([]byte, error) {
+			return []byte(tc.up[string(k)]), nil
+		})
+
+		// check if the value has been updated
+		for k, v := range tc.up {
+			assert.Equal(t, []byte(v), bkt.Get([]byte(k)))
+		}
+	}
+}
+
+func TestIsExsit(t *testing.T) {
+	testCases := []struct {
+		init  map[string]string
+		k     string
+		exist bool
+	}{
+		{
+			map[string]string{
+				"a": "1",
+				"b": "2",
+			},
+			"a",
+			true,
+		},
+		{
+			map[string]string{
+				"a": "1",
+				"b": "2",
+			},
+			"b",
+			true,
+		},
+		{
+			map[string]string{
+				"a": "1",
+				"b": "2",
+			},
+			"c",
+			false,
+		},
+		{
+			map[string]string{},
+			"c",
+			false,
+		},
+	}
+
+	db, cancel := prepareDB(t)
+	defer cancel()
+
+	for _, tc := range testCases {
+		bkt, err := New([]byte(fmt.Sprintf("asdf%d", rand.Int31n(1024))), db)
+		assert.Nil(t, err)
+
+		// init the bucket
+		for k, v := range tc.init {
+			bkt.Put([]byte(k), []byte(v))
+		}
+
+		assert.Equal(t, tc.exist, bkt.IsExist([]byte(tc.k)))
+	}
+}
+
+func TestForEach(t *testing.T) {
+	testCases := []struct {
+		init map[string]string
+	}{
+		{
+			map[string]string{
+				"a": "1",
+				"b": "2",
+				"c": "3",
+			},
+		},
+		{
+			map[string]string{},
+		},
+	}
+	db, cancel := prepareDB(t)
+	defer cancel()
+	for _, tc := range testCases {
+		bkt, err := New([]byte(fmt.Sprintf("fasd%d", rand.Int31n(1024))), db)
+		assert.Nil(t, err)
+		for k, v := range tc.init {
+			bkt.Put([]byte(k), []byte(v))
+		}
+
+		var count int
+		bkt.ForEach(func(k, v []byte) error {
+			count++
+			assert.Equal(t, string(v), tc.init[string(k)])
+			return nil
+		})
+
+		assert.Equal(t, len(tc.init), count)
+	}
+}
+
+func TestLen(t *testing.T) {
+	testCases := []struct {
+		data map[string]string
+		len  int
+	}{
+		{
+			map[string]string{},
+			0,
+		},
+		{
+			map[string]string{
+				"a": "1",
+			},
+			1,
+		},
+		{
+			map[string]string{
+				"a": "1",
+				"b": "2",
+				"c": "3",
+				"d": "4",
+			},
+			4,
+		},
+	}
+
+	db, cl := prepareDB(t)
+	defer cl()
+	for _, tc := range testCases {
+		bkt, err := New([]byte(fmt.Sprintf("adsf%d", rand.Int31n(1024))), db)
+		assert.Nil(t, err)
+		for k, v := range tc.data {
+			bkt.Put([]byte(k), []byte(v))
+		}
+
+		assert.Equal(t, tc.len, bkt.Len())
+	}
+}

--- a/src/visor/historydb/historydb.go
+++ b/src/visor/historydb/historydb.go
@@ -3,6 +3,7 @@
 package historydb
 
 import (
+	"errors"
 	"path/filepath"
 
 	"github.com/boltdb/bolt"
@@ -85,6 +86,10 @@ func (hd *HistoryDB) GetUxout(uxID cipher.SHA256) (*UxOut, error) {
 
 // ProcessBlock will index the transaction, outputs,etc.
 func (hd *HistoryDB) ProcessBlock(b *coin.Block) error {
+	if b == nil {
+		return errors.New("process nil block")
+	}
+
 	// index the transactions
 	for _, t := range b.Body.Transactions {
 		tx := Transaction{

--- a/src/visor/readable.go
+++ b/src/visor/readable.go
@@ -247,6 +247,7 @@ type ReadableUnconfirmedTxn struct {
 	Received  time.Time           `json:"received"`
 	Checked   time.Time           `json:"checked"`
 	Announced time.Time           `json:"announced"`
+	IsValid   bool                `json:"is_valid"`
 }
 
 func NewReadableUnconfirmedTxn(unconfirmed *UnconfirmedTxn) ReadableUnconfirmedTxn {
@@ -255,6 +256,7 @@ func NewReadableUnconfirmedTxn(unconfirmed *UnconfirmedTxn) ReadableUnconfirmedT
 		Received:  nanoToTime(unconfirmed.Received),
 		Checked:   nanoToTime(unconfirmed.Checked),
 		Announced: nanoToTime(unconfirmed.Announced),
+		IsValid:   unconfirmed.IsValid == 1,
 	}
 }
 

--- a/src/visor/readable.go
+++ b/src/visor/readable.go
@@ -1,11 +1,11 @@
 package visor
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"time"
-	"encoding/json"
-	"errors"
 
 	"strconv"
 
@@ -28,7 +28,7 @@ func NewBlockchainMetadata(v *Visor) BlockchainMetadata {
 	return BlockchainMetadata{
 		Head:        NewReadableBlockHeader(&head),
 		Unspents:    uint64(len(v.Blockchain.GetUnspent().Pool)),
-		Unconfirmed: uint64(len(v.Unconfirmed.Txns)),
+		Unconfirmed: uint64(v.Unconfirmed.Txns.len()),
 	}
 }
 
@@ -116,6 +116,7 @@ type ReadableTransactionInput struct {
 	Hash    string `json:"uxid"`
 	Address string `json:"owner"`
 }
+
 //convert balance to string
 //each 1,000,000 units is 1 coin
 //skyoin has up to 6 decimal places but no more
@@ -237,7 +238,7 @@ type ReadableAddressTransaction struct {
 	Timestamp uint64 `json:"timestamp,omitempty"`
 
 	Sigs []string                    `json:"sigs"`
-	In   []ReadableTransactionInput   `json:"inputs"`
+	In   []ReadableTransactionInput  `json:"inputs"`
 	Out  []ReadableTransactionOutput `json:"outputs"`
 }
 
@@ -251,9 +252,9 @@ type ReadableUnconfirmedTxn struct {
 func NewReadableUnconfirmedTxn(unconfirmed *UnconfirmedTxn) ReadableUnconfirmedTxn {
 	return ReadableUnconfirmedTxn{
 		Txn:       NewReadableTransaction(&Transaction{Txn: unconfirmed.Txn}),
-		Received:  unconfirmed.Received,
-		Checked:   unconfirmed.Checked,
-		Announced: unconfirmed.Announced,
+		Received:  nanoToTime(unconfirmed.Received),
+		Checked:   nanoToTime(unconfirmed.Checked),
+		Announced: nanoToTime(unconfirmed.Announced),
 	}
 }
 

--- a/src/visor/readable_test.go
+++ b/src/visor/readable_test.go
@@ -4,6 +4,8 @@ import (
 	"crypto/rand"
 
 	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/coin"
+	"github.com/skycoin/skycoin/src/util"
 )
 
 const (
@@ -108,27 +110,28 @@ func randSHA256() cipher.SHA256 {
 	return cipher.SumSHA256(b)
 }
 
-// func createUnconfirmedTxn() UnconfirmedTxn {
-// 	ut := UnconfirmedTxn{}
-// 	ut.Txn = coin.Transaction{}
-// 	ut.Txn.Head.Hash = randSHA256()
-// 	ut.Received = util.Now()
-// 	ut.Checked = ut.Received
-// 	ut.Announced = util.ZeroTime()
-// 	return ut
-// }
+func createUnconfirmedTxn() UnconfirmedTxn {
+	ut := UnconfirmedTxn{}
+	ut.Txn = coin.Transaction{}
+	ut.Txn.InnerHash = randSHA256()
+	ut.Received = util.Now().UnixNano()
+	ut.Checked = ut.Received
+	ut.Announced = util.ZeroTime().UnixNano()
+	return ut
+}
 
-// func addUnconfirmedTxn(v *Visor) UnconfirmedTxn {
-// 	ut := createUnconfirmedTxn()
-// 	v.Unconfirmed.Txns[ut.Hash()] = ut
-// 	return ut
-// }
+func addUnconfirmedTxn(v *Visor) UnconfirmedTxn {
+	ut := createUnconfirmedTxn()
+	ut.Hash()
+	v.Unconfirmed.Txns.put(&ut)
+	return ut
+}
 
-// func addUnconfirmedTxnToPool(utp *UnconfirmedTxnPool) UnconfirmedTxn {
-// 	ut := createUnconfirmedTxn()
-// 	utp.Txns[ut.Hash()] = ut
-// 	return ut
-// }
+func addUnconfirmedTxnToPool(utp *UnconfirmedTxnPool) UnconfirmedTxn {
+	ut := createUnconfirmedTxn()
+	utp.Txns.put(&ut)
+	return ut
+}
 
 // func transferCoinsToSelf(v *Visor, addr cipher.Address) error {
 // 	tx, err := v.Spend(v.Wallets[0].GetFilename(), wallet.Balance{1e6, 0}, 0, addr)

--- a/src/visor/rpc.go
+++ b/src/visor/rpc.go
@@ -70,7 +70,7 @@ func (self RPC) GetUnspentOutputReadables(v *Visor) []ReadableOutput {
 }
 
 func (self RPC) GetUnconfirmedTxns(v *Visor, addresses []cipher.Address) []ReadableUnconfirmedTxn {
-	ret := v.GetUnconfirmedTxns(addresses)
+	ret := v.GetUnconfirmedTxns(ToAddresses(addresses))
 	rut := make([]ReadableUnconfirmedTxn, len(ret))
 	for i := range ret {
 		rut[i] = NewReadableUnconfirmedTxn(&ret[i])

--- a/src/visor/spend_test.go
+++ b/src/visor/spend_test.go
@@ -197,11 +197,12 @@ func TestCreateSpends(t *testing.T) {
 
 func TestCreateSpendingTransaction(t *testing.T) {
 	// Setup
-
+	db, close := prepareDB(t)
+	defer close()
 	w := wallet.NewWallet("fortest.wlt")
 
 	w.GenerateAddresses(4)
-	uncf := NewUnconfirmedTxnPool()
+	uncf := NewUnconfirmedTxnPool(db)
 	now := tNow()
 	a := makeAddress()
 
@@ -271,7 +272,8 @@ func TestCreateSpendingTransaction(t *testing.T) {
 	tx, err = CreateSpendingTransaction(w, uncf, &unsp, now, amt, a)
 	assert.Nil(t, err)
 	// Add it to the unconfirmed pool (bypass InjectTxn to avoid blockchain)
-	uncf.Txns[tx.Hash()] = uncf.createUnconfirmedTxn(&unsp, tx)
+	ux := uncf.createUnconfirmedTxn(&unsp, tx)
+	uncf.Txns.put(&ux)
 	// Make a spend that must not reuse previous addresses
 	_, err = CreateSpendingTransaction(w, uncf, &unsp, now, amt, a)
 	assertError(t, err, "Not enough coins")

--- a/src/visor/unconfirmed.go
+++ b/src/visor/unconfirmed.go
@@ -5,9 +5,12 @@ import (
 
 	"time"
 
+	"github.com/boltdb/bolt"
+	"github.com/skycoin/skycoin/src/aether/encoder"
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/coin"
 	"github.com/skycoin/skycoin/src/util"
+	"github.com/skycoin/skycoin/src/visor/bucket"
 )
 
 // BurnFactor half of coinhours must be burnt
@@ -52,11 +55,11 @@ func (tus TxnUnspents) AllForAddress(a cipher.Address) coin.UxArray {
 type UnconfirmedTxn struct {
 	Txn coin.Transaction
 	// Time the txn was last received
-	Received time.Time
+	Received int64
 	// Time the txn was last checked against the blockchain
-	Checked time.Time
+	Checked int64
 	// Last time we announced this txn
-	Announced time.Time
+	Announced int64
 }
 
 // Hash returns the coin.Transaction's hash
@@ -64,9 +67,120 @@ func (ut *UnconfirmedTxn) Hash() cipher.SHA256 {
 	return ut.Txn.Hash()
 }
 
+// unconfirmed transactions bucket
+type uncfmTxnBkt struct {
+	bkt *bucket.Bucket
+}
+
+func newUncfmTxBkt(db *bolt.DB) (*uncfmTxnBkt, error) {
+	bkt, err := bucket.New([]byte("unconfirmed_txns"), db)
+	if err != nil {
+		return nil, err
+	}
+	return &uncfmTxnBkt{bkt: bkt}, nil
+}
+
+func (utb *uncfmTxnBkt) get(hash cipher.SHA256) (*UnconfirmedTxn, bool) {
+	v := utb.bkt.Get([]byte(hash.Hex()))
+	if v == nil {
+		return nil, false
+	}
+	var tx UnconfirmedTxn
+	if err := encoder.DeserializeRaw(v, &tx); err != nil {
+		return nil, false
+	}
+	return &tx, true
+}
+
+func (utb *uncfmTxnBkt) put(v *UnconfirmedTxn) error {
+	key := []byte(v.Hash().Hex())
+	d := encoder.Serialize(v)
+	return utb.bkt.Put(key, d)
+}
+
+func (utb *uncfmTxnBkt) update(key cipher.SHA256, f func(v *UnconfirmedTxn)) error {
+	updateFun := func(v []byte) ([]byte, error) {
+		var tx UnconfirmedTxn
+		if err := encoder.DeserializeRaw(v, &tx); err != nil {
+			return nil, err
+		}
+
+		f(&tx)
+		return encoder.Serialize(tx), nil
+	}
+
+	return utb.bkt.Update([]byte(key.Hex()), updateFun)
+}
+
+func (utb *uncfmTxnBkt) delete(key cipher.SHA256) error {
+	return utb.bkt.Delete([]byte(key.Hex()))
+}
+
+func (utb *uncfmTxnBkt) getAll() (map[cipher.SHA256]UnconfirmedTxn, error) {
+	vs := utb.bkt.GetAll()
+	txns := make(map[cipher.SHA256]UnconfirmedTxn, len(vs))
+	for k, v := range vs {
+		key, err := cipher.SHA256FromHex(k.(string))
+		if err != nil {
+			return nil, err
+		}
+
+		var tx UnconfirmedTxn
+		if err := encoder.DeserializeRaw(v, &tx); err != nil {
+			return nil, err
+		}
+		txns[key] = tx
+	}
+	return txns, nil
+}
+
+func (utb *uncfmTxnBkt) rangeUpdate(f func(key cipher.SHA256, tx *UnconfirmedTxn)) error {
+	return utb.bkt.RangeUpdate(func(k, v []byte) ([]byte, error) {
+		key, err := cipher.SHA256FromHex(string(k))
+		if err != nil {
+			return nil, err
+		}
+
+		var tx UnconfirmedTxn
+		if err := encoder.DeserializeRaw(v, &tx); err != nil {
+			return nil, err
+		}
+
+		f(key, &tx)
+
+		// encoder the tx
+		d := encoder.Serialize(tx)
+		return d, nil
+	})
+}
+
+func (utb *uncfmTxnBkt) isExist(key cipher.SHA256) bool {
+	return utb.bkt.IsExist([]byte(key.Hex()))
+}
+
+func (utb *uncfmTxnBkt) forEach(f func(key cipher.SHA256, tx *UnconfirmedTxn) error) error {
+	return utb.bkt.ForEach(func(k, v []byte) error {
+		key, err := cipher.SHA256FromHex(string(k))
+		if err != nil {
+			return err
+		}
+		var tx UnconfirmedTxn
+		if err := encoder.DeserializeRaw(v, &tx); err != nil {
+			return err
+		}
+
+		return f(key, &tx)
+	})
+}
+
+func (utb *uncfmTxnBkt) len() int {
+	return utb.bkt.Len()
+}
+
 // UnconfirmedTxnPool manages unconfirmed transactions
 type UnconfirmedTxnPool struct {
-	Txns map[cipher.SHA256]UnconfirmedTxn
+	// Txns map[cipher.SHA256]UnconfirmedTxn
+	Txns *uncfmTxnBkt
 	// Predicted unspents, assuming txns are valid.  Needed to predict
 	// our future balance and avoid double spending our own coins
 	// Maps from Transaction.Hash() to UxArray.
@@ -74,19 +188,28 @@ type UnconfirmedTxnPool struct {
 }
 
 // NewUnconfirmedTxnPool creates an UnconfirmedTxnPool instance
-func NewUnconfirmedTxnPool() *UnconfirmedTxnPool {
+func NewUnconfirmedTxnPool(db *bolt.DB) *UnconfirmedTxnPool {
+	txnBkt, err := newUncfmTxBkt(db)
+	if err != nil {
+		panic(err)
+	}
+
 	return &UnconfirmedTxnPool{
-		Txns:    make(map[cipher.SHA256]UnconfirmedTxn),
+		Txns:    txnBkt,
 		Unspent: make(TxnUnspents),
 	}
 }
 
 // SetAnnounced updates announced time of specific tx
 func (utp *UnconfirmedTxnPool) SetAnnounced(h cipher.SHA256, t time.Time) {
-	if tx, ok := utp.Txns[h]; ok {
-		tx.Announced = t
-		utp.Txns[h] = tx
-	}
+	utp.Txns.update(h, func(tx *UnconfirmedTxn) {
+		tx.Announced = t.UnixNano()
+	})
+
+	// if tx, ok := utp.Txns[h]; ok {
+	// 	tx.Announced = t.UnixNano()
+	// 	utp.Txns[h] = tx
+	// }
 }
 
 // Creates an unconfirmed transaction
@@ -95,9 +218,9 @@ func (utp *UnconfirmedTxnPool) createUnconfirmedTxn(bcUnsp *coin.UnspentPool,
 	now := util.Now()
 	return UnconfirmedTxn{
 		Txn:       t,
-		Received:  now,
-		Checked:   now,
-		Announced: util.ZeroTime(),
+		Received:  now.UnixNano(),
+		Checked:   now.UnixNano(),
+		Announced: util.ZeroTime().UnixNano(),
 	}
 }
 
@@ -120,18 +243,32 @@ func (utp *UnconfirmedTxnPool) InjectTxn(bc *Blockchain,
 
 	// Update if we already have this txn
 	h := t.Hash()
-	ut, ok := utp.Txns[h]
-	if ok {
+	// update the time if exist
+	var exist bool
+	utp.Txns.update(h, func(tx *UnconfirmedTxn) {
+		exist = true
 		now := util.Now()
-		ut.Received = now
-		ut.Checked = now
-		utp.Txns[h] = ut
+		tx.Received = now.UnixNano()
+		tx.Checked = now.UnixNano()
+	})
+
+	if exist {
 		return nil, true
 	}
+	// ut, ok := utp.Txns[h]
+	// if ok {
+	// 	now := util.Now()
+	// 	ut.Received = now.UnixNano()
+	// 	ut.Checked = now.UnixNano()
+	// 	utp.Txns[h] = ut
+	// 	return nil, true
+	// }
 
 	// Add txn to index
 	unspent := bc.GetUnspent()
-	utp.Txns[h] = utp.createUnconfirmedTxn(unspent, t)
+	utx := utp.createUnconfirmedTxn(unspent, t)
+	utp.Txns.put(&utx)
+	// utp.Txns[h] = utp.createUnconfirmedTxn(unspent, t)
 	// Add predicted unspents
 	utp.Unspent[h] = coin.CreateUnspents(bc.Head().Head, t)
 
@@ -140,9 +277,14 @@ func (utp *UnconfirmedTxnPool) InjectTxn(bc *Blockchain,
 
 // RawTxns returns underlying coin.Transactions
 func (utp *UnconfirmedTxnPool) RawTxns() coin.Transactions {
-	txns := make(coin.Transactions, len(utp.Txns))
+	allUtx, err := utp.Txns.getAll()
+	if err != nil {
+		return coin.Transactions{}
+	}
+
+	txns := make(coin.Transactions, len(allUtx))
 	i := 0
-	for _, t := range utp.Txns {
+	for _, t := range allUtx {
 		txns[i] = t.Txn
 		i++
 	}
@@ -151,7 +293,8 @@ func (utp *UnconfirmedTxnPool) RawTxns() coin.Transactions {
 
 // Remove a single txn by hash
 func (utp *UnconfirmedTxnPool) removeTxn(bc *Blockchain, txHash cipher.SHA256) {
-	delete(utp.Txns, txHash)
+	// delete(utp.Txns, txHash)
+	utp.Txns.delete(txHash)
 	delete(utp.Unspent, txHash)
 }
 
@@ -160,7 +303,8 @@ func (utp *UnconfirmedTxnPool) removeTxn(bc *Blockchain, txHash cipher.SHA256) {
 func (utp *UnconfirmedTxnPool) removeTxns(bc *Blockchain,
 	hashes []cipher.SHA256) {
 	for i := range hashes {
-		delete(utp.Txns, hashes[i])
+		// delete(utp.Txns, hashes[i])
+		utp.Txns.delete(hashes[i])
 		delete(utp.Unspent, hashes[i])
 	}
 }
@@ -183,18 +327,30 @@ func (utp *UnconfirmedTxnPool) Refresh(bc *Blockchain,
 
 	now := util.Now()
 	var toRemove []cipher.SHA256
-	for k, t := range utp.Txns {
-		if now.Sub(t.Received) >= maxAge {
-			toRemove = append(toRemove, k)
-		} else if now.Sub(t.Checked) >= checkPeriod {
-			if bc.VerifyTransaction(t.Txn) == nil {
-				t.Checked = now
-				utp.Txns[k] = t
+	utp.Txns.rangeUpdate(func(key cipher.SHA256, tx *UnconfirmedTxn) {
+		if now.Sub(nanoToTime(tx.Received)) >= maxAge {
+			toRemove = append(toRemove, key)
+		} else if now.Sub(nanoToTime(tx.Checked)) >= checkPeriod {
+			if bc.VerifyTransaction(tx.Txn) == nil {
+				tx.Checked = now.UnixNano()
 			} else {
-				toRemove = append(toRemove, k)
+				toRemove = append(toRemove, key)
 			}
 		}
-	}
+	})
+
+	// for k, t := range utp.Txns {
+	// 	if now.Sub(nanoToTime(t.Received)) >= maxAge {
+	// 		toRemove = append(toRemove, k)
+	// 	} else if now.Sub(nanoToTime(t.Checked)) >= checkPeriod {
+	// 		if bc.VerifyTransaction(t.Txn) == nil {
+	// 			t.Checked = now.UnixNano()
+	// 			utp.Txns[k] = t
+	// 		} else {
+	// 			toRemove = append(toRemove, k)
+	// 		}
+	// 	}
+	// }
 	utp.removeTxns(bc, toRemove)
 }
 
@@ -202,9 +358,12 @@ func (utp *UnconfirmedTxnPool) Refresh(bc *Blockchain,
 func (utp *UnconfirmedTxnPool) FilterKnown(txns []cipher.SHA256) []cipher.SHA256 {
 	var unknown []cipher.SHA256
 	for _, h := range txns {
-		if _, known := utp.Txns[h]; !known {
+		if !utp.Txns.isExist(h) {
 			unknown = append(unknown, h)
 		}
+		// if _, known := utp.Txns[h]; !known {
+		// 	unknown = append(unknown, h)
+		// }
 	}
 	return unknown
 }
@@ -213,9 +372,12 @@ func (utp *UnconfirmedTxnPool) FilterKnown(txns []cipher.SHA256) []cipher.SHA256
 func (utp *UnconfirmedTxnPool) GetKnown(txns []cipher.SHA256) coin.Transactions {
 	var known coin.Transactions
 	for _, h := range txns {
-		if txn, have := utp.Txns[h]; have {
-			known = append(known, txn.Txn)
+		if tx, ok := utp.Txns.get(h); ok {
+			known = append(known, tx.Txn)
 		}
+		// if txn, have := utp.Txns[h]; have {
+		// 	known = append(known, txn.Txn)
+		// }
 	}
 	return known
 }
@@ -226,15 +388,25 @@ func (utp *UnconfirmedTxnPool) GetKnown(txns []cipher.SHA256) coin.Transactions 
 func (utp *UnconfirmedTxnPool) SpendsForAddresses(bcUnspent *coin.UnspentPool,
 	a map[cipher.Address]byte) coin.AddressUxOuts {
 	auxs := make(coin.AddressUxOuts, len(a))
-	for _, utx := range utp.Txns {
-		for _, h := range utx.Txn.In {
+	utp.Txns.forEach(func(_ cipher.SHA256, tx *UnconfirmedTxn) error {
+		for _, h := range tx.Txn.In {
 			if ux, ok := bcUnspent.Get(h); ok {
 				if _, ok := a[ux.Body.Address]; ok {
 					auxs[ux.Body.Address] = append(auxs[ux.Body.Address], ux)
 				}
 			}
 		}
-	}
+		return nil
+	})
+	// for _, utx := range utp.Txns {
+	// 	for _, h := range utx.Txn.In {
+	// 		if ux, ok := bcUnspent.Get(h); ok {
+	// 			if _, ok := a[ux.Body.Address]; ok {
+	// 				auxs[ux.Body.Address] = append(auxs[ux.Body.Address], ux)
+	// 			}
+	// 		}
+	// 	}
+	// }
 	return auxs
 }
 
@@ -248,24 +420,58 @@ func (utp *UnconfirmedTxnPool) SpendsForAddress(bcUnspent *coin.UnspentPool,
 // AllSpendsOutputs returns all spending outputs in unconfirmed tx pool.
 func (utp *UnconfirmedTxnPool) AllSpendsOutputs(bcUnspent *coin.UnspentPool) []ReadableOutput {
 	outs := []ReadableOutput{}
-	for _, tx := range utp.Txns {
+	utp.Txns.forEach(func(_ cipher.SHA256, tx *UnconfirmedTxn) error {
 		for _, in := range tx.Txn.In {
 			if ux, ok := bcUnspent.Get(in); ok {
 				outs = append(outs, NewReadableOutput(ux))
 			}
 		}
-	}
+		return nil
+	})
+	// for _, tx := range utp.Txns {
+	// 	for _, in := range tx.Txn.In {
+	// 		if ux, ok := bcUnspent.Get(in); ok {
+	// 			outs = append(outs, NewReadableOutput(ux))
+	// 		}
+	// 	}
+	// }
 	return outs
 }
 
 // AllIncommingOutputs returns all predicted incomming outputs.
 func (utp *UnconfirmedTxnPool) AllIncommingOutputs(bh coin.BlockHeader) []ReadableOutput {
 	outs := []ReadableOutput{}
-	for _, tx := range utp.Txns {
+	utp.Txns.forEach(func(_ cipher.SHA256, tx *UnconfirmedTxn) error {
 		uxOuts := coin.CreateUnspents(bh, tx.Txn)
 		for _, ux := range uxOuts {
 			outs = append(outs, NewReadableOutput(ux))
 		}
-	}
+		return nil
+	})
+	// for _, tx := range utp.Txns {
+	// }
 	return outs
+}
+
+// Get returns the unconfirmed transaction of given tx hash.
+func (utp *UnconfirmedTxnPool) Get(key cipher.SHA256) (*UnconfirmedTxn, bool) {
+	return utp.Txns.get(key)
+}
+
+// GetAllUnconfirmedTxns returns all unconfirmed transactions array
+func (utp *UnconfirmedTxnPool) GetAllUnconfirmedTxns() []UnconfirmedTxn {
+	all, err := utp.Txns.getAll()
+	if err != nil {
+		return []UnconfirmedTxn{}
+	}
+
+	txns := make([]UnconfirmedTxn, 0, len(all))
+	for _, tx := range all {
+		txns = append(txns, tx)
+	}
+	return txns
+}
+
+func nanoToTime(n int64) time.Time {
+	return time.Unix(n/int64(time.Second), n%int64(time.Second))
 }

--- a/src/visor/unconfirmed.go
+++ b/src/visor/unconfirmed.go
@@ -63,7 +63,7 @@ type UnconfirmedTxn struct {
 	// Last time we announced this txn
 	Announced int64
 	// If this txn is valid
-	IsValid bool
+	IsValid int8
 }
 
 // Hash returns the coin.Transaction's hash
@@ -387,7 +387,7 @@ func (utp *UnconfirmedTxnPool) createUnconfirmedTxn(bcUnsp *coin.UnspentPool,
 // Returns an error if txn is invalid, and whether the transaction already
 // existed in the pool.
 func (utp *UnconfirmedTxnPool) InjectTxn(bc *Blockchain, t coin.Transaction) (error, bool) {
-	var valid bool
+	var valid int8
 	for {
 		if err := VerifyTransactionFee(bc, &t); err != nil {
 			if err == ErrUnspentNotExist {
@@ -400,7 +400,7 @@ func (utp *UnconfirmedTxnPool) InjectTxn(bc *Blockchain, t coin.Transaction) (er
 			return err, false
 		}
 
-		valid = true
+		valid = 1
 		break
 	}
 
@@ -483,9 +483,9 @@ func (utp *UnconfirmedTxnPool) Refresh(bc *Blockchain) (hashes []cipher.SHA256) 
 	now := util.Now()
 	utp.Txns.rangeUpdate(func(key cipher.SHA256, tx *UnconfirmedTxn) {
 		tx.Checked = now.UnixNano()
-		if !tx.IsValid {
+		if tx.IsValid == 0 {
 			if bc.VerifyTransaction(tx.Txn) == nil {
-				tx.IsValid = true
+				tx.IsValid = 1
 				hashes = append(hashes, tx.Hash())
 			}
 		}

--- a/src/visor/unconfirmed.go
+++ b/src/visor/unconfirmed.go
@@ -309,7 +309,7 @@ func (utp *UnconfirmedTxnPool) InjectTxn(bc *Blockchain, t coin.Transaction) (er
 	// update the time if exist
 	var exist bool
 	utp.Txns.update(h, func(tx *UnconfirmedTxn) {
-		exist = true
+		know = true
 		now := util.Now()
 		tx.Received = now.UnixNano()
 		tx.Checked = now.UnixNano()
@@ -317,7 +317,7 @@ func (utp *UnconfirmedTxnPool) InjectTxn(bc *Blockchain, t coin.Transaction) (er
 	})
 
 	if exist {
-		return nil, true
+		return
 	}
 
 	// Add txn to index
@@ -326,8 +326,7 @@ func (utp *UnconfirmedTxnPool) InjectTxn(bc *Blockchain, t coin.Transaction) (er
 	utx.IsValid = valid
 	utp.Txns.put(&utx)
 	utp.Unspent.put(h, coin.CreateUnspents(bc.Head().Head, t))
-
-	return nil, false
+	return
 }
 
 // RawTxns returns underlying coin.Transactions

--- a/src/visor/unconfirmed.go
+++ b/src/visor/unconfirmed.go
@@ -574,19 +574,36 @@ func (utp *UnconfirmedTxnPool) Get(key cipher.SHA256) (*UnconfirmedTxn, bool) {
 	return utp.Txns.get(key)
 }
 
-// GetAllUnconfirmedTxns returns all unconfirmed transactions array
-func (utp *UnconfirmedTxnPool) GetAllUnconfirmedTxns() []UnconfirmedTxn {
-	txns, err := utp.Txns.getAll()
-	if err != nil {
-		return []UnconfirmedTxn{}
-	}
-
-	return txns
+// GetTxns returns all transactions that can pass the filter
+func (utp *UnconfirmedTxnPool) GetTxns(filter func(tx UnconfirmedTxn) bool) (txns []UnconfirmedTxn) {
+	utp.Txns.forEach(func(hash cipher.SHA256, tx *UnconfirmedTxn) error {
+		if filter(*tx) {
+			txns = append(txns, *tx)
+		}
+		return nil
+	})
+	return
 }
 
-// GetAllTxnHashes returns all unconfirmed txns hashes
-func (utp *UnconfirmedTxnPool) GetAllTxnHashes() []cipher.SHA256 {
-	return utp.Txns.mustGetTxHashes()
+// GetTxHashes returns transaction hashes that can pass the filter
+func (utp *UnconfirmedTxnPool) GetTxHashes(filter func(tx UnconfirmedTxn) bool) (hashes []cipher.SHA256) {
+	utp.Txns.forEach(func(hash cipher.SHA256, tx *UnconfirmedTxn) error {
+		if filter(*tx) {
+			hashes = append(hashes, hash)
+		}
+		return nil
+	})
+	return
+}
+
+// IsValid can be used as filter function
+func IsValid(tx UnconfirmedTxn) bool {
+	return tx.IsValid == 1
+}
+
+// All use as return all filter
+func All(tx UnconfirmedTxn) bool {
+	return true
 }
 
 // Len returns the number of unconfirmed transactions

--- a/src/visor/unconfirmed.go
+++ b/src/visor/unconfirmed.go
@@ -522,7 +522,7 @@ func (utp *UnconfirmedTxnPool) GetKnown(txns []cipher.SHA256) coin.Transactions 
 func (utp *UnconfirmedTxnPool) SpendsForAddresses(bcUnspent *coin.UnspentPool,
 	a map[cipher.Address]byte) coin.AddressUxOuts {
 	auxs := make(coin.AddressUxOuts, len(a))
-	utp.Txns.forEach(func(_ cipher.SHA256, tx *UnconfirmedTxn) error {
+	if err := utp.Txns.forEach(func(_ cipher.SHA256, tx *UnconfirmedTxn) error {
 		for _, h := range tx.Txn.In {
 			if ux, ok := bcUnspent.Get(h); ok {
 				if _, ok := a[ux.Body.Address]; ok {
@@ -531,7 +531,9 @@ func (utp *UnconfirmedTxnPool) SpendsForAddresses(bcUnspent *coin.UnspentPool,
 			}
 		}
 		return nil
-	})
+	}); err != nil {
+		logger.Debug("SpendsForAddresses error:%v", err)
+	}
 	return auxs
 }
 
@@ -545,27 +547,31 @@ func (utp *UnconfirmedTxnPool) SpendsForAddress(bcUnspent *coin.UnspentPool,
 // AllSpendsOutputs returns all spending outputs in unconfirmed tx pool.
 func (utp *UnconfirmedTxnPool) AllSpendsOutputs(bcUnspent *coin.UnspentPool) []ReadableOutput {
 	outs := []ReadableOutput{}
-	utp.Txns.forEach(func(_ cipher.SHA256, tx *UnconfirmedTxn) error {
+	if err := utp.Txns.forEach(func(_ cipher.SHA256, tx *UnconfirmedTxn) error {
 		for _, in := range tx.Txn.In {
 			if ux, ok := bcUnspent.Get(in); ok {
 				outs = append(outs, NewReadableOutput(ux))
 			}
 		}
 		return nil
-	})
+	}); err != nil {
+		logger.Debug("AllSpendsOutputs error:%v", err)
+	}
 	return outs
 }
 
 // AllIncommingOutputs returns all predicted incomming outputs.
 func (utp *UnconfirmedTxnPool) AllIncommingOutputs(bh coin.BlockHeader) []ReadableOutput {
 	outs := []ReadableOutput{}
-	utp.Txns.forEach(func(_ cipher.SHA256, tx *UnconfirmedTxn) error {
+	if err := utp.Txns.forEach(func(_ cipher.SHA256, tx *UnconfirmedTxn) error {
 		uxOuts := coin.CreateUnspents(bh, tx.Txn)
 		for _, ux := range uxOuts {
 			outs = append(outs, NewReadableOutput(ux))
 		}
 		return nil
-	})
+	}); err != nil {
+		logger.Debug("AllIncommingOutputs error:%v", err)
+	}
 	return outs
 }
 
@@ -576,23 +582,27 @@ func (utp *UnconfirmedTxnPool) Get(key cipher.SHA256) (*UnconfirmedTxn, bool) {
 
 // GetTxns returns all transactions that can pass the filter
 func (utp *UnconfirmedTxnPool) GetTxns(filter func(tx UnconfirmedTxn) bool) (txns []UnconfirmedTxn) {
-	utp.Txns.forEach(func(hash cipher.SHA256, tx *UnconfirmedTxn) error {
+	if err := utp.Txns.forEach(func(hash cipher.SHA256, tx *UnconfirmedTxn) error {
 		if filter(*tx) {
 			txns = append(txns, *tx)
 		}
 		return nil
-	})
+	}); err != nil {
+		logger.Debug("GetTxns error:%v", err)
+	}
 	return
 }
 
 // GetTxHashes returns transaction hashes that can pass the filter
 func (utp *UnconfirmedTxnPool) GetTxHashes(filter func(tx UnconfirmedTxn) bool) (hashes []cipher.SHA256) {
-	utp.Txns.forEach(func(hash cipher.SHA256, tx *UnconfirmedTxn) error {
+	if err := utp.Txns.forEach(func(hash cipher.SHA256, tx *UnconfirmedTxn) error {
 		if filter(*tx) {
 			hashes = append(hashes, hash)
 		}
 		return nil
-	})
+	}); err != nil {
+		logger.Debug("GetTxHashes error:%v", err)
+	}
 	return
 }
 

--- a/src/visor/unconfirmed_test.go
+++ b/src/visor/unconfirmed_test.go
@@ -1,28 +1,21 @@
 package visor
 
 import (
-	"crypto/rand"
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
 	"testing"
+
 	"time"
 
+	"github.com/boltdb/bolt"
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/coin"
 	"github.com/skycoin/skycoin/src/util"
 	"github.com/skycoin/skycoin/src/wallet"
 	"github.com/stretchr/testify/assert"
 )
-
-// import (
-// 	"crypto/rand"
-// 	"testing"
-// 	"time"
-
-// 	"github.com/skycoin/skycoin/src/cipher"
-// 	"github.com/skycoin/skycoin/src/coin"
-// 	"github.com/skycoin/skycoin/src/util"
-// 	"github.com/skycoin/skycoin/src/wallet"
-// 	"github.com/stretchr/testify/assert"
-// )
 
 // const (
 // 	testBlockSize = 1024 * 1024
@@ -76,21 +69,31 @@ func getFee(t *coin.Transaction) (uint64, error) {
 	return 0, nil
 }
 
-func makeValidTxn() (coin.Transaction, error) {
-	w := wallet.NewWallet("test")
-	w.GenerateAddresses(2)
-	uncf := NewUnconfirmedTxnPool()
-	now := tNow()
-	a := makeAddress()
-	uxs := makeUxBalancesForAddresses([]wallet.Balance{
-		wallet.Balance{10e6, 150},
-		wallet.Balance{15e6, 150},
-	}, now, w.GetAddresses()[:2])
-	unsp := coin.NewUnspentPool()
-	addUxArrayToUnspentPool(&unsp, uxs)
-	amt := wallet.Balance{10 * 1e6, 0}
-	return CreateSpendingTransaction(w, uncf, &unsp, now, amt, a)
+func prepareDB(t *testing.T) (*bolt.DB, func()) {
+	f := fmt.Sprintf("test%d.db", rand.Intn(1024))
+	db, err := bolt.Open(f, 0700, nil)
+	assert.Nil(t, err)
+	return db, func() {
+		db.Close()
+		os.Remove(f)
+	}
 }
+
+// func makeValidTxn(t *testing.T, utp *UnconfirmedTxnPool) (coin.Transaction, error) {
+// 	w := wallet.NewWallet("test")
+// 	w.GenerateAddresses(2)
+// 	now := tNow()
+// 	a := makeAddress()
+
+// 	uxs := makeUxBalancesForAddresses([]wallet.Balance{
+// 		wallet.Balance{10e6, 150},
+// 		wallet.Balance{15e6, 150},
+// 	}, now, w.GetAddresses()[:2])
+// 	unsp := coin.NewUnspentPool()
+// 	addUxArrayToUnspentPool(&unsp, uxs)
+// 	amt := wallet.Balance{10 * 1e6, 0}
+// 	return CreateSpendingTransaction(w, utp, &unsp, now, amt, a)
+// }
 
 // func makeValidTxnWithFeeFactor(mv *Visor,
 // 	factor, extra uint64) (coin.Transaction, error) {
@@ -114,10 +117,12 @@ func makeValidTxn() (coin.Transaction, error) {
 // 	return tx, err
 // }
 
-func makeValidTxnNoChange() (coin.Transaction, error) {
+func makeValidTxnNoChange(t *testing.T) (coin.Transaction, error) {
 	w := wallet.NewWallet("test")
 	w.GenerateAddresses(2)
-	uncf := NewUnconfirmedTxnPool()
+	db, close := prepareDB(t)
+	defer close()
+	uncf := NewUnconfirmedTxnPool(db)
 	now := tNow()
 	a := makeAddress()
 	uxs := makeUxBalancesForAddresses([]wallet.Balance{
@@ -130,10 +135,12 @@ func makeValidTxnNoChange() (coin.Transaction, error) {
 	return CreateSpendingTransaction(w, uncf, &unsp, now, amt, a)
 }
 
-func makeInvalidTxn() (coin.Transaction, error) {
+func makeInvalidTxn(t *testing.T) (coin.Transaction, error) {
 	w := wallet.NewWallet("test")
 	w.GenerateAddresses(2)
-	uncf := NewUnconfirmedTxnPool()
+	db, close := prepareDB(t)
+	defer close()
+	uncf := NewUnconfirmedTxnPool(db)
 	now := tNow()
 	a := makeAddress()
 	uxs := makeUxBalancesForAddresses([]wallet.Balance{}, now, w.GetAddresses()[:2])
@@ -150,15 +157,18 @@ func makeInvalidTxn() (coin.Transaction, error) {
 }
 
 func assertValidUnspent(t *testing.T, bc *Blockchain,
-	unspent TxnUnspents, tx coin.Transaction) {
+	unspent *txUnspents, tx coin.Transaction) {
 	expect := coin.CreateUnspents(bc.Head().Head, tx)
 	assert.NotEqual(t, len(expect), 0)
 	sum := 0
-	for _, uxs := range unspent {
-		sum += len(uxs)
-	}
+
+	unspent.forEach(func(_ cipher.SHA256, uxo coin.UxArray) {
+		sum += len(uxo)
+	})
+
 	assert.Equal(t, len(expect), sum)
-	uxs := unspent[tx.Hash()]
+	uxs, err := unspent.get(tx.Hash())
+	assert.Nil(t, err)
 	for _, ux := range expect {
 		found := false
 		for _, u := range uxs {
@@ -181,16 +191,17 @@ func assertValidUnconfirmed(t *testing.T, txns map[cipher.SHA256]UnconfirmedTxn,
 	assert.False(t, nanoToTime(ut.Checked).IsZero())
 }
 
-func createUnconfirmedTxns(t *testing.T, up *UnconfirmedTxnPool, n int) []UnconfirmedTxn {
+func createUnconfirmedTxns(t *testing.T, up *UnconfirmedTxnPool, bc *Blockchain, n int) []UnconfirmedTxn {
 	uts := make([]UnconfirmedTxn, 4)
-	usp := coin.NewUnspentPool()
+	// usp := coin.NewUnspentPool()
 	for i := 0; i < len(uts); i++ {
-		tx, _ := makeValidTxn()
-		ut := up.createUnconfirmedTxn(&usp, tx)
+		// tx, _ := makeValidTxn(t, up)
+		tx := makeTransactionForChain(t, bc)
+		ut := up.createUnconfirmedTxn(bc.GetUnspent(), tx)
 		uts[i] = ut
-		up.Txns[ut.Hash()] = ut
+		up.Txns.put(&ut)
 	}
-	assert.Equal(t, len(up.Txns), 4)
+	assert.Equal(t, up.Txns.len(), 4)
 	return uts
 }
 
@@ -217,216 +228,211 @@ func createUnconfirmedTxns(t *testing.T, up *UnconfirmedTxnPool, n int) []Unconf
 // 	assert.Nil(t, err)
 // }
 
-// func TestUnconfirmedTxnHash(t *testing.T) {
-// 	up := NewUnconfirmedTxnPool()
-// 	uts := createUnconfirmedTxns(t, up, 1)
-// 	utx := uts[0]
-// 	assert.Equal(t, utx.Hash(), utx.Txn.Hash())
-// 	assert.NotEqual(t, utx.Hash(), utx.Txn.Head.Hash)
-// }
+func TestUnconfirmedTxnHash(t *testing.T) {
+	db, close := prepareDB(t)
+	defer close()
+	up := NewUnconfirmedTxnPool(db)
+	bc := makeBlockchain()
+	uts := createUnconfirmedTxns(t, up, bc, 1)
+	utx := uts[0]
+	assert.Equal(t, utx.Hash(), utx.Txn.Hash())
+}
 
 func TestNewUnconfirmedTxnPool(t *testing.T) {
-	ut := NewUnconfirmedTxnPool()
+	db, close := prepareDB(t)
+	defer close()
+	ut := NewUnconfirmedTxnPool(db)
 	assert.NotNil(t, ut.Txns)
-	assert.Equal(t, len(ut.Txns), 0)
+	assert.Equal(t, ut.Txns.len(), 0)
 }
 
 func TestSetAnnounced(t *testing.T) {
-	ut := NewUnconfirmedTxnPool()
-	assert.Equal(t, len(ut.Txns), 0)
+	db, close := prepareDB(t)
+	defer close()
+	ut := NewUnconfirmedTxnPool(db)
+	assert.Equal(t, ut.Txns.len(), 0)
 	// Unknown should be safe and a noop
 	assert.NotPanics(t, func() {
 		ut.SetAnnounced(cipher.SHA256{}, util.Now())
 	})
-	assert.Equal(t, len(ut.Txns), 0)
-	utx := createUnconfirmedTxns(t, ut, 1)[0]
+	assert.Equal(t, ut.Txns.len(), 0)
+	bc := makeBlockchain()
+	utx := createUnconfirmedTxns(t, ut, bc, 1)[0]
 	assert.True(t, nanoToTime(utx.Announced).IsZero())
-	ut.Txns[utx.Hash()] = utx
+	ut.Txns.put(&utx)
 	now := util.Now()
 	ut.SetAnnounced(utx.Hash(), now)
-	assert.Equal(t, ut.Txns[utx.Hash()].Announced, now)
+	v, ok := ut.Txns.get(utx.Hash())
+	assert.True(t, ok)
+	assert.Equal(t, v.Announced, now.UnixNano())
+}
+
+func makeBlockchain() *Blockchain {
+	ft := FakeTree{}
+	b := NewBlockchain(&ft, nil)
+	b.CreateGenesisBlock(genAddress, _genCoins, _genTime)
+	return b
 }
 
 func TestInjectTxn(t *testing.T) {
-	defer cleanupVisor()
-	// Test with invalid txn
-	mv := setupMasterVisor()
-	ut := NewUnconfirmedTxnPool()
-	txn, err := makeInvalidTxn(mv)
+	db, close := prepareDB(t)
+	defer close()
+	ut := NewUnconfirmedTxnPool(db)
+	bc := makeBlockchain()
+	txn := makeTransactionForChain(t, bc)
+	err, known := ut.InjectTxn(bc, txn)
 	assert.Nil(t, err)
-	err, known := ut.InjectTxn(mv.blockchain, txn, nil, testBlockSize, 0)
-	assert.NotNil(t, err)
-	assert.False(t, known)
-	assert.Equal(t, len(ut.Txns), 0)
 
-	// Test didAnnounce=false
-	mv = setupMasterVisor()
-	ut = NewUnconfirmedTxnPool()
-	txn, err = makeValidTxn(mv)
-	assert.Nil(t, err)
-	err, known = ut.InjectTxn(mv.blockchain, txn, nil, testBlockSize, 0)
-	assert.Nil(t, err)
 	assert.False(t, known)
-	assertValidUnspent(t, mv.blockchain, ut.Unspent, txn)
-	assertValidUnconfirmed(t, ut.Txns, txn)
+	assert.Equal(t, ut.Txns.len(), 1)
 
-	// Test didAnnounce=true
-	mv = setupMasterVisor()
-	ut = NewUnconfirmedTxnPool()
-	txn, err = makeValidTxn(mv)
+	assertValidUnspent(t, bc, ut.Unspent, txn)
+	allUncfmTxs, err := ut.Txns.getAll()
 	assert.Nil(t, err)
-	err, known = ut.InjectTxn(mv.blockchain, txn, nil, testBlockSize, 0)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	assertValidUnspent(t, mv.blockchain, ut.Unspent, txn)
-	assertValidUnconfirmed(t, ut.Txns, txn)
-
-	// Test txn too large
-	mv = setupMasterVisor()
-	ut = NewUnconfirmedTxnPool()
-	txn, err = makeValidTxn(mv)
-	assert.Nil(t, err)
-	err, known = ut.InjectTxn(mv.blockchain, txn, nil, txn.Size()-1, 1)
-	assertError(t, err, "Transaction too large")
-	assert.False(t, known)
-	assert.Equal(t, len(ut.Txns), 0)
+	assertValidUnconfirmed(t, allUncfmTxs, txn)
 
 	// Test where we are receiver of ux outputs
-	mv = setupMasterVisor()
-	assert.Equal(t, len(mv.blockchain.Unspent.Pool), 1)
-	ut = NewUnconfirmedTxnPool()
-	txn, err = makeValidTxn(mv)
-	assert.Nil(t, err)
-	addrs := make(map[cipher.Address]byte, 1)
-	addrs[txn.Out[1].Address] = byte(1)
-	err, known = ut.InjectTxn(mv.blockchain, txn, addrs, testBlockSize, 0)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	assertValidUnspent(t, mv.blockchain, ut.Unspent, txn)
-	assertValidUnconfirmed(t, ut.Txns, txn)
+	// mv = setupMasterVisor()
+	// assert.Equal(t, len(mv.blockchain.Unspent.Pool), 1)
+	// ut = NewUnconfirmedTxnPool()
+	// txn, err = makeValidTxn(mv)
+	// assert.Nil(t, err)
+	// addrs := make(map[cipher.Address]byte, 1)
+	// addrs[txn.Out[1].Address] = byte(1)
+	// err, known = ut.InjectTxn(mv.blockchain, txn, addrs, testBlockSize, 0)
+	// assert.Nil(t, err)
+	// assert.False(t, known)
+	// assertValidUnspent(t, mv.blockchain, ut.Unspent, txn)
+	// assertValidUnconfirmed(t, ut.Txns, txn)
 
-	// Test where we are spender of ux outputs
-	mv = setupMasterVisor()
-	assert.Equal(t, len(mv.blockchain.Unspent.Pool), 1)
-	ut = NewUnconfirmedTxnPool()
-	txn, err = makeValidTxnNoChange(mv)
-	assert.Nil(t, err)
-	addrs = make(map[cipher.Address]byte, 1)
-	ux, ok := mv.blockchain.Unspent.Get(txn.In[0])
-	assert.True(t, ok)
-	addrs[ux.Body.Address] = byte(1)
-	err, known = ut.InjectTxn(mv.blockchain, txn, addrs, testBlockSize, 0)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	assertValidUnspent(t, mv.blockchain, ut.Unspent, txn)
-	assertValidUnconfirmed(t, ut.Txns, txn)
+	// // Test where we are spender of ux outputs
+	// mv = setupMasterVisor()
+	// assert.Equal(t, len(mv.blockchain.Unspent.Pool), 1)
+	// ut = NewUnconfirmedTxnPool()
+	// txn, err = makeValidTxnNoChange(mv)
+	// assert.Nil(t, err)
+	// addrs = make(map[cipher.Address]byte, 1)
+	// ux, ok := mv.blockchain.Unspent.Get(txn.In[0])
+	// assert.True(t, ok)
+	// addrs[ux.Body.Address] = byte(1)
+	// err, known = ut.InjectTxn(mv.blockchain, txn, addrs, testBlockSize, 0)
+	// assert.Nil(t, err)
+	// assert.False(t, known)
+	// assertValidUnspent(t, mv.blockchain, ut.Unspent, txn)
+	// assertValidUnconfirmed(t, ut.Txns, txn)
 
-	// Test where we are both spender and receiver of ux outputs
-	mv = setupMasterVisor()
-	ut = NewUnconfirmedTxnPool()
-	txn, err = makeValidTxn(mv)
-	assert.Nil(t, err)
-	addrs = make(map[cipher.Address]byte, 2)
-	addrs[txn.Out[0].Address] = byte(1)
-	ux, ok = mv.blockchain.Unspent.Get(txn.In[0])
-	assert.True(t, ok)
-	addrs[ux.Body.Address] = byte(1)
-	err, known = ut.InjectTxn(mv.blockchain, txn, addrs, testBlockSize, 0)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	assertValidUnspent(t, mv.blockchain, ut.Unspent, txn)
-	assertValidUnconfirmed(t, ut.Txns, txn)
-	assert.Equal(t, len(ut.Txns), 1)
-	assert.Equal(t, len(ut.Unspent), 1)
-	for _, uxs := range ut.Unspent {
-		assert.Equal(t, len(uxs), 2)
-	}
+	// // Test where we are both spender and receiver of ux outputs
+	// mv = setupMasterVisor()
+	// ut = NewUnconfirmedTxnPool()
+	// txn, err = makeValidTxn(mv)
+	// assert.Nil(t, err)
+	// addrs = make(map[cipher.Address]byte, 2)
+	// addrs[txn.Out[0].Address] = byte(1)
+	// ux, ok = mv.blockchain.Unspent.Get(txn.In[0])
+	// assert.True(t, ok)
+	// addrs[ux.Body.Address] = byte(1)
+	// err, known = ut.InjectTxn(mv.blockchain, txn, addrs, testBlockSize, 0)
+	// assert.Nil(t, err)
+	// assert.False(t, known)
+	// assertValidUnspent(t, mv.blockchain, ut.Unspent, txn)
+	// assertValidUnconfirmed(t, ut.Txns, txn)
+	// assert.Equal(t, len(ut.Txns), 1)
+	// assert.Equal(t, len(ut.Unspent), 1)
+	// for _, uxs := range ut.Unspent {
+	// 	assert.Equal(t, len(uxs), 2)
+	// }
 
 	// Test duplicate Record, should be no-op besides state change
-	utx := ut.Txns[txn.Hash()]
+	utx, ok := ut.Txns.get(txn.Hash())
+	assert.True(t, ok)
 	// Set a placeholder value on the utx to check if we overwrote it
-	utx.Announced = util.ZeroTime().Add(time.Minute)
-	ut.Txns[txn.Hash()] = utx
-	err, known = ut.InjectTxn(mv.blockchain, txn, addrs, testBlockSize, 0)
+	utx.Announced = util.ZeroTime().Add(time.Minute).UnixNano()
+	ut.Txns.put(utx)
+	err, known = ut.InjectTxn(bc, txn)
 	assert.Nil(t, err)
 	assert.True(t, known)
-	utx2 := ut.Txns[txn.Hash()]
-	assert.Equal(t, utx2.Announced, util.ZeroTime().Add(time.Minute))
-	utx2.Announced = util.ZeroTime()
-	ut.Txns[utx2.Hash()] = utx2
+	utx2, ok := ut.Txns.get(txn.Hash())
+	assert.True(t, ok)
+	assert.Equal(t, utx2.Announced, util.ZeroTime().Add(time.Minute).UnixNano())
+	utx2.Announced = util.ZeroTime().UnixNano()
+	ut.Txns.put(utx2)
 	// Received & checked should be updated
-	assert.True(t, utx2.Received.After(utx.Received))
-	assert.True(t, utx2.Checked.After(utx.Checked))
-	assertValidUnconfirmed(t, ut.Txns, txn)
-	assert.Equal(t, len(ut.Txns), 1)
-	assert.Equal(t, len(ut.Unspent), 1)
-	for _, uxs := range ut.Unspent {
-		assert.Equal(t, len(uxs), 2)
-	}
+	assert.True(t, nanoToTime(utx2.Received).After(nanoToTime(utx.Received)))
+	assert.True(t, nanoToTime(utx2.Checked).After(nanoToTime(utx.Checked)))
+	all, err := ut.Txns.getAll()
+	assert.Nil(t, err)
+	assertValidUnconfirmed(t, all, txn)
+	assert.Equal(t, ut.Txns.len(), 1)
+	assert.Equal(t, ut.Unspent.len(), 1)
+	ut.Unspent.forEach(func(_ cipher.SHA256, uxa coin.UxArray) {
+		assert.Equal(t, len(uxa), 2)
+	})
 
 	// Test with valid fee, exact
-	mv = setupMasterVisor()
-	assert.Equal(t, len(mv.blockchain.Unspent.Pool), 1)
-	ut = NewUnconfirmedTxnPool()
-	txn, err = makeValidTxnWithFeeFactor(mv, 4, 0)
-	assert.Nil(t, err)
-	addrs = make(map[cipher.Address]byte, 1)
-	addrs[txn.Out[1].Address] = byte(1)
-	err, known = ut.InjectTxn(mv.blockchain, txn, addrs, testBlockSize, 4)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	assertValidUnspent(t, mv.blockchain, ut.Unspent, txn)
-	assertValidUnconfirmed(t, ut.Txns, txn)
+	// mv = setupMasterVisor()
+	// assert.Equal(t, len(mv.blockchain.Unspent.Pool), 1)
+	// ut = NewUnconfirmedTxnPool()
+	// txn, err = makeValidTxnWithFeeFactor(mv, 4, 0)
+	// assert.Nil(t, err)
+	// addrs = make(map[cipher.Address]byte, 1)
+	// addrs[txn.Out[1].Address] = byte(1)
+	// err, known = ut.InjectTxn(mv.blockchain, txn, addrs, testBlockSize, 4)
+	// assert.Nil(t, err)
+	// assert.False(t, known)
+	// assertValidUnspent(t, mv.blockchain, ut.Unspent, txn)
+	// assertValidUnconfirmed(t, ut.Txns, txn)
 
-	// Test with valid fee, surplus
-	mv = setupMasterVisor()
-	assert.Equal(t, len(mv.blockchain.Unspent.Pool), 1)
-	ut = NewUnconfirmedTxnPool()
-	txn, err = makeValidTxnWithFeeFactor(mv, 4, 100)
-	assert.Nil(t, err)
-	addrs = make(map[cipher.Address]byte, 1)
-	addrs[txn.Out[1].Address] = byte(1)
-	err, known = ut.InjectTxn(mv.blockchain, txn, addrs, testBlockSize, 4)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	assertValidUnspent(t, mv.blockchain, ut.Unspent, txn)
-	assertValidUnconfirmed(t, ut.Txns, txn)
+	// // Test with valid fee, surplus
+	// mv = setupMasterVisor()
+	// assert.Equal(t, len(mv.blockchain.Unspent.Pool), 1)
+	// ut = NewUnconfirmedTxnPool()
+	// txn, err = makeValidTxnWithFeeFactor(mv, 4, 100)
+	// assert.Nil(t, err)
+	// addrs = make(map[cipher.Address]byte, 1)
+	// addrs[txn.Out[1].Address] = byte(1)
+	// err, known = ut.InjectTxn(mv.blockchain, txn, addrs, testBlockSize, 4)
+	// assert.Nil(t, err)
+	// assert.False(t, known)
+	// assertValidUnspent(t, mv.blockchain, ut.Unspent, txn)
+	// assertValidUnconfirmed(t, ut.Txns, txn)
 
-	// Test with invalid fee
-	mv = setupMasterVisor()
-	assert.Equal(t, len(mv.blockchain.Unspent.Pool), 1)
-	ut = NewUnconfirmedTxnPool()
-	txn, err = makeValidTxnWithFeeFactor(mv, 5, 0)
-	assert.Nil(t, err)
-	_, err = mv.blockchain.TransactionFee(&txn)
-	assert.Nil(t, err)
-	addrs = make(map[cipher.Address]byte, 1)
-	addrs[txn.Out[1].Address] = byte(1)
-	err, known = ut.InjectTxn(mv.blockchain, txn, addrs, testBlockSize, 4)
-	assertError(t, err, "Transaction fee minimum not met")
-	assert.False(t, known)
-	assert.Equal(t, len(ut.Txns), 0)
+	// // Test with invalid fee
+	// mv = setupMasterVisor()
+	// assert.Equal(t, len(mv.blockchain.Unspent.Pool), 1)
+	// ut = NewUnconfirmedTxnPool()
+	// txn, err = makeValidTxnWithFeeFactor(mv, 5, 0)
+	// assert.Nil(t, err)
+	// _, err = mv.blockchain.TransactionFee(&txn)
+	// assert.Nil(t, err)
+	// addrs = make(map[cipher.Address]byte, 1)
+	// addrs[txn.Out[1].Address] = byte(1)
+	// err, known = ut.InjectTxn(mv.blockchain, txn, addrs, testBlockSize, 4)
+	// assertError(t, err, "Transaction fee minimum not met")
+	// assert.False(t, known)
+	// assert.Equal(t, len(ut.Txns), 0)
 
-	// Test with bc.TransactionFee failing
-	mv = setupMasterVisor()
-	assert.Equal(t, len(mv.blockchain.Unspent.Pool), 1)
-	ut = NewUnconfirmedTxnPool()
-	txn, err = makeValidTxnWithFeeFactor(mv, 4, 100)
-	assert.Nil(t, err)
-	txn.Out[1].Hours = 1e16
-	txn.Head.Sigs = make([]cipher.Sig, 0)
-	txn.SignInputs([]cipher.SecKey{mv.Config.MasterKeys.Secret})
-	txn.UpdateHeader()
-	addrs = make(map[cipher.Address]byte, 1)
-	addrs[txn.Out[1].Address] = byte(1)
-	err, known = ut.InjectTxn(mv.blockchain, txn, addrs, testBlockSize, 4)
-	assertError(t, err, "Insufficient coinhours for transaction outputs")
-	assert.False(t, known)
-	assert.Equal(t, len(ut.Txns), 0)
+	// // Test with bc.TransactionFee failing
+	// mv = setupMasterVisor()
+	// assert.Equal(t, len(mv.blockchain.Unspent.Pool), 1)
+	// ut = NewUnconfirmedTxnPool()
+	// txn, err = makeValidTxnWithFeeFactor(mv, 4, 100)
+	// assert.Nil(t, err)
+	// txn.Out[1].Hours = 1e16
+	// txn.Head.Sigs = make([]cipher.Sig, 0)
+	// txn.SignInputs([]cipher.SecKey{mv.Config.MasterKeys.Secret})
+	// txn.UpdateHeader()
+	// addrs = make(map[cipher.Address]byte, 1)
+	// addrs[txn.Out[1].Address] = byte(1)
+	// err, known = ut.InjectTxn(mv.blockchain, txn, addrs, testBlockSize, 4)
+	// assertError(t, err, "Insufficient coinhours for transaction outputs")
+	// assert.False(t, known)
+	// assert.Equal(t, len(ut.Txns), 0)
 }
 
 func TestRawTxns(t *testing.T) {
-	ut := NewUnconfirmedTxnPool()
+	db, close := prepareDB(t)
+	defer close()
+	ut := NewUnconfirmedTxnPool(db)
 	utxs := make(coin.Transactions, 4)
 	for i := 0; i < len(utxs); i++ {
 		utx := addUnconfirmedTxnToPool(ut)
@@ -441,363 +447,350 @@ func TestRawTxns(t *testing.T) {
 }
 
 func TestRemoveTxn(t *testing.T) {
-	defer cleanupVisor()
-	mv := setupMasterVisor()
-	ut := NewUnconfirmedTxnPool()
+	db, close := prepareDB(t)
+	defer close()
+	ut := NewUnconfirmedTxnPool(db)
 
-	utx, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	err, known := ut.InjectTxn(mv.blockchain, utx, nil, testBlockSize, 0)
+	bc := makeBlockchain()
+	utx := makeTransactionForChain(t, bc)
+	err, known := ut.InjectTxn(bc, utx)
 	assert.Nil(t, err)
 	assert.False(t, known)
-	assert.Equal(t, len(ut.Txns), 1)
-	assert.Equal(t, len(ut.Unspent), 1)
-	for _, uxs := range ut.Unspent {
-		assert.Equal(t, len(uxs), 2)
-	}
+	assert.Equal(t, ut.Txns.len(), 1)
+	assert.Equal(t, ut.Unspent.len(), 1)
+	ut.Unspent.forEach(func(_ cipher.SHA256, uxa coin.UxArray) {
+		assert.Equal(t, len(uxa), 2)
+	})
 
 	// Unknown txn is no-op
 	badh := randSHA256()
 	assert.NotEqual(t, badh, utx.Hash())
-	assert.Equal(t, len(ut.Txns), 1)
-	assert.Equal(t, len(ut.Unspent), 1)
-	for _, uxs := range ut.Unspent {
+	assert.Equal(t, ut.Txns.len(), 1)
+	assert.Equal(t, ut.Unspent.len(), 1)
+	ut.Unspent.forEach(func(_ cipher.SHA256, uxs coin.UxArray) {
 		assert.Equal(t, len(uxs), 2)
-	}
-	ut.removeTxn(mv.blockchain, badh)
-	assert.Equal(t, len(ut.Txns), 1)
-	assert.Equal(t, len(ut.Unspent), 1)
-	for _, uxs := range ut.Unspent {
+	})
+	ut.removeTxn(bc, badh)
+	assert.Equal(t, ut.Txns.len(), 1)
+	assert.Equal(t, ut.Unspent.len(), 1)
+	ut.Unspent.forEach(func(_ cipher.SHA256, uxs coin.UxArray) {
 		assert.Equal(t, len(uxs), 2)
-	}
+	})
 
 	// Known txn updates Txns, predicted Unspents
-	utx2, err := makeValidTxn(mv)
+	// utx2, err := makeValidTxn(mv)
+	utx2 := makeTransactionForChain(t, bc)
 	assert.Nil(t, err)
-	err, known = ut.InjectTxn(mv.blockchain, utx2, nil, testBlockSize, 0)
+	err, known = ut.InjectTxn(bc, utx2)
 	assert.Nil(t, err)
 	assert.False(t, known)
-	assert.Equal(t, len(ut.Txns), 2)
-	assert.Equal(t, len(ut.Unspent), 2)
-	for _, uxs := range ut.Unspent {
+	assert.Equal(t, ut.Txns.len(), 2)
+	assert.Equal(t, ut.Unspent.len(), 2)
+	ut.Unspent.forEach(func(_ cipher.SHA256, uxs coin.UxArray) {
 		assert.Equal(t, len(uxs), 2)
-	}
-	ut.removeTxn(mv.blockchain, utx.Hash())
-	assert.Equal(t, len(ut.Txns), 1)
-	assert.Equal(t, len(ut.Unspent), 1)
-	for _, uxs := range ut.Unspent {
+	})
+	ut.removeTxn(bc, utx.Hash())
+	assert.Equal(t, ut.Txns.len(), 1)
+	assert.Equal(t, ut.Unspent.len(), 1)
+	ut.Unspent.forEach(func(_ cipher.SHA256, uxs coin.UxArray) {
 		assert.Equal(t, len(uxs), 2)
-	}
-	ut.removeTxn(mv.blockchain, utx.Hash())
-	assert.Equal(t, len(ut.Txns), 1)
-	assert.Equal(t, len(ut.Unspent), 1)
-	for _, uxs := range ut.Unspent {
+	})
+
+	ut.removeTxn(bc, utx.Hash())
+	assert.Equal(t, ut.Len(), 1)
+	assert.Equal(t, ut.Unspent.len(), 1)
+	ut.Unspent.forEach(func(_ cipher.SHA256, uxs coin.UxArray) {
 		assert.Equal(t, len(uxs), 2)
-	}
-	ut.removeTxn(mv.blockchain, utx2.Hash())
-	assert.Equal(t, len(ut.Txns), 0)
-	assert.Equal(t, len(ut.Unspent), 0)
+	})
+	ut.removeTxn(bc, utx2.Hash())
+	assert.Equal(t, ut.Len(), 0)
+	assert.Equal(t, ut.Unspent.len(), 0)
 }
 
 func TestRemoveTxns(t *testing.T) {
-	defer cleanupVisor()
-	mv := setupMasterVisor()
-	up := NewUnconfirmedTxnPool()
+	db, close := prepareDB(t)
+	defer close()
+	up := NewUnconfirmedTxnPool(db)
 
 	// Include an unknown hash, and omit a known hash. The other two should
 	// be removed.
 	hashes := make([]cipher.SHA256, 0, 3)
 	hashes = append(hashes, randSHA256()) // unknown hash
-	ut, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	err, known := up.InjectTxn(mv.blockchain, ut, nil, testBlockSize, 0)
+	bc := makeBlockchain()
+	ut := makeTransactionForChain(t, bc)
+	err, known := up.InjectTxn(bc, ut)
 	assert.Nil(t, err)
 	assert.False(t, known)
 	hashes = append(hashes, ut.Hash())
-	ut2, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	err, known = up.InjectTxn(mv.blockchain, ut2, nil, testBlockSize, 0)
-	assert.Nil(t, err)
+	ut2 := makeTransactionForChain(t, bc)
+	err, known = up.InjectTxn(bc, ut2)
 	assert.False(t, known)
 	hashes = append(hashes, ut2.Hash())
-	ut3, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	err, known = up.InjectTxn(mv.blockchain, ut3, nil, testBlockSize, 0)
-	assert.Nil(t, err)
+	ut3 := makeTransactionForChain(t, bc)
+	err, known = up.InjectTxn(bc, ut3)
 	assert.False(t, known)
 
-	assert.Equal(t, len(up.Unspent), 3)
-	for _, uxs := range up.Unspent {
+	assert.Equal(t, up.Unspent.len(), 3)
+	up.Unspent.forEach(func(_ cipher.SHA256, uxs coin.UxArray) {
 		assert.Equal(t, len(uxs), 2)
-	}
-	assert.Equal(t, len(up.Txns), 3)
-	up.removeTxns(mv.blockchain, hashes)
-	assert.Equal(t, len(up.Unspent), 1)
-	for _, uxs := range up.Unspent {
+	})
+	assert.Equal(t, up.Len(), 3)
+	up.removeTxns(bc, hashes)
+	assert.Equal(t, up.Unspent.len(), 1)
+	up.Unspent.forEach(func(_ cipher.SHA256, uxs coin.UxArray) {
 		assert.Equal(t, len(uxs), 2)
-	}
-	assert.Equal(t, len(up.Txns), 1)
-	_, ok := up.Txns[ut3.Hash()]
+	})
+	assert.Equal(t, up.Len(), 1)
+	_, ok := up.Txns.get(ut3.Hash())
 	assert.True(t, ok)
 }
 
 func TestRemoveTransactions(t *testing.T) {
-	defer cleanupVisor()
-	mv := setupMasterVisor()
-	up := NewUnconfirmedTxnPool()
+	bc := makeBlockchain()
+	db, close := prepareDB(t)
+	defer close()
+	up := NewUnconfirmedTxnPool(db)
 
 	// Include an unknown txn, and omit a known hash. The other two should
 	// be removed.
-	unkUt, err := makeValidTxn(mv)
-	assert.Nil(t, err)
+	unkUt := makeTransactionForChain(t, bc)
 	txns := make(coin.Transactions, 0, 3)
 	txns = append(txns, unkUt) // unknown txn
-	ut, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	err, known := up.InjectTxn(mv.blockchain, ut, nil, testBlockSize, 0)
+	ut := makeTransactionForChain(t, bc)
+	err, known := up.InjectTxn(bc, ut)
 	assert.Nil(t, err)
 	assert.False(t, known)
 	txns = append(txns, ut)
-	ut2, err := makeValidTxn(mv)
+	ut2 := makeTransactionForChain(t, bc)
 	assert.Nil(t, err)
-	err, known = up.InjectTxn(mv.blockchain, ut2, nil, testBlockSize, 0)
+	err, known = up.InjectTxn(bc, ut2)
 	assert.Nil(t, err)
 	assert.False(t, known)
 	txns = append(txns, ut2)
-	ut3, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	err, known = up.InjectTxn(mv.blockchain, ut3, nil, testBlockSize, 0)
+	ut3 := makeTransactionForChain(t, bc)
+	err, known = up.InjectTxn(bc, ut3)
 	assert.Nil(t, err)
 	assert.False(t, known)
 
-	assert.Equal(t, len(up.Unspent), 3)
-	for _, uxs := range up.Unspent {
+	assert.Equal(t, up.Unspent.len(), 3)
+	up.Unspent.forEach(func(_ cipher.SHA256, uxs coin.UxArray) {
 		assert.Equal(t, len(uxs), 2)
-	}
-	assert.Equal(t, len(up.Txns), 3)
-	up.RemoveTransactions(mv.blockchain, txns)
-	assert.Equal(t, len(up.Unspent), 1)
-	for _, uxs := range up.Unspent {
-		assert.Equal(t, len(uxs), 2)
-	}
-	assert.Equal(t, len(up.Txns), 1)
-	_, ok := up.Txns[ut3.Hash()]
-	assert.True(t, ok)
-}
-
-func testRefresh(t *testing.T, mv *Visor,
-	refresh func(checkPeriod, maxAge time.Duration)) {
-	up := mv.Unconfirmed
-	// Add a transaction that is invalid, but will not be checked yet
-	// Add a transaction that is invalid, and will be checked and removed
-	invalidTxUnchecked, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	invalidTxChecked, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	assert.Nil(t, invalidTxUnchecked.Verify())
-	assert.Nil(t, invalidTxChecked.Verify())
-	// Invalidate it by spending the output that this txn references
-	invalidator, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	err, known := up.InjectTxn(mv.blockchain, invalidator, nil, testBlockSize, 0)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	assert.Equal(t, len(up.Txns), 1)
-	_, err = mv.CreateAndExecuteBlock()
-	assert.Nil(t, err)
-	assert.Equal(t, len(up.Txns), 0)
-	assert.NotNil(t, mv.blockchain.VerifyTransaction(invalidTxUnchecked))
-	assert.NotNil(t, mv.blockchain.VerifyTransaction(invalidTxChecked))
-
-	invalidUtxUnchecked := UnconfirmedTxn{
-		Txn:       invalidTxUnchecked,
-		Received:  util.Now(),
-		Checked:   util.Now(),
-		Announced: util.ZeroTime(),
-	}
-	invalidUtxChecked := invalidUtxUnchecked
-	invalidUtxChecked.Txn = invalidTxChecked
-	invalidUtxUnchecked.Checked = util.Now().Add(time.Hour)
-	invalidUtxChecked.Checked = util.Now().Add(-time.Hour)
-	up.Txns[invalidUtxUnchecked.Hash()] = invalidUtxUnchecked
-	up.Txns[invalidUtxChecked.Hash()] = invalidUtxChecked
-	assert.Equal(t, len(up.Txns), 2)
-	uncheckedHash := invalidTxUnchecked.Hash()
-	checkedHash := invalidTxChecked.Hash()
-	up.Unspent[uncheckedHash] = coin.CreateUnspents(coin.BlockHeader{},
-		invalidTxUnchecked)
-	up.Unspent[checkedHash] = coin.CreateUnspents(coin.BlockHeader{},
-		invalidTxChecked)
-
-	// Create a transaction that is valid, and will not be checked yet
-	validTxUnchecked, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	// Create a transaction that is valid, and will be checked
-	validTxChecked, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	// Create a transaction that is expired
-	validTxExpired, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-
-	// Add the transaction that is valid, and will not be checked yet
-	err, known = up.InjectTxn(mv.blockchain, validTxUnchecked, nil,
-		testBlockSize, 0)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	validUtxUnchecked := up.Txns[validTxUnchecked.Hash()]
-	validUtxUnchecked.Checked = util.Now().Add(time.Hour)
-	up.Txns[validUtxUnchecked.Hash()] = validUtxUnchecked
-	assert.Equal(t, len(up.Txns), 3)
-
-	// Add the transaction that is valid, and will be checked
-	err, known = up.InjectTxn(mv.blockchain, validTxChecked, nil,
-		testBlockSize, 0)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	validUtxChecked := up.Txns[validTxChecked.Hash()]
-	validUtxChecked.Checked = util.Now().Add(-time.Hour)
-	up.Txns[validUtxChecked.Hash()] = validUtxChecked
-	assert.Equal(t, len(up.Txns), 4)
-
-	// Add the transaction that is expired
-	err, known = up.InjectTxn(mv.blockchain, validTxExpired, nil,
-		testBlockSize, 0)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	validUtxExpired := up.Txns[validTxExpired.Hash()]
-	validUtxExpired.Received = util.Now().Add(-time.Hour)
-	up.Txns[validTxExpired.Hash()] = validUtxExpired
-	assert.Equal(t, len(up.Txns), 5)
-
-	// Pre-sanity check
-	assert.Equal(t, len(up.Unspent), 5)
-	for _, uxs := range up.Unspent {
-		assert.Equal(t, len(uxs), 2)
-	}
-	assert.Equal(t, len(up.Txns), 5)
-
-	// Refresh
-	checkPeriod := time.Second * 2
-	maxAge := time.Second * 4
-	refresh(checkPeriod, maxAge)
-
-	// All utxns that are unchecked should be exactly the same
-	assert.Equal(t, up.Txns[validUtxUnchecked.Hash()], validUtxUnchecked)
-	assert.Equal(t, up.Txns[invalidUtxUnchecked.Hash()], invalidUtxUnchecked)
-	// The valid one that is checked should have its checked status updated
-	validUtxCheckedUpdated := up.Txns[validUtxChecked.Hash()]
-	assert.True(t,
-		validUtxCheckedUpdated.Checked.After(validUtxChecked.Checked))
-	validUtxChecked.Checked = validUtxCheckedUpdated.Checked
-	assert.Equal(t, validUtxChecked, validUtxCheckedUpdated)
-	// The invalid checked one and the expired one should be removed
-	_, ok := up.Txns[invalidUtxChecked.Hash()]
-	assert.False(t, ok)
-	_, ok = up.Txns[validUtxExpired.Hash()]
-	assert.False(t, ok)
-	// Also, the unspents should have 2 * nRemaining
-	assert.Equal(t, len(up.Unspent), 3)
-	for _, uxs := range up.Unspent {
-		assert.Equal(t, len(uxs), 2)
-	}
-	assert.Equal(t, len(up.Txns), 3)
-}
-
-func TestRefresh(t *testing.T) {
-	defer cleanupVisor()
-	mv := setupMasterVisor()
-	testRefresh(t, mv, func(checkPeriod, maxAge time.Duration) {
-		mv.Unconfirmed.Refresh(mv.blockchain, checkPeriod, maxAge)
 	})
+	assert.Equal(t, up.Txns.len(), 3)
+	up.RemoveTransactions(bc, txns)
+	assert.Equal(t, up.Unspent.len(), 1)
+	up.Unspent.forEach(func(_ cipher.SHA256, uxs coin.UxArray) {
+		assert.Equal(t, len(uxs), 2)
+	})
+	assert.Equal(t, up.Txns.len(), 1)
+	_, ok := up.Txns.get(ut3.Hash())
+	assert.True(t, ok)
 }
 
-func TestGetOldOwnedTransactions(t *testing.T) {
-	mv := setupMasterVisor()
-	up := mv.Unconfirmed
+// func testRefresh(t *testing.T, mv *Visor, refresh func(checkPeriod, maxAge time.Duration)) {
+// 	up := mv.Unconfirmed
+// 	// Add a transaction that is invalid, but will not be checked yet
+// 	// Add a transaction that is invalid, and will be checked and removed
+// 	invalidTxUnchecked := makeTransactionForChain(t, bc)
+// 	invalidTxChecked := makeTransaction(t, bc)
+// 	assert.Nil(t, err)
+// 	assert.Nil(t, invalidTxUnchecked.Verify())
+// 	assert.Nil(t, invalidTxChecked.Verify())
+// 	// Invalidate it by spending the output that this txn references
+// 	invalidator, err := makeValidTxn(mv)
+// 	assert.Nil(t, err)
+// 	err, known := up.InjectTxn(mv.blockchain, invalidator, nil, testBlockSize, 0)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// 	assert.Equal(t, len(up.Txns), 1)
+// 	_, err = mv.CreateAndExecuteBlock()
+// 	assert.Nil(t, err)
+// 	assert.Equal(t, len(up.Txns), 0)
+// 	assert.NotNil(t, mv.blockchain.VerifyTransaction(invalidTxUnchecked))
+// 	assert.NotNil(t, mv.blockchain.VerifyTransaction(invalidTxChecked))
 
-	// Setup txns
-	notOursNew, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	notOursOld, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	ourSpendNew, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	ourSpendOld, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	ourReceiveNew, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	ourReceiveOld, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	ourBothNew, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	ourBothOld, err := makeValidTxn(mv)
-	assert.Nil(t, err)
+// 	invalidUtxUnchecked := UnconfirmedTxn{
+// 		Txn:       invalidTxUnchecked,
+// 		Received:  util.Now(),
+// 		Checked:   util.Now(),
+// 		Announced: util.ZeroTime(),
+// 	}
+// 	invalidUtxChecked := invalidUtxUnchecked
+// 	invalidUtxChecked.Txn = invalidTxChecked
+// 	invalidUtxUnchecked.Checked = util.Now().Add(time.Hour)
+// 	invalidUtxChecked.Checked = util.Now().Add(-time.Hour)
+// 	up.Txns[invalidUtxUnchecked.Hash()] = invalidUtxUnchecked
+// 	up.Txns[invalidUtxChecked.Hash()] = invalidUtxChecked
+// 	assert.Equal(t, len(up.Txns), 2)
+// 	uncheckedHash := invalidTxUnchecked.Hash()
+// 	checkedHash := invalidTxChecked.Hash()
+// 	up.Unspent[uncheckedHash] = coin.CreateUnspents(coin.BlockHeader{},
+// 		invalidTxUnchecked)
+// 	up.Unspent[checkedHash] = coin.CreateUnspents(coin.BlockHeader{},
+// 		invalidTxChecked)
 
-	// Add a transaction that is not ours, both new and old
-	err, known := up.InjectTxn(mv.blockchain, notOursNew, nil, testBlockSize, 0)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	up.SetAnnounced(notOursNew.Hash(), util.Now())
-	err, known = up.InjectTxn(mv.blockchain, notOursOld, nil, testBlockSize, 0)
-	assert.Nil(t, err)
-	assert.False(t, known)
+// 	// Create a transaction that is valid, and will not be checked yet
+// 	validTxUnchecked, err := makeValidTxn(mv)
+// 	assert.Nil(t, err)
+// 	// Create a transaction that is valid, and will be checked
+// 	validTxChecked, err := makeValidTxn(mv)
+// 	assert.Nil(t, err)
+// 	// Create a transaction that is expired
+// 	validTxExpired, err := makeValidTxn(mv)
+// 	assert.Nil(t, err)
 
-	// Add a transaction that is our spend, both new and old
-	addrs := make(map[cipher.Address]byte, 1)
-	ux, ok := mv.blockchain.Unspent.Get(ourSpendNew.In[0])
-	assert.True(t, ok)
-	addrs[ux.Body.Address] = byte(1)
-	err, known = up.InjectTxn(mv.blockchain, ourSpendNew, addrs, testBlockSize, 0)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	up.SetAnnounced(ourSpendNew.Hash(), util.Now())
-	addrs = make(map[cipher.Address]byte, 1)
-	ux, ok = mv.blockchain.Unspent.Get(ourSpendNew.In[0])
-	assert.True(t, ok)
-	addrs[ux.Body.Address] = byte(1)
-	err, known = up.InjectTxn(mv.blockchain, ourSpendOld, addrs, testBlockSize, 0)
-	assert.Nil(t, err)
-	assert.False(t, known)
+// 	// Add the transaction that is valid, and will not be checked yet
+// 	err, known = up.InjectTxn(mv.blockchain, validTxUnchecked, nil,
+// 		testBlockSize, 0)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// 	validUtxUnchecked := up.Txns[validTxUnchecked.Hash()]
+// 	validUtxUnchecked.Checked = util.Now().Add(time.Hour)
+// 	up.Txns[validUtxUnchecked.Hash()] = validUtxUnchecked
+// 	assert.Equal(t, len(up.Txns), 3)
 
-	// Add a transaction that is our receive, both new and old
-	addrs = make(map[cipher.Address]byte, 1)
-	addrs[ourReceiveNew.Out[1].Address] = byte(1)
-	err, known = up.InjectTxn(mv.blockchain, ourReceiveNew, addrs,
-		testBlockSize, 0)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	up.SetAnnounced(ourReceiveNew.Hash(), util.Now())
-	addrs = make(map[cipher.Address]byte, 1)
-	addrs[ourReceiveOld.Out[1].Address] = byte(1)
-	err, known = up.InjectTxn(mv.blockchain, ourReceiveOld, addrs,
-		testBlockSize, 0)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	// Add a transaction that is both our spend and receive, both new and old
-	addrs = make(map[cipher.Address]byte, 2)
-	ux, ok = mv.blockchain.Unspent.Get(ourBothNew.In[0])
-	assert.True(t, ok)
-	addrs[ux.Body.Address] = byte(1)
-	addrs[ourBothNew.Out[1].Address] = byte(1)
-	assert.Equal(t, len(addrs), 2)
-	err, known = up.InjectTxn(mv.blockchain, ourBothNew, addrs, testBlockSize, 0)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	up.SetAnnounced(ourBothNew.Hash(), util.Now())
-	addrs = make(map[cipher.Address]byte, 1)
-	ux, ok = mv.blockchain.Unspent.Get(ourBothOld.In[0])
-	assert.True(t, ok)
-	addrs[ux.Body.Address] = byte(1)
-	addrs[ourBothOld.Out[1].Address] = byte(1)
-	assert.Equal(t, len(addrs), 2)
-	err, known = up.InjectTxn(mv.blockchain, ourBothOld, addrs, testBlockSize, 0)
-	assert.Nil(t, err)
-	assert.False(t, known)
-}
+// 	// Add the transaction that is valid, and will be checked
+// 	err, known = up.InjectTxn(mv.blockchain, validTxChecked, nil,
+// 		testBlockSize, 0)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// 	validUtxChecked := up.Txns[validTxChecked.Hash()]
+// 	validUtxChecked.Checked = util.Now().Add(-time.Hour)
+// 	up.Txns[validUtxChecked.Hash()] = validUtxChecked
+// 	assert.Equal(t, len(up.Txns), 4)
+
+// 	// Add the transaction that is expired
+// 	err, known = up.InjectTxn(mv.blockchain, validTxExpired, nil,
+// 		testBlockSize, 0)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// 	validUtxExpired := up.Txns[validTxExpired.Hash()]
+// 	validUtxExpired.Received = util.Now().Add(-time.Hour)
+// 	up.Txns[validTxExpired.Hash()] = validUtxExpired
+// 	assert.Equal(t, len(up.Txns), 5)
+
+// 	// Pre-sanity check
+// 	assert.Equal(t, len(up.Unspent), 5)
+// 	for _, uxs := range up.Unspent {
+// 		assert.Equal(t, len(uxs), 2)
+// 	}
+// 	assert.Equal(t, len(up.Txns), 5)
+
+// 	// Refresh
+// 	checkPeriod := time.Second * 2
+// 	maxAge := time.Second * 4
+// 	refresh(checkPeriod, maxAge)
+
+// 	// All utxns that are unchecked should be exactly the same
+// 	assert.Equal(t, up.Txns[validUtxUnchecked.Hash()], validUtxUnchecked)
+// 	assert.Equal(t, up.Txns[invalidUtxUnchecked.Hash()], invalidUtxUnchecked)
+// 	// The valid one that is checked should have its checked status updated
+// 	validUtxCheckedUpdated := up.Txns[validUtxChecked.Hash()]
+// 	assert.True(t,
+// 		validUtxCheckedUpdated.Checked.After(validUtxChecked.Checked))
+// 	validUtxChecked.Checked = validUtxCheckedUpdated.Checked
+// 	assert.Equal(t, validUtxChecked, validUtxCheckedUpdated)
+// 	// The invalid checked one and the expired one should be removed
+// 	_, ok := up.Txns[invalidUtxChecked.Hash()]
+// 	assert.False(t, ok)
+// 	_, ok = up.Txns[validUtxExpired.Hash()]
+// 	assert.False(t, ok)
+// 	// Also, the unspents should have 2 * nRemaining
+// 	assert.Equal(t, len(up.Unspent), 3)
+// 	for _, uxs := range up.Unspent {
+// 		assert.Equal(t, len(uxs), 2)
+// 	}
+// 	assert.Equal(t, len(up.Txns), 3)
+// }
+
+// func TestRefresh(t *testing.T) {
+// 	bc := makeBlockchain()
+// 	testRefresh(t, bc, func(checkPeriod, maxAge time.Duration) {
+// 		mv.Unconfirmed.Refresh(mv.blockchain, checkPeriod, maxAge)
+// 	})
+// }
+
+// func TestGetOldOwnedTransactions(t *testing.T) {
+// 	db, close := prepareDB(t)
+// 	defer close()
+// 	up := NewUnconfirmedTxnPool(db)
+// 	bc := makeBlockchain()
+// 	// Setup txns
+// 	notOursNew := makeTransactionForChain(t, bc)
+// 	notOursOld := makeTransactionForChain(t, bc)
+// 	ourSpendNew := makeTransactionForChain(t, bc)
+// 	ourSpendOld := makeTransactionForChain(t, bc)
+// 	ourReceiveNew := makeTransactionForChain(t, bc)
+// 	ourReceiveOld := makeTransactionForChain(t, bc)
+// 	ourBothNew := makeTransactionForChain(t, bc)
+// 	ourBothOld := makeTransactionForChain(t, bc)
+
+// 	// Add a transaction that is not ours, both new and old
+// 	err, known := up.InjectTxn(bc, notOursNew)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// 	up.SetAnnounced(notOursNew.Hash(), util.Now())
+// 	err, known = up.InjectTxn(bc, notOursOld)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+
+// 	// Add a transaction that is our spend, both new and old
+// 	addrs := make(map[cipher.Address]byte, 1)
+// 	ux, ok := bc.GetUnspent().Get(ourSpendNew.In[0])
+// 	assert.True(t, ok)
+// 	addrs[ux.Body.Address] = byte(1)
+// 	err, known = up.InjectTxn(bc, ourSpendNew)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// 	up.SetAnnounced(ourSpendNew.Hash(), util.Now())
+// 	addrs = make(map[cipher.Address]byte, 1)
+// 	ux, ok = bc.GetUnspent().Get(ourSpendNew.In[0])
+// 	assert.True(t, ok)
+// 	addrs[ux.Body.Address] = byte(1)
+// 	err, known = up.InjectTxn(bc, ourSpendOld)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+
+// 	// Add a transaction that is our receive, both new and old
+// 	addrs = make(map[cipher.Address]byte, 1)
+// 	addrs[ourReceiveNew.Out[1].Address] = byte(1)
+// 	err, known = up.InjectTxn(bc, ourReceiveNew)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// 	up.SetAnnounced(ourReceiveNew.Hash(), util.Now())
+// 	addrs = make(map[cipher.Address]byte, 1)
+// 	addrs[ourReceiveOld.Out[1].Address] = byte(1)
+// 	err, known = up.InjectTxn(bc, ourReceiveOld)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// 	// Add a transaction that is both our spend and receive, both new and old
+// 	addrs = make(map[cipher.Address]byte, 2)
+// 	ux, ok = bc.GetUnspent().Get(ourBothNew.In[0])
+// 	assert.True(t, ok)
+// 	addrs[ux.Body.Address] = byte(1)
+// 	addrs[ourBothNew.Out[1].Address] = byte(1)
+// 	assert.Equal(t, len(addrs), 2)
+// 	err, known = up.InjectTxn(bc, ourBothNew)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// 	up.SetAnnounced(ourBothNew.Hash(), util.Now())
+// 	addrs = make(map[cipher.Address]byte, 1)
+// 	ux, ok = bc.GetUnspent().Get(ourBothOld.In[0])
+// 	assert.True(t, ok)
+// 	addrs[ux.Body.Address] = byte(1)
+// 	addrs[ourBothOld.Out[1].Address] = byte(1)
+// 	assert.Equal(t, len(addrs), 2)
+// 	err, known = up.InjectTxn(bc, ourBothOld)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// }
 
 func TestFilterKnown(t *testing.T) {
-	up := NewUnconfirmedTxnPool()
-	uts := createUnconfirmedTxns(t, up, 4)
+	db, close := prepareDB(t)
+	defer close()
+	up := NewUnconfirmedTxnPool(db)
+	bc := makeBlockchain()
+	uts := createUnconfirmedTxns(t, up, bc, 4)
 	hashes := []cipher.SHA256{
 		uts[0].Hash(),
 		uts[1].Hash(),
@@ -810,15 +803,18 @@ func TestFilterKnown(t *testing.T) {
 	for i, h := range known {
 		assert.Equal(t, h, hashes[i+2])
 	}
-	_, ok := up.Txns[known[0]]
+	_, ok := up.Txns.get(known[0])
 	assert.False(t, ok)
-	_, ok = up.Txns[known[1]]
+	_, ok = up.Txns.get(known[1])
 	assert.False(t, ok)
 }
 
 func TestGetKnown(t *testing.T) {
-	up := NewUnconfirmedTxnPool()
-	uts := createUnconfirmedTxns(t, up, 4)
+	db, close := prepareDB(t)
+	defer close()
+	up := NewUnconfirmedTxnPool(db)
+	bc := makeBlockchain()
+	uts := createUnconfirmedTxns(t, up, bc, 4)
 	hashes := []cipher.SHA256{
 		uts[0].Hash(),
 		uts[1].Hash(),
@@ -832,19 +828,60 @@ func TestGetKnown(t *testing.T) {
 		assert.Equal(t, tx.Hash(), hashes[i])
 		assert.Equal(t, tx, uts[i].Txn)
 	}
-	_, ok := up.Txns[known[0].Hash()]
+	_, ok := up.Txns.get(known[0].Hash())
 	assert.True(t, ok)
-	_, ok = up.Txns[known[1].Hash()]
+	_, ok = up.Txns.get(known[1].Hash())
 	assert.True(t, ok)
 }
 
+func TestTxUnspentsGetAllForAddress(t *testing.T) {
+	db, close := prepareDB(t)
+	defer close()
+	up := NewUnconfirmedTxnPool(db)
+
+	addrs := make(map[cipher.Address]byte, 0)
+	useAddrs := make([]cipher.Address, 4)
+	for i := range useAddrs {
+		useAddrs[i] = makeAddress()
+	}
+	useAddrs[1] = useAddrs[0]
+	for _, a := range useAddrs {
+		addrs[a] = byte(1)
+	}
+	// Make confirmed transactions to add to unspent pool
+	uxs := make(coin.UxArray, 0)
+	for i := 0; i < 4; i++ {
+		txn := coin.Transaction{}
+		txn.PushInput(randSHA256())
+		txn.PushOutput(useAddrs[i], 10e6, 1000)
+		uxa := coin.CreateUnspents(coin.BlockHeader{BkSeq: 1}, txn)
+		assert.Nil(t, up.Unspent.put(txn.Hash(), uxa))
+		uxs = append(uxs, uxa...)
+	}
+	assert.Equal(t, len(uxs), 4)
+
+	uxa := up.Unspent.getAllForAddress(useAddrs[0])
+	assert.Equal(t, 2, len(uxa))
+	for _, u := range uxa {
+		var has bool
+		for _, ux := range uxs[:2] {
+			if ux.Hash() == u.Hash() {
+				has = true
+			}
+		}
+		assert.True(t, has)
+	}
+}
+
 func TestSpendsForAddresses(t *testing.T) {
-	up := NewUnconfirmedTxnPool()
+	db, close := prepareDB(t)
+	defer close()
+	up := NewUnconfirmedTxnPool(db)
 	unspent := coin.NewUnspentPool()
 	addrs := make(map[cipher.Address]byte, 0)
 	n := 4
 	useAddrs := make([]cipher.Address, n)
-	for i, _ := range useAddrs {
+	for i := range useAddrs {
 		useAddrs[i] = makeAddress()
 	}
 	useAddrs[1] = useAddrs[0]
@@ -857,7 +894,7 @@ func TestSpendsForAddresses(t *testing.T) {
 		txn := coin.Transaction{}
 		txn.PushInput(randSHA256())
 		txn.PushOutput(useAddrs[i], 10e6, 1000)
-		uxa := coin.CreateUnspents(coin.BlockHeader{}, txn)
+		uxa := coin.CreateUnspents(coin.BlockHeader{BkSeq: 1}, txn)
 		for _, ux := range uxa {
 			unspent.Add(ux)
 		}
@@ -873,18 +910,321 @@ func TestSpendsForAddresses(t *testing.T) {
 		ut := UnconfirmedTxn{
 			Txn: txn,
 		}
-		up.Txns[ut.Hash()] = ut
+		up.Txns.put(&ut)
+		up.Unspent.put(ut.Hash(), coin.CreateUnspents(coin.BlockHeader{BkSeq: 1}, txn))
 	}
 
 	// Now look them up
 	assert.Equal(t, len(addrs), 3)
-	assert.Equal(t, len(up.Txns), 4)
+	assert.Equal(t, up.Txns.len(), 4)
+
 	auxs := up.SpendsForAddresses(&unspent, addrs)
 	assert.Equal(t, len(auxs), 3)
 	assert.Equal(t, len(auxs[useAddrs[0]]), 2)
 	assert.Equal(t, len(auxs[useAddrs[2]]), 1)
 	assert.Equal(t, len(auxs[useAddrs[3]]), 1)
-	assert.Equal(t, auxs[useAddrs[0]], coin.UxArray{uxs[0], uxs[1]})
+	for _, u := range uxs[:2] {
+		var has bool
+		for _, u1 := range auxs[useAddrs[0]] {
+			if u.Hash() == u1.Hash() {
+				has = true
+				break
+			}
+		}
+		assert.True(t, has)
+	}
 	assert.Equal(t, auxs[useAddrs[2]], coin.UxArray{uxs[2]})
 	assert.Equal(t, auxs[useAddrs[3]], coin.UxArray{uxs[3]})
+}
+
+func TestUnconfirmTxBktPutAndGet(t *testing.T) {
+	uctxs := []UnconfirmedTxn{
+		createUnconfirmedTxn(),
+		createUnconfirmedTxn(),
+		createUnconfirmedTxn(),
+	}
+
+	now := time.Now()
+	for i := range uctxs {
+		uctxs[i].Received = now.Add(time.Duration(i) * time.Minute).UnixNano()
+		uctxs[i].Checked = uctxs[i].Received
+		uctxs[i].Announced = uctxs[i].Received + 100
+	}
+
+	testCases := []struct {
+		name  string
+		init  []UnconfirmedTxn
+		get   UnconfirmedTxn
+		exist bool
+	}{
+		{
+			"get success",
+			uctxs[:2],
+			uctxs[1],
+			true,
+		},
+		{
+			"get success",
+			uctxs[:2],
+			uctxs[0],
+			true,
+		},
+		{
+			"get failed",
+			uctxs[:2],
+			uctxs[2],
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, close := prepareDB(t)
+			defer close()
+			up := NewUnconfirmedTxnPool(db)
+			for _, u := range tc.init {
+				err := up.Txns.put(&u)
+				assert.Nil(t, err)
+			}
+			// check
+			u, ok := up.Txns.get(tc.get.Hash())
+			assert.Equal(t, tc.exist, ok)
+			if !ok {
+				return
+			}
+			assert.Equal(t, tc.get, *u)
+		})
+	}
+}
+
+func TestUnconfirmTxBktUpdate(t *testing.T) {
+	uctxs := []UnconfirmedTxn{
+		createUnconfirmedTxn(),
+		createUnconfirmedTxn(),
+		createUnconfirmedTxn(),
+	}
+
+	testCases := []struct {
+		name      string
+		init      []UnconfirmedTxn
+		index     int   // update index
+		timestamp int64 // update all time to this
+		err       error
+	}{
+		{
+			"update success",
+			uctxs,
+			0,
+			time.Now().UnixNano(),
+			nil,
+		},
+		{
+			"update not exist",
+			uctxs[:2],
+			2,
+			time.Now().UnixNano(),
+			errors.New("not exist in bucket"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, close := prepareDB(t)
+			defer close()
+			bkt := newUncfmTxBkt(db)
+			for _, u := range tc.init {
+				err := bkt.put(&u)
+				assert.Nil(t, err)
+			}
+
+			// update
+			err := bkt.update(uctxs[tc.index].Hash(), func(u *UnconfirmedTxn) {
+				u.Announced = tc.timestamp
+				u.Checked = tc.timestamp
+				u.Received = tc.timestamp
+			})
+			assert.Equal(t, tc.err, err)
+
+			uctxs[tc.index].Announced = tc.timestamp
+			uctxs[tc.index].Received = tc.timestamp
+			uctxs[tc.index].Checked = tc.timestamp
+
+			for _, u := range tc.init {
+				ux, ok := bkt.get(u.Hash())
+				assert.True(t, ok)
+				assert.Equal(t, u, *ux)
+			}
+		})
+	}
+}
+
+func TestUnconfirmedBktGetAll(t *testing.T) {
+	uctxs := []UnconfirmedTxn{
+		createUnconfirmedTxn(),
+		createUnconfirmedTxn(),
+		createUnconfirmedTxn(),
+	}
+
+	db, close := prepareDB(t)
+	defer close()
+	bkt := newUncfmTxBkt(db)
+	for _, u := range uctxs {
+		err := bkt.put(&u)
+		assert.Nil(t, err)
+	}
+
+	vm, err := bkt.getAll()
+	assert.Nil(t, err)
+	for _, u := range uctxs {
+		vu, ok := vm[u.Hash()]
+		assert.True(t, ok)
+		assert.Equal(t, u, vu)
+	}
+}
+
+func TestUnconfirmedTxRangeUpdate(t *testing.T) {
+	uctxs := []UnconfirmedTxn{
+		createUnconfirmedTxn(),
+		createUnconfirmedTxn(),
+		createUnconfirmedTxn(),
+	}
+
+	testCases := []struct {
+		name  string
+		init  []UnconfirmedTxn
+		index int
+		time  int64
+	}{
+		{
+			"range update success",
+			uctxs,
+			0,
+			time.Now().UnixNano(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, close := prepareDB(t)
+			defer close()
+			bkt := newUncfmTxBkt(db)
+			for _, u := range tc.init {
+				assert.Nil(t, bkt.put(&u))
+			}
+
+			bkt.rangeUpdate(func(key cipher.SHA256, ux *UnconfirmedTxn) {
+				if key == uctxs[tc.index].Hash() {
+					ux.Announced = tc.time
+					ux.Checked = tc.time
+					ux.Received = tc.time
+				}
+			})
+
+			uctxs[tc.index].Announced = tc.time
+			uctxs[tc.index].Checked = tc.time
+			uctxs[tc.index].Received = tc.time
+
+			for _, u := range uctxs {
+				ux, ok := bkt.get(u.Hash())
+				assert.True(t, ok)
+				assert.Equal(t, u, *ux)
+			}
+		})
+	}
+}
+
+func TestUnconfirmedTxDelete(t *testing.T) {
+	uctxs := []UnconfirmedTxn{
+		createUnconfirmedTxn(),
+		createUnconfirmedTxn(),
+		createUnconfirmedTxn(),
+	}
+
+	testCases := []struct {
+		name  string
+		init  []UnconfirmedTxn
+		index int // delete index
+		exist bool
+	}{
+		{
+			"delete exist",
+			uctxs,
+			0,
+			false,
+		},
+		{
+			"delete not exist",
+			uctxs[:2],
+			2,
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, close := prepareDB(t)
+			defer close()
+			bkt := newUncfmTxBkt(db)
+			for _, u := range tc.init {
+				assert.Nil(t, bkt.put(&u))
+			}
+
+			key := uctxs[tc.index].Hash()
+			assert.Nil(t, bkt.delete(key))
+
+			_, ok := bkt.get(key)
+			assert.Equal(t, tc.exist, ok)
+			assert.Equal(t, tc.exist, bkt.isExist(key))
+		})
+	}
+}
+
+func TestUnconfirmedTxForEach(t *testing.T) {
+	uctxs := []UnconfirmedTxn{
+		createUnconfirmedTxn(),
+		createUnconfirmedTxn(),
+		createUnconfirmedTxn(),
+	}
+
+	um := make(map[cipher.SHA256]UnconfirmedTxn, len(uctxs))
+
+	db, close := prepareDB(t)
+	defer close()
+	bkt := newUncfmTxBkt(db)
+	for _, u := range uctxs {
+		um[u.Hash()] = u
+		assert.Nil(t, bkt.put(&u))
+	}
+
+	var count int
+	bkt.forEach(func(k cipher.SHA256, ux *UnconfirmedTxn) error {
+		assert.Equal(t, um[k], *ux)
+		count++
+		return nil
+	})
+	assert.Equal(t, len(uctxs), count)
+}
+
+func TestUnconfirmedTxLen(t *testing.T) {
+	uctxs := []UnconfirmedTxn{
+		createUnconfirmedTxn(),
+		createUnconfirmedTxn(),
+		createUnconfirmedTxn(),
+	}
+	db, close := prepareDB(t)
+	defer close()
+	bkt := newUncfmTxBkt(db)
+	for _, u := range uctxs[:2] {
+		assert.Nil(t, bkt.put(&u))
+	}
+	assert.Equal(t, len(uctxs[:2]), bkt.len())
+
+	// add the last one
+	assert.Nil(t, bkt.put(&uctxs[2]))
+	assert.Equal(t, bkt.len(), len(uctxs))
+
+	for i := 0; i < len(uctxs); i++ {
+		assert.Nil(t, bkt.delete(uctxs[i].Hash()))
+		assert.Equal(t, bkt.len(), len(uctxs)-1-i)
+	}
 }

--- a/src/visor/unconfirmed_test.go
+++ b/src/visor/unconfirmed_test.go
@@ -176,9 +176,9 @@ func assertValidUnconfirmed(t *testing.T, txns map[cipher.SHA256]UnconfirmedTxn,
 	ut, ok := txns[txn.Hash()]
 	assert.True(t, ok)
 	assert.Equal(t, ut.Txn, txn)
-	assert.True(t, ut.Announced.IsZero())
-	assert.False(t, ut.Received.IsZero())
-	assert.False(t, ut.Checked.IsZero())
+	assert.True(t, nanoToTime(ut.Announced).IsZero())
+	assert.False(t, nanoToTime(ut.Received).IsZero())
+	assert.False(t, nanoToTime(ut.Checked).IsZero())
 }
 
 func createUnconfirmedTxns(t *testing.T, up *UnconfirmedTxnPool, n int) []UnconfirmedTxn {
@@ -240,7 +240,7 @@ func TestSetAnnounced(t *testing.T) {
 	})
 	assert.Equal(t, len(ut.Txns), 0)
 	utx := createUnconfirmedTxns(t, ut, 1)[0]
-	assert.True(t, utx.Announced.IsZero())
+	assert.True(t, nanoToTime(utx.Announced).IsZero())
 	ut.Txns[utx.Hash()] = utx
 	now := util.Now()
 	ut.SetAnnounced(utx.Hash(), now)

--- a/src/visor/unconfirmed_test.go
+++ b/src/visor/unconfirmed_test.go
@@ -289,7 +289,11 @@ func TestInjectTxn(t *testing.T) {
 	assertValidUnspent(t, bc, ut.Unspent, txn)
 	allUncfmTxs, err := ut.Txns.getAll()
 	assert.Nil(t, err)
-	assertValidUnconfirmed(t, allUncfmTxs, txn)
+	uncfmMap := make(map[cipher.SHA256]UnconfirmedTxn, len(allUncfmTxs))
+	for _, txn := range allUncfmTxs {
+		uncfmMap[txn.Hash()] = txn
+	}
+	assertValidUnconfirmed(t, uncfmMap, txn)
 
 	// Test where we are receiver of ux outputs
 	// mv = setupMasterVisor()
@@ -361,7 +365,11 @@ func TestInjectTxn(t *testing.T) {
 	assert.True(t, nanoToTime(utx2.Checked).After(nanoToTime(utx.Checked)))
 	all, err := ut.Txns.getAll()
 	assert.Nil(t, err)
-	assertValidUnconfirmed(t, all, txn)
+	allMap := make(map[cipher.SHA256]UnconfirmedTxn, len(all))
+	for _, tx := range all {
+		allMap[tx.Hash()] = tx
+	}
+	assertValidUnconfirmed(t, allMap, txn)
 	assert.Equal(t, ut.Txns.len(), 1)
 	assert.Equal(t, ut.Unspent.len(), 1)
 	ut.Unspent.forEach(func(_ cipher.SHA256, uxa coin.UxArray) {
@@ -457,6 +465,7 @@ func TestRemoveTxn(t *testing.T) {
 	assert.Nil(t, err)
 	assert.False(t, known)
 	assert.Equal(t, ut.Txns.len(), 1)
+	assert.Equal(t, 1, ut.Txns.indexLen())
 	assert.Equal(t, ut.Unspent.len(), 1)
 	ut.Unspent.forEach(func(_ cipher.SHA256, uxa coin.UxArray) {
 		assert.Equal(t, len(uxa), 2)
@@ -472,6 +481,7 @@ func TestRemoveTxn(t *testing.T) {
 	})
 	ut.removeTxn(bc, badh)
 	assert.Equal(t, ut.Txns.len(), 1)
+	assert.Equal(t, 1, ut.Txns.indexLen())
 	assert.Equal(t, ut.Unspent.len(), 1)
 	ut.Unspent.forEach(func(_ cipher.SHA256, uxs coin.UxArray) {
 		assert.Equal(t, len(uxs), 2)
@@ -491,17 +501,17 @@ func TestRemoveTxn(t *testing.T) {
 	})
 	ut.removeTxn(bc, utx.Hash())
 	assert.Equal(t, ut.Txns.len(), 1)
+	assert.Equal(t, 1, ut.Txns.indexLen())
 	assert.Equal(t, ut.Unspent.len(), 1)
 	ut.Unspent.forEach(func(_ cipher.SHA256, uxs coin.UxArray) {
 		assert.Equal(t, len(uxs), 2)
 	})
-
-	ut.removeTxn(bc, utx.Hash())
-	assert.Equal(t, ut.Len(), 1)
-	assert.Equal(t, ut.Unspent.len(), 1)
-	ut.Unspent.forEach(func(_ cipher.SHA256, uxs coin.UxArray) {
-		assert.Equal(t, len(uxs), 2)
-	})
+	// ut.removeTxn(bc, utx.Hash())
+	// assert.Equal(t, ut.Len(), 1)
+	// assert.Equal(t, ut.Unspent.len(), 1)
+	// ut.Unspent.forEach(func(_ cipher.SHA256, uxs coin.UxArray) {
+	// 	assert.Equal(t, len(uxs), 2)
+	// })
 	ut.removeTxn(bc, utx2.Hash())
 	assert.Equal(t, ut.Len(), 0)
 	assert.Equal(t, ut.Unspent.len(), 0)
@@ -1075,18 +1085,77 @@ func TestUnconfirmedBktGetAll(t *testing.T) {
 
 	vm, err := bkt.getAll()
 	assert.Nil(t, err)
+	assert.Equal(t, uctxs, vm)
+	// for _, u := range uctxs {
+	// 	vu, ok := vm[u.Hash()]
+	// 	assert.True(t, ok)
+	// 	assert.Equal(t, u, vu)
+	// }
+}
+
+func TestUnconfirmedBktGetSlice(t *testing.T) {
+	uctxs := []UnconfirmedTxn{
+		createUnconfirmedTxn(),
+		createUnconfirmedTxn(),
+		createUnconfirmedTxn(),
+	}
+
+	db, close := prepareDB(t)
+	defer close()
+	bkt := newUncfmTxBkt(db)
 	for _, u := range uctxs {
-		vu, ok := vm[u.Hash()]
-		assert.True(t, ok)
-		assert.Equal(t, u, vu)
+		err := bkt.put(&u)
+		assert.Nil(t, err)
+	}
+
+	testCases := []struct {
+		n     int
+		index []int
+		Txns  []UnconfirmedTxn
+	}{
+		{
+			0,
+			[]int{},
+			[]UnconfirmedTxn{},
+		},
+		{
+			1,
+			[]int{1},
+			[]UnconfirmedTxn{uctxs[1]},
+		},
+		{
+			2,
+			[]int{0, 1},
+			[]UnconfirmedTxn{uctxs[0], uctxs[1]},
+		},
+		{
+			2,
+			[]int{0, 2},
+			[]UnconfirmedTxn{uctxs[0], uctxs[2]},
+		},
+		{
+			3,
+			[]int{0, 1, 2},
+			[]UnconfirmedTxn{uctxs[0], uctxs[1], uctxs[2]},
+		},
+	}
+
+	for _, tc := range testCases {
+		keys := make([]cipher.SHA256, 0, tc.n)
+		for _, i := range tc.index {
+			keys = append(keys, uctxs[i].Hash())
+		}
+		uxs, err := bkt.getSlice(keys)
+		assert.Nil(t, err)
+		assert.Equal(t, tc.Txns, uxs)
 	}
 }
 
 func TestUnconfirmedTxRangeUpdate(t *testing.T) {
 	uctxs := []UnconfirmedTxn{
 		createUnconfirmedTxn(),
-		createUnconfirmedTxn(),
-		createUnconfirmedTxn(),
+		// createUnconfirmedTxn(),
+		// createUnconfirmedTxn(),
 	}
 
 	testCases := []struct {
@@ -1112,13 +1181,14 @@ func TestUnconfirmedTxRangeUpdate(t *testing.T) {
 				assert.Nil(t, bkt.put(&u))
 			}
 
-			bkt.rangeUpdate(func(key cipher.SHA256, ux *UnconfirmedTxn) {
+			err := bkt.rangeUpdate(func(key cipher.SHA256, ux *UnconfirmedTxn) {
 				if key == uctxs[tc.index].Hash() {
 					ux.Announced = tc.time
 					ux.Checked = tc.time
 					ux.Received = tc.time
 				}
 			})
+			assert.Nil(t, err)
 
 			uctxs[tc.index].Announced = tc.time
 			uctxs[tc.index].Checked = tc.time

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -90,9 +90,10 @@ func NewVisorConfig() VisorConfig {
 
 		UnconfirmedCheckInterval: time.Hour * 2,
 		UnconfirmedMaxAge:        time.Hour * 48,
-		UnconfirmedRefreshRate:   time.Minute * 30,
-		UnconfirmedResendPeriod:  time.Minute,
-		MaxBlockSize:             1024 * 32,
+		UnconfirmedRefreshRate:   time.Minute,
+		// UnconfirmedRefreshRate:   time.Minute * 30,
+		UnconfirmedResendPeriod: time.Minute,
+		MaxBlockSize:            1024 * 32,
 
 		GenesisAddress:    cipher.Address{},
 		GenesisSignature:  cipher.Sig{},
@@ -198,10 +199,10 @@ func (vs *Visor) GenesisPreconditions() {
 	}
 }
 
-// RefreshUnconfirmed checks unconfirmed txns against the blockchain and purges ones too old
-func (vs *Visor) RefreshUnconfirmed() {
-	vs.Unconfirmed.Refresh(vs.Blockchain,
-		vs.Config.UnconfirmedCheckInterval, vs.Config.UnconfirmedMaxAge)
+// RefreshUnconfirmed checks unconfirmed txns against the blockchain and returns
+// all transaction that turn to valid.
+func (vs *Visor) RefreshUnconfirmed() []cipher.SHA256 {
+	return vs.Unconfirmed.Refresh(vs.Blockchain)
 }
 
 // CreateBlock creates a SignedBlock from pending transactions

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -126,11 +126,6 @@ func NewVisor(c VisorConfig) *Visor {
 		}
 	}
 
-	// db, err := historydb.NewDB()
-	// if err != nil {
-	// 	log.Panic(err)
-	// }
-
 	history, err := historydb.New(c.DB)
 	if err != nil {
 		log.Panic(err)
@@ -176,19 +171,6 @@ func NewVisor(c VisorConfig) *Visor {
 		log.Panicf("Invalid block signatures: %v", err)
 	}
 
-	// db, err := historydb.NewDB()
-	// if err != nil {
-	// 	log.Panic(err)
-	// }
-
-	// v.history, err = historydb.New(db)
-	// if err != nil {
-	// 	log.Panic(err)
-	// }
-
-	// init the blockchain parser instance
-	// v.bcParser = NewBlockchainParser(v.history, v.Blockchain)
-	// v.StartParser()
 	return v
 }
 
@@ -461,7 +443,7 @@ func (vs *Visor) GetAddressTransactions(a cipher.Address) []Transaction {
 	}
 
 	// Look in the unconfirmed pool
-	uxs = vs.Unconfirmed.Unspent.AllForAddress(a)
+	uxs = vs.Unconfirmed.Unspent.getAllForAddress(a)
 	for _, ux := range uxs {
 		tx, ok := vs.Unconfirmed.Txns.get(ux.Body.SrcTransaction)
 		if !ok {

--- a/src/visor/visor_test.go
+++ b/src/visor/visor_test.go
@@ -1,1055 +1,1055 @@
 package visor
 
-import (
-	"os"
-	"path/filepath"
-	"testing"
-	"time"
-
-	"github.com/skycoin/skycoin/src/cipher"
-	"github.com/skycoin/skycoin/src/coin"
-	"github.com/skycoin/skycoin/src/util"
-	"github.com/skycoin/skycoin/src/wallet"
-	"github.com/stretchr/testify/assert"
-)
-
-/* Helper functions */
-
-func setupVisorWriting(vc VisorConfig) *Visor {
-	vc.WalletDirectory = testWalletDir
-	v := NewVisor(vc)
-	v.Wallets[0].SetFilename(testWalletFile)
-	cleanupVisor() // delete the automatically saved wallet
-	return v
-}
-
-func writeVisorFilesDirect(t *testing.T, v *Visor) {
-	assert.True(t, len(v.Wallets) > 0)
-	for _, w := range v.Wallets {
-		assert.NotEqual(t, w.GetFilename(), "")
-	}
-	assert.Nil(t, v.SaveWallet(v.Wallets[0].GetFilename()))
-	assert.Nil(t, v.SaveBlockSigs())
-	assert.Nil(t, v.SaveBlockchain())
-	assertDirExists(t, v.Config.WalletDirectory)
-	walletFile := filepath.Join(v.Config.WalletDirectory, testWalletFile)
-	assertFileExists(t, walletFile)
-	assertFileExists(t, v.Config.BlockSigsFile)
-	assertFileExists(t, v.Config.BlockchainFile)
-}
-
-func writeVisorFiles(t *testing.T, vc VisorConfig) *Visor {
-	cleanupVisor()
-	v := setupVisorWriting(vc)
-	writeVisorFilesDirect(t, v)
-	return v
-}
-
-func newWalletEntry(t *testing.T) wallet.WalletEntry {
-	we := wallet.NewWalletEntry()
-	assert.Nil(t, we.Verify())
-	return we
-}
-
-func setupGenesis(t *testing.T) (wallet.WalletEntry, cipher.Sig, uint64) {
-	we := newWalletEntry(t)
-	vc := NewVisorConfig()
-	vc.IsMaster = true
-	vc.MasterKeys = we
-	vc.GenesisSignature = createGenesisSignature(we)
-	v := NewVisor(vc)
-	we.Secret = cipher.SecKey{}
-	return we, v.blockSigs.Sigs[0], v.blockchain.Blocks[0].Head.Time
-}
-
-func newGenesisConfig(t *testing.T) VisorConfig {
-	refvc := NewVisorConfig()
-	we, sig, ts := setupGenesis(t)
-	refvc.MasterKeys = we
-	refvc.GenesisSignature = sig
-	refvc.GenesisTimestamp = ts
-	refvc.IsMaster = false
-	refvc.WalletDirectory = testWalletDir
-	return refvc
-}
-
-func corruptFile(t *testing.T, filename string) {
-	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_TRUNC, 0600)
-	assert.Nil(t, err)
-	_, err = f.Write([]byte("xxxxx"))
-	assert.Nil(t, err)
-	f.Close()
-}
-
-func setupChildVisorConfig(refvc VisorConfig, master bool) VisorConfig {
-	vc := NewVisorConfig()
-	vc.IsMaster = master
-	vc.MasterKeys = refvc.MasterKeys
-	vc.WalletDirectory = testWalletDir
-	vc.BlockchainFile = testBlockchainFile
-	vc.BlockSigsFile = testBlocksigsFile
-	return vc
-}
-
-func newMasterVisorConfig(t *testing.T) VisorConfig {
-	vc := NewVisorConfig()
-	vc.CoinHourBurnFactor = 0
-	mw := newWalletEntry(t)
-	vc.MasterKeys = mw
-	vc.GenesisSignature = createGenesisSignature(mw)
-	vc.IsMaster = true
-	return vc
-}
-
-func addValidTxns(t *testing.T, v *Visor, n int) coin.Transactions {
-	txns := make(coin.Transactions, n)
-	for i := 0; i < len(txns); i++ {
-		txn, err := makeValidTxn(v)
-		assert.Nil(t, err)
-		txns[i] = txn
-	}
-	for _, txn := range txns {
-		err, known := v.InjectTxn(txn)
-		assert.Nil(t, err)
-		assert.False(t, known)
-	}
-	txns = coin.SortTransactions(txns, getFee)
-	assert.Equal(t, len(v.Unconfirmed.Txns), n)
-	return txns
-}
-
-func addSignedBlockAt(t *testing.T, v *Visor, when uint64) coin.SignedBlock {
-	we := wallet.NewWalletEntry()
-	tx, err := v.Spend(v.Wallets[0].GetFilename(), wallet.Balance{1e6, 0}, 0, we.Address)
-	assert.Nil(t, err)
-	err, known := v.InjectTxn(tx)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	sb, err := v.CreateBlock(when)
-	assert.Nil(t, err)
-	if err != nil {
-		return sb
-	}
-	err = v.ExecuteSignedBlock(sb)
-	assert.Nil(t, err)
-	return sb
-}
-
-func addSignedBlock(t *testing.T, v *Visor) coin.SignedBlock {
-	return addSignedBlockAt(t, v, uint64(util.UnixNow()))
-}
-
-func addSignedBlocks(t *testing.T, v *Visor, n int) []coin.SignedBlock {
-	sbs := make([]SignedBlock, n)
-	now := uint64(util.UnixNow())
-	for i := 0; i < n; i++ {
-		sbs[i] = addSignedBlockAt(t, v, now+1+uint64(i))
-	}
-	return sbs
-}
-
-func assertSignedBlocks(t *testing.T, v *Visor, sbs []coin.SignedBlock,
-	start, ct uint64) {
-	have := v.HeadBkSeq()
-	if have <= start {
-		assert.Equal(t, len(sbs), 0)
-	} else if have-start < ct {
-		assert.Equal(t, len(sbs), int(have-start))
-	} else {
-		assert.Equal(t, len(sbs), int(ct))
-	}
-	for i, sb := range sbs {
-		assert.Nil(t, v.verifySignedBlock(&sb))
-		assert.Equal(t, sb.Sig, v.blockSigs.Sigs[sb.Block.Head.BkSeq])
-		assert.Equal(t, sb.Block.Head.BkSeq, start+uint64(i)+1)
-		assert.Equal(t, v.blockchain.Blocks[start+uint64(i)+1], sb.Block)
-	}
-}
-
-func assertReadableBlocks(t *testing.T, v *Visor, rbs []ReadableBlock,
-	sbs []coin.SignedBlock) {
-	assert.Equal(t, len(rbs), len(sbs))
-	for i, rb := range rbs {
-		assertReadableBlock(t, rb, sbs[i].Block)
-	}
-}
-
-func assertBlocks(t *testing.T, v *Visor, bs []coin.Block, sbs []coin.SignedBlock) {
-	assert.Equal(t, len(bs), len(sbs))
-	for i, b := range bs {
-		assert.Equal(t, b, sbs[i].Block)
-	}
-}
-
-/* Actual tests */
-
-func TestNewVisorConfig(t *testing.T) {
-	vc := NewVisorConfig()
-	assert.False(t, vc.IsMaster)
-	assert.Equal(t, vc.WalletDirectory, "")
-	assert.Equal(t, vc.BlockchainFile, "")
-	assert.Equal(t, vc.BlockSigsFile, "")
-	assert.Panics(t, func() { vc.MasterKeys.Verify() })
-	assert.NotNil(t, vc.MasterKeys.VerifyPublic())
-	assert.Equal(t, vc.GenesisSignature, cipher.Sig{})
-}
-
-func TestNewVisor(t *testing.T) {
-	defer cleanupVisor()
-
-	// Not master, Invalid master keys
-	cleanupVisor()
-	we := wallet.NewWalletEntry()
-	we.Public = cipher.PubKey{}
-	vc := NewVisorConfig()
-	vc.IsMaster = false
-	assert.Panics(t, func() { NewVisor(vc) })
-	vc.MasterKeys = we
-	assert.Panics(t, func() { NewVisor(vc) })
-
-	// Master, invalid master keys
-	cleanupVisor()
-	vc.IsMaster = true
-	vc.MasterKeys = wallet.WalletEntry{}
-	assert.Panics(t, func() { NewVisor(vc) })
-	vc.MasterKeys = we
-	assert.Panics(t, func() { NewVisor(vc) })
-
-	// Not master, no wallet, blockchain, blocksigs file
-	cleanupVisor()
-	vc = NewVisorConfig()
-	vc.IsMaster = false
-	we, sig, ts := setupGenesis(t)
-	vc.MasterKeys = we
-	vc.GenesisSignature = sig
-	vc.GenesisTimestamp = ts
-	v := NewVisor(vc)
-	assert.Equal(t, len(v.blockchain.Blocks), 1)
-	assert.Equal(t, len(v.blockSigs.Sigs), 1)
-
-	// Master, no wallet, blockchain, blocksigs file
-	cleanupVisor()
-	vc = NewVisorConfig()
-	we = newWalletEntry(t)
-	vc.MasterKeys = we
-	vc.GenesisSignature = createGenesisSignature(we)
-	vc.IsMaster = true
-	v = NewVisor(vc)
-	assert.Equal(t, len(v.Wallets), 1)
-	// Wallet should only have 1 entry if master
-	assert.Equal(t, v.Wallets[0].NumEntries(), 1)
-	assert.Equal(t, len(v.blockchain.Blocks), 1)
-	assert.Equal(t, len(v.blockSigs.Sigs), 1)
-
-	// Not master, has all files
-	cleanupVisor()
-	refvc := newGenesisConfig(t)
-	refv := writeVisorFiles(t, refvc)
-	vc = setupChildVisorConfig(refvc, false)
-	v = NewVisor(vc)
-	assert.Equal(t, v.Wallets, refv.Wallets)
-	assert.Equal(t, len(v.Wallets), 1)
-	assert.Equal(t, v.blockchain, refv.blockchain)
-	assert.Equal(t, v.blockSigs, refv.blockSigs)
-
-	// Master, has all files
-	cleanupVisor()
-	refvc = newMasterVisorConfig(t)
-	refv = writeVisorFiles(t, refvc)
-	vc = setupChildVisorConfig(refvc, true)
-	v = NewVisor(vc)
-	assert.Equal(t, v.Wallets[0].GetEntries(), refv.Wallets[0].GetEntries())
-	assert.Equal(t, v.blockchain, refv.blockchain)
-
-	// Not master, wallet is corrupt
-	cleanupVisor()
-	refvc = newGenesisConfig(t)
-	refv = writeVisorFiles(t, refvc)
-	walletFile := filepath.Join(testWalletDir, testWalletFile)
-	assertFileExists(t, walletFile)
-	corruptFile(t, walletFile)
-	vc = setupChildVisorConfig(refvc, false)
-	assert.Panics(t, func() { NewVisor(vc) })
-
-	// Master, wallet is corrupt.  Nothing happens because master ignores
-	// wallet
-	cleanupVisor()
-	refvc = newMasterVisorConfig(t)
-	refv = writeVisorFiles(t, refvc)
-	assertFileExists(t, walletFile)
-	corruptFile(t, walletFile)
-	vc = setupChildVisorConfig(refvc, true)
-	assert.NotPanics(t, func() { NewVisor(vc) })
-
-	// Not master, blocksigs is corrupt
-	cleanupVisor()
-	refvc = newGenesisConfig(t)
-	assertFileNotExists(t, testWalletFile)
-	refv = writeVisorFiles(t, refvc)
-	corruptFile(t, testBlocksigsFile)
-	vc = setupChildVisorConfig(refvc, false)
-	assert.Panics(t, func() { NewVisor(vc) })
-
-	// Master, blocksigs is corrupt
-	cleanupVisor()
-	refvc = newMasterVisorConfig(t)
-	refv = writeVisorFiles(t, refvc)
-	corruptFile(t, testBlocksigsFile)
-	assertFileExists(t, testBlocksigsFile)
-	vc = setupChildVisorConfig(refvc, true)
-	assert.Panics(t, func() { NewVisor(vc) })
-
-	// Not master, blockchain is corrupt
-	cleanupVisor()
-	refvc = newGenesisConfig(t)
-	refv = writeVisorFiles(t, refvc)
-	corruptFile(t, testBlockchainFile)
-	vc = setupChildVisorConfig(refvc, false)
-	assert.Panics(t, func() { NewVisor(vc) })
-
-	// Master, blockchain is corrupt
-	cleanupVisor()
-	refvc = newMasterVisorConfig(t)
-	refv = writeVisorFiles(t, refvc)
-	corruptFile(t, testBlockchainFile)
-	vc = setupChildVisorConfig(refvc, true)
-	assert.Panics(t, func() { NewVisor(vc) })
-
-	// Not master, blocksigs is not valid for blockchain
-	cleanupVisor()
-	refvc = newGenesisConfig(t)
-	refv = setupVisorWriting(refvc)
-	// Corrupt the signature
-	refv.blockSigs.Sigs[uint64(0)] = cipher.Sig{}
-	writeVisorFilesDirect(t, refv)
-	vc = setupChildVisorConfig(refvc, false)
-	assert.Panics(t, func() { NewVisor(vc) })
-
-	// Master, blocksigs is not valid for blockchain
-	cleanupVisor()
-	refvc = newMasterVisorConfig(t)
-	refv = setupVisorWriting(refvc)
-	// Corrupt the signature
-	refv.blockSigs.Sigs[uint64(0)] = cipher.Sig{}
-	writeVisorFilesDirect(t, refv)
-	vc = setupChildVisorConfig(refvc, true)
-	assert.Panics(t, func() { NewVisor(vc) })
-}
-
-func TestNewMinimalVisor(t *testing.T) {
-	defer cleanupVisor()
-	vc := newMasterVisorConfig(t)
-	v := NewMinimalVisor(vc)
-	assert.Equal(t, v.Config, vc)
-	assert.NotNil(t, v.Unconfirmed)
-	assert.Nil(t, v.Wallets)
-	assert.Equal(t, len(v.blockchain.Blocks), 0)
-	assert.Equal(t, len(v.blockSigs.Sigs), 0)
-}
-
-func TestCreateGenesisBlockVisor(t *testing.T) {
-	defer cleanupVisor()
-	// Test as master, successful
-	vc := newMasterVisorConfig(t)
-	v := NewMinimalVisor(vc)
-	assert.True(t, v.Config.IsMaster)
-	assert.Equal(t, len(v.blockchain.Blocks), 0)
-	assert.Equal(t, len(v.blockSigs.Sigs), 0)
-	sb := v.CreateGenesisBlock()
-	assert.NotEqual(t, sb.Block, coin.Block{})
-	assert.NotEqual(t, sb.Sig, cipher.Sig{})
-	assert.Equal(t, len(v.blockchain.Blocks), 1)
-	assert.Equal(t, len(v.blockSigs.Sigs), 1)
-	assert.Nil(t, v.blockSigs.Verify(vc.MasterKeys.Public, v.blockchain))
-
-	// Test as not master, successful
-	vc = newGenesisConfig(t)
-	v = NewMinimalVisor(vc)
-	assert.False(t, v.Config.IsMaster)
-	assert.Equal(t, len(v.blockchain.Blocks), 0)
-	assert.Equal(t, len(v.blockSigs.Sigs), 0)
-	sb = v.CreateGenesisBlock()
-	assert.NotEqual(t, sb.Block, coin.Block{})
-	assert.NotEqual(t, sb.Sig, cipher.Sig{})
-	assert.Equal(t, len(v.blockchain.Blocks), 1)
-	assert.Equal(t, len(v.blockSigs.Sigs), 1)
-	assert.Nil(t, v.blockSigs.Verify(vc.MasterKeys.Public, v.blockchain))
-	assert.Equal(t, v.Config.GenesisSignature, sb.Sig)
-	assert.Equal(t, v.blockchain.Blocks[0].Head.Time, v.Config.GenesisTimestamp)
-
-	// Test as master, blockSigs invalid for pubkey
-	vc = newMasterVisorConfig(t)
-	vc.MasterKeys.Public = cipher.PubKey{}
-	v = NewMinimalVisor(vc)
-	assert.True(t, v.Config.IsMaster)
-	assert.Equal(t, len(v.blockchain.Blocks), 0)
-	assert.Equal(t, len(v.blockSigs.Sigs), 0)
-	assert.Panics(t, func() { v.CreateGenesisBlock() })
-
-	// Test as not master, blockSigs invalid for pubkey
-	vc = newGenesisConfig(t)
-	vc.MasterKeys.Public = cipher.PubKey{}
-	v = NewMinimalVisor(vc)
-	assert.False(t, v.Config.IsMaster)
-	assert.Equal(t, len(v.blockchain.Blocks), 0)
-	assert.Equal(t, len(v.blockSigs.Sigs), 0)
-	assert.Panics(t, func() { v.CreateGenesisBlock() })
-
-	// Test as master, signing failed
-	vc = newMasterVisorConfig(t)
-	vc.MasterKeys.Secret = cipher.SecKey{}
-	vc.GenesisSignature = cipher.Sig{}
-	assert.Equal(t, vc.MasterKeys.Secret, cipher.SecKey{})
-	v = NewMinimalVisor(vc)
-	assert.True(t, v.Config.IsMaster)
-	assert.Equal(t, v.Config, vc)
-	assert.Equal(t, v.Config.MasterKeys.Secret, cipher.SecKey{})
-	assert.Equal(t, len(v.blockchain.Blocks), 0)
-	assert.Equal(t, len(v.blockSigs.Sigs), 0)
-	assert.Panics(t, func() { v.CreateGenesisBlock() })
-}
-
-func TestVisorRefreshUnconfirmed(t *testing.T) {
-	defer cleanupVisor()
-	mv := setupMasterVisor()
-	testRefresh(t, mv, func(checkPeriod, maxAge time.Duration) {
-		mv.Config.UnconfirmedCheckInterval = checkPeriod
-		mv.Config.UnconfirmedMaxAge = maxAge
-		mv.RefreshUnconfirmed()
-	})
-}
-
-func TestVisorSaveBlockchain(t *testing.T) {
-	cleanupVisor()
-	defer cleanupVisor()
-	vc := newMasterVisorConfig(t)
-	vc.BlockchainFile = ""
-
-	// Test with no blockchain file set
-	v := NewVisor(vc)
-	assertFileNotExists(t, testBlockchainFile)
-	err := v.SaveBlockchain()
-	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "No BlockchainFile location set")
-	assertFileNotExists(t, testBlockchainFile)
-
-	// Test with blockchain file set
-	vc.BlockchainFile = testBlockchainFile
-	v = NewVisor(vc)
-	assert.Nil(t, v.SaveBlockchain())
-	assertFileExists(t, testBlockchainFile)
-	assert.NotPanics(t, func() {
-		loadBlockchain(testBlockchainFile, vc.MasterKeys.Address)
-	})
-	bc := loadBlockchain(testBlockchainFile, vc.MasterKeys.Address)
-	assert.Equal(t, v.blockchain, bc)
-}
-
-func TestVisorSaveWallets(t *testing.T) {
-	cleanupVisor()
-	defer cleanupVisor()
-	vc := newGenesisConfig(t)
-	assert.False(t, vc.IsMaster)
-	vc.WalletDirectory = testWalletDir
-	v := NewVisor(vc)
-	assertFileNotExists(t, filepath.Join(testWalletDir, testWalletFile))
-	v.Wallets[0].SetFilename(testWalletFile)
-	assert.Equal(t, len(v.SaveWallets()), 0)
-	assertFileExists(t, filepath.Join(testWalletDir, testWalletFile))
-	w, err := wallet.LoadSimpleWallet(testWalletDir, testWalletFile)
-	assert.Nil(t, err)
-	assert.Equal(t, v.Wallets[0], w)
-}
-
-func TestVisorSaveBlockSigs(t *testing.T) {
-	cleanupVisor()
-	defer cleanupVisor()
-	vc := newMasterVisorConfig(t)
-	vc.BlockSigsFile = ""
-
-	// Test with no blocksigs file set
-	v := NewVisor(vc)
-	assertFileNotExists(t, testBlocksigsFile)
-	err := v.SaveBlockSigs()
-	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "No BlockSigsFile location set")
-	assertFileNotExists(t, testBlocksigsFile)
-
-	vc.BlockSigsFile = testBlocksigsFile
-	v = NewVisor(vc)
-	assert.Nil(t, v.SaveBlockSigs())
-	assertFileExists(t, testBlocksigsFile)
-
-	bs, err := LoadBlockSigs(testBlocksigsFile)
-	assert.Nil(t, err)
-	assert.Equal(t, v.blockSigs, bs)
-}
-
-func TestCreateAndExecuteBlock(t *testing.T) {
-	defer cleanupVisor()
-
-	// Test as not master, should fail
-	vc := newGenesisConfig(t)
-	v := NewVisor(vc)
-	assert.Panics(t, func() { v.CreateAndExecuteBlock() })
-
-	// Test as master, no txns
-	vc = newMasterVisorConfig(t)
-	v = NewVisor(vc)
-	_, err := v.CreateAndExecuteBlock()
-	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "No transactions")
-
-	// Test as master, more txns than allowed
-	vc.BlockCreationInterval = uint64(101)
-	v = NewVisor(vc)
-	txns := addValidTxns(t, v, 3)
-	txns = coin.SortTransactions(txns, v.blockchain.TransactionFee)
-	v.Config.MaxBlockSize = txns[0].Size()
-	assert.Equal(t, len(v.blockchain.Blocks), 1)
-	assert.Equal(t, len(v.blockSigs.Sigs), 1)
-	sb, err := v.CreateAndExecuteBlock()
-	assert.Nil(t, err)
-
-	assert.Equal(t, len(sb.Block.Body.Transactions), 1)
-	assert.Equal(t, sb.Block.Body.Transactions[0], txns[0])
-	assert.Equal(t, len(v.blockchain.Blocks), 2)
-	assert.Equal(t, len(v.blockSigs.Sigs), 2)
-	assert.Equal(t, v.blockchain.Blocks[1], sb.Block)
-	assert.Equal(t, v.blockSigs.Sigs[1], sb.Sig)
-	assert.Equal(t, len(v.Unconfirmed.Txns), 2)
-	assert.True(t, sb.Block.Head.Time > v.blockchain.Blocks[0].Head.Time)
-	rawTxns := v.Unconfirmed.RawTxns()
-	assert.Equal(t, len(rawTxns), 2)
-	for _, tx := range sb.Block.Body.Transactions {
-		assert.NotEqual(t, tx.Hash(), rawTxns[0].Hash())
-		assert.NotEqual(t, tx.Hash(), rawTxns[1].Hash())
-	}
-	if txns[1].Hash() == rawTxns[0].Hash() {
-		assert.Equal(t, txns[2].Hash(), rawTxns[1].Hash())
-	} else {
-		assert.Equal(t, txns[2].Hash(), rawTxns[0].Hash())
-	}
-	assert.Nil(t, v.blockSigs.Verify(v.Config.MasterKeys.Public, v.blockchain))
-
-	// No txns, forcing NewBlockFromTransactions to fail
-	v = NewVisor(vc)
-	assert.Equal(t, len(v.Unconfirmed.Txns), 0)
-	txns = addValidTxns(t, v, 3)
-	v.Config.MaxBlockSize = 0
-	sb, err = v.CreateAndExecuteBlock()
-	assert.NotNil(t, err)
-	assert.Equal(t, len(v.blockchain.Blocks), 1)
-	assert.Equal(t, len(v.blockSigs.Sigs), 1)
-	assert.Equal(t, len(v.Unconfirmed.Txns), 3)
-}
-
-func TestVisorSpend(t *testing.T) {
-	defer cleanupVisor()
-	we := wallet.NewWalletEntry()
-	addr := we.Address
-	vc := newMasterVisorConfig(t)
-	assert.Equal(t, vc.CoinHourBurnFactor, uint64(0))
-	v := NewVisor(vc)
-	wid := v.Wallets[0].GetFilename()
-	ogb := v.WalletBalance(wid).Confirmed
-
-	// Test spend 0 amount
-	v = NewVisor(vc)
-	b = wallet.Balance{0, 0}
-	_, err = v.Spend(v.Wallets[0].GetFilename(), b, 0, addr)
-	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "Zero spend amount")
-
-	// Test lacking funds
-	v = NewVisor(vc)
-	b = wallet.Balance{10e16, 10e16}
-	_, err = v.Spend(v.Wallets[0].GetFilename(), b, 10e16, addr)
-	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "Not enough coins")
-
-	// Test created txn too large
-	v = NewVisor(vc)
-	v.Config.MaxBlockSize = 0
-	b = wallet.Balance{10e6, 10}
-	assert.Panics(t, func() { v.Spend(v.Wallets[0].GetFilename(), b, 0, addr) })
-
-	// Test simple spend (we have only 1 address to spend from, no fee)
-	v = NewVisor(vc)
-	assert.Equal(t, v.Config.CoinHourBurnFactor, uint64(0))
-	b = wallet.Balance{10e6, 10}
-	tx, err := v.Spend(v.Wallets[0].GetFilename(), b, 0, addr)
-	assert.Nil(t, err)
-	assert.Equal(t, len(tx.In), 1)
-	assert.Equal(t, len(tx.Out), 2)
-	// Hash should be updated
-	assert.NotEqual(t, tx.Head.Hash, cipher.SHA256{})
-	// Should be 1 signature for the single input
-	assert.Equal(t, len(tx.Head.Sigs), 1)
-	// Spent amount should be correct
-	assert.Equal(t, tx.Out[1].Address, addr)
-	assert.Equal(t, tx.Out[1].Coins, b.Coins)
-	assert.Equal(t, tx.Out[1].Hours, b.Hours)
-	// Change amount should be correct
-	ourAddr := v.Wallets[0].GetAddresses()[0]
-	assert.Equal(t, tx.Out[0].Address, ourAddr)
-	assert.Equal(t, tx.Out[0].Coins, ogb.Coins-b.Coins)
-	assert.Equal(t, tx.Out[0].Hours, ogb.Hours-b.Hours)
-	assert.Nil(t, tx.Verify())
-}
-
-func TestExecuteSignedBlock(t *testing.T) {
-	defer cleanupVisor()
-	cleanupVisor()
-	we := wallet.NewWalletEntry()
-	vc := newMasterVisorConfig(t)
-	v := NewVisor(vc)
-	wid := v.Wallets[0].GetFilename()
-	assert.Equal(t, len(v.Unconfirmed.Txns), 0)
-	tx, err := v.Spend(wid, wallet.Balance{1e6, 0}, 0, we.Address)
-	assert.Nil(t, err)
-	err, known := v.InjectTxn(tx)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	assert.Equal(t, len(v.Unconfirmed.Txns), 1)
-	assert.Equal(t, len(v.blockSigs.Sigs), 1)
-	now := uint64(util.UnixNow())
-
-	// Invalid signed block
-	sb, err := v.CreateBlock(now)
-	assert.Equal(t, len(v.blockSigs.Sigs), 1)
-	assert.Nil(t, err)
-	sb.Sig = cipher.Sig{}
-	err = v.ExecuteSignedBlock(sb)
-	assert.NotNil(t, err)
-	assert.Equal(t, len(v.Unconfirmed.Txns), 1)
-	assert.Equal(t, len(v.blockSigs.Sigs), 1)
-
-	// Invalid block
-	sb, err = v.CreateBlock(now)
-	assert.Nil(t, err)
-	// TODO -- empty BodyHash is being accepted, fix blockchain verification
-	sb.Block.Head.BodyHash = cipher.SHA256{}
-	sb.Block.Body.Transactions = make(coin.Transactions, 0)
-	sb = v.SignBlock(sb.Block)
-	err = v.ExecuteSignedBlock(sb)
-	assert.NotNil(t, err)
-	assert.Equal(t, len(v.Unconfirmed.Txns), 1)
-	assert.Equal(t, len(v.blockSigs.Sigs), 1)
-
-	// Valid block
-	sb, err = v.CreateBlock(now)
-	assert.Nil(t, err)
-	err = v.ExecuteSignedBlock(sb)
-	assert.Nil(t, err)
-	assert.Equal(t, len(v.blockSigs.Sigs), 2)
-	assert.Equal(t, v.blockSigs.Sigs[uint64(1)], sb.Sig)
-	assert.Equal(t, v.blockchain.Blocks[1], sb.Block)
-	assert.Equal(t, len(v.Unconfirmed.Txns), 0)
-
-	// Test a valid block created by a master but executing in non master
-	vc2, mv := setupVisorConfig()
-	v2 := NewVisor(vc2)
-	w := v2.Wallets[0]
-	addr := w.GetAddresses()[0]
-	tx, err = mv.Spend(mv.Wallets[0].GetFilename(), wallet.Balance{1e6, 0}, 0, addr)
-	assert.Nil(t, err)
-	err, known = mv.InjectTxn(tx)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	sb, err = mv.CreateAndExecuteBlock()
-	assert.Nil(t, err)
-	err = v2.ExecuteSignedBlock(sb)
-	assert.Nil(t, err)
-	assert.Equal(t, len(v2.blockSigs.Sigs), 2)
-	assert.Equal(t, v2.blockSigs.Sigs[uint64(1)], sb.Sig)
-	assert.Equal(t, v2.blockchain.Blocks[1], sb.Block)
-	assert.Equal(t, len(v2.Unconfirmed.Txns), 0)
-}
-
-func TestGetSignedBlocksSince(t *testing.T) {
-	defer cleanupVisor()
-	cleanupVisor()
-	vc := newMasterVisorConfig(t)
-	v := NewVisor(vc)
-
-	// No blocks
-	sbs := v.GetSignedBlocksSince(0, 10)
-	assert.Equal(t, len(sbs), 0)
-
-	// All available blocks
-	addSignedBlocks(t, v, 10)
-	sbs = v.GetSignedBlocksSince(2, 4)
-	assertSignedBlocks(t, v, sbs, 2, 4)
-
-	// No available blocks
-	sbs = v.GetSignedBlocksSince(100, 20)
-	assert.Equal(t, len(sbs), 0)
-
-	// Some, but not all
-	sbs = v.GetSignedBlocksSince(7, 5)
-	assertSignedBlocks(t, v, sbs, 7, 5)
-}
-
-func TestGetGenesisBlock(t *testing.T) {
-	defer cleanupVisor()
-	vc := newMasterVisorConfig(t)
-
-	// Panics with no signed genesis block
-	v := NewMinimalVisor(vc)
-	assert.Panics(t, func() { v.GetGenesisBlock() })
-
-	// Panics with no blocks
-	v = NewMinimalVisor(vc)
-	v.blockSigs.Sigs[0] = cipher.Sig{}
-	assert.Panics(t, func() { v.GetGenesisBlock() })
-
-	// Correct result
-	v = NewVisor(vc)
-	gb := v.GetGenesisBlock()
-	assert.Equal(t, v.blockSigs.Sigs[0], gb.Sig)
-	assert.Equal(t, v.blockchain.Blocks[0], gb.Block)
-}
-
-func TestHeadBkSeq(t *testing.T) {
-	defer cleanupVisor()
-	vc := newMasterVisorConfig(t)
-	v := NewVisor(vc)
-	assert.Equal(t, v.HeadBkSeq(), uint64(0))
-	addSignedBlocks(t, v, 10)
-	assert.Equal(t, v.HeadBkSeq(), uint64(10))
-	v = NewMinimalVisor(vc)
-	assert.Panics(t, func() { v.HeadBkSeq() })
-}
-
-func TestGetBlockchainMetadata(t *testing.T) {
-	defer cleanupVisor()
-	vc := newMasterVisorConfig(t)
-	v := NewVisor(vc)
-	addSignedBlocks(t, v, 8)
-	addUnconfirmedTxn(v)
-	addUnconfirmedTxn(v)
-	bcm := v.GetBlockchainMetadata()
-	assert.Equal(t, bcm.Unspents, uint64(9))
-	assert.Equal(t, bcm.Unconfirmed, uint64(2))
-	assertReadableBlockHeader(t, bcm.Head, v.blockchain.Head().Head)
-}
-
-func TestGetReadableBlock(t *testing.T) {
-	defer cleanupVisor()
-	vc := newMasterVisorConfig(t)
-	v := NewVisor(vc)
-
-	rb, err := v.GetReadableBlock(1)
-	assert.NotNil(t, err)
-	sb := addSignedBlock(t, v)
-	rb, err = v.GetReadableBlock(1)
-	assert.Nil(t, err)
-	assertReadableBlock(t, rb, sb.Block)
-}
-
-func TestGetReadableBlocks(t *testing.T) {
-	defer cleanupVisor()
-	vc := newMasterVisorConfig(t)
-	v := NewVisor(vc)
-
-	rbs := v.GetReadableBlocks(1, 10)
-	assert.Equal(t, len(rbs), 0)
-	rbs = v.GetReadableBlocks(0, 10)
-	sbs := []SignedBlock{SignedBlock{
-		Sig:   v.blockSigs.Sigs[0],
-		Block: v.blockchain.Blocks[0],
-	}}
-	assertReadableBlocks(t, v, rbs, sbs)
-	sbs = append(sbs, addSignedBlocks(t, v, 5)...)
-	rbs = v.GetReadableBlocks(0, 10)
-	assertReadableBlocks(t, v, rbs, sbs)
-	rbs = v.GetReadableBlocks(2, 4)
-	sbs = sbs[2:4]
-	assertReadableBlocks(t, v, rbs, sbs)
-}
-
-func TestGetBlock(t *testing.T) {
-	defer cleanupVisor()
-	vc := newMasterVisorConfig(t)
-	v := NewVisor(vc)
-
-	b, err := v.GetBlock(1)
-	assert.NotNil(t, err)
-	sb := addSignedBlock(t, v)
-	b, err = v.GetBlock(1)
-	assert.Nil(t, err)
-	assert.Equal(t, b, sb.Block)
-}
-
-func TestGetBlocks(t *testing.T) {
-	defer cleanupVisor()
-	vc := newMasterVisorConfig(t)
-	v := NewVisor(vc)
-
-	bs := v.GetBlocks(1, 10)
-	assert.Equal(t, len(bs), 0)
-	bs = v.GetBlocks(0, 10)
-	sbs := []SignedBlock{SignedBlock{
-		Sig:   v.blockSigs.Sigs[0],
-		Block: v.blockchain.Blocks[0],
-	}}
-	assertBlocks(t, v, bs, sbs)
-	sbs = append(sbs, addSignedBlocks(t, v, 5)...)
-	bs = v.GetBlocks(0, 10)
-	assertBlocks(t, v, bs, sbs)
-	bs = v.GetBlocks(2, 4)
-	sbs = sbs[2:4]
-	assertBlocks(t, v, bs, sbs)
-}
-
-/*
-func TestVisorSetAnnounced(t *testing.T) {
-	defer cleanupVisor()
-	vc := newMasterVisorConfig(t)
-	v := NewVisor(vc)
-
-	now := util.Now()
-	utx := addUnconfirmedTxn(v)
-	assert.True(t, utx.Announced.IsZero())
-	assert.True(t, v.Unconfirmed.Txns[utx.Hash()].Announced.IsZero())
-	v.SetAnnounced(utx.Hash(), now)
-	assert.False(t, v.Unconfirmed.Txns[utx.Hash()].Announced.IsZero())
-	assert.Equal(t, v.Unconfirmed.Txns[utx.Hash()].Announced, now)
-}
-*/
-
-func TestVisorInjectTxn(t *testing.T) {
-	defer cleanupVisor()
-	vc := newMasterVisorConfig(t)
-	v := NewVisor(vc)
-
-	// Setup txns
-	tx, err := makeValidTxn(v)
-	assert.Nil(t, err)
-	we := v.Wallets[0].CreateEntry()
-	tx2, err := v.Spend(v.Wallets[0].GetFilename(), wallet.Balance{1e6, 0}, 0, we.Address)
-	assert.Nil(t, err)
-
-	// Valid record, did not announce
-	assert.Equal(t, len(v.Unconfirmed.Txns), 0)
-	err, known := v.InjectTxn(tx)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	assert.Equal(t, len(v.Unconfirmed.Txns), 1)
-	assert.True(t, v.Unconfirmed.Txns[tx.Hash()].Announced.IsZero())
-
-	// Invalid txn
-	tx.Out = make([]coin.TransactionOutput, 0)
-	err, known = v.InjectTxn(tx)
-	assert.NotNil(t, err)
-	assert.False(t, known)
-	assert.Equal(t, len(v.Unconfirmed.Txns), 1)
-	assert.True(t, v.Unconfirmed.Txns[tx.Hash()].Announced.IsZero())
-
-	// Make sure isOurSpend and isOurReceive is correct
-	tx = tx2
-	err, known = v.InjectTxn(tx)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	assert.Equal(t, len(v.Unconfirmed.Txns), 2)
-	assert.True(t, v.Unconfirmed.Txns[tx.Hash()].Announced.IsZero())
-}
-
-func TestGetAddressTransactions(t *testing.T) {
-	defer cleanupVisor()
-	vc := newMasterVisorConfig(t)
-	v := NewVisor(vc)
-
-	// An confirmed txn
-	w := v.Wallets[0]
-	we := w.CreateEntry()
-	tx, err := v.Spend(w.GetFilename(), wallet.Balance{1e6, 0}, 0, we.Address)
-	assert.Nil(t, err)
-	err, known := v.InjectTxn(tx)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	assert.Equal(t, len(v.Unconfirmed.Txns), 1)
-	_, err = v.CreateAndExecuteBlock()
-	assert.Nil(t, err)
-	assert.Equal(t, len(v.Unconfirmed.Txns), 0)
-	txns := v.GetAddressTransactions(we.Address)
-	assert.Equal(t, len(txns), 1)
-	assert.Equal(t, txns[0].Txn, tx)
-	assert.True(t, txns[0].Status.Confirmed)
-	assert.Equal(t, txns[0].Status.Height, uint64(1))
-
-	// An unconfirmed txn
-	assert.Equal(t, len(v.Unconfirmed.Txns), 0)
-	assert.Equal(t, len(v.Unconfirmed.Unspent), 0)
-	we = w.CreateEntry()
-	tx, err = v.Spend(w.GetFilename(), wallet.Balance{2e6, 0}, 0, we.Address)
-	err, known = v.InjectTxn(tx)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	assert.Equal(t, len(v.Unconfirmed.Txns), 1)
-	assert.Equal(t, len(v.Unconfirmed.Unspent), 1)
-	assert.Equal(t, len(v.Unconfirmed.Unspent[tx.Hash()]), 2)
-	found := false
-	for _, uxs := range v.Unconfirmed.Unspent {
-		if found {
-			break
-		}
-		for _, ux := range uxs {
-			if ux.Body.Address == we.Address {
-				found = true
-				break
-			}
-		}
-	}
-	auxs := v.Unconfirmed.Unspent.AllForAddress(we.Address)
-	assert.Equal(t, len(auxs), 1)
-	assert.True(t, found)
-	txns = v.GetAddressTransactions(we.Address)
-	assert.Equal(t, len(txns), 1)
-	assert.Equal(t, txns[0].Txn, tx)
-	assert.True(t, txns[0].Status.Unconfirmed)
-
-	// An unconfirmed txn, but pool is corrupted
-	assert.True(t, len(v.Unconfirmed.Unspent) > 0)
-	ux := coin.UxOut{}
-	found = false
-	for _, uxs := range v.Unconfirmed.Unspent {
-		if len(uxs) > 0 {
-			ux = uxs[0]
-			found = true
-			break
-		}
-	}
-	assert.True(t, found)
-	srcTxn := ux.Body.SrcTransaction
-	delete(v.Unconfirmed.Txns, srcTxn)
-	txns = v.GetAddressTransactions(we.Address)
-	assert.Equal(t, len(txns), 0)
-}
-
-func TestGetTransaction(t *testing.T) {
-	defer cleanupVisor()
-	vc := newMasterVisorConfig(t)
-	v := NewVisor(vc)
-
-	// Unknown
-	tx, err := makeValidTxn(v)
-	assert.Nil(t, err)
-	tx2 := v.GetTransaction(tx.Hash())
-	assert.True(t, tx2.Status.Unknown)
-
-	// Unconfirmed
-	err, known := v.InjectTxn(tx)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	tx2 = v.GetTransaction(tx.Hash())
-	assert.True(t, tx2.Status.Unconfirmed)
-	assert.Equal(t, tx, tx2.Txn)
-
-	// Confirmed
-	_, err = v.CreateAndExecuteBlock()
-	assert.Nil(t, err)
-	assert.Equal(t, len(v.Unconfirmed.Txns), 0)
-	tx2 = v.GetTransaction(tx.Hash())
-	assert.True(t, tx2.Status.Confirmed)
-	assert.Equal(t, tx2.Status.Height, uint64(1))
-	assert.Equal(t, tx, tx2.Txn)
-}
-
-func TestBalances(t *testing.T) {
-	defer cleanupVisor()
-	v, mv := setupVisor()
-	w := v.Wallets[0]
-	assert.Equal(t, len(w.GetEntries()), 1)
-	we := w.CreateEntry()
-	we2 := w.CreateEntry()
-	assert.Equal(t, len(w.GetEntries()), 3)
-	assert.Equal(t, v.TotalBalance().Confirmed, wallet.Balance{0, 0})
-	startCoins := mv.Config.GenesisCoinVolume
-
-	// Without predicted outputs
-	assert.Nil(t,
-		transferCoinsAdvanced(mv, v, wallet.Balance{10e6, 10}, 0, we.Address))
-	assert.Nil(t,
-		transferCoinsAdvanced(mv, v, wallet.Balance{10e6, 10}, 0, we.Address))
-	assert.Nil(t,
-		transferCoinsAdvanced(mv, v, wallet.Balance{5e6, 5}, 0, we2.Address))
-	assert.Equal(t, v.WalletBalance(w.GetFilename()).Confirmed, wallet.Balance{25e6, 25})
-	assert.Equal(t, v.AddressBalance(we.Address).Confirmed, wallet.Balance{20e6, 20})
-	assert.Equal(t, v.AddressBalance(we2.Address).Confirmed, wallet.Balance{5e6, 5})
-	assert.Equal(t, v.TotalBalance().Confirmed, wallet.Balance{25e6, 25})
-	mvBalance := wallet.Balance{startCoins - 25e6, startCoins - 25}
-	assert.Equal(t, mv.TotalBalance().Confirmed, mvBalance)
-	assert.Equal(t, v.AddressBalance(we.Address).Confirmed, wallet.Balance{20e6, 20})
-	assert.Equal(t, v.AddressBalance(we2.Address).Confirmed, wallet.Balance{5e6, 5})
-
-	// TODO -- test the predicted balances
-}
-
-func TestVisorVerifySignedBlock(t *testing.T) {
-	defer cleanupVisor()
-	vc := newMasterVisorConfig(t)
-	v := NewVisor(vc)
-	w := v.Wallets[0]
-	we := w.CreateEntry()
-
-	// Master should verify its own blocks correctly
-	txn, err := v.Spend(w.GetFilename(), wallet.Balance{1e6, 0}, 0, we.Address)
-	assert.Nil(t, err)
-	err, known := v.InjectTxn(txn)
-	assert.Nil(t, err)
-	assert.False(t, known)
-	b, err := v.CreateBlock(uint64(util.UnixNow()))
-	assert.Nil(t, err)
-	assert.Nil(t, v.verifySignedBlock(&b))
-	badb := b
-	badb.Sig = cipher.Sig{}
-	assert.NotNil(t, v.verifySignedBlock(&badb))
-
-	// Non master should verify signed blocks generated by master
-	mv := v
-	v = setupVisorFromMaster(mv)
-	assert.Nil(t, v.verifySignedBlock(&b))
-	assert.NotNil(t, v.verifySignedBlock(&badb))
-}
-
-func TestVisorSignBlock(t *testing.T) {
-	defer cleanupVisor()
-	vc := newMasterVisorConfig(t)
-	v := NewVisor(vc)
-
-	// Non master should panic
-	b := v.blockchain.Blocks[0]
-	v.Config.IsMaster = false
-	assert.Panics(t, func() { v.SignBlock(b) })
-
-	// Master should generate valid signed block
-	v.Config.IsMaster = true
-	sb := v.SignBlock(b)
-	assert.Nil(t, v.verifySignedBlock(&sb))
-}
-
-func TestCreateMasterWallet(t *testing.T) {
-	defer cleanupVisor()
-	cleanupVisor()
-	we := wallet.NewWalletEntry()
-	w := CreateMasterWallet(we)
-	assert.Equal(t, w.NumEntries(), 1)
-	assert.Equal(t, w.GetAddresses()[0], we.Address)
-
-	// Having a wallet file present should not affect loading master wallet
-	w.Save(testWalletFile)
-	we = wallet.NewWalletEntry()
-	w = CreateMasterWallet(we)
-	assert.Equal(t, w.NumEntries(), 1)
-	assert.Equal(t, w.GetAddresses()[0], we.Address)
-
-	// Creating with an invalid wallet entry should panic
-	we = wallet.NewWalletEntry()
-	we.Secret = cipher.SecKey{}
-	assert.Panics(t, func() { CreateMasterWallet(we) })
-	we = wallet.NewWalletEntry()
-	we.Public = cipher.PubKey{}
-	assert.Panics(t, func() { CreateMasterWallet(we) })
-}
+// import (
+// 	"os"
+// 	"path/filepath"
+// 	"testing"
+// 	"time"
+
+// 	"github.com/skycoin/skycoin/src/cipher"
+// 	"github.com/skycoin/skycoin/src/coin"
+// 	"github.com/skycoin/skycoin/src/util"
+// 	"github.com/skycoin/skycoin/src/wallet"
+// 	"github.com/stretchr/testify/assert"
+// )
+
+// /* Helper functions */
+
+// func setupVisorWriting(vc VisorConfig) *Visor {
+// 	vc.WalletDirectory = testWalletDir
+// 	v := NewVisor(vc)
+// 	v.Wallets[0].SetFilename(testWalletFile)
+// 	cleanupVisor() // delete the automatically saved wallet
+// 	return v
+// }
+
+// func writeVisorFilesDirect(t *testing.T, v *Visor) {
+// 	assert.True(t, len(v.Wallets) > 0)
+// 	for _, w := range v.Wallets {
+// 		assert.NotEqual(t, w.GetFilename(), "")
+// 	}
+// 	assert.Nil(t, v.SaveWallet(v.Wallets[0].GetFilename()))
+// 	assert.Nil(t, v.SaveBlockSigs())
+// 	assert.Nil(t, v.SaveBlockchain())
+// 	assertDirExists(t, v.Config.WalletDirectory)
+// 	walletFile := filepath.Join(v.Config.WalletDirectory, testWalletFile)
+// 	assertFileExists(t, walletFile)
+// 	assertFileExists(t, v.Config.BlockSigsFile)
+// 	assertFileExists(t, v.Config.BlockchainFile)
+// }
+
+// func writeVisorFiles(t *testing.T, vc VisorConfig) *Visor {
+// 	cleanupVisor()
+// 	v := setupVisorWriting(vc)
+// 	writeVisorFilesDirect(t, v)
+// 	return v
+// }
+
+// func newWalletEntry(t *testing.T) wallet.WalletEntry {
+// 	we := wallet.NewWalletEntry()
+// 	assert.Nil(t, we.Verify())
+// 	return we
+// }
+
+// func setupGenesis(t *testing.T) (wallet.WalletEntry, cipher.Sig, uint64) {
+// 	we := newWalletEntry(t)
+// 	vc := NewVisorConfig()
+// 	vc.IsMaster = true
+// 	vc.MasterKeys = we
+// 	vc.GenesisSignature = createGenesisSignature(we)
+// 	v := NewVisor(vc)
+// 	we.Secret = cipher.SecKey{}
+// 	return we, v.blockSigs.Sigs[0], v.blockchain.Blocks[0].Head.Time
+// }
+
+// func newGenesisConfig(t *testing.T) VisorConfig {
+// 	refvc := NewVisorConfig()
+// 	we, sig, ts := setupGenesis(t)
+// 	refvc.MasterKeys = we
+// 	refvc.GenesisSignature = sig
+// 	refvc.GenesisTimestamp = ts
+// 	refvc.IsMaster = false
+// 	refvc.WalletDirectory = testWalletDir
+// 	return refvc
+// }
+
+// func corruptFile(t *testing.T, filename string) {
+// 	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_TRUNC, 0600)
+// 	assert.Nil(t, err)
+// 	_, err = f.Write([]byte("xxxxx"))
+// 	assert.Nil(t, err)
+// 	f.Close()
+// }
+
+// func setupChildVisorConfig(refvc VisorConfig, master bool) VisorConfig {
+// 	vc := NewVisorConfig()
+// 	vc.IsMaster = master
+// 	vc.MasterKeys = refvc.MasterKeys
+// 	vc.WalletDirectory = testWalletDir
+// 	vc.BlockchainFile = testBlockchainFile
+// 	vc.BlockSigsFile = testBlocksigsFile
+// 	return vc
+// }
+
+// func newMasterVisorConfig(t *testing.T) VisorConfig {
+// 	vc := NewVisorConfig()
+// 	vc.CoinHourBurnFactor = 0
+// 	mw := newWalletEntry(t)
+// 	vc.MasterKeys = mw
+// 	vc.GenesisSignature = createGenesisSignature(mw)
+// 	vc.IsMaster = true
+// 	return vc
+// }
+
+// func addValidTxns(t *testing.T, v *Visor, n int) coin.Transactions {
+// 	txns := make(coin.Transactions, n)
+// 	for i := 0; i < len(txns); i++ {
+// 		txn, err := makeValidTxn(v)
+// 		assert.Nil(t, err)
+// 		txns[i] = txn
+// 	}
+// 	for _, txn := range txns {
+// 		err, known := v.InjectTxn(txn)
+// 		assert.Nil(t, err)
+// 		assert.False(t, known)
+// 	}
+// 	txns = coin.SortTransactions(txns, getFee)
+// 	assert.Equal(t, len(v.Unconfirmed.Txns), n)
+// 	return txns
+// }
+
+// func addSignedBlockAt(t *testing.T, v *Visor, when uint64) coin.SignedBlock {
+// 	we := wallet.NewWalletEntry()
+// 	tx, err := v.Spend(v.Wallets[0].GetFilename(), wallet.Balance{1e6, 0}, 0, we.Address)
+// 	assert.Nil(t, err)
+// 	err, known := v.InjectTxn(tx)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// 	sb, err := v.CreateBlock(when)
+// 	assert.Nil(t, err)
+// 	if err != nil {
+// 		return sb
+// 	}
+// 	err = v.ExecuteSignedBlock(sb)
+// 	assert.Nil(t, err)
+// 	return sb
+// }
+
+// func addSignedBlock(t *testing.T, v *Visor) coin.SignedBlock {
+// 	return addSignedBlockAt(t, v, uint64(util.UnixNow()))
+// }
+
+// func addSignedBlocks(t *testing.T, v *Visor, n int) []coin.SignedBlock {
+// 	sbs := make([]SignedBlock, n)
+// 	now := uint64(util.UnixNow())
+// 	for i := 0; i < n; i++ {
+// 		sbs[i] = addSignedBlockAt(t, v, now+1+uint64(i))
+// 	}
+// 	return sbs
+// }
+
+// func assertSignedBlocks(t *testing.T, v *Visor, sbs []coin.SignedBlock,
+// 	start, ct uint64) {
+// 	have := v.HeadBkSeq()
+// 	if have <= start {
+// 		assert.Equal(t, len(sbs), 0)
+// 	} else if have-start < ct {
+// 		assert.Equal(t, len(sbs), int(have-start))
+// 	} else {
+// 		assert.Equal(t, len(sbs), int(ct))
+// 	}
+// 	for i, sb := range sbs {
+// 		assert.Nil(t, v.verifySignedBlock(&sb))
+// 		assert.Equal(t, sb.Sig, v.blockSigs.Sigs[sb.Block.Head.BkSeq])
+// 		assert.Equal(t, sb.Block.Head.BkSeq, start+uint64(i)+1)
+// 		assert.Equal(t, v.blockchain.Blocks[start+uint64(i)+1], sb.Block)
+// 	}
+// }
+
+// func assertReadableBlocks(t *testing.T, v *Visor, rbs []ReadableBlock,
+// 	sbs []coin.SignedBlock) {
+// 	assert.Equal(t, len(rbs), len(sbs))
+// 	for i, rb := range rbs {
+// 		assertReadableBlock(t, rb, sbs[i].Block)
+// 	}
+// }
+
+// func assertBlocks(t *testing.T, v *Visor, bs []coin.Block, sbs []coin.SignedBlock) {
+// 	assert.Equal(t, len(bs), len(sbs))
+// 	for i, b := range bs {
+// 		assert.Equal(t, b, sbs[i].Block)
+// 	}
+// }
+
+// /* Actual tests */
+
+// func TestNewVisorConfig(t *testing.T) {
+// 	vc := NewVisorConfig()
+// 	assert.False(t, vc.IsMaster)
+// 	assert.Equal(t, vc.WalletDirectory, "")
+// 	assert.Equal(t, vc.BlockchainFile, "")
+// 	assert.Equal(t, vc.BlockSigsFile, "")
+// 	assert.Panics(t, func() { vc.MasterKeys.Verify() })
+// 	assert.NotNil(t, vc.MasterKeys.VerifyPublic())
+// 	assert.Equal(t, vc.GenesisSignature, cipher.Sig{})
+// }
+
+// func TestNewVisor(t *testing.T) {
+// 	defer cleanupVisor()
+
+// 	// Not master, Invalid master keys
+// 	cleanupVisor()
+// 	we := wallet.NewWalletEntry()
+// 	we.Public = cipher.PubKey{}
+// 	vc := NewVisorConfig()
+// 	vc.IsMaster = false
+// 	assert.Panics(t, func() { NewVisor(vc) })
+// 	vc.MasterKeys = we
+// 	assert.Panics(t, func() { NewVisor(vc) })
+
+// 	// Master, invalid master keys
+// 	cleanupVisor()
+// 	vc.IsMaster = true
+// 	vc.MasterKeys = wallet.WalletEntry{}
+// 	assert.Panics(t, func() { NewVisor(vc) })
+// 	vc.MasterKeys = we
+// 	assert.Panics(t, func() { NewVisor(vc) })
+
+// 	// Not master, no wallet, blockchain, blocksigs file
+// 	cleanupVisor()
+// 	vc = NewVisorConfig()
+// 	vc.IsMaster = false
+// 	we, sig, ts := setupGenesis(t)
+// 	vc.MasterKeys = we
+// 	vc.GenesisSignature = sig
+// 	vc.GenesisTimestamp = ts
+// 	v := NewVisor(vc)
+// 	assert.Equal(t, len(v.blockchain.Blocks), 1)
+// 	assert.Equal(t, len(v.blockSigs.Sigs), 1)
+
+// 	// Master, no wallet, blockchain, blocksigs file
+// 	cleanupVisor()
+// 	vc = NewVisorConfig()
+// 	we = newWalletEntry(t)
+// 	vc.MasterKeys = we
+// 	vc.GenesisSignature = createGenesisSignature(we)
+// 	vc.IsMaster = true
+// 	v = NewVisor(vc)
+// 	assert.Equal(t, len(v.Wallets), 1)
+// 	// Wallet should only have 1 entry if master
+// 	assert.Equal(t, v.Wallets[0].NumEntries(), 1)
+// 	assert.Equal(t, len(v.blockchain.Blocks), 1)
+// 	assert.Equal(t, len(v.blockSigs.Sigs), 1)
+
+// 	// Not master, has all files
+// 	cleanupVisor()
+// 	refvc := newGenesisConfig(t)
+// 	refv := writeVisorFiles(t, refvc)
+// 	vc = setupChildVisorConfig(refvc, false)
+// 	v = NewVisor(vc)
+// 	assert.Equal(t, v.Wallets, refv.Wallets)
+// 	assert.Equal(t, len(v.Wallets), 1)
+// 	assert.Equal(t, v.blockchain, refv.blockchain)
+// 	assert.Equal(t, v.blockSigs, refv.blockSigs)
+
+// 	// Master, has all files
+// 	cleanupVisor()
+// 	refvc = newMasterVisorConfig(t)
+// 	refv = writeVisorFiles(t, refvc)
+// 	vc = setupChildVisorConfig(refvc, true)
+// 	v = NewVisor(vc)
+// 	assert.Equal(t, v.Wallets[0].GetEntries(), refv.Wallets[0].GetEntries())
+// 	assert.Equal(t, v.blockchain, refv.blockchain)
+
+// 	// Not master, wallet is corrupt
+// 	cleanupVisor()
+// 	refvc = newGenesisConfig(t)
+// 	refv = writeVisorFiles(t, refvc)
+// 	walletFile := filepath.Join(testWalletDir, testWalletFile)
+// 	assertFileExists(t, walletFile)
+// 	corruptFile(t, walletFile)
+// 	vc = setupChildVisorConfig(refvc, false)
+// 	assert.Panics(t, func() { NewVisor(vc) })
+
+// 	// Master, wallet is corrupt.  Nothing happens because master ignores
+// 	// wallet
+// 	cleanupVisor()
+// 	refvc = newMasterVisorConfig(t)
+// 	refv = writeVisorFiles(t, refvc)
+// 	assertFileExists(t, walletFile)
+// 	corruptFile(t, walletFile)
+// 	vc = setupChildVisorConfig(refvc, true)
+// 	assert.NotPanics(t, func() { NewVisor(vc) })
+
+// 	// Not master, blocksigs is corrupt
+// 	cleanupVisor()
+// 	refvc = newGenesisConfig(t)
+// 	assertFileNotExists(t, testWalletFile)
+// 	refv = writeVisorFiles(t, refvc)
+// 	corruptFile(t, testBlocksigsFile)
+// 	vc = setupChildVisorConfig(refvc, false)
+// 	assert.Panics(t, func() { NewVisor(vc) })
+
+// 	// Master, blocksigs is corrupt
+// 	cleanupVisor()
+// 	refvc = newMasterVisorConfig(t)
+// 	refv = writeVisorFiles(t, refvc)
+// 	corruptFile(t, testBlocksigsFile)
+// 	assertFileExists(t, testBlocksigsFile)
+// 	vc = setupChildVisorConfig(refvc, true)
+// 	assert.Panics(t, func() { NewVisor(vc) })
+
+// 	// Not master, blockchain is corrupt
+// 	cleanupVisor()
+// 	refvc = newGenesisConfig(t)
+// 	refv = writeVisorFiles(t, refvc)
+// 	corruptFile(t, testBlockchainFile)
+// 	vc = setupChildVisorConfig(refvc, false)
+// 	assert.Panics(t, func() { NewVisor(vc) })
+
+// 	// Master, blockchain is corrupt
+// 	cleanupVisor()
+// 	refvc = newMasterVisorConfig(t)
+// 	refv = writeVisorFiles(t, refvc)
+// 	corruptFile(t, testBlockchainFile)
+// 	vc = setupChildVisorConfig(refvc, true)
+// 	assert.Panics(t, func() { NewVisor(vc) })
+
+// 	// Not master, blocksigs is not valid for blockchain
+// 	cleanupVisor()
+// 	refvc = newGenesisConfig(t)
+// 	refv = setupVisorWriting(refvc)
+// 	// Corrupt the signature
+// 	refv.blockSigs.Sigs[uint64(0)] = cipher.Sig{}
+// 	writeVisorFilesDirect(t, refv)
+// 	vc = setupChildVisorConfig(refvc, false)
+// 	assert.Panics(t, func() { NewVisor(vc) })
+
+// 	// Master, blocksigs is not valid for blockchain
+// 	cleanupVisor()
+// 	refvc = newMasterVisorConfig(t)
+// 	refv = setupVisorWriting(refvc)
+// 	// Corrupt the signature
+// 	refv.blockSigs.Sigs[uint64(0)] = cipher.Sig{}
+// 	writeVisorFilesDirect(t, refv)
+// 	vc = setupChildVisorConfig(refvc, true)
+// 	assert.Panics(t, func() { NewVisor(vc) })
+// }
+
+// func TestNewMinimalVisor(t *testing.T) {
+// 	defer cleanupVisor()
+// 	vc := newMasterVisorConfig(t)
+// 	v := NewMinimalVisor(vc)
+// 	assert.Equal(t, v.Config, vc)
+// 	assert.NotNil(t, v.Unconfirmed)
+// 	assert.Nil(t, v.Wallets)
+// 	assert.Equal(t, len(v.blockchain.Blocks), 0)
+// 	assert.Equal(t, len(v.blockSigs.Sigs), 0)
+// }
+
+// func TestCreateGenesisBlockVisor(t *testing.T) {
+// 	defer cleanupVisor()
+// 	// Test as master, successful
+// 	vc := newMasterVisorConfig(t)
+// 	v := NewMinimalVisor(vc)
+// 	assert.True(t, v.Config.IsMaster)
+// 	assert.Equal(t, len(v.blockchain.Blocks), 0)
+// 	assert.Equal(t, len(v.blockSigs.Sigs), 0)
+// 	sb := v.CreateGenesisBlock()
+// 	assert.NotEqual(t, sb.Block, coin.Block{})
+// 	assert.NotEqual(t, sb.Sig, cipher.Sig{})
+// 	assert.Equal(t, len(v.blockchain.Blocks), 1)
+// 	assert.Equal(t, len(v.blockSigs.Sigs), 1)
+// 	assert.Nil(t, v.blockSigs.Verify(vc.MasterKeys.Public, v.blockchain))
+
+// 	// Test as not master, successful
+// 	vc = newGenesisConfig(t)
+// 	v = NewMinimalVisor(vc)
+// 	assert.False(t, v.Config.IsMaster)
+// 	assert.Equal(t, len(v.blockchain.Blocks), 0)
+// 	assert.Equal(t, len(v.blockSigs.Sigs), 0)
+// 	sb = v.CreateGenesisBlock()
+// 	assert.NotEqual(t, sb.Block, coin.Block{})
+// 	assert.NotEqual(t, sb.Sig, cipher.Sig{})
+// 	assert.Equal(t, len(v.blockchain.Blocks), 1)
+// 	assert.Equal(t, len(v.blockSigs.Sigs), 1)
+// 	assert.Nil(t, v.blockSigs.Verify(vc.MasterKeys.Public, v.blockchain))
+// 	assert.Equal(t, v.Config.GenesisSignature, sb.Sig)
+// 	assert.Equal(t, v.blockchain.Blocks[0].Head.Time, v.Config.GenesisTimestamp)
+
+// 	// Test as master, blockSigs invalid for pubkey
+// 	vc = newMasterVisorConfig(t)
+// 	vc.MasterKeys.Public = cipher.PubKey{}
+// 	v = NewMinimalVisor(vc)
+// 	assert.True(t, v.Config.IsMaster)
+// 	assert.Equal(t, len(v.blockchain.Blocks), 0)
+// 	assert.Equal(t, len(v.blockSigs.Sigs), 0)
+// 	assert.Panics(t, func() { v.CreateGenesisBlock() })
+
+// 	// Test as not master, blockSigs invalid for pubkey
+// 	vc = newGenesisConfig(t)
+// 	vc.MasterKeys.Public = cipher.PubKey{}
+// 	v = NewMinimalVisor(vc)
+// 	assert.False(t, v.Config.IsMaster)
+// 	assert.Equal(t, len(v.blockchain.Blocks), 0)
+// 	assert.Equal(t, len(v.blockSigs.Sigs), 0)
+// 	assert.Panics(t, func() { v.CreateGenesisBlock() })
+
+// 	// Test as master, signing failed
+// 	vc = newMasterVisorConfig(t)
+// 	vc.MasterKeys.Secret = cipher.SecKey{}
+// 	vc.GenesisSignature = cipher.Sig{}
+// 	assert.Equal(t, vc.MasterKeys.Secret, cipher.SecKey{})
+// 	v = NewMinimalVisor(vc)
+// 	assert.True(t, v.Config.IsMaster)
+// 	assert.Equal(t, v.Config, vc)
+// 	assert.Equal(t, v.Config.MasterKeys.Secret, cipher.SecKey{})
+// 	assert.Equal(t, len(v.blockchain.Blocks), 0)
+// 	assert.Equal(t, len(v.blockSigs.Sigs), 0)
+// 	assert.Panics(t, func() { v.CreateGenesisBlock() })
+// }
+
+// func TestVisorRefreshUnconfirmed(t *testing.T) {
+// 	defer cleanupVisor()
+// 	mv := setupMasterVisor()
+// 	testRefresh(t, mv, func(checkPeriod, maxAge time.Duration) {
+// 		mv.Config.UnconfirmedCheckInterval = checkPeriod
+// 		mv.Config.UnconfirmedMaxAge = maxAge
+// 		mv.RefreshUnconfirmed()
+// 	})
+// }
+
+// func TestVisorSaveBlockchain(t *testing.T) {
+// 	cleanupVisor()
+// 	defer cleanupVisor()
+// 	vc := newMasterVisorConfig(t)
+// 	vc.BlockchainFile = ""
+
+// 	// Test with no blockchain file set
+// 	v := NewVisor(vc)
+// 	assertFileNotExists(t, testBlockchainFile)
+// 	err := v.SaveBlockchain()
+// 	assert.NotNil(t, err)
+// 	assert.Equal(t, err.Error(), "No BlockchainFile location set")
+// 	assertFileNotExists(t, testBlockchainFile)
+
+// 	// Test with blockchain file set
+// 	vc.BlockchainFile = testBlockchainFile
+// 	v = NewVisor(vc)
+// 	assert.Nil(t, v.SaveBlockchain())
+// 	assertFileExists(t, testBlockchainFile)
+// 	assert.NotPanics(t, func() {
+// 		loadBlockchain(testBlockchainFile, vc.MasterKeys.Address)
+// 	})
+// 	bc := loadBlockchain(testBlockchainFile, vc.MasterKeys.Address)
+// 	assert.Equal(t, v.blockchain, bc)
+// }
+
+// func TestVisorSaveWallets(t *testing.T) {
+// 	cleanupVisor()
+// 	defer cleanupVisor()
+// 	vc := newGenesisConfig(t)
+// 	assert.False(t, vc.IsMaster)
+// 	vc.WalletDirectory = testWalletDir
+// 	v := NewVisor(vc)
+// 	assertFileNotExists(t, filepath.Join(testWalletDir, testWalletFile))
+// 	v.Wallets[0].SetFilename(testWalletFile)
+// 	assert.Equal(t, len(v.SaveWallets()), 0)
+// 	assertFileExists(t, filepath.Join(testWalletDir, testWalletFile))
+// 	w, err := wallet.LoadSimpleWallet(testWalletDir, testWalletFile)
+// 	assert.Nil(t, err)
+// 	assert.Equal(t, v.Wallets[0], w)
+// }
+
+// func TestVisorSaveBlockSigs(t *testing.T) {
+// 	cleanupVisor()
+// 	defer cleanupVisor()
+// 	vc := newMasterVisorConfig(t)
+// 	vc.BlockSigsFile = ""
+
+// 	// Test with no blocksigs file set
+// 	v := NewVisor(vc)
+// 	assertFileNotExists(t, testBlocksigsFile)
+// 	err := v.SaveBlockSigs()
+// 	assert.NotNil(t, err)
+// 	assert.Equal(t, err.Error(), "No BlockSigsFile location set")
+// 	assertFileNotExists(t, testBlocksigsFile)
+
+// 	vc.BlockSigsFile = testBlocksigsFile
+// 	v = NewVisor(vc)
+// 	assert.Nil(t, v.SaveBlockSigs())
+// 	assertFileExists(t, testBlocksigsFile)
+
+// 	bs, err := LoadBlockSigs(testBlocksigsFile)
+// 	assert.Nil(t, err)
+// 	assert.Equal(t, v.blockSigs, bs)
+// }
+
+// func TestCreateAndExecuteBlock(t *testing.T) {
+// 	defer cleanupVisor()
+
+// 	// Test as not master, should fail
+// 	vc := newGenesisConfig(t)
+// 	v := NewVisor(vc)
+// 	assert.Panics(t, func() { v.CreateAndExecuteBlock() })
+
+// 	// Test as master, no txns
+// 	vc = newMasterVisorConfig(t)
+// 	v = NewVisor(vc)
+// 	_, err := v.CreateAndExecuteBlock()
+// 	assert.NotNil(t, err)
+// 	assert.Equal(t, err.Error(), "No transactions")
+
+// 	// Test as master, more txns than allowed
+// 	vc.BlockCreationInterval = uint64(101)
+// 	v = NewVisor(vc)
+// 	txns := addValidTxns(t, v, 3)
+// 	txns = coin.SortTransactions(txns, v.blockchain.TransactionFee)
+// 	v.Config.MaxBlockSize = txns[0].Size()
+// 	assert.Equal(t, len(v.blockchain.Blocks), 1)
+// 	assert.Equal(t, len(v.blockSigs.Sigs), 1)
+// 	sb, err := v.CreateAndExecuteBlock()
+// 	assert.Nil(t, err)
+
+// 	assert.Equal(t, len(sb.Block.Body.Transactions), 1)
+// 	assert.Equal(t, sb.Block.Body.Transactions[0], txns[0])
+// 	assert.Equal(t, len(v.blockchain.Blocks), 2)
+// 	assert.Equal(t, len(v.blockSigs.Sigs), 2)
+// 	assert.Equal(t, v.blockchain.Blocks[1], sb.Block)
+// 	assert.Equal(t, v.blockSigs.Sigs[1], sb.Sig)
+// 	assert.Equal(t, len(v.Unconfirmed.Txns), 2)
+// 	assert.True(t, sb.Block.Head.Time > v.blockchain.Blocks[0].Head.Time)
+// 	rawTxns := v.Unconfirmed.RawTxns()
+// 	assert.Equal(t, len(rawTxns), 2)
+// 	for _, tx := range sb.Block.Body.Transactions {
+// 		assert.NotEqual(t, tx.Hash(), rawTxns[0].Hash())
+// 		assert.NotEqual(t, tx.Hash(), rawTxns[1].Hash())
+// 	}
+// 	if txns[1].Hash() == rawTxns[0].Hash() {
+// 		assert.Equal(t, txns[2].Hash(), rawTxns[1].Hash())
+// 	} else {
+// 		assert.Equal(t, txns[2].Hash(), rawTxns[0].Hash())
+// 	}
+// 	assert.Nil(t, v.blockSigs.Verify(v.Config.MasterKeys.Public, v.blockchain))
+
+// 	// No txns, forcing NewBlockFromTransactions to fail
+// 	v = NewVisor(vc)
+// 	assert.Equal(t, len(v.Unconfirmed.Txns), 0)
+// 	txns = addValidTxns(t, v, 3)
+// 	v.Config.MaxBlockSize = 0
+// 	sb, err = v.CreateAndExecuteBlock()
+// 	assert.NotNil(t, err)
+// 	assert.Equal(t, len(v.blockchain.Blocks), 1)
+// 	assert.Equal(t, len(v.blockSigs.Sigs), 1)
+// 	assert.Equal(t, len(v.Unconfirmed.Txns), 3)
+// }
+
+// func TestVisorSpend(t *testing.T) {
+// 	defer cleanupVisor()
+// 	we := wallet.NewWalletEntry()
+// 	addr := we.Address
+// 	vc := newMasterVisorConfig(t)
+// 	assert.Equal(t, vc.CoinHourBurnFactor, uint64(0))
+// 	v := NewVisor(vc)
+// 	wid := v.Wallets[0].GetFilename()
+// 	ogb := v.WalletBalance(wid).Confirmed
+
+// 	// Test spend 0 amount
+// 	v = NewVisor(vc)
+// 	b = wallet.Balance{0, 0}
+// 	_, err = v.Spend(v.Wallets[0].GetFilename(), b, 0, addr)
+// 	assert.NotNil(t, err)
+// 	assert.Equal(t, err.Error(), "Zero spend amount")
+
+// 	// Test lacking funds
+// 	v = NewVisor(vc)
+// 	b = wallet.Balance{10e16, 10e16}
+// 	_, err = v.Spend(v.Wallets[0].GetFilename(), b, 10e16, addr)
+// 	assert.NotNil(t, err)
+// 	assert.Equal(t, err.Error(), "Not enough coins")
+
+// 	// Test created txn too large
+// 	v = NewVisor(vc)
+// 	v.Config.MaxBlockSize = 0
+// 	b = wallet.Balance{10e6, 10}
+// 	assert.Panics(t, func() { v.Spend(v.Wallets[0].GetFilename(), b, 0, addr) })
+
+// 	// Test simple spend (we have only 1 address to spend from, no fee)
+// 	v = NewVisor(vc)
+// 	assert.Equal(t, v.Config.CoinHourBurnFactor, uint64(0))
+// 	b = wallet.Balance{10e6, 10}
+// 	tx, err := v.Spend(v.Wallets[0].GetFilename(), b, 0, addr)
+// 	assert.Nil(t, err)
+// 	assert.Equal(t, len(tx.In), 1)
+// 	assert.Equal(t, len(tx.Out), 2)
+// 	// Hash should be updated
+// 	assert.NotEqual(t, tx.Head.Hash, cipher.SHA256{})
+// 	// Should be 1 signature for the single input
+// 	assert.Equal(t, len(tx.Head.Sigs), 1)
+// 	// Spent amount should be correct
+// 	assert.Equal(t, tx.Out[1].Address, addr)
+// 	assert.Equal(t, tx.Out[1].Coins, b.Coins)
+// 	assert.Equal(t, tx.Out[1].Hours, b.Hours)
+// 	// Change amount should be correct
+// 	ourAddr := v.Wallets[0].GetAddresses()[0]
+// 	assert.Equal(t, tx.Out[0].Address, ourAddr)
+// 	assert.Equal(t, tx.Out[0].Coins, ogb.Coins-b.Coins)
+// 	assert.Equal(t, tx.Out[0].Hours, ogb.Hours-b.Hours)
+// 	assert.Nil(t, tx.Verify())
+// }
+
+// func TestExecuteSignedBlock(t *testing.T) {
+// 	defer cleanupVisor()
+// 	cleanupVisor()
+// 	we := wallet.NewWalletEntry()
+// 	vc := newMasterVisorConfig(t)
+// 	v := NewVisor(vc)
+// 	wid := v.Wallets[0].GetFilename()
+// 	assert.Equal(t, len(v.Unconfirmed.Txns), 0)
+// 	tx, err := v.Spend(wid, wallet.Balance{1e6, 0}, 0, we.Address)
+// 	assert.Nil(t, err)
+// 	err, known := v.InjectTxn(tx)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// 	assert.Equal(t, len(v.Unconfirmed.Txns), 1)
+// 	assert.Equal(t, len(v.blockSigs.Sigs), 1)
+// 	now := uint64(util.UnixNow())
+
+// 	// Invalid signed block
+// 	sb, err := v.CreateBlock(now)
+// 	assert.Equal(t, len(v.blockSigs.Sigs), 1)
+// 	assert.Nil(t, err)
+// 	sb.Sig = cipher.Sig{}
+// 	err = v.ExecuteSignedBlock(sb)
+// 	assert.NotNil(t, err)
+// 	assert.Equal(t, len(v.Unconfirmed.Txns), 1)
+// 	assert.Equal(t, len(v.blockSigs.Sigs), 1)
+
+// 	// Invalid block
+// 	sb, err = v.CreateBlock(now)
+// 	assert.Nil(t, err)
+// 	// TODO -- empty BodyHash is being accepted, fix blockchain verification
+// 	sb.Block.Head.BodyHash = cipher.SHA256{}
+// 	sb.Block.Body.Transactions = make(coin.Transactions, 0)
+// 	sb = v.SignBlock(sb.Block)
+// 	err = v.ExecuteSignedBlock(sb)
+// 	assert.NotNil(t, err)
+// 	assert.Equal(t, len(v.Unconfirmed.Txns), 1)
+// 	assert.Equal(t, len(v.blockSigs.Sigs), 1)
+
+// 	// Valid block
+// 	sb, err = v.CreateBlock(now)
+// 	assert.Nil(t, err)
+// 	err = v.ExecuteSignedBlock(sb)
+// 	assert.Nil(t, err)
+// 	assert.Equal(t, len(v.blockSigs.Sigs), 2)
+// 	assert.Equal(t, v.blockSigs.Sigs[uint64(1)], sb.Sig)
+// 	assert.Equal(t, v.blockchain.Blocks[1], sb.Block)
+// 	assert.Equal(t, len(v.Unconfirmed.Txns), 0)
+
+// 	// Test a valid block created by a master but executing in non master
+// 	vc2, mv := setupVisorConfig()
+// 	v2 := NewVisor(vc2)
+// 	w := v2.Wallets[0]
+// 	addr := w.GetAddresses()[0]
+// 	tx, err = mv.Spend(mv.Wallets[0].GetFilename(), wallet.Balance{1e6, 0}, 0, addr)
+// 	assert.Nil(t, err)
+// 	err, known = mv.InjectTxn(tx)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// 	sb, err = mv.CreateAndExecuteBlock()
+// 	assert.Nil(t, err)
+// 	err = v2.ExecuteSignedBlock(sb)
+// 	assert.Nil(t, err)
+// 	assert.Equal(t, len(v2.blockSigs.Sigs), 2)
+// 	assert.Equal(t, v2.blockSigs.Sigs[uint64(1)], sb.Sig)
+// 	assert.Equal(t, v2.blockchain.Blocks[1], sb.Block)
+// 	assert.Equal(t, len(v2.Unconfirmed.Txns), 0)
+// }
+
+// func TestGetSignedBlocksSince(t *testing.T) {
+// 	defer cleanupVisor()
+// 	cleanupVisor()
+// 	vc := newMasterVisorConfig(t)
+// 	v := NewVisor(vc)
+
+// 	// No blocks
+// 	sbs := v.GetSignedBlocksSince(0, 10)
+// 	assert.Equal(t, len(sbs), 0)
+
+// 	// All available blocks
+// 	addSignedBlocks(t, v, 10)
+// 	sbs = v.GetSignedBlocksSince(2, 4)
+// 	assertSignedBlocks(t, v, sbs, 2, 4)
+
+// 	// No available blocks
+// 	sbs = v.GetSignedBlocksSince(100, 20)
+// 	assert.Equal(t, len(sbs), 0)
+
+// 	// Some, but not all
+// 	sbs = v.GetSignedBlocksSince(7, 5)
+// 	assertSignedBlocks(t, v, sbs, 7, 5)
+// }
+
+// func TestGetGenesisBlock(t *testing.T) {
+// 	defer cleanupVisor()
+// 	vc := newMasterVisorConfig(t)
+
+// 	// Panics with no signed genesis block
+// 	v := NewMinimalVisor(vc)
+// 	assert.Panics(t, func() { v.GetGenesisBlock() })
+
+// 	// Panics with no blocks
+// 	v = NewMinimalVisor(vc)
+// 	v.blockSigs.Sigs[0] = cipher.Sig{}
+// 	assert.Panics(t, func() { v.GetGenesisBlock() })
+
+// 	// Correct result
+// 	v = NewVisor(vc)
+// 	gb := v.GetGenesisBlock()
+// 	assert.Equal(t, v.blockSigs.Sigs[0], gb.Sig)
+// 	assert.Equal(t, v.blockchain.Blocks[0], gb.Block)
+// }
+
+// func TestHeadBkSeq(t *testing.T) {
+// 	defer cleanupVisor()
+// 	vc := newMasterVisorConfig(t)
+// 	v := NewVisor(vc)
+// 	assert.Equal(t, v.HeadBkSeq(), uint64(0))
+// 	addSignedBlocks(t, v, 10)
+// 	assert.Equal(t, v.HeadBkSeq(), uint64(10))
+// 	v = NewMinimalVisor(vc)
+// 	assert.Panics(t, func() { v.HeadBkSeq() })
+// }
+
+// func TestGetBlockchainMetadata(t *testing.T) {
+// 	defer cleanupVisor()
+// 	vc := newMasterVisorConfig(t)
+// 	v := NewVisor(vc)
+// 	addSignedBlocks(t, v, 8)
+// 	addUnconfirmedTxn(v)
+// 	addUnconfirmedTxn(v)
+// 	bcm := v.GetBlockchainMetadata()
+// 	assert.Equal(t, bcm.Unspents, uint64(9))
+// 	assert.Equal(t, bcm.Unconfirmed, uint64(2))
+// 	assertReadableBlockHeader(t, bcm.Head, v.blockchain.Head().Head)
+// }
+
+// func TestGetReadableBlock(t *testing.T) {
+// 	defer cleanupVisor()
+// 	vc := newMasterVisorConfig(t)
+// 	v := NewVisor(vc)
+
+// 	rb, err := v.GetReadableBlock(1)
+// 	assert.NotNil(t, err)
+// 	sb := addSignedBlock(t, v)
+// 	rb, err = v.GetReadableBlock(1)
+// 	assert.Nil(t, err)
+// 	assertReadableBlock(t, rb, sb.Block)
+// }
+
+// func TestGetReadableBlocks(t *testing.T) {
+// 	defer cleanupVisor()
+// 	vc := newMasterVisorConfig(t)
+// 	v := NewVisor(vc)
+
+// 	rbs := v.GetReadableBlocks(1, 10)
+// 	assert.Equal(t, len(rbs), 0)
+// 	rbs = v.GetReadableBlocks(0, 10)
+// 	sbs := []SignedBlock{SignedBlock{
+// 		Sig:   v.blockSigs.Sigs[0],
+// 		Block: v.blockchain.Blocks[0],
+// 	}}
+// 	assertReadableBlocks(t, v, rbs, sbs)
+// 	sbs = append(sbs, addSignedBlocks(t, v, 5)...)
+// 	rbs = v.GetReadableBlocks(0, 10)
+// 	assertReadableBlocks(t, v, rbs, sbs)
+// 	rbs = v.GetReadableBlocks(2, 4)
+// 	sbs = sbs[2:4]
+// 	assertReadableBlocks(t, v, rbs, sbs)
+// }
+
+// func TestGetBlock(t *testing.T) {
+// 	defer cleanupVisor()
+// 	vc := newMasterVisorConfig(t)
+// 	v := NewVisor(vc)
+
+// 	b, err := v.GetBlock(1)
+// 	assert.NotNil(t, err)
+// 	sb := addSignedBlock(t, v)
+// 	b, err = v.GetBlock(1)
+// 	assert.Nil(t, err)
+// 	assert.Equal(t, b, sb.Block)
+// }
+
+// func TestGetBlocks(t *testing.T) {
+// 	defer cleanupVisor()
+// 	vc := newMasterVisorConfig(t)
+// 	v := NewVisor(vc)
+
+// 	bs := v.GetBlocks(1, 10)
+// 	assert.Equal(t, len(bs), 0)
+// 	bs = v.GetBlocks(0, 10)
+// 	sbs := []SignedBlock{SignedBlock{
+// 		Sig:   v.blockSigs.Sigs[0],
+// 		Block: v.blockchain.Blocks[0],
+// 	}}
+// 	assertBlocks(t, v, bs, sbs)
+// 	sbs = append(sbs, addSignedBlocks(t, v, 5)...)
+// 	bs = v.GetBlocks(0, 10)
+// 	assertBlocks(t, v, bs, sbs)
+// 	bs = v.GetBlocks(2, 4)
+// 	sbs = sbs[2:4]
+// 	assertBlocks(t, v, bs, sbs)
+// }
+
+// /*
+// func TestVisorSetAnnounced(t *testing.T) {
+// 	defer cleanupVisor()
+// 	vc := newMasterVisorConfig(t)
+// 	v := NewVisor(vc)
+
+// 	now := util.Now()
+// 	utx := addUnconfirmedTxn(v)
+// 	assert.True(t, utx.Announced.IsZero())
+// 	assert.True(t, v.Unconfirmed.Txns[utx.Hash()].Announced.IsZero())
+// 	v.SetAnnounced(utx.Hash(), now)
+// 	assert.False(t, v.Unconfirmed.Txns[utx.Hash()].Announced.IsZero())
+// 	assert.Equal(t, v.Unconfirmed.Txns[utx.Hash()].Announced, now)
+// }
+// */
+
+// func TestVisorInjectTxn(t *testing.T) {
+// 	defer cleanupVisor()
+// 	vc := newMasterVisorConfig(t)
+// 	v := NewVisor(vc)
+
+// 	// Setup txns
+// 	tx, err := makeValidTxn(v)
+// 	assert.Nil(t, err)
+// 	we := v.Wallets[0].CreateEntry()
+// 	tx2, err := v.Spend(v.Wallets[0].GetFilename(), wallet.Balance{1e6, 0}, 0, we.Address)
+// 	assert.Nil(t, err)
+
+// 	// Valid record, did not announce
+// 	assert.Equal(t, len(v.Unconfirmed.Txns), 0)
+// 	err, known := v.InjectTxn(tx)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// 	assert.Equal(t, len(v.Unconfirmed.Txns), 1)
+// 	assert.True(t, v.Unconfirmed.Txns[tx.Hash()].Announced.IsZero())
+
+// 	// Invalid txn
+// 	tx.Out = make([]coin.TransactionOutput, 0)
+// 	err, known = v.InjectTxn(tx)
+// 	assert.NotNil(t, err)
+// 	assert.False(t, known)
+// 	assert.Equal(t, len(v.Unconfirmed.Txns), 1)
+// 	assert.True(t, v.Unconfirmed.Txns[tx.Hash()].Announced.IsZero())
+
+// 	// Make sure isOurSpend and isOurReceive is correct
+// 	tx = tx2
+// 	err, known = v.InjectTxn(tx)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// 	assert.Equal(t, len(v.Unconfirmed.Txns), 2)
+// 	assert.True(t, v.Unconfirmed.Txns[tx.Hash()].Announced.IsZero())
+// }
+
+// func TestGetAddressTransactions(t *testing.T) {
+// 	defer cleanupVisor()
+// 	vc := newMasterVisorConfig(t)
+// 	v := NewVisor(vc)
+
+// 	// An confirmed txn
+// 	w := v.Wallets[0]
+// 	we := w.CreateEntry()
+// 	tx, err := v.Spend(w.GetFilename(), wallet.Balance{1e6, 0}, 0, we.Address)
+// 	assert.Nil(t, err)
+// 	err, known := v.InjectTxn(tx)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// 	assert.Equal(t, len(v.Unconfirmed.Txns), 1)
+// 	_, err = v.CreateAndExecuteBlock()
+// 	assert.Nil(t, err)
+// 	assert.Equal(t, len(v.Unconfirmed.Txns), 0)
+// 	txns := v.GetAddressTransactions(we.Address)
+// 	assert.Equal(t, len(txns), 1)
+// 	assert.Equal(t, txns[0].Txn, tx)
+// 	assert.True(t, txns[0].Status.Confirmed)
+// 	assert.Equal(t, txns[0].Status.Height, uint64(1))
+
+// 	// An unconfirmed txn
+// 	assert.Equal(t, len(v.Unconfirmed.Txns), 0)
+// 	assert.Equal(t, len(v.Unconfirmed.Unspent), 0)
+// 	we = w.CreateEntry()
+// 	tx, err = v.Spend(w.GetFilename(), wallet.Balance{2e6, 0}, 0, we.Address)
+// 	err, known = v.InjectTxn(tx)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// 	assert.Equal(t, len(v.Unconfirmed.Txns), 1)
+// 	assert.Equal(t, len(v.Unconfirmed.Unspent), 1)
+// 	assert.Equal(t, len(v.Unconfirmed.Unspent[tx.Hash()]), 2)
+// 	found := false
+// 	for _, uxs := range v.Unconfirmed.Unspent {
+// 		if found {
+// 			break
+// 		}
+// 		for _, ux := range uxs {
+// 			if ux.Body.Address == we.Address {
+// 				found = true
+// 				break
+// 			}
+// 		}
+// 	}
+// 	auxs := v.Unconfirmed.Unspent.AllForAddress(we.Address)
+// 	assert.Equal(t, len(auxs), 1)
+// 	assert.True(t, found)
+// 	txns = v.GetAddressTransactions(we.Address)
+// 	assert.Equal(t, len(txns), 1)
+// 	assert.Equal(t, txns[0].Txn, tx)
+// 	assert.True(t, txns[0].Status.Unconfirmed)
+
+// 	// An unconfirmed txn, but pool is corrupted
+// 	assert.True(t, len(v.Unconfirmed.Unspent) > 0)
+// 	ux := coin.UxOut{}
+// 	found = false
+// 	for _, uxs := range v.Unconfirmed.Unspent {
+// 		if len(uxs) > 0 {
+// 			ux = uxs[0]
+// 			found = true
+// 			break
+// 		}
+// 	}
+// 	assert.True(t, found)
+// 	srcTxn := ux.Body.SrcTransaction
+// 	delete(v.Unconfirmed.Txns, srcTxn)
+// 	txns = v.GetAddressTransactions(we.Address)
+// 	assert.Equal(t, len(txns), 0)
+// }
+
+// func TestGetTransaction(t *testing.T) {
+// 	defer cleanupVisor()
+// 	vc := newMasterVisorConfig(t)
+// 	v := NewVisor(vc)
+
+// 	// Unknown
+// 	tx, err := makeValidTxn(v)
+// 	assert.Nil(t, err)
+// 	tx2 := v.GetTransaction(tx.Hash())
+// 	assert.True(t, tx2.Status.Unknown)
+
+// 	// Unconfirmed
+// 	err, known := v.InjectTxn(tx)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// 	tx2 = v.GetTransaction(tx.Hash())
+// 	assert.True(t, tx2.Status.Unconfirmed)
+// 	assert.Equal(t, tx, tx2.Txn)
+
+// 	// Confirmed
+// 	_, err = v.CreateAndExecuteBlock()
+// 	assert.Nil(t, err)
+// 	assert.Equal(t, len(v.Unconfirmed.Txns), 0)
+// 	tx2 = v.GetTransaction(tx.Hash())
+// 	assert.True(t, tx2.Status.Confirmed)
+// 	assert.Equal(t, tx2.Status.Height, uint64(1))
+// 	assert.Equal(t, tx, tx2.Txn)
+// }
+
+// func TestBalances(t *testing.T) {
+// 	defer cleanupVisor()
+// 	v, mv := setupVisor()
+// 	w := v.Wallets[0]
+// 	assert.Equal(t, len(w.GetEntries()), 1)
+// 	we := w.CreateEntry()
+// 	we2 := w.CreateEntry()
+// 	assert.Equal(t, len(w.GetEntries()), 3)
+// 	assert.Equal(t, v.TotalBalance().Confirmed, wallet.Balance{0, 0})
+// 	startCoins := mv.Config.GenesisCoinVolume
+
+// 	// Without predicted outputs
+// 	assert.Nil(t,
+// 		transferCoinsAdvanced(mv, v, wallet.Balance{10e6, 10}, 0, we.Address))
+// 	assert.Nil(t,
+// 		transferCoinsAdvanced(mv, v, wallet.Balance{10e6, 10}, 0, we.Address))
+// 	assert.Nil(t,
+// 		transferCoinsAdvanced(mv, v, wallet.Balance{5e6, 5}, 0, we2.Address))
+// 	assert.Equal(t, v.WalletBalance(w.GetFilename()).Confirmed, wallet.Balance{25e6, 25})
+// 	assert.Equal(t, v.AddressBalance(we.Address).Confirmed, wallet.Balance{20e6, 20})
+// 	assert.Equal(t, v.AddressBalance(we2.Address).Confirmed, wallet.Balance{5e6, 5})
+// 	assert.Equal(t, v.TotalBalance().Confirmed, wallet.Balance{25e6, 25})
+// 	mvBalance := wallet.Balance{startCoins - 25e6, startCoins - 25}
+// 	assert.Equal(t, mv.TotalBalance().Confirmed, mvBalance)
+// 	assert.Equal(t, v.AddressBalance(we.Address).Confirmed, wallet.Balance{20e6, 20})
+// 	assert.Equal(t, v.AddressBalance(we2.Address).Confirmed, wallet.Balance{5e6, 5})
+
+// 	// TODO -- test the predicted balances
+// }
+
+// func TestVisorVerifySignedBlock(t *testing.T) {
+// 	defer cleanupVisor()
+// 	vc := newMasterVisorConfig(t)
+// 	v := NewVisor(vc)
+// 	w := v.Wallets[0]
+// 	we := w.CreateEntry()
+
+// 	// Master should verify its own blocks correctly
+// 	txn, err := v.Spend(w.GetFilename(), wallet.Balance{1e6, 0}, 0, we.Address)
+// 	assert.Nil(t, err)
+// 	err, known := v.InjectTxn(txn)
+// 	assert.Nil(t, err)
+// 	assert.False(t, known)
+// 	b, err := v.CreateBlock(uint64(util.UnixNow()))
+// 	assert.Nil(t, err)
+// 	assert.Nil(t, v.verifySignedBlock(&b))
+// 	badb := b
+// 	badb.Sig = cipher.Sig{}
+// 	assert.NotNil(t, v.verifySignedBlock(&badb))
+
+// 	// Non master should verify signed blocks generated by master
+// 	mv := v
+// 	v = setupVisorFromMaster(mv)
+// 	assert.Nil(t, v.verifySignedBlock(&b))
+// 	assert.NotNil(t, v.verifySignedBlock(&badb))
+// }
+
+// func TestVisorSignBlock(t *testing.T) {
+// 	defer cleanupVisor()
+// 	vc := newMasterVisorConfig(t)
+// 	v := NewVisor(vc)
+
+// 	// Non master should panic
+// 	b := v.blockchain.Blocks[0]
+// 	v.Config.IsMaster = false
+// 	assert.Panics(t, func() { v.SignBlock(b) })
+
+// 	// Master should generate valid signed block
+// 	v.Config.IsMaster = true
+// 	sb := v.SignBlock(b)
+// 	assert.Nil(t, v.verifySignedBlock(&sb))
+// }
+
+// func TestCreateMasterWallet(t *testing.T) {
+// 	defer cleanupVisor()
+// 	cleanupVisor()
+// 	we := wallet.NewWalletEntry()
+// 	w := CreateMasterWallet(we)
+// 	assert.Equal(t, w.NumEntries(), 1)
+// 	assert.Equal(t, w.GetAddresses()[0], we.Address)
+
+// 	// Having a wallet file present should not affect loading master wallet
+// 	w.Save(testWalletFile)
+// 	we = wallet.NewWalletEntry()
+// 	w = CreateMasterWallet(we)
+// 	assert.Equal(t, w.NumEntries(), 1)
+// 	assert.Equal(t, w.GetAddresses()[0], we.Address)
+
+// 	// Creating with an invalid wallet entry should panic
+// 	we = wallet.NewWalletEntry()
+// 	we.Secret = cipher.SecKey{}
+// 	assert.Panics(t, func() { CreateMasterWallet(we) })
+// 	we = wallet.NewWalletEntry()
+// 	we.Public = cipher.PubKey{}
+// 	assert.Panics(t, func() { CreateMasterWallet(we) })
+// }


### PR DESCRIPTION
- Use boltdb to persist unconfirmed transactions
- Add txns exchange on connect
- Move blocks.db and history.db to data.db
- Fix bug in peer exchange