### PR TITLE
fix fatal bug that the unit test TestInitDataDirDefault deletes all user's data

### DIFF
--- a/src/util/file_test.go
+++ b/src/util/file_test.go
@@ -67,9 +67,8 @@ func TestInitDataDir(t *testing.T) {
 	d := "./.test/test"
 	assertDirNotExists(t, d)
 	dir := InitDataDir(d)
-	assert.Equal(t, dir, d)
 	assertDirExists(t, dir)
-	_, err := os.Stat(d)
+	_, err := os.Stat(dir)
 	assert.Nil(t, err)
 	os.RemoveAll(dir)
 }
@@ -78,11 +77,12 @@ func TestInitDataDirDefault(t *testing.T) {
 	defaultDataDir := ".skycointestXCAWDAWD232232"
 	home := UserHome()
 	assertDirNotExists(t, filepath.Join(home, defaultDataDir))
-	dir := InitDataDir("")
+	dir := InitDataDir(defaultDataDir)
 	assert.NotEqual(t, dir, "")
 	assert.True(t, strings.HasSuffix(dir, defaultDataDir))
 	assertDirExists(t, dir)
 	os.RemoveAll(dir)
+
 }
 
 func TestUserHome(t *testing.T) {


### PR DESCRIPTION

1. TestInitDataDirDefault deletes all  data from the user's home directory (I have beed lost all my files)
2. TestInitDataDir can't passed, also modified two lines

<img width="988" alt="codebugthatdeldata" src="https://user-images.githubusercontent.com/897759/27528158-b5d502e8-5a14-11e7-8945-29d3d4f54c41.png">


