### PR TITLE
Fixed the UI to read the duplicate exception and show an Alert

### DIFF
--- a/src/gui/static/src/app/app.loadWallet.ts
+++ b/src/gui/static/src/app/app.loadWallet.ts
@@ -642,6 +642,9 @@ export class LoadWalletComponent implements OnInit {
                 }
             },
             err => {
+                if(err._body.indexOf("duplicate wallet ") !=-1){
+                    alert("Your are tying to load a wallet that has the same seed! ");
+                }
                 console.log(err);
             },
             () => {}
@@ -696,7 +699,12 @@ export class LoadWalletComponent implements OnInit {
                 //Load wallet for refresh list
                 this.loadWallet();
             },
-            err => console.log("Error on create load wallet seed: "+JSON.stringify(err)),
+            err => {
+                if(err._body.indexOf("duplicate wallet ") !=-1){
+                    alert("Your are tying to load a wallet that has the same seed! ");
+                }
+                console.log("Error on create load wallet seed: "+JSON.stringify(err))
+            },
             () => {
                 //console.log('Load wallet seed done')
             }


### PR DESCRIPTION
When wallet gets loaded from seed and the seed is already in use than the API throws an Error that needs to be shown to the user. This PR has the code to handle "load from wallet" and "Create new wallet" functionality in case of duplicate seed