### PR TITLE
Remove dependency on util pkg for MustGetLogger

### DIFF
--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -27,7 +27,7 @@ import (
 var (
 	// Version node version which will be set when build wallet by LDFLAGS
 	Version    = "0.0.0"
-	logger     = util.MustGetLogger("main")
+	logger     = logging.MustGetLogger("main")
 	logFormat  = "[skycoin.%{module}:%{level}] %{message}"
 	logModules = []string{
 		"main",

--- a/src/api/webrpc/webrpc.go
+++ b/src/api/webrpc/webrpc.go
@@ -7,8 +7,9 @@ import (
 
 	"encoding/json"
 
-	"github.com/skycoin/skycoin/src/util"
 	wh "github.com/skycoin/skycoin/src/util/http"
+
+	logging "github.com/op/go-logging"
 
 	"bytes"
 	"strings"
@@ -36,7 +37,7 @@ var (
 	jsonRPC = "2.0"
 )
 
-var logger = util.MustGetLogger("webrpc")
+var logger = logging.MustGetLogger("webrpc")
 
 // Request rpc request struct
 type Request struct {

--- a/src/cipher/crypto.go
+++ b/src/cipher/crypto.go
@@ -10,13 +10,14 @@ import (
 	"time"
 
 	"github.com/skycoin/skycoin/src/cipher/ripemd160"
-	"github.com/skycoin/skycoin/src/util"
 
 	"github.com/skycoin/skycoin/src/cipher/secp256k1-go"
+
+	logging "github.com/op/go-logging"
 )
 
 var (
-	logger = util.MustGetLogger("crypto")
+	logger = logging.MustGetLogger("crypto")
 	// DebugLevel1 debug level one
 	DebugLevel1 = true //checks for extremely unlikely conditions (10e-40)
 	// DebugLevel2 debug level two

--- a/src/coin/block.go
+++ b/src/coin/block.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/cipher/encoder"
-	"github.com/skycoin/skycoin/src/util"
+
+	logging "github.com/op/go-logging"
 )
 
-var logger = util.MustGetLogger("coin")
+var logger = logging.MustGetLogger("coin")
 
 // Block represents the block struct
 type Block struct {

--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -13,6 +13,8 @@ import (
 	"github.com/skycoin/skycoin/src/daemon/gnet"
 	"github.com/skycoin/skycoin/src/daemon/pex"
 	"github.com/skycoin/skycoin/src/util"
+
+	logging "github.com/op/go-logging"
 )
 
 /*
@@ -46,7 +48,7 @@ var (
 	// e.g. net.Conn.Addr() returns an invalid ip:port
 	ErrDisconnectOtherError gnet.DisconnectReason = errors.New("Incomprehensible error")
 
-	logger = util.MustGetLogger("daemon")
+	logger = logging.MustGetLogger("daemon")
 )
 
 // Config subsystem configurations

--- a/src/daemon/gnet/pool.go
+++ b/src/daemon/gnet/pool.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/skycoin/skycoin/src/cipher/encoder"
 	"github.com/skycoin/skycoin/src/util"
+
+	logging "github.com/op/go-logging"
 )
 
 // DisconnectReason is passed to ConnectionPool's DisconnectCallback
@@ -37,7 +39,7 @@ var (
 	ErrDisconnectUnexpectedError DisconnectReason = errors.New("Unexpected error encountered")
 
 	// Logger
-	logger = util.MustGetLogger("gnet")
+	logger = logging.MustGetLogger("gnet")
 )
 
 // Config gnet config

--- a/src/daemon/pex/pex.go
+++ b/src/daemon/pex/pex.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 
 	"github.com/skycoin/skycoin/src/util"
+
+	logging "github.com/op/go-logging"
 )
 
 //TODO:
@@ -43,7 +45,7 @@ var (
 	RefreshBlacklistRate = time.Second * 30
 	// Logging. See http://godoc.org/github.com/op/go-logging for
 	// instructions on how to include this log's output
-	logger = util.MustGetLogger("pex")
+	logger = logging.MustGetLogger("pex")
 	// Default rng
 	rnum = rand.New(rand.NewSource(time.Now().Unix()))
 	// For removing inadvertent whitespace from addresses

--- a/src/gui/http.go
+++ b/src/gui/http.go
@@ -12,10 +12,12 @@ import (
 	"github.com/skycoin/skycoin/src/util"
 
 	wh "github.com/skycoin/skycoin/src/util/http" //http,json helpers
+
+	logging "github.com/op/go-logging"
 )
 
 var (
-	logger   = util.MustGetLogger("gui")
+	logger   = logging.MustGetLogger("gui")
 	listener net.Listener
 	quit     chan struct{}
 )

--- a/src/util/file.go
+++ b/src/util/file.go
@@ -18,13 +18,8 @@ var (
 	// DataDir app folder
 	DataDir = ""
 
-	logger = MustGetLogger("util")
+	logger = logging.MustGetLogger("util")
 )
-
-// DisableLogging disables the logger completely
-func DisableLogging() {
-	logging.SetBackend(logging.NewLogBackend(ioutil.Discard, "", 0))
-}
 
 // InitDataDir if dir is "", uses the default directory of ~/.skycoin.  The path to dir
 // is created, and the dir used is returned

--- a/src/util/logging.go
+++ b/src/util/logging.go
@@ -7,10 +7,10 @@
 package util
 
 import (
+	"io"
+	"io/ioutil"
 	"log"
 	"os"
-
-	"io"
 
 	logging "github.com/op/go-logging"
 )
@@ -18,12 +18,6 @@ import (
 const (
 	defaultLogFormat = "[%{module}:%{level}] %{message}"
 )
-
-// MustGetLogger wrapper for logging.MustGetLogger to avoid import
-func MustGetLogger(moduleName string) *logging.Logger {
-	// may be some stuff here (or may be not)
-	return logging.MustGetLogger(moduleName)
-}
 
 // LogConfig logger configurations
 type LogConfig struct {
@@ -91,4 +85,9 @@ func (l *LogConfig) InitLogger() {
 	stdout := logging.NewLogBackend(l.Output, "", 0)
 	stdout.Color = l.Colors
 	logging.SetBackend(stdout)
+}
+
+// DisableLogging disables the logger completely
+func DisableLogging() {
+	logging.SetBackend(logging.NewLogBackend(ioutil.Discard, "", 0))
 }

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -12,10 +12,12 @@ import (
 	"github.com/skycoin/skycoin/src/util"
 	"github.com/skycoin/skycoin/src/visor/blockdb"
 	"github.com/skycoin/skycoin/src/visor/historydb"
+
+	logging "github.com/op/go-logging"
 )
 
 var (
-	logger = util.MustGetLogger("visor")
+	logger = logging.MustGetLogger("visor")
 )
 
 // Config configuration parameters for the Visor

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -7,12 +7,13 @@ import (
 	"encoding/hex"
 
 	"github.com/skycoin/skycoin/src/cipher"
-	"github.com/skycoin/skycoin/src/util"
 	//"math/rand"
+
+	logging "github.com/op/go-logging"
 )
 
 var (
-	logger = util.MustGetLogger("wallet")
+	logger = logging.MustGetLogger("wallet")
 )
 
 // WalletExt  wallet file extension


### PR DESCRIPTION
`cipher` calls `MustGetLogger`; by importing from `util`, other packages (skywire, viscript) will vendor all dependencies from `util`, which has methods for file management, opening a web browser etc.