### PR TITLE
Hostnames support, 

### DIFF
--- a/src/mesh/app/app.go
+++ b/src/mesh/app/app.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/mesh/messages"
 )
 
@@ -25,13 +24,13 @@ type app struct {
 
 const PACKET_SIZE = 1024
 
-var APP_TIMEOUT = 100000 * time.Duration(time.Millisecond)
+var APP_TIMEOUT = 10000 * time.Duration(time.Millisecond)
 
 func (self *app) Id() messages.AppId {
 	return self.id
 }
 
-func (self *app) Connect(appId messages.AppId, address cipher.PubKey) error {
+func (self *app) Connect(appId messages.AppId, address string) error {
 
 	msg := messages.ConnectToAppMessage{
 		address,

--- a/src/mesh/app/app_test.go
+++ b/src/mesh/app/app_test.go
@@ -13,10 +13,10 @@ import (
 
 func TestCreateServer(t *testing.T) {
 	messages.SetDebugLogLevel()
-	meshnet := network.NewNetwork("127.0.0.1:5999")
+	meshnet, _ := network.NewNetwork("apps.network", "127.0.0.1:5999")
 	defer meshnet.Shutdown()
 
-	serverNode, err := node.CreateNode(&node.NodeConfig{"127.0.0.1:5000", []string{"127.0.0.1:5999"}, 4000})
+	serverNode, err := node.CreateNode(&node.NodeConfig{"127.0.0.1:5000", []string{"127.0.0.1:5999"}, 4000, ""})
 	assert.Nil(t, err)
 	defer serverNode.Shutdown()
 
@@ -32,10 +32,10 @@ func TestCreateServer(t *testing.T) {
 
 func TestCreateClient(t *testing.T) {
 	messages.SetDebugLogLevel()
-	meshnet := network.NewNetwork("127.0.0.1:5999")
+	meshnet, _ := network.NewNetwork("apps.network", "127.0.0.1:5999")
 	defer meshnet.Shutdown()
 
-	clientNode, err := node.CreateNode(&node.NodeConfig{"127.0.0.1:5000", []string{"127.0.0.1:5999"}, 4001})
+	clientNode, err := node.CreateNode(&node.NodeConfig{"127.0.0.1:5000", []string{"127.0.0.1:5999"}, 4001, ""})
 	assert.Nil(t, err)
 	defer clientNode.Shutdown()
 
@@ -52,7 +52,7 @@ func TestCreateClient(t *testing.T) {
 func TestSendWithFindRoute(t *testing.T) {
 	messages.SetDebugLogLevel()
 
-	meshnet := network.NewNetwork("127.0.0.1:5999")
+	meshnet, _ := network.NewNetwork("apps.network", "127.0.0.1:5999")
 	defer meshnet.Shutdown()
 
 	clientNode, serverNode := meshnet.CreateThreeRoutes(14000)
@@ -67,7 +67,7 @@ func TestSendWithFindRoute(t *testing.T) {
 	assert.Nil(t, err)
 	defer client.Shutdown()
 
-	err = client.Connect(server.Id(), serverNode.Id())
+	err = client.Connect(server.Id(), serverNode.Id().Hex())
 	assert.Nil(t, err)
 
 	response, err := client.Send([]byte("test"))
@@ -80,7 +80,7 @@ func TestSendWithFindRoute(t *testing.T) {
 func TestHandle(t *testing.T) {
 	messages.SetInfoLogLevel()
 
-	meshnet := network.NewNetwork("127.0.0.1:5999")
+	meshnet, _ := network.NewNetwork("apps.network", "127.0.0.1:5999")
 	defer meshnet.Shutdown()
 
 	clientNode, serverNode := meshnet.CreateThreeRoutes(15000)
@@ -100,7 +100,7 @@ func TestHandle(t *testing.T) {
 	assert.Nil(t, err)
 	defer client.Shutdown()
 
-	err = client.Connect(server.Id(), serverNode.Id())
+	err = client.Connect(server.Id(), serverNode.Id().Hex())
 	assert.Nil(t, err)
 
 	size := 100000
@@ -126,7 +126,7 @@ func TestHandle(t *testing.T) {
 func TestSocks(t *testing.T) {
 	messages.SetInfoLogLevel()
 
-	meshnet := network.NewNetwork("127.0.0.1:5999")
+	meshnet, _ := network.NewNetwork("apps.network", "127.0.0.1:5999")
 	defer meshnet.Shutdown()
 
 	clientNode, serverNode := meshnet.CreateSequenceOfNodes(20, 16000)
@@ -143,7 +143,7 @@ func TestSocks(t *testing.T) {
 
 	assert.Equal(t, server.ProxyAddress, "127.0.0.1:8001")
 
-	err = client.Connect(server.Id(), serverNode.Id())
+	err = client.Connect(server.Id(), "node20.apps.network")
 	assert.Nil(t, err)
 	time.Sleep(1 * time.Second)
 }
@@ -151,7 +151,7 @@ func TestSocks(t *testing.T) {
 func TestVPN(t *testing.T) {
 	messages.SetInfoLogLevel()
 
-	meshnet := network.NewNetwork("127.0.0.1:5999")
+	meshnet, _ := network.NewNetwork("apps.network", "127.0.0.1:5999")
 	defer meshnet.Shutdown()
 
 	clientNode, serverNode := meshnet.CreateSequenceOfNodes(20, 17000)
@@ -165,6 +165,6 @@ func TestVPN(t *testing.T) {
 	assert.Nil(t, err)
 	defer server.Shutdown()
 
-	err = client.Connect(server.Id(), serverNode.Id())
+	err = client.Connect(server.Id(), "node20.apps.network")
 	assert.Nil(t, err)
 }

--- a/src/mesh/app/viscript.go
+++ b/src/mesh/app/viscript.go
@@ -3,7 +3,8 @@ package app
 import (
 	"log"
 
-	"github.com/skycoin/skycoin/src/mesh/messages"
+	vsmsg "github.com/corpusc/viscript/msg"
+
 	"github.com/skycoin/skycoin/src/mesh/viscript"
 )
 
@@ -18,34 +19,34 @@ func (self *app) TalkToViscript(sequence, appId uint32) {
 	vs.Init(sequence, appId)
 }
 
-func (self *AppViscriptServer) handleUserCommand(uc *messages.UserCommand) {
+func (self *AppViscriptServer) handleUserCommand(uc *vsmsg.MessageUserCommand) {
 	log.Println("command received:", uc)
 	sequence := uc.Sequence
 	appId := uc.AppId
 	message := uc.Payload
 
-	switch messages.GetMessageType(message) {
+	switch vsmsg.GetType(message) {
 
-	case messages.MsgPing:
-		ack := &messages.PingAck{}
-		ackS := messages.Serialize(messages.MsgPingAck, ack)
+	case vsmsg.TypePing:
+		ack := &vsmsg.MessagePingAck{}
+		ackS := vsmsg.Serialize(vsmsg.TypePingAck, ack)
 		self.SendAck(ackS, sequence, appId)
 
-	case messages.MsgResourceUsage:
+	case vsmsg.TypeResourceUsage:
 		cpu, memory, err := self.GetResources()
 		if err == nil {
-			ack := &messages.ResourceUsageAck{
+			ack := &vsmsg.MessageResourceUsageAck{
 				cpu,
 				memory,
 			}
-			ackS := messages.Serialize(messages.MsgResourceUsageAck, ack)
+			ackS := vsmsg.Serialize(vsmsg.TypeResourceUsageAck, ack)
 			self.SendAck(ackS, sequence, appId)
 		}
 
-	case messages.MsgUserShutdown:
+	case vsmsg.TypeShutdown:
 		self.app.Shutdown()
-		ack := &messages.UserShutdownAck{}
-		ackS := messages.Serialize(messages.MsgUserShutdownAck, ack)
+		ack := &vsmsg.MessageShutdownAck{}
+		ackS := vsmsg.Serialize(vsmsg.TypeShutdownAck, ack)
 		self.SendAck(ackS, sequence, appId)
 		panic("goodbye")
 

--- a/src/mesh/cmd/benchmarks/overall.go
+++ b/src/mesh/cmd/benchmarks/overall.go
@@ -95,7 +95,7 @@ func main() {
 		sizeStr += "b"
 	}
 
-	meshnet := network.NewNetwork("127.0.0.1:5999")
+	meshnet, _ := network.NewNetwork("test.network", "127.0.0.1:5999")
 	defer meshnet.Shutdown()
 
 	clientNode, serverNode := meshnet.CreateSequenceOfNodes(hops+1, 14000)
@@ -108,7 +108,7 @@ func main() {
 		panic(err)
 	}
 
-	err = client.Connect(messages.MakeAppId("echoServer"), serverAddr) // client dials to server
+	err = client.Connect(messages.MakeAppId("echoServer"), serverAddr.Hex()) // client dials to server
 	if err != nil {
 		panic(err)
 	}

--- a/src/mesh/cmd/integration/integration.go
+++ b/src/mesh/cmd/integration/integration.go
@@ -14,7 +14,7 @@ func main() {
 }
 
 func testSendAndReceive(n int) {
-	meshnet := network.NewNetwork("127.0.0.1:5999")
+	meshnet, _ := network.NewNetwork("test.network", "127.0.0.1:5999")
 	defer meshnet.Shutdown()
 
 	clientNode, serverNode := meshnet.CreateSequenceOfNodes(n, 14000) // create sequence and get addresses of the first and the last node in it
@@ -35,7 +35,7 @@ func testSendAndReceive(n int) {
 	}
 	defer client.Shutdown()
 
-	err = client.Connect(serverId, serverNode.Id()) // client dials to server
+	err = client.Connect(serverId, serverNode.Id().Hex()) // client dials to server
 	if err != nil {
 		panic(err)
 	}

--- a/src/mesh/cmd/ping/ping.go
+++ b/src/mesh/cmd/ping/ping.go
@@ -17,7 +17,7 @@ func main() {
 }
 
 func pingPong(size, pings int) {
-	meshnet := network.NewNetwork("127.0.0.1:5999")
+	meshnet, _ := network.NewNetwork("test.network", "127.0.0.1:5999")
 	defer meshnet.Shutdown()
 
 	nodes := meshnet.CreateRandomNetwork(size, 10000)
@@ -41,7 +41,7 @@ func pingPong(size, pings int) {
 	}
 	defer client.Shutdown()
 
-	err = client.Connect(messages.MakeAppId("pong"), serverAddr) // client dials to server
+	err = client.Connect(messages.MakeAppId("pong"), serverAddr.Hex()) // client dials to server
 	if err != nil {
 		panic(err)
 	}

--- a/src/mesh/cmd/socks-vpn/socks-vpn.go
+++ b/src/mesh/cmd/socks-vpn/socks-vpn.go
@@ -12,7 +12,6 @@ import (
 
 func main() {
 
-	//messages.SetDebugLogLevel()
 	messages.SetInfoLogLevel()
 
 	var (
@@ -43,7 +42,7 @@ func main() {
 		return
 	}
 
-	meshnet := network.NewNetwork("127.0.0.1:5999")
+	meshnet, _ := network.NewNetwork("mesh.network", "127.0.0.1:5999")
 	defer meshnet.Shutdown()
 
 	clientNode, serverNode := meshnet.CreateSequenceOfNodes(hops+1, 15000)
@@ -63,7 +62,7 @@ func main() {
 	}
 	defer socksClient.Shutdown()
 
-	err = socksClient.Connect(socksServerId, serverNode.Id())
+	err = socksClient.Connect(socksServerId, serverNode.Id().Hex())
 	if err != nil {
 		panic(err)
 	}
@@ -85,7 +84,7 @@ func main() {
 	}
 	defer vpnClient.Shutdown()
 
-	err = vpnClient.Connect(vpnServerId, serverNode.Id())
+	err = vpnClient.Connect(vpnServerId, serverNode.Id().Hex())
 	if err != nil {
 		panic(err)
 	}

--- a/src/mesh/cmd/socks/socks.go
+++ b/src/mesh/cmd/socks/socks.go
@@ -43,7 +43,7 @@ func main() {
 		return
 	}
 
-	meshnet := network.NewNetwork("127.0.0.1:5999")
+	meshnet, _ := network.NewNetwork("mesh.network", "127.0.0.1:5999")
 	defer meshnet.Shutdown()
 
 	clientNode, serverNode := meshnet.CreateSequenceOfNodes(hops+1, 15000)
@@ -62,7 +62,7 @@ func main() {
 	}
 	defer client.Shutdown()
 
-	err = client.Connect(serverId, serverNode.Id())
+	err = client.Connect(serverId, serverNode.Id().Hex())
 	if err != nil {
 		panic(err)
 	}

--- a/src/mesh/cmd/vpn/vpn.go
+++ b/src/mesh/cmd/vpn/vpn.go
@@ -12,7 +12,6 @@ import (
 
 func main() {
 
-	//messages.SetDebugLogLevel()
 	messages.SetInfoLogLevel()
 
 	var (
@@ -43,7 +42,7 @@ func main() {
 		return
 	}
 
-	meshnet := network.NewNetwork("127.0.0.1:5999")
+	meshnet, _ := network.NewNetwork("mesh.network", "127.0.0.1:5999")
 	defer meshnet.Shutdown()
 
 	clientNode, serverNode := meshnet.CreateSequenceOfNodes(hops+1, 15000)
@@ -63,7 +62,7 @@ func main() {
 	}
 	defer client.Shutdown()
 
-	err = client.Connect(serverId, serverNode.Id())
+	err = client.Connect(serverId, serverNode.Id().Hex())
 	if err != nil {
 		panic(err)
 	}

--- a/src/mesh/messages/config.go
+++ b/src/mesh/messages/config.go
@@ -61,22 +61,22 @@ type ConfigFromFile struct {
 var config = &ConfigStruct{ // default values
 	LogLevel:          INFO,
 	StartPort:         6000,
-	AppTimeout:        1000000,
+	AppTimeout:        10000,
 	VPNSubnet:         "192.168.11.",
 	ProxyPacketSize:   16384,
-	ProxyTimeout:      300000 * time.Millisecond,
-	TransportTimeout:  100000,
+	ProxyTimeout:      10000 * time.Millisecond,
+	TransportTimeout:  500,
 	RetransmitLimit:   10,
 	SimulateDelay:     false,
-	MaxSimulatedDelay: 500,
-	ConnectionTimeout: 1000000,
+	MaxSimulatedDelay: 300,
+	ConnectionTimeout: 5000,
 	MaxPacketSize:     16384,
 	MaxBuffer:         8192,
 	SendInterval:      1500 * time.Microsecond,
 	SendIntervalNum:   1500,
 	TimeUnit:          10 * time.Microsecond,
 	TimeUnitNum:       10,
-	MsgSrvTimeout:     1000,
+	MsgSrvTimeout:     500,
 }
 
 func init() {

--- a/src/mesh/messages/errors.go
+++ b/src/mesh/messages/errors.go
@@ -30,3 +30,8 @@ var ERR_INCORRECT_HOST = errors.New("Incorrect host passed")
 var ERR_CONNECTION_DOESNT_EXIST = errors.New("Connection doesn't exist")
 var ERR_APP_ID_EXISTS = errors.New("App ID already exists")
 var ERR_APP_DOESNT_EXIST = errors.New("App isn't registered at node")
+
+var ERR_INVALID_DOMAIN_NAME = errors.New("Wrong domain name format")
+var ERR_INVALID_HOST = errors.New("Wrong host format")
+var ERR_HOST_DOESNT_EXIST = errors.New("Host doesn't exist")
+var ERR_HOST_EXISTS = errors.New("Host alredy exists")

--- a/src/mesh/messages/interfaces.go
+++ b/src/mesh/messages/interfaces.go
@@ -6,7 +6,7 @@ import (
 
 type NodeInterface interface {
 	Id() cipher.PubKey
-	ConnectDirectly(cipher.PubKey) error
+	ConnectDirectly(string) error
 	AppTalkAddr() string
 	Shutdown()
 	TalkToViscript(uint32, uint32)

--- a/src/mesh/messages/messages.go
+++ b/src/mesh/messages/messages.go
@@ -42,19 +42,8 @@ const (
 	MsgConnectionOnCM             // NodeManager -> Node
 	MsgShutdownCM                 // NodeManager -> Node
 
-	MsgUserCommand      // Viscript -> Meshnet
-	MsgUserCommandAck   // Meshnet -> Viscript
-	MsgPing             // Viscript -> Meshnet
-	MsgPingAck          // Meshnet -> Viscript
-	MsgCreateAck        // Meshnet -> Viscript
-	MsgResourceUsage    // Viscript -> Meshnet
-	MsgResourceUsageAck // Meshnet -> Viscript
-	MsgUserShutdown     // Viscript -> Meshnet
-	MsgUserShutdownAck  // Meshnet -> Viscript
-
-	MsgNodeAppMessage  // Application -> Node
-	MsgNodeAppResponse // Node -> Application
-	//	MsgAppDataMessage      // Node -> Application
+	MsgNodeAppMessage      // Application -> Node
+	MsgNodeAppResponse     // Node -> Application
 	MsgSendFromAppMessage  // Application -> Node
 	MsgRegisterAppMessage  // Application -> Node
 	MsgConnectToAppMessage // Application -> Node
@@ -165,8 +154,9 @@ type ProxyMessage struct {
 // ==================== control messages ========================
 
 type RegisterNodeCM struct {
-	Host    string
-	Connect bool
+	Hostname string
+	Host     string
+	Connect  bool
 }
 
 type RegisterNodeCMAck struct {
@@ -216,7 +206,7 @@ type CommonCMAck struct {
 type ConnectDirectlyCM struct {
 	Sequence uint32
 	From     cipher.PubKey
-	To       cipher.PubKey
+	To       string
 }
 
 type ConnectDirectlyCMAck struct {
@@ -229,7 +219,7 @@ type ConnectWithRouteCM struct {
 	AppIdFrom AppId
 	AppIdTo   AppId
 	From      cipher.PubKey
-	To        cipher.PubKey
+	To        string
 }
 
 type ConnectWithRouteCMAck struct {
@@ -259,29 +249,6 @@ type UserCommand struct {
 	Payload  []byte
 }
 
-type UserCommandAck struct {
-	Sequence uint32
-	AppId    uint32
-	Payload  []byte
-}
-
-type CreateAck struct{}
-
-type ResourceUsage struct{}
-
-type ResourceUsageAck struct {
-	CPU    float64
-	Memory uint64
-}
-
-type UserShutdown struct{}
-
-type UserShutdownAck struct{}
-
-type Ping struct{}
-
-type PingAck struct{}
-
 type NodeAppMessage struct {
 	Sequence uint32
 	AppId    AppId
@@ -305,13 +272,7 @@ type AssignConnectionNAM struct {
 }
 
 type ConnectToAppMessage struct {
-	Address cipher.PubKey
+	Address string
 	AppFrom AppId
 	AppTo   AppId
 }
-
-/*
-type AppDataMessage struct {
-	Data []byte
-}
-*/

--- a/src/mesh/messages/names.go
+++ b/src/mesh/messages/names.go
@@ -1,0 +1,11 @@
+package messages
+
+import (
+	"regexp"
+)
+
+const seg = "[a-z\\d_]*[a-z\\d]"
+const dot = "\\."
+
+var HostRX = regexp.MustCompile("^" + seg + "$")
+var DomainRX = regexp.MustCompile("^" + seg + dot + seg + "$")

--- a/src/mesh/node/node_4test.go
+++ b/src/mesh/node/node_4test.go
@@ -10,7 +10,7 @@ func CreateNodeList(n, startPort int) []messages.NodeInterface {
 	nodes := []messages.NodeInterface{}
 
 	for i := 0; i < n; i++ {
-		node, err := CreateNode(&NodeConfig{"127.0.0.1:" + strconv.Itoa(startPort+i), []string{"127.0.0.1:5999"}, startPort + n + i})
+		node, err := CreateNode(&NodeConfig{"127.0.0.1:" + strconv.Itoa(startPort+i), []string{"127.0.0.1:5999"}, startPort + n + i, "node" + strconv.Itoa(i+1)})
 		if err != nil {
 			panic(err)
 		}

--- a/src/mesh/node/node_config.go
+++ b/src/mesh/node/node_config.go
@@ -4,4 +4,5 @@ type NodeConfig struct {
 	ClientAddr  string   // address for talking with servers
 	ServerAddrs []string // addresses of servers
 	AppTalkPort int      // will establish connection with apps here
+	Hostname    string   // can be empty, in this case node will respond only by pubkey
 }

--- a/src/mesh/node/node_control.go
+++ b/src/mesh/node/node_control.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/mesh/messages"
 )
 
@@ -80,14 +79,14 @@ func (self *Node) sendAckToServer(sequence uint32, ack *messages.CommonCMAck) er
 	return self.sendToServer(sequence, ackS)
 }
 
-func (self *Node) sendRegisterNodeToServer(host string, connect bool) error {
-	msg := messages.RegisterNodeCM{host, connect}
+func (self *Node) sendRegisterNodeToServer(hostname, host string, connect bool) error {
+	msg := messages.RegisterNodeCM{hostname, host, connect}
 	msgS := messages.Serialize(messages.MsgRegisterNodeCM, msg)
 	err := self.sendMessageToServer(msgS)
 	return err
 }
 
-func (self *Node) sendConnectDirectlyToServer(nodeToId cipher.PubKey) error {
+func (self *Node) sendConnectDirectlyToServer(nodeToId string) error {
 	responseChannel := make(chan bool)
 
 	self.lock.Lock()
@@ -112,7 +111,7 @@ func (self *Node) sendConnectDirectlyToServer(nodeToId cipher.PubKey) error {
 	}
 }
 
-func (self *Node) sendConnectWithRouteToServer(nodeToId cipher.PubKey, appIdFrom, appIdTo messages.AppId) (messages.ConnectionId, error) {
+func (self *Node) sendConnectWithRouteToServer(nodeToId string, appIdFrom, appIdTo messages.AppId) (messages.ConnectionId, error) {
 	responseChannel := make(chan messages.ConnectionId)
 
 	self.lock.Lock()

--- a/src/mesh/node/viscript.go
+++ b/src/mesh/node/viscript.go
@@ -3,7 +3,8 @@ package node
 import (
 	"log"
 
-	"github.com/skycoin/skycoin/src/mesh/messages"
+	vsmsg "github.com/corpusc/viscript/msg"
+
 	"github.com/skycoin/skycoin/src/mesh/viscript"
 )
 
@@ -18,34 +19,47 @@ func (self *Node) TalkToViscript(sequence, appId uint32) {
 	vs.Init(sequence, appId)
 }
 
-func (self *NodeViscriptServer) handleUserCommand(uc *messages.UserCommand) {
+func (self *NodeViscriptServer) handleUserCommand(uc *vsmsg.MessageUserCommand) {
 	log.Println("command received:", uc)
 	sequence := uc.Sequence
 	appId := uc.AppId
 	message := uc.Payload
 
-	switch messages.GetMessageType(message) {
+	switch vsmsg.GetType(message) {
 
-	case messages.MsgPing:
-		ack := &messages.PingAck{}
-		ackS := messages.Serialize(messages.MsgPingAck, ack)
+	case vsmsg.TypePing:
+		ack := &vsmsg.MessagePingAck{}
+		ackS := vsmsg.Serialize(vsmsg.TypePingAck, ack)
 		self.SendAck(ackS, sequence, appId)
 
-	case messages.MsgResourceUsage:
+	case vsmsg.TypeResourceUsage:
 		cpu, memory, err := self.GetResources()
 		if err == nil {
-			ack := &messages.ResourceUsageAck{
+			ack := &vsmsg.MessageResourceUsageAck{
 				cpu,
 				memory,
 			}
-			ackS := messages.Serialize(messages.MsgResourceUsageAck, ack)
+			ackS := vsmsg.Serialize(vsmsg.TypeResourceUsageAck, ack)
 			self.SendAck(ackS, sequence, appId)
 		}
 
-	case messages.MsgUserShutdown:
+	case vsmsg.TypeConnectDirectly:
+		ucd := &vsmsg.MessageConnectDirectly{}
+		err := vsmsg.Deserialize(message, ucd)
+		if err == nil {
+			address := ucd.Address
+			err = self.node.ConnectDirectly(address)
+			if err != nil {
+				ack := &vsmsg.MessageConnectDirectlyAck{}
+				ackS := vsmsg.Serialize(vsmsg.TypeConnectDirectlyAck, ack)
+				self.SendAck(ackS, sequence, appId)
+			}
+		}
+
+	case vsmsg.TypeShutdown:
 		self.node.Shutdown()
-		ack := &messages.UserShutdownAck{}
-		ackS := messages.Serialize(messages.MsgUserShutdownAck, ack)
+		ack := &vsmsg.MessageShutdownAck{}
+		ackS := vsmsg.Serialize(vsmsg.TypeShutdownAck, ack)
 		self.SendAck(ackS, sequence, appId)
 		panic("goodbye")
 

--- a/src/mesh/nodemanager/control_messages.go
+++ b/src/mesh/nodemanager/control_messages.go
@@ -19,8 +19,15 @@ func (self *NodeManager) handleControlMessage(cm *messages.InControlMessage) {
 			log.Println(err)
 			return
 		}
+
 		from := m1.From
-		to := m1.To
+
+		to, err := self.resolveName(m1.To)
+		if err != nil {
+			log.Println(err)
+			return
+		}
+
 		connectSequence := m1.Sequence
 		_, err = self.connectNodeToNode(from, to)
 		if err != nil {
@@ -28,6 +35,7 @@ func (self *NodeManager) handleControlMessage(cm *messages.InControlMessage) {
 			self.sendConnectDirectlyAck(from, sequence, connectSequence, false)
 			return
 		}
+
 		self.sendConnectDirectlyAck(from, sequence, connectSequence, true)
 
 	case messages.MsgConnectWithRouteCM:
@@ -38,7 +46,11 @@ func (self *NodeManager) handleControlMessage(cm *messages.InControlMessage) {
 			return
 		}
 		from := m1.From
-		to := m1.To
+		to, err := self.resolveName(m1.To)
+		if err != nil {
+			log.Println(err)
+			return
+		}
 		connSequence := m1.Sequence
 		appIdFrom := m1.AppIdFrom
 		appIdTo := m1.AppIdTo
@@ -58,17 +70,18 @@ func (self *NodeManager) handleControlMessage(cm *messages.InControlMessage) {
 			return
 		}
 		host := m1.Host
+		hostname := m1.Hostname
 		connect := m1.Connect
 		var nodeId cipher.PubKey
 		if !connect {
-			id, err := self.addNewNode(host)
+			id, err := self.addNewNode(host, hostname)
 			if err == nil {
 				nodeId = id
 			} else {
 				return
 			}
 		} else {
-			id, err := self.addAndConnect(host)
+			id, err := self.addAndConnect(host, hostname)
 			if err == nil {
 				nodeId = id
 			} else {

--- a/src/mesh/nodemanager/dns.go
+++ b/src/mesh/nodemanager/dns.go
@@ -1,0 +1,86 @@
+package nodemanager
+
+import (
+	"sync"
+
+	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/mesh/messages"
+)
+
+type DNSServer struct {
+	domain  string
+	pubkeys map[string]cipher.PubKey
+	lock    *sync.Mutex
+}
+
+func newDNSServer(domain string) (*DNSServer, error) {
+	valid := messages.DomainRX.MatchString(domain)
+	if !valid {
+		return nil, messages.ERR_INVALID_DOMAIN_NAME
+	}
+
+	dnsServer := DNSServer{domain: domain}
+	dnsServer.pubkeys = map[string]cipher.PubKey{}
+	dnsServer.lock = &sync.Mutex{}
+	return &dnsServer, nil
+}
+
+func (nm *NodeManager) resolveName(host string) (cipher.PubKey, error) {
+
+	pkFromDN, err := nm.dnsServer.resolve(host)
+	if err == nil {
+		return pkFromDN, nil
+	}
+
+	pubKey, err := cipher.PubKeyFromHex(host)
+
+	nm.lock.Lock()
+	defer nm.lock.Unlock()
+	if err == nil {
+		_, ok := nm.nodeList[pubKey]
+		if ok {
+			return pubKey, nil
+		}
+	}
+	return cipher.PubKey{}, messages.ERR_HOST_DOESNT_EXIST
+}
+
+func (self *DNSServer) resolve(host string) (cipher.PubKey, error) {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	pubkey, ok := self.pubkeys[host]
+	if !ok {
+		return cipher.PubKey{}, messages.ERR_HOST_DOESNT_EXIST
+	}
+	return pubkey, nil
+}
+
+func (self *DNSServer) register(pubkey cipher.PubKey, host_prefix string) error {
+
+	valid := messages.HostRX.MatchString(host_prefix)
+	if !valid {
+		return messages.ERR_INVALID_HOST
+	}
+
+	host := host_prefix + "." + self.domain
+
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	_, ok := self.pubkeys[host]
+	if ok {
+		return messages.ERR_HOST_EXISTS
+	}
+	self.pubkeys[host] = pubkey
+	return nil
+}
+
+func (self *DNSServer) unregister(host string) error {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	_, ok := self.pubkeys[host]
+	if !ok {
+		return messages.ERR_HOST_DOESNT_EXIST
+	}
+	delete(self.pubkeys, host)
+	return nil
+}

--- a/src/mesh/nodemanager/node_record.go
+++ b/src/mesh/nodemanager/node_record.go
@@ -29,7 +29,7 @@ type NodeRecord struct {
 	lock *sync.Mutex
 }
 
-func (self *NodeManager) newNode(host string) (*NodeRecord, error) {
+func (self *NodeManager) newNode(host, hostname string) (*NodeRecord, error) {
 	node := new(NodeRecord)
 	id := createPubKey()
 	node.id = id
@@ -55,6 +55,13 @@ func (self *NodeManager) newNode(host string) (*NodeRecord, error) {
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
 		return nil, err
+	}
+
+	if hostname != "" {
+		err = self.dnsServer.register(id, hostname)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	nodeAddr := &net.UDPAddr{IP: ip, Port: port}

--- a/src/mesh/nodemanager/nodemanager_4test.go
+++ b/src/mesh/nodemanager/nodemanager_4test.go
@@ -17,7 +17,7 @@ func (self *NodeManager) CreateRandomNetwork(n, startPort int) []messages.NodeIn
 	nodes := []messages.NodeInterface{}
 
 	for i := 0; i < n; i++ {
-		node, err := node.CreateAndConnectNode(&node.NodeConfig{"127.0.0.1:" + strconv.Itoa(startPort+i), []string{"127.0.0.1:5999"}, startPort + n + i})
+		node, err := node.CreateAndConnectNode(&node.NodeConfig{"127.0.0.1:" + strconv.Itoa(startPort+i), []string{"127.0.0.1:5999"}, startPort + n + i, ""})
 		if err != nil {
 			panic(err)
 		}

--- a/src/mesh/nodemanager/rpc_receiver.go
+++ b/src/mesh/nodemanager/rpc_receiver.go
@@ -20,6 +20,7 @@ func (receiver *RPCReceiver) addNode() cipher.PubKey {
 		"127.0.0.1:" + strconv.Itoa(receiver.cmPort),
 		[]string{"127.0.0.1:5999"},
 		receiver.cmPort + 2000,
+		"",
 	}
 	n, err := node.CreateNode(nodeConfig)
 	if err != nil {

--- a/src/mesh/nodemanager/rpc_server.go
+++ b/src/mesh/nodemanager/rpc_server.go
@@ -24,7 +24,7 @@ func (self *RPC) Serve() {
 		log.Println("No MESH_RPC_PORT environmental variable is found, assigning default port value:", DEFAULT_PORT)
 		port = DEFAULT_PORT
 	}
-	nm := newNodeManager("127.0.0.1:5999")
+	nm, _ := newNodeManager("demo.network", "127.0.0.1:5999")
 	receiver := new(RPCReceiver)
 	receiver.NodeManager = nm
 	receiver.cmPort = 5000

--- a/src/mesh/nodemanager/viscript.go
+++ b/src/mesh/nodemanager/viscript.go
@@ -3,7 +3,8 @@ package nodemanager
 import (
 	"log"
 
-	"github.com/skycoin/skycoin/src/mesh/messages"
+	vsmsg "github.com/corpusc/viscript/msg"
+
 	"github.com/skycoin/skycoin/src/mesh/viscript"
 )
 
@@ -18,34 +19,34 @@ func (self *NodeManager) TalkToViscript(sequence, appId uint32) {
 	vs.Init(sequence, appId)
 }
 
-func (self *NMViscriptServer) handleUserCommand(uc *messages.UserCommand) {
+func (self *NMViscriptServer) handleUserCommand(uc *vsmsg.MessageUserCommand) {
 	log.Println("command received:", uc)
 	sequence := uc.Sequence
 	appId := uc.AppId
 	message := uc.Payload
 
-	switch messages.GetMessageType(message) {
+	switch vsmsg.GetType(message) {
 
-	case messages.MsgPing:
-		ack := &messages.PingAck{}
-		ackS := messages.Serialize(messages.MsgPingAck, ack)
+	case vsmsg.TypePing:
+		ack := &vsmsg.MessagePingAck{}
+		ackS := vsmsg.Serialize(vsmsg.TypePingAck, ack)
 		self.SendAck(ackS, sequence, appId)
 
-	case messages.MsgResourceUsage:
+	case vsmsg.TypeResourceUsage:
 		cpu, memory, err := self.GetResources()
 		if err == nil {
-			ack := &messages.ResourceUsageAck{
+			ack := &vsmsg.MessageResourceUsageAck{
 				cpu,
 				memory,
 			}
-			ackS := messages.Serialize(messages.MsgResourceUsageAck, ack)
+			ackS := vsmsg.Serialize(vsmsg.TypeResourceUsageAck, ack)
 			self.SendAck(ackS, sequence, appId)
 		}
 
-	case messages.MsgUserShutdown:
+	case vsmsg.TypeShutdown:
 		self.nm.Shutdown()
-		ack := &messages.UserShutdownAck{}
-		ackS := messages.Serialize(messages.MsgUserShutdownAck, ack)
+		ack := &vsmsg.MessageShutdownAck{}
+		ackS := vsmsg.Serialize(vsmsg.TypeShutdownAck, ack)
 		self.SendAck(ackS, sequence, appId)
 		panic("goodbye")
 

--- a/src/mesh/viscript/viscript.go
+++ b/src/mesh/viscript/viscript.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/skycoin/skycoin/src/mesh/messages"
+	vsmsg "github.com/corpusc/viscript/msg"
 )
 
 type ViscriptServer struct {
@@ -48,8 +48,8 @@ func (self *ViscriptServer) serve() {
 			} else {
 				if n > 0 {
 					log.Printf("connection at %s received %d bytes\n", self.conn.LocalAddr().String(), n)
-					uc := messages.UserCommand{}
-					err := messages.Deserialize(buffer[:n], &uc)
+					uc := vsmsg.MessageUserCommand{}
+					err := vsmsg.Deserialize(buffer[:n], &uc)
 					if err != nil {
 						log.Println("Incorrect UserCommand:", buffer[:n])
 						continue
@@ -64,17 +64,17 @@ func (self *ViscriptServer) serve() {
 	self.conn.Close()
 }
 
-func (self *ViscriptServer) handleUserCommand(uc *messages.UserCommand) {
+func (self *ViscriptServer) handleUserCommand(uc *vsmsg.MessageUserCommand) {
 	log.Println("command received:", uc)
 }
 
 func (self *ViscriptServer) SendAck(ackS []byte, sequence, appId uint32) {
-	ucAck := &messages.UserCommand{
+	ucAck := &vsmsg.MessageUserCommandAck{
 		sequence,
 		appId,
 		ackS,
 	}
-	ucAckS := messages.Serialize(messages.MsgUserCommand, ucAck)
+	ucAckS := vsmsg.Serialize(vsmsg.TypeUserCommandAck, ucAck)
 	self.send(ucAckS)
 }
 
@@ -86,7 +86,7 @@ func (self *ViscriptServer) send(data []byte) {
 }
 
 func (self *ViscriptServer) sendFirstAck(sequence, appId uint32) {
-	ack := messages.CreateAck{}
-	ackS := messages.Serialize(messages.MsgCreateAck, ack)
+	ack := vsmsg.MessageCreateAck{}
+	ackS := vsmsg.Serialize(vsmsg.TypeCreateAck, ack)
 	self.SendAck(ackS, sequence, appId)
 }


### PR DESCRIPTION
Nodes have hostnames, nodemanager resolves them, connect to node is possible through both hostnames and hexed pubkeys; viscript messages are moved from repo to viscript.

Nodemanager now has domain name (such as "mysterious.network") - mandatory.

When we add nodes to the meshnet we can point a hostname (if it is "" or not pointed, node will be accessed only through it's pubkey) as one word without domain part (for example "myhost"). After that node will be accessible through "myhost.mysterious.network".