### PR TITLE
Remove util.DataDir; Remove os.RemoveAll from file tests

### DIFF
--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -335,7 +335,10 @@ func (c *Config) postProcess() {
 		c.BlockchainSeckey = cipher.SecKey{}
 	}
 
-	c.DataDirectory = util.InitDataDir(c.DataDirectory)
+	err = util.InitDataDir(c.DataDirectory)
+	panicIfError(err, "Invalid DataDirectory")
+	c.DataDirectory = util.DataDir
+
 	if c.WebInterfaceCert == "" {
 		c.WebInterfaceCert = filepath.Join(c.DataDirectory, "cert.pem")
 	}

--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -335,9 +335,8 @@ func (c *Config) postProcess() {
 		c.BlockchainSeckey = cipher.SecKey{}
 	}
 
-	err = util.InitDataDir(c.DataDirectory)
+	c.DataDirectory, err = util.InitDataDir(c.DataDirectory)
 	panicIfError(err, "Invalid DataDirectory")
-	c.DataDirectory = util.DataDir
 
 	if c.WebInterfaceCert == "" {
 		c.WebInterfaceCert = filepath.Join(c.DataDirectory, "cert.pem")

--- a/src/util/file.go
+++ b/src/util/file.go
@@ -16,9 +16,6 @@ import (
 )
 
 var (
-	// DataDir app folder. A shared global value. Initialize it with InitDataDir.
-	DataDir = ""
-
 	EmptyDirectoryNameError = errors.New("data directory must not be empty")
 	DotDirectoryNameError   = errors.New("data directory must not be equivalent to .")
 
@@ -28,22 +25,19 @@ var (
 // Joins dir with the user's $HOME directory.
 // If $HOME cannot be determined, uses the current working directory.
 // dir must not be the empty string
-func InitDataDir(dir string) error {
+func InitDataDir(dir string) (string, error) {
 	dir, err := buildDataDir(dir)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	DataDir = dir
-	logger.Info("Set data directory to %s", DataDir)
-
-	if err := os.MkdirAll(DataDir, os.FileMode(0700)); err != nil {
-		logger.Error("Failed to create directory %s: %v", DataDir, err)
-		return err
+	if err := os.MkdirAll(dir, os.FileMode(0700)); err != nil {
+		logger.Error("Failed to create directory %s: %v", dir, err)
+		return "", err
 	}
 
-	logger.Info("Created data directory %s", DataDir)
-	return nil
+	logger.Info("Created data directory %s", dir)
+	return dir, nil
 }
 
 // Construct the full data directory by adding to $HOME or ./
@@ -66,7 +60,7 @@ func buildDataDir(dir string) (string, error) {
 
 	// The joined directory must not be equal to $HOME or a parent path of $HOME
 	if strings.HasPrefix(home, fullDir) {
-		logger.Error("join(%[0]s, %[1]s) == %[0]s", home, dir)
+		logger.Error("join(%[1]s, %[2]s) == %[1]s", home, dir)
 		return "", DotDirectoryNameError
 	}
 

--- a/src/util/file.go
+++ b/src/util/file.go
@@ -10,37 +10,67 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	logging "github.com/op/go-logging"
 )
 
 var (
-	// DataDir app folder
+	// DataDir app folder. A shared global value. Initialize it with InitDataDir.
 	DataDir = ""
+
+	EmptyDirectoryNameError = errors.New("data directory must not be empty")
+	DotDirectoryNameError   = errors.New("data directory must not be equivalent to .")
 
 	logger = logging.MustGetLogger("util")
 )
 
-// InitDataDir if dir is "", uses the default directory of ~/.skycoin.  The path to dir
-// is created, and the dir used is returned
-func InitDataDir(dir string) string {
-	//DataDir = dir
+// Joins dir with the user's $HOME directory.
+// If $HOME cannot be determined, uses the current working directory.
+// dir must not be the empty string
+func InitDataDir(dir string) error {
+	dir, err := buildDataDir(dir)
+	if err != nil {
+		return err
+	}
+
+	DataDir = dir
+	logger.Info("Set data directory to %s", DataDir)
+
+	if err := os.MkdirAll(DataDir, os.FileMode(0700)); err != nil {
+		logger.Error("Failed to create directory %s: %v", DataDir, err)
+		return err
+	}
+
+	logger.Info("Created data directory %s", DataDir)
+	return nil
+}
+
+// Construct the full data directory by adding to $HOME or ./
+func buildDataDir(dir string) (string, error) {
 	if dir == "" {
-		logger.Error("data directory is nil")
+		logger.Error("data directory is empty")
+		return "", EmptyDirectoryNameError
 	}
 
 	home := UserHome()
 	if home == "" {
-		logger.Warning("Failed to get home directory")
-		DataDir = filepath.Join("./", dir)
+		logger.Warning("Failed to get home directory, using ./")
+		home = "./"
 	} else {
-		DataDir = filepath.Join(home, dir)
+		home = filepath.Clean(home)
 	}
 
-	if err := os.MkdirAll(DataDir, os.FileMode(0700)); err != nil {
-		logger.Error("Failed to create directory %s: %v", DataDir, err)
+	fullDir := filepath.Join(home, dir)
+	fullDir = filepath.Clean(fullDir)
+
+	// The joined directory must not be equal to $HOME or a parent path of $HOME
+	if strings.HasPrefix(home, fullDir) {
+		logger.Error("join(%[0]s, %[1]s) == %[0]s", home, dir)
+		return "", DotDirectoryNameError
 	}
-	return DataDir
+
+	return fullDir, nil
 }
 
 // UserHome returns the current user home path

--- a/src/util/file_test.go
+++ b/src/util/file_test.go
@@ -50,14 +50,7 @@ func cleanup(fn string) {
 	os.Remove(fn + ".bak")
 }
 
-func resetDataDir() {
-	DataDir = ""
-}
-
 func TestBuildDataDir(t *testing.T) {
-	require.Empty(t, DataDir)
-	defer resetDataDir()
-
 	dir := "./.test-skycoin/test"
 	builtDir, err := buildDataDir(dir)
 	require.NoError(t, err)
@@ -75,27 +68,17 @@ func TestBuildDataDir(t *testing.T) {
 }
 
 func TestBuildDataDirEmptyError(t *testing.T) {
-	require.Empty(t, DataDir)
-	defer resetDataDir()
-
-	require.Empty(t, DataDir)
 	dir, err := buildDataDir("")
 	require.Empty(t, dir)
-	require.Empty(t, DataDir)
 	require.Error(t, err)
 	require.Equal(t, EmptyDirectoryNameError, err)
 }
 
 func TestBuildDataDirDotError(t *testing.T) {
-	require.Empty(t, DataDir)
-	defer resetDataDir()
-
-	require.Empty(t, DataDir)
 	bad := []string{".", "./", "./.", "././", "./../"}
 	for _, b := range bad {
 		dir, err := buildDataDir(b)
 		require.Empty(t, dir)
-		require.Empty(t, DataDir)
 		require.Error(t, err)
 		require.Equal(t, DotDirectoryNameError, err)
 	}

--- a/src/util/file_test.go
+++ b/src/util/file_test.go
@@ -8,52 +8,40 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func assertFileMode(t *testing.T, filename string, mode os.FileMode) {
+func requireFileMode(t *testing.T, filename string, mode os.FileMode) {
 	stat, err := os.Stat(filename)
-	assert.Nil(t, err)
-	assert.Equal(t, stat.Mode(), mode)
+	require.Nil(t, err)
+	require.Equal(t, stat.Mode(), mode)
 }
 
-func assertFileContentsBinary(t *testing.T, filename string, contents []byte) {
+func requireFileContentsBinary(t *testing.T, filename string, contents []byte) {
 	f, err := os.Open(filename)
 	defer f.Close()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	b := make([]byte, len(contents)*16)
 	n, err := f.Read(b)
-	assert.Nil(t, err)
-	assert.Equal(t, n, len(contents))
-	assert.True(t, bytes.Equal(b[:n], contents))
+	require.Nil(t, err)
+	require.Equal(t, n, len(contents))
+	require.True(t, bytes.Equal(b[:n], contents))
 }
 
-func assertFileContents(t *testing.T, filename, contents string) {
-	assertFileContentsBinary(t, filename, []byte(contents))
+func requireFileContents(t *testing.T, filename, contents string) {
+	requireFileContentsBinary(t, filename, []byte(contents))
 }
 
-func assertFileExists(t *testing.T, filename string) {
+func requireFileExists(t *testing.T, filename string) {
 	stat, err := os.Stat(filename)
-	assert.Nil(t, err)
-	assert.True(t, stat.Mode().IsRegular())
+	require.Nil(t, err)
+	require.True(t, stat.Mode().IsRegular())
 }
 
-func assertFileNotExists(t *testing.T, filename string) {
+func requireFileNotExists(t *testing.T, filename string) {
 	_, err := os.Stat(filename)
-	assert.NotNil(t, err)
-	assert.True(t, os.IsNotExist(err))
-}
-
-func assertDirExists(t *testing.T, dirname string) {
-	stat, err := os.Stat(dirname)
-	assert.Nil(t, err)
-	assert.True(t, stat.IsDir())
-}
-
-func assertDirNotExists(t *testing.T, dirname string) {
-	_, err := os.Stat(dirname)
-	assert.NotNil(t, err)
-	assert.True(t, os.IsNotExist(err))
+	require.NotNil(t, err)
+	require.True(t, os.IsNotExist(err))
 }
 
 func cleanup(fn string) {
@@ -62,32 +50,60 @@ func cleanup(fn string) {
 	os.Remove(fn + ".bak")
 }
 
-func TestInitDataDir(t *testing.T) {
-	defer os.RemoveAll("./.test")
-	d := "./.test/test"
-	assertDirNotExists(t, d)
-	dir := InitDataDir(d)
-	assertDirExists(t, dir)
-	_, err := os.Stat(dir)
-	assert.Nil(t, err)
-	os.RemoveAll(dir)
+func resetDataDir() {
+	DataDir = ""
 }
 
-func TestInitDataDirDefault(t *testing.T) {
-	defaultDataDir := ".skycointestXCAWDAWD232232"
-	home := UserHome()
-	assertDirNotExists(t, filepath.Join(home, defaultDataDir))
-	dir := InitDataDir(defaultDataDir)
-	assert.NotEqual(t, dir, "")
-	assert.True(t, strings.HasSuffix(dir, defaultDataDir))
-	assertDirExists(t, dir)
-	os.RemoveAll(dir)
+func TestBuildDataDir(t *testing.T) {
+	require.Empty(t, DataDir)
+	defer resetDataDir()
 
+	dir := "./.test-skycoin/test"
+	builtDir, err := buildDataDir(dir)
+	require.NoError(t, err)
+
+	cleanDir := filepath.Clean(dir)
+	require.True(t, strings.HasSuffix(builtDir, cleanDir))
+
+	home := filepath.Clean(UserHome())
+	if home == "" {
+		require.Equal(t, cleanDir, builtDir)
+	} else {
+		require.True(t, strings.HasPrefix(builtDir, home))
+		require.NotEqual(t, builtDir, filepath.Clean(home))
+	}
+}
+
+func TestBuildDataDirEmptyError(t *testing.T) {
+	require.Empty(t, DataDir)
+	defer resetDataDir()
+
+	require.Empty(t, DataDir)
+	dir, err := buildDataDir("")
+	require.Empty(t, dir)
+	require.Empty(t, DataDir)
+	require.Error(t, err)
+	require.Equal(t, EmptyDirectoryNameError, err)
+}
+
+func TestBuildDataDirDotError(t *testing.T) {
+	require.Empty(t, DataDir)
+	defer resetDataDir()
+
+	require.Empty(t, DataDir)
+	bad := []string{".", "./", "./.", "././", "./../"}
+	for _, b := range bad {
+		dir, err := buildDataDir(b)
+		require.Empty(t, dir)
+		require.Empty(t, DataDir)
+		require.Error(t, err)
+		require.Equal(t, DotDirectoryNameError, err)
+	}
 }
 
 func TestUserHome(t *testing.T) {
 	home := UserHome()
-	assert.NotEqual(t, home, "")
+	require.NotEqual(t, home, "")
 }
 
 func TestLoadJSON(t *testing.T) {
@@ -96,20 +112,20 @@ func TestLoadJSON(t *testing.T) {
 	defer cleanup(fn)
 
 	// Loading nonexistant file
-	assertFileNotExists(t, fn)
+	requireFileNotExists(t, fn)
 	err := LoadJSON(fn, &obj)
-	assert.NotNil(t, err)
-	assert.True(t, os.IsNotExist(err))
+	require.NotNil(t, err)
+	require.True(t, os.IsNotExist(err))
 
 	f, err := os.Create(fn)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	_, err = f.WriteString("{\"key\":\"value\"}")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	f.Close()
 
 	err = LoadJSON(fn, &obj)
-	assert.Nil(t, err)
-	assert.Equal(t, obj.Key, "value")
+	require.Nil(t, err)
+	require.Equal(t, obj.Key, "value")
 }
 
 func TestSaveJSON(t *testing.T) {
@@ -119,22 +135,22 @@ func TestSaveJSON(t *testing.T) {
 		Key string `json:"key"`
 	}{Key: "value"}
 	err := SaveJSON(fn, obj, 0644)
-	assert.Nil(t, err)
-	assertFileExists(t, fn)
-	assertFileNotExists(t, fn+".bak")
-	assertFileMode(t, fn, 0644)
-	assertFileContents(t, fn, "{\"key\":\"value\"}")
+	require.Nil(t, err)
+	requireFileExists(t, fn)
+	requireFileNotExists(t, fn+".bak")
+	requireFileMode(t, fn, 0644)
+	requireFileContents(t, fn, "{\"key\":\"value\"}")
 
 	// Saving again should result in a .bak file same as original
 	obj.Key = "value2"
 	err = SaveJSON(fn, obj, 0644)
-	assert.Nil(t, err)
-	assertFileMode(t, fn, 0644)
-	assertFileExists(t, fn)
-	assertFileExists(t, fn+".bak")
-	assertFileContents(t, fn, "{\"key\":\"value2\"}")
-	assertFileContents(t, fn+".bak", "{\"key\":\"value\"}")
-	assertFileNotExists(t, fn+".tmp")
+	require.Nil(t, err)
+	requireFileMode(t, fn, 0644)
+	requireFileExists(t, fn)
+	requireFileExists(t, fn+".bak")
+	requireFileContents(t, fn, "{\"key\":\"value2\"}")
+	requireFileContents(t, fn+".bak", "{\"key\":\"value\"}")
+	requireFileNotExists(t, fn+".tmp")
 }
 
 func TestSaveJSONSafe(t *testing.T) {
@@ -144,19 +160,19 @@ func TestSaveJSONSafe(t *testing.T) {
 		Key string `json:"key"`
 	}{Key: "value"}
 	err := SaveJSONSafe(fn, obj, 0600)
-	assert.Nil(t, err)
-	assertFileExists(t, fn)
-	assertFileMode(t, fn, 0600)
-	assertFileContents(t, fn, "{\"key\":\"value\"}")
+	require.Nil(t, err)
+	requireFileExists(t, fn)
+	requireFileMode(t, fn, 0600)
+	requireFileContents(t, fn, "{\"key\":\"value\"}")
 
 	// Saving again should result in error, and original file not changed
 	obj.Key = "value2"
 	err = SaveJSONSafe(fn, obj, 0600)
-	assert.NotNil(t, err)
-	assertFileExists(t, fn)
-	assertFileContents(t, fn, "{\"key\":\"value\"}")
-	assertFileNotExists(t, fn+".bak")
-	assertFileNotExists(t, fn+".tmp")
+	require.NotNil(t, err)
+	requireFileExists(t, fn)
+	requireFileContents(t, fn, "{\"key\":\"value\"}")
+	requireFileNotExists(t, fn+".bak")
+	requireFileNotExists(t, fn+".tmp")
 }
 
 func TestSaveBinary(t *testing.T) {
@@ -165,23 +181,23 @@ func TestSaveBinary(t *testing.T) {
 	b := make([]byte, 128)
 	rand.Read(b)
 	err := SaveBinary(fn, b, 0644)
-	assert.Nil(t, err)
-	assertFileNotExists(t, fn+".tmp")
-	assertFileNotExists(t, fn+".bak")
-	assertFileExists(t, fn)
-	assertFileContentsBinary(t, fn, b)
-	assertFileMode(t, fn, 0644)
+	require.Nil(t, err)
+	requireFileNotExists(t, fn+".tmp")
+	requireFileNotExists(t, fn+".bak")
+	requireFileExists(t, fn)
+	requireFileContentsBinary(t, fn, b)
+	requireFileMode(t, fn, 0644)
 
 	b2 := make([]byte, 128)
 	rand.Read(b2)
-	assert.False(t, bytes.Equal(b, b2))
+	require.False(t, bytes.Equal(b, b2))
 
 	err = SaveBinary(fn, b2, 0644)
-	assertFileExists(t, fn)
-	assertFileExists(t, fn+".bak")
-	assertFileNotExists(t, fn+".tmp")
-	assertFileContentsBinary(t, fn, b2)
-	assertFileContentsBinary(t, fn+".bak", b)
-	assertFileMode(t, fn, 0644)
-	assertFileMode(t, fn+".bak", 0644)
+	requireFileExists(t, fn)
+	requireFileExists(t, fn+".bak")
+	requireFileNotExists(t, fn+".tmp")
+	requireFileContentsBinary(t, fn, b2)
+	requireFileContentsBinary(t, fn+".bak", b)
+	requireFileMode(t, fn, 0644)
+	requireFileMode(t, fn+".bak", 0644)
 }

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -123,7 +123,6 @@ func walker(hps []coin.HashPair) cipher.SHA256 {
 
 // open the blockdb.
 func openDB(dbFile string) (*bolt.DB, func(), error) {
-	// dbFile := filepath.Join(util.DataDir, dbpath)
 	db, err := bolt.Open(dbFile, 0600, &bolt.Options{
 		Timeout: 500 * time.Millisecond,
 	})


### PR DESCRIPTION
Restructure test to only test the folder path concatenation.  Does not test the folder creation, to avoid needing to clean up the folder.

Adds more checks for invalid dir and returns error if invalid.

Related: #386 