### PR TITLE
Use specific error message

### DIFF
--- a/src/gui/wallet.go
+++ b/src/gui/wallet.go
@@ -382,17 +382,6 @@ func walletSpendHandler(gateway *daemon.Gateway) http.HandlerFunc {
 			return
 		}
 
-		//set fee automatically for now
-		/*
-			sfee := r.FormValue("fee")
-			fee, err := strconv.ParseUint(sfee, 10, 64)
-			if err != nil {
-				Error400(w, "Invalid \"fee\" value")
-				return
-			}
-		*/
-		//var fee uint64 = 0
-
 		scoins := r.FormValue("coins")
 		//shours := r.FormValue("hours")
 		coins, err := strconv.ParseUint(scoins, 10, 64)

--- a/src/visor/spend.go
+++ b/src/visor/spend.go
@@ -73,7 +73,7 @@ func createSpends(headTime uint64, uxa coin.UxArray,
 	}
 
 	if amt.Coins > have.Coins {
-		return nil, errors.New("Not enough coins")
+		return nil, errors.New("Not enough confirmed coins")
 	}
 
 	return spending, nil


### PR DESCRIPTION
Replace error message of "Not enough coins" with "Not enough confirmed coins".

Related: #372 