### PR TITLE
Bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ src/gui/static/dist
 .idea/
 
 *.iml
+*.test

--- a/cmd/explorer/explorer.go
+++ b/cmd/explorer/explorer.go
@@ -54,7 +54,7 @@ func getBlockChainMetaData(w http.ResponseWriter, r *http.Request) {
 
 func getAddress(w http.ResponseWriter, r *http.Request) {
 	address := r.URL.Query().Get("address")
-	resp, err := http.Get("http://127.0.0.1:6420/explorer/address?address=" + address)
+	resp, err := http.Get("http://127.0.0.1:6420/explorer/transactions?address=" + address)
 	if err != nil {
 		wh.Error500(w, "Unable to respond back")
 	}

--- a/cmd/explorer/explorer.go
+++ b/cmd/explorer/explorer.go
@@ -33,7 +33,7 @@ func getBlocks(w http.ResponseWriter, r *http.Request) {
 }
 
 func getSupply(w http.ResponseWriter, r *http.Request) {
-	resp, err := http.Get("http://127.0.0.1:6420/explorer/coinSupply")
+	resp, err := http.Get("http://127.0.0.1:6420/explorer/getEffectiveOutputs")
 	if err != nil {
 		wh.Error500(w, "Unable to respond back")
 	}
@@ -54,7 +54,7 @@ func getBlockChainMetaData(w http.ResponseWriter, r *http.Request) {
 
 func getAddress(w http.ResponseWriter, r *http.Request) {
 	address := r.URL.Query().Get("address")
-	resp, err := http.Get("http://127.0.0.1:6420/explorer/transactions?address=" + address)
+	resp, err := http.Get("http://127.0.0.1:6420/explorer/address?address=" + address)
 	if err != nil {
 		wh.Error500(w, "Unable to respond back")
 	}

--- a/cmd/explorer/explorer.go
+++ b/cmd/explorer/explorer.go
@@ -33,7 +33,7 @@ func getBlocks(w http.ResponseWriter, r *http.Request) {
 }
 
 func getSupply(w http.ResponseWriter, r *http.Request) {
-	resp, err := http.Get("http://127.0.0.1:6420/explorer/getEffectiveOutputs")
+	resp, err := http.Get("http://127.0.0.1:6420/explorer/coinSupply")
 	if err != nil {
 		wh.Error500(w, "Unable to respond back")
 	}

--- a/cmd/explorer/server/routes/api.js
+++ b/cmd/explorer/server/routes/api.js
@@ -32,7 +32,7 @@ router.get('/blockchain/metadata', (req, res) => {
 
 // address uxouts!
 router.get('/address', (req, res) => {
-  axios.get(`${API}/explorer/address?address=`+req.query.address)
+  axios.get(`${API}/explorer/transactions?address=`+req.query.address)
   .then(blocks => {
   res.status(200).json(blocks.data);
 })

--- a/cmd/explorer/server/routes/api.js
+++ b/cmd/explorer/server/routes/api.js
@@ -95,7 +95,7 @@ router.get('/currentBalance', (req, res) => {
 
 // Get the block details
 router.get('/coinSupply', (req, res) => {
-  axios.get("http://127.0.0.1:6420/explorer/getEffectiveOutputs")
+  axios.get("http://127.0.0.1:6420/explorer/coinSupply")
   .then(blocks => {
     res.status(200).json(blocks.data);
 })

--- a/cmd/explorer/server/routes/api.js
+++ b/cmd/explorer/server/routes/api.js
@@ -32,7 +32,7 @@ router.get('/blockchain/metadata', (req, res) => {
 
 // address uxouts!
 router.get('/address', (req, res) => {
-  axios.get(`${API}/explorer/transactions?address=`+req.query.address)
+  axios.get(`${API}/explorer/address?address=`+req.query.address)
   .then(blocks => {
   res.status(200).json(blocks.data);
 })
@@ -95,7 +95,7 @@ router.get('/currentBalance', (req, res) => {
 
 // Get the block details
 router.get('/coinSupply', (req, res) => {
-  axios.get("http://127.0.0.1:6420/explorer/coinSupply")
+  axios.get("http://127.0.0.1:6420/explorer/getEffectiveOutputs")
   .then(blocks => {
     res.status(200).json(blocks.data);
 })

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -343,10 +343,10 @@ func (gw *Gateway) InjectTransaction(txn coin.Transaction) (tx coin.Transaction,
 	return
 }
 
-// GetAddressTransactions returns a *visor.TransactionResults
-func (gw *Gateway) GetAddressTransactions(a cipher.Address) (tx *visor.TransactionResults, err error) {
+// GetAddressTxns returns a *visor.TransactionResults
+func (gw *Gateway) GetAddressTxns(a cipher.Address) (tx *visor.TransactionResults, err error) {
 	gw.strand(func() {
-		tx, err = gw.vrpc.GetAddressTransactions(gw.v, a)
+		tx, err = gw.vrpc.GetAddressTxns(gw.v, a)
 	})
 	return
 }

--- a/src/daemon/visor.go
+++ b/src/daemon/visor.go
@@ -718,7 +718,7 @@ func (gtm *GiveTxnsMessage) Process(d *Daemon) {
 			if !known {
 				logger.Warning("Failed to record txn: %v", err)
 			} else {
-				logger.Warning("Duplicate Transaction: %v", txn.Hash())
+				logger.Warning("Duplicate Transaction: %s", txn.Hash().Hex())
 			}
 		}
 	}

--- a/src/gui/explorer.go
+++ b/src/gui/explorer.go
@@ -170,7 +170,7 @@ func getCoinSupply(gateway *daemon.Gateway) http.HandlerFunc {
 }
 
 // method: GET
-// url: /explorer/transactions?address=${address}
+// url: /explorer/address?address=${address}
 func getTransactionsForAddress(gateway *daemon.Gateway) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {

--- a/src/gui/explorer.go
+++ b/src/gui/explorer.go
@@ -14,9 +14,9 @@ import (
 // RegisterExplorerHandlers register explorer handlers
 func RegisterExplorerHandlers(mux *http.ServeMux, gateway *daemon.Gateway) {
 	// get set of pending transactions
-	mux.HandleFunc("/explorer/transactions", getTransactionsForAddress(gateway))
+	mux.HandleFunc("/explorer/address", getTransactionsForAddress(gateway))
 
-	mux.HandleFunc("/explorer/coinSupply", getCoinSupply(gateway))
+	mux.HandleFunc("/explorer/getEffectiveOutputs", getCoinSupply(gateway))
 }
 
 var addrList = []string{

--- a/src/gui/explorer.go
+++ b/src/gui/explorer.go
@@ -16,7 +16,7 @@ func RegisterExplorerHandlers(mux *http.ServeMux, gateway *daemon.Gateway) {
 	// get set of pending transactions
 	mux.HandleFunc("/explorer/transactions", getTransactionsForAddress(gateway))
 
-	mux.HandleFunc("/explorer/coinsupply", getCoinSupply(gateway))
+	mux.HandleFunc("/explorer/coinSupply", getCoinSupply(gateway))
 }
 
 var addrList = []string{

--- a/src/gui/static/src/app/app.loadWallet.ts
+++ b/src/gui/static/src/app/app.loadWallet.ts
@@ -588,6 +588,9 @@ export class LoadWalletComponent implements OnInit {
             return;
         }
 
+        // new wallet will have a default address
+        addressCount--;
+
         //check if label is duplicated
         var old = _.find(this.wallets, function(o){
             return (o.meta.label == label)
@@ -611,53 +614,43 @@ export class LoadWalletComponent implements OnInit {
         .map((res:Response) => res.json())
         .subscribe(
             response => {
-                console.log(response)
-
-                if(addressCount > 1) {
-                    var repeats = [];
-                    for(var i = 0; i < addressCount - 1 ; i++) {
-                        repeats.push(i)
-                    }
-
-                    async.map(repeats, (idx, callback) => {
-                        var stringConvert = 'id='+response.meta.filename;
-                        this.http.post('/wallet/newAddress', stringConvert, {headers: headers})
-                        .map((res:Response) => res.json())
-                        .subscribe(
-                            response => {
-                                console.log(response)
-                                callback(null, null)
-                            },
-                            err => {
-                                callback(err, null)
-                            },
-                            () => {}
-                        );
-                    }, (err, ret) => {
-                        if(err) {
+                console.log('response:', response);
+                if (addressCount > 0) {
+                    let url = 'id='+response.meta.filename+'&num='+addressCount
+                    this.http.post('/wallet/newAddress', url, {headers: headers})
+                    .map((res:Response) => res.json())
+                    .subscribe(
+                        response => {
+                            //Hide new wallet popup
+                            this.NewWalletIsVisible = false;
+                            toastr.info("New wallet created successfully");
+                            //Load wallet for refresh list
+                            this.loadWallet();
+                        },
+                        err => {
                             console.log(err);
-                            return;
                         }
-
-                        //Hide new wallet popup
-                        this.NewWalletIsVisible = false;
-                        toastr.info("New wallet created successfully");
-                        //Load wallet for refresh list
-                        this.loadWallet();
-                    })
-                } else {
-                    //Hide new wallet popup
-                    this.NewWalletIsVisible = false;
-                    toastr.info("New wallet created successfully");
-                    //Load wallet for refresh list
-                    this.loadWallet();
+                    );
+                    return
                 }
+
+                //Hide new wallet popup
+                this.NewWalletIsVisible = false;
+                toastr.info("New wallet created successfully");
+                //Load wallet for refresh list
+                this.loadWallet();
             },
             err => {
-                if(err._body.indexOf("duplicate wallet ") !=-1){
-                    toastr.info("Can't load same wallet twice!");
+                // when node is down, the response header status is 200
+                if (err.status == 200) {
+                    return
                 }
-                console.log(err);
+
+                if (err.status == 400) {
+                    if(err._body.indexOf("duplicate wallet ") !=-1){
+                        toastr.info("Can't load same wallet twice!");
+                    }
+                }
             },
             () => {}
         );
@@ -702,6 +695,8 @@ export class LoadWalletComponent implements OnInit {
             return;
         }
 
+        addressCount--;
+
         //Set http headers
         var headers = new Headers();
         headers.append('Content-Type', 'application/x-www-form-urlencoded');
@@ -711,47 +706,42 @@ export class LoadWalletComponent implements OnInit {
         .map((res:Response) => res.json())
         .subscribe(
             response => {
-                if(addressCount > 1) {
-                    var repeats = [];
-                    for(var i = 0; i < addressCount - 1 ; i++) {
-                        repeats.push(i)
-                    }
-                    async.map(repeats, (idx, callback) => {
-                        var stringConvert = 'id='+response.meta.filename;
-                        this.http.post('/wallet/newAddress', stringConvert, {headers: headers})
-                        .map((res:Response) => res.json())
-                        .subscribe(
-                            response => {
-                                console.log(response)
-                                callback(null, null)
-                            },
-                            err => {
-                                callback(err, null)
-                            },
-                            () => {}
-                        );
-                    }, (err, ret) => {
-                        if(err) {
+                if(addressCount > 0) {
+                    let params='id=' + response.meta.filename + '&num=' + addressCount;
+                    this.http.post('/wallet/newAddress', params, {headers: headers})
+                    .map((res:Response) => res.json())
+                    .subscribe(
+                        response => {
+                            //Hide new wallet popup
+                            this.loadSeedIsVisible = false;
+                            toastr.info("Wallet loaded successfully");
+                            //Load wallet for refresh list
+                            this.loadWallet();
+                        },
+                        err => {
                             console.log(err);
-                            return;
-                        }
-                        //Hide new wallet popup
-                        this.loadSeedIsVisible = false;
-                        toastr.info("Wallet loaded successfully");
-                        //Load wallet for refresh list
-                        this.loadWallet();
-                    })
-                } else {
-                    //Hide new wallet popup
-                    this.loadSeedIsVisible = false;
-                    toastr.info("Wallet loaded successfully");
-                    //Load wallet for refresh list
-                    this.loadWallet();
-                }
+                        },
+                        () => {}
+                    );
+                    return
+                } 
+
+                //Hide new wallet popup
+                this.loadSeedIsVisible = false;
+                toastr.info("Wallet loaded successfully");
+                //Load wallet for refresh list
+                this.loadWallet();
             },
             err => {
-                if(err._body.indexOf("duplicate wallet ") !=-1){
-                    toastr.info("Can't load same wallet twice!");
+                // when node is down, the response header status is 200
+                if (err.status == 200) {
+                    return
+                }
+
+                if (err.status == 400) {
+                    if(err._body.indexOf("duplicate wallet ") !=-1){
+                        toastr.info("Can't load same wallet twice!");
+                    }
                 }
             },
             () => {

--- a/src/gui/static/src/app/app.loadWallet.ts
+++ b/src/gui/static/src/app/app.loadWallet.ts
@@ -616,8 +616,8 @@ export class LoadWalletComponent implements OnInit {
             response => {
                 console.log('response:', response);
                 if (addressCount > 0) {
-                    let url = 'id='+response.meta.filename+'&num='+addressCount
-                    this.http.post('/wallet/newAddress', url, {headers: headers})
+                    let param = 'id='+response.meta.filename+'&num='+addressCount
+                    this.http.post('/wallet/newAddress', param, {headers: headers})
                     .map((res:Response) => res.json())
                     .subscribe(
                         response => {

--- a/src/gui/static/src/app/app.loadWallet.ts
+++ b/src/gui/static/src/app/app.loadWallet.ts
@@ -254,12 +254,13 @@ export class LoadWalletComponent implements OnInit {
 
 
         _.each(addresses,(address)=>{
-            this.http.get('/explorer/address?address='+address, {})
+            this.http.get('/explorer/transactions?address='+address, {})
             .map((res) => res.json())
             .subscribe(transactions => {
                 _.each(transactions,(transaction)=>{
+                    let confirmed = transaction.status.confirmed? 'Confirmed': 'UnConfirmed'
                     this.userTransactions.push({'type':'confirmed','transactionInputs':transaction.inputs,'transactionOutputs':transaction.outputs
-                        ,'actualTransaction':transaction
+                        ,'actualTransaction':transaction, 'confirmed': confirmed
                     });
                 });
             });

--- a/src/gui/static/src/app/app.loadWallet.ts
+++ b/src/gui/static/src/app/app.loadWallet.ts
@@ -254,7 +254,7 @@ export class LoadWalletComponent implements OnInit {
 
 
         _.each(addresses,(address)=>{
-            this.http.get('/explorer/transactions?address='+address, {})
+            this.http.get('/explorer/address?address='+address, {})
             .map((res) => res.json())
             .subscribe(transactions => {
                 _.each(transactions,(transaction)=>{

--- a/src/gui/static/src/app/templates/wallet.html
+++ b/src/gui/static/src/app/templates/wallet.html
@@ -202,8 +202,7 @@
                             <tr *ngFor="let trnsObj of userTransactions">
                                 <td *ngIf="trnsObj.type == 'confirmed'">{{getDateTimeString(trnsObj.actualTransaction.timestamp)}}</td>
                                 <td *ngIf="trnsObj.type == 'pending'" >NA</td>
-
-                                <td *ngIf="trnsObj.type == 'confirmed'">Confirmed</td>
+                                <td>{{trnsObj.confirmed}}</td>
                                 <td *ngIf="trnsObj.type == 'pending'" >Pending</td>
                                 <td>{{trnsObj.actualTransaction.type}}</td>
                                 <td>

--- a/src/gui/wallet.go
+++ b/src/gui/wallet.go
@@ -497,10 +497,13 @@ func walletNewAddresses(gateway *daemon.Gateway) http.HandlerFunc {
 		}
 
 		var rlt = struct {
-			Address string `json:"address"`
-		}{
-			addrs[0].String(),
+			Address []string `json:"addresses"`
+		}{}
+
+		for _, a := range addrs {
+			rlt.Address = append(rlt.Address, a.String())
 		}
+
 		wh.SendOr404(w, rlt)
 		return
 	}

--- a/src/gui/wallet.go
+++ b/src/gui/wallet.go
@@ -454,6 +454,11 @@ func walletCreate(gateway *daemon.Gateway) http.HandlerFunc {
 	}
 }
 
+// method: POST
+// url: /wallet/newAddress
+// params:
+// 		id: wallet id
+// 	   num: number of address need to create, if not set the default value is 1
 func walletNewAddresses(gateway *daemon.Gateway) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
@@ -467,7 +472,19 @@ func walletNewAddresses(gateway *daemon.Gateway) http.HandlerFunc {
 			return
 		}
 
-		addrs, err := Wg.NewAddresses(wltID, 1)
+		// the number of address that need to create, default is 1
+		n := 1
+		var err error
+		num := r.FormValue("num")
+		if num != "" {
+			n, err = strconv.Atoi(num)
+			if err != nil {
+				wh.Error400(w, "invalid num value")
+				return
+			}
+		}
+
+		addrs, err := Wg.NewAddresses(wltID, n)
 		if err != nil {
 			wh.Error400(w, err.Error())
 			return

--- a/src/visor/blockchain_parser.go
+++ b/src/visor/blockchain_parser.go
@@ -41,12 +41,14 @@ func (bcp *BlockchainParser) BlockListener(b coin.Block) {
 	bcp.blkC <- b
 }
 
-// Run starts blockchain parser, the q channel will be
-// closed to notify the invoker that the running process
-// is going to shutdown.
+// Run starts blockchain parser
 func (bcp *BlockchainParser) Run() error {
 	logger.Info("Blockchain parser start")
 	defer logger.Info("Blockchain parser closed")
+
+	if err := bcp.historyDB.ResetIfNeed(); err != nil {
+		return err
+	}
 
 	// parse to the blockchain head
 	headSeq := bcp.bc.Head().Seq()

--- a/src/visor/bucket/bucket.go
+++ b/src/visor/bucket/bucket.go
@@ -156,6 +156,21 @@ func (b *Bucket) IsExist(k []byte) bool {
 	return exist
 }
 
+// IsEmpty check if the bucket is empty
+func (b *Bucket) IsEmpty() bool {
+	var notEmpty bool
+	b.db.View(func(tx *bolt.Tx) error {
+		c := tx.Bucket(b.Name).Cursor()
+		k, _ := c.First()
+		if k != nil {
+			notEmpty = true
+		}
+
+		return nil
+	})
+	return !notEmpty
+}
+
 // ForEach iterate the whole bucket
 func (b *Bucket) ForEach(f func(k, v []byte) error) error {
 	return b.db.View(func(tx *bolt.Tx) error {

--- a/src/visor/bucket/bucket.go
+++ b/src/visor/bucket/bucket.go
@@ -158,17 +158,17 @@ func (b *Bucket) IsExist(k []byte) bool {
 
 // IsEmpty check if the bucket is empty
 func (b *Bucket) IsEmpty() bool {
-	var notEmpty bool
+	var empty = true
 	b.db.View(func(tx *bolt.Tx) error {
 		c := tx.Bucket(b.Name).Cursor()
 		k, _ := c.First()
 		if k != nil {
-			notEmpty = true
+			empty = false
 		}
 
 		return nil
 	})
-	return !notEmpty
+	return empty
 }
 
 // ForEach iterate the whole bucket

--- a/src/visor/bucket/bucket.go
+++ b/src/visor/bucket/bucket.go
@@ -2,7 +2,6 @@ package bucket
 
 import (
 	"encoding/binary"
-	"fmt"
 
 	"github.com/boltdb/bolt"
 )
@@ -110,15 +109,11 @@ func (b *Bucket) Update(key []byte, f func([]byte) ([]byte, error)) error {
 	return b.db.Update(func(tx *bolt.Tx) error {
 		// get the value of given key
 		bkt := tx.Bucket(b.Name)
-		if v := bkt.Get(key); v != nil {
-			var err error
-			v, err = f(v)
-			if err != nil {
-				return err
-			}
-			return bkt.Put(key, v)
+		v, err := f(bkt.Get(key))
+		if err != nil {
+			return err
 		}
-		return fmt.Errorf("%s not exist in bucket %s", string(key), string(b.Name))
+		return bkt.Put(key, v)
 	})
 }
 

--- a/src/visor/bucket/bucket_test.go
+++ b/src/visor/bucket/bucket_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type person struct {
@@ -357,4 +358,21 @@ func TestLen(t *testing.T) {
 
 		assert.Equal(t, tc.len, bkt.Len())
 	}
+}
+
+func TestBucketIsEmpty(t *testing.T) {
+	db, td := prepareDB(t)
+	defer td()
+
+	bkt, err := New([]byte("bkt1"), db)
+	require.Nil(t, err)
+
+	require.True(t, bkt.IsEmpty())
+
+	require.Nil(t, bkt.Put([]byte("k1"), []byte("v1")))
+
+	require.False(t, bkt.IsEmpty())
+
+	bkt.Reset()
+	require.True(t, bkt.IsEmpty())
 }

--- a/src/visor/historydb/address_txn.go
+++ b/src/visor/historydb/address_txn.go
@@ -2,8 +2,8 @@ package historydb
 
 import (
 	"github.com/boltdb/bolt"
-	"github.com/skycoin/examples/aether/encoder"
 	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/cipher/encoder"
 	"github.com/skycoin/skycoin/src/visor/bucket"
 )
 

--- a/src/visor/historydb/address_txn.go
+++ b/src/visor/historydb/address_txn.go
@@ -1,0 +1,76 @@
+package historydb
+
+import (
+	"github.com/boltdb/bolt"
+	"github.com/skycoin/examples/aether/encoder"
+	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/visor/bucket"
+)
+
+var addressTxnsBktName = []byte("address_txns")
+
+// addressTxn buckets for storing address related transactions
+// address as key, transaction id slice as value
+type addressTxns struct {
+	bkt *bucket.Bucket
+}
+
+func newAddressTxnsBkt(db *bolt.DB) (*addressTxns, error) {
+	bkt, err := bucket.New(addressTxnsBktName, db)
+	if err != nil {
+		return nil, err
+	}
+
+	return &addressTxns{bkt}, nil
+}
+
+// Get returns the transaction hashes of given address
+func (atx *addressTxns) Get(address cipher.Address) ([]cipher.SHA256, error) {
+	var txHashes []cipher.SHA256
+	v := atx.bkt.Get(address.Bytes())
+	if v == nil {
+		return []cipher.SHA256{}, nil
+	}
+
+	if err := encoder.DeserializeRaw(v, &txHashes); err != nil {
+		return []cipher.SHA256{}, err
+	}
+
+	return txHashes, nil
+}
+
+// IsEmpty checks if address transactions bucket is empty
+func (atx *addressTxns) IsEmpty() bool {
+	return atx.bkt.IsEmpty()
+}
+
+// Reset resets the bucket
+func (atx *addressTxns) Reset() error {
+	return atx.bkt.Reset()
+}
+
+func setAddressTxns(bkt *bolt.Bucket, addr cipher.Address, hash cipher.SHA256) error {
+	// get hashes
+	addrBytes := addr.Bytes()
+	v := bkt.Get(addrBytes)
+	if v == nil {
+		bin := encoder.Serialize([]cipher.SHA256{hash})
+		return bkt.Put(addrBytes, bin)
+	}
+
+	var hashes []cipher.SHA256
+	if err := encoder.DeserializeRaw(v, &hashes); err != nil {
+		return err
+	}
+
+	// check dup
+	for _, u := range hashes {
+		if u == hash {
+			return nil
+		}
+	}
+
+	hashes = append(hashes, hash)
+	bin := encoder.Serialize(hashes)
+	return bkt.Put(addrBytes, bin)
+}

--- a/src/visor/historydb/address_txn_test.go
+++ b/src/visor/historydb/address_txn_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/boltdb/bolt"
-	"github.com/skycoin/examples/aether/encoder"
 	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/cipher/encoder"
 	"github.com/stretchr/testify/require"
 )
 

--- a/src/visor/historydb/address_txn_test.go
+++ b/src/visor/historydb/address_txn_test.go
@@ -1,0 +1,274 @@
+package historydb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/boltdb/bolt"
+	"github.com/skycoin/examples/aether/encoder"
+	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAddressTxns(t *testing.T) {
+	db, td, err := setup(t)
+	require.Nil(t, err)
+
+	defer td()
+
+	_, err = newAddressTxnsBkt(db)
+	require.Nil(t, err)
+
+	// the address_txns bucket must be exist
+	db.View(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket([]byte("address_txns"))
+		require.NotNil(t, bkt)
+		return nil
+	})
+}
+
+func TestAddAddressTxns(t *testing.T) {
+	var preAddrs []cipher.Address
+	var preTxHashes []cipher.SHA256
+
+	type pair struct {
+		addr   cipher.Address
+		txHash cipher.SHA256
+	}
+
+	type expectPair struct {
+		addr cipher.Address
+		txs  []cipher.SHA256
+	}
+
+	for i := 0; i < 3; i++ {
+		preAddrs = append(preAddrs, makeAddress())
+		preTxHashes = append(preTxHashes, cipher.SumSHA256([]byte(fmt.Sprintf("tx%d", i))))
+	}
+
+	var testCases = []struct {
+		name     string
+		addPairs []pair
+		expect   []expectPair
+	}{
+		{
+			"address with single tx",
+			[]pair{
+				{
+					addr:   preAddrs[0],
+					txHash: preTxHashes[0],
+				},
+				{
+					addr:   preAddrs[1],
+					txHash: preTxHashes[1],
+				},
+			},
+			[]expectPair{
+				{
+					preAddrs[0],
+					preTxHashes[:1],
+				},
+				{
+					preAddrs[1],
+					preTxHashes[1:2],
+				},
+			},
+		},
+		{
+			"address with multiple transactions",
+			[]pair{
+				{
+					addr:   preAddrs[0],
+					txHash: preTxHashes[0],
+				},
+				{
+					addr:   preAddrs[0],
+					txHash: preTxHashes[1],
+				},
+			},
+			[]expectPair{
+				{
+					preAddrs[0],
+					preTxHashes[:2],
+				},
+			},
+		},
+		{
+			"add address with multiple same transactions",
+			[]pair{
+				{
+					addr:   preAddrs[0],
+					txHash: preTxHashes[0],
+				},
+				{
+					addr:   preAddrs[0],
+					txHash: preTxHashes[0],
+				},
+				{
+					addr:   preAddrs[0],
+					txHash: preTxHashes[0],
+				},
+			},
+			[]expectPair{
+				{
+					preAddrs[0],
+					preTxHashes[:1],
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, td, err := setup(t)
+			require.Nil(t, err)
+			defer td()
+
+			_, err = newAddressTxnsBkt(db)
+			require.Nil(t, err)
+
+			require.Nil(t, db.Update(func(tx *bolt.Tx) error {
+				bkt := tx.Bucket(addressTxnsBktName)
+				for _, pr := range tc.addPairs {
+					require.Nil(t, setAddressTxns(bkt, pr.addr, pr.txHash))
+				}
+				return nil
+			}))
+
+			for _, e := range tc.expect {
+				db.View(func(tx *bolt.Tx) error {
+					bkt := tx.Bucket(addressTxnsBktName)
+					v := bkt.Get(e.addr.Bytes())
+					require.NotNil(t, v)
+					var hashes []cipher.SHA256
+					require.Nil(t, encoder.DeserializeRaw(v, &hashes))
+					require.Equal(t, e.txs, hashes)
+					return nil
+				})
+			}
+
+		})
+	}
+}
+
+func TestGetAddressTxns(t *testing.T) {
+	var preAddrs []cipher.Address
+	var preTxHashes []cipher.SHA256
+
+	type pair struct {
+		addr   cipher.Address
+		txHash cipher.SHA256
+	}
+
+	type expectPair struct {
+		addr cipher.Address
+		txs  []cipher.SHA256
+	}
+
+	for i := 0; i < 3; i++ {
+		preAddrs = append(preAddrs, makeAddress())
+		preTxHashes = append(preTxHashes, cipher.SumSHA256([]byte(fmt.Sprintf("tx%d", i))))
+	}
+
+	var testCases = []struct {
+		name     string
+		addPairs []pair
+		expect   []expectPair
+	}{
+		{
+			"address with single tx",
+			[]pair{
+				{
+					addr:   preAddrs[0],
+					txHash: preTxHashes[0],
+				},
+				{
+					addr:   preAddrs[1],
+					txHash: preTxHashes[1],
+				},
+			},
+			[]expectPair{
+				{
+					preAddrs[0],
+					preTxHashes[:1],
+				},
+				{
+					preAddrs[1],
+					preTxHashes[1:2],
+				},
+			},
+		},
+		{
+			"address with multiple transactions",
+			[]pair{
+				{
+					addr:   preAddrs[0],
+					txHash: preTxHashes[0],
+				},
+				{
+					addr:   preAddrs[0],
+					txHash: preTxHashes[1],
+				},
+			},
+			[]expectPair{
+				{
+					preAddrs[0],
+					preTxHashes[:2],
+				},
+			},
+		},
+		{
+			"add address with multiple same transactions",
+			[]pair{
+				{
+					addr:   preAddrs[0],
+					txHash: preTxHashes[0],
+				},
+				{
+					addr:   preAddrs[0],
+					txHash: preTxHashes[0],
+				},
+				{
+					addr:   preAddrs[0],
+					txHash: preTxHashes[0],
+				},
+			},
+			[]expectPair{
+				{
+					preAddrs[0],
+					preTxHashes[:1],
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, td, err := setup(t)
+			require.Nil(t, err)
+			defer td()
+
+			addrTxnsBkt, err := newAddressTxnsBkt(db)
+			require.Nil(t, err)
+
+			require.Nil(t, db.Update(func(tx *bolt.Tx) error {
+				bkt := tx.Bucket(addressTxnsBktName)
+
+				for _, pr := range tc.addPairs {
+					if err := setAddressTxns(bkt, pr.addr, pr.txHash); err != nil {
+						return err
+					}
+				}
+
+				return nil
+			}))
+
+			for _, e := range tc.expect {
+				hashes, err := addrTxnsBkt.Get(e.addr)
+				require.Nil(t, err)
+				require.Equal(t, e.txs, hashes)
+			}
+
+		})
+	}
+}

--- a/src/visor/historydb/address_uxout.go
+++ b/src/visor/historydb/address_uxout.go
@@ -12,9 +12,6 @@ type addressUx struct {
 	bkt *bucket.Bucket
 }
 
-// func newAddressUx(db *bolt.DB, name []byte) (*addressUx, error) {
-// }
-
 // create address affected UxOuts bucket.
 func newAddressUxBkt(db *bolt.DB) (*addressUx, error) {
 	bkt, err := bucket.New([]byte("address_in"), db)
@@ -59,6 +56,16 @@ func (au *addressUx) Add(address cipher.Address, uxHash cipher.SHA256) error {
 	hashes = append(hashes, uxHash)
 	bin := encoder.Serialize(hashes)
 	return au.bkt.Put(address.Bytes(), bin)
+}
+
+// IsEmpty checks if the addressUx bucket is empty
+func (au *addressUx) IsEmpty() bool {
+	return au.bkt.IsEmpty()
+}
+
+// Reset resets the bucket
+func (au *addressUx) Reset() error {
+	return au.bkt.Reset()
 }
 
 func setAddressUx(bkt *bolt.Bucket, addr cipher.Address, uxHash cipher.SHA256) error {

--- a/src/visor/historydb/address_uxout.go
+++ b/src/visor/historydb/address_uxout.go
@@ -12,18 +12,17 @@ type addressUx struct {
 	bkt *bucket.Bucket
 }
 
-func newAddressUx(db *bolt.DB, name []byte) (*addressUx, error) {
-	bkt, err := bucket.New(name, db)
+// func newAddressUx(db *bolt.DB, name []byte) (*addressUx, error) {
+// }
+
+// create address affected UxOuts bucket.
+func newAddressUxBkt(db *bolt.DB) (*addressUx, error) {
+	bkt, err := bucket.New([]byte("address_in"), db)
 	if err != nil {
 		return nil, err
 	}
 
 	return &addressUx{bkt}, nil
-}
-
-// create address affected UxOuts bucket.
-func newAddressUxBkt(db *bolt.DB) (*addressUx, error) {
-	return newAddressUx(db, []byte("address_in"))
 }
 
 // Get return nil on not found.

--- a/src/visor/historydb/history_meta.go
+++ b/src/visor/historydb/history_meta.go
@@ -34,3 +34,13 @@ func (hm *historyMeta) ParsedHeight() int64 {
 func (hm *historyMeta) setParsedHeight(h uint64) error {
 	return hm.v.Put(parsedHeightKey, bucket.Itob(h))
 }
+
+// IsEmpty checks if history meta bucket is empty
+func (hm *historyMeta) IsEmpty() bool {
+	return hm.v.IsEmpty()
+}
+
+// Reset resets the bucket
+func (hm *historyMeta) Reset() error {
+	return hm.v.Reset()
+}

--- a/src/visor/historydb/history_meta_test.go
+++ b/src/visor/historydb/history_meta_test.go
@@ -1,6 +1,3 @@
-// +build ignore
-// These tests need to be rewritten to conform with blockdb changes
-
 package historydb
 
 import (
@@ -57,10 +54,10 @@ func TestHistoryMetaSetParsedHeight(t *testing.T) {
 
 	hm, err := newHistoryMeta(db)
 	assert.Nil(t, err)
-	assert.Nil(t, hm.SetParsedHeight(0))
+	assert.Nil(t, hm.setParsedHeight(0))
 	assert.Equal(t, uint64(0), bucket.Btoi(hm.v.Get(parsedHeightKey)))
 
 	// set 10
-	hm.SetParsedHeight(10)
+	hm.setParsedHeight(10)
 	assert.Equal(t, uint64(10), bucket.Btoi(hm.v.Get(parsedHeightKey)))
 }

--- a/src/visor/historydb/historydb.go
+++ b/src/visor/historydb/historydb.go
@@ -26,6 +26,7 @@ type HistoryDB struct {
 	txns         *transactions // transactions bucket.
 	outputs      *UxOuts       // outputs bucket.
 	addrUx       *addressUx    // bucket which stores all UxOuts that address recved.
+	addrTxns     *addressTxns  //  address related transaction bucket
 	*historyMeta               // stores history meta info
 }
 
@@ -83,6 +84,7 @@ func (hd *HistoryDB) ProcessBlock(b *coin.Block) error {
 			txnsBkt := tx.Bucket(hd.txns.bkt.Name)
 			outputsBkt := tx.Bucket(hd.outputs.bkt.Name)
 			addrUxBkt := tx.Bucket(hd.addrUx.bkt.Name)
+			addrTxnsBkt := tx.Bucket(hd.addrTxns.bkt.Name)
 
 			if err := addTrandaction(txnsBkt, &txn); err != nil {
 				return err
@@ -101,6 +103,11 @@ func (hd *HistoryDB) ProcessBlock(b *coin.Block) error {
 					if err := setOutput(outputsBkt, *o); err != nil {
 						return err
 					}
+
+					// store the IN address with txid
+					if err := setAddressTxns(addrTxnsBkt, o.Out.Body.Address, t.Hash()); err != nil {
+						return err
+					}
 				}
 			}
 
@@ -115,6 +122,10 @@ func (hd *HistoryDB) ProcessBlock(b *coin.Block) error {
 				}
 
 				if err := setAddressUx(addrUxBkt, ux.Body.Address, ux.Hash()); err != nil {
+					return err
+				}
+
+				if err := setAddressTxns(addrTxnsBkt, ux.Body.Address, t.Hash()); err != nil {
 					return err
 				}
 			}
@@ -165,4 +176,14 @@ func (hd HistoryDB) GetAddrUxOuts(address cipher.Address) ([]*UxOut, error) {
 		uxOuts[i] = ux
 	}
 	return uxOuts, nil
+}
+
+// GetAddrTxns returns all the address related transactions
+func (hd HistoryDB) GetAddrTxns(address cipher.Address) ([]Transaction, error) {
+	hashes, err := hd.addrTxns.Get(address)
+	if err != nil {
+		return []Transaction{}, err
+	}
+
+	return hd.txns.GetSlice(hashes)
 }

--- a/src/visor/historydb/historydb.go
+++ b/src/visor/historydb/historydb.go
@@ -77,32 +77,10 @@ func (hd *HistoryDB) ResetIfNeed() error {
 	}
 
 	// if any of the following buckets are empty, need to reset
-	var reset bool
-	for {
-		if hd.addrTxns.IsEmpty() {
-			reset = true
-			break
-		}
-
-		if hd.addrUx.IsEmpty() {
-			reset = true
-			break
-		}
-
-		if hd.txns.IsEmpty() {
-			reset = true
-			break
-		}
-
-		if hd.outputs.IsEmpty() {
-			reset = true
-			break
-		}
-
-		break
-	}
-
-	if reset {
+	if hd.addrTxns.IsEmpty() ||
+		hd.addrUx.IsEmpty() ||
+		hd.txns.IsEmpty() ||
+		hd.outputs.IsEmpty() {
 		return hd.reset()
 	}
 

--- a/src/visor/historydb/output.go
+++ b/src/visor/historydb/output.go
@@ -66,15 +66,15 @@ func newOutputsBkt(db *bolt.DB) (*UxOuts, error) {
 }
 
 // Set sets out value
-func (op *UxOuts) Set(out UxOut) error {
+func (ux *UxOuts) Set(out UxOut) error {
 	key := out.Hash()
 	bin := encoder.Serialize(out)
-	return op.bkt.Put(key[:], bin)
+	return ux.bkt.Put(key[:], bin)
 }
 
 // Get gets UxOut of given id
-func (op *UxOuts) Get(uxID cipher.SHA256) (*UxOut, error) {
-	bin := op.bkt.Get(uxID[:])
+func (ux *UxOuts) Get(uxID cipher.SHA256) (*UxOut, error) {
+	bin := ux.bkt.Get(uxID[:])
 	if bin == nil {
 		return nil, nil
 	}
@@ -85,6 +85,16 @@ func (op *UxOuts) Get(uxID cipher.SHA256) (*UxOut, error) {
 	}
 
 	return &out, nil
+}
+
+// IsEmpty checks if the uxout bucekt is empty
+func (ux *UxOuts) IsEmpty() bool {
+	return ux.bkt.IsEmpty()
+}
+
+// Reset resets the bucket
+func (ux *UxOuts) Reset() error {
+	return ux.bkt.Reset()
 }
 
 func getOutput(bkt *bolt.Bucket, hash cipher.SHA256) (*UxOut, error) {

--- a/src/visor/historydb/transaction.go
+++ b/src/visor/historydb/transaction.go
@@ -101,7 +101,7 @@ func (txs *transactions) IsEmpty() bool {
 	return txs.bkt.IsEmpty()
 }
 
-// Reset resets the bucekt
+// Reset resets the bucket
 func (txs *transactions) Reset() error {
 	return txs.bkt.Reset()
 }

--- a/src/visor/historydb/transaction.go
+++ b/src/visor/historydb/transaction.go
@@ -61,7 +61,7 @@ func (txs *transactions) Add(t *Transaction) error {
 }
 
 // Get get transaction by tx hash, return nil on not found.
-func (txs transactions) Get(hash cipher.SHA256) (*Transaction, error) {
+func (txs *transactions) Get(hash cipher.SHA256) (*Transaction, error) {
 	bin := txs.bkt.Get(hash[:])
 	if bin == nil {
 		return nil, nil
@@ -76,8 +76,38 @@ func (txs transactions) Get(hash cipher.SHA256) (*Transaction, error) {
 	return &tx, nil
 }
 
+// GetSlice returns transactions slice of given hashes
+func (txs *transactions) GetSlice(hashes []cipher.SHA256) ([]Transaction, error) {
+	keys := [][]byte{}
+	for i := range hashes {
+		keys = append(keys, hashes[i][:])
+	}
+
+	vs := txs.bkt.GetSlice(keys)
+	txns := make([]Transaction, 0, len(vs))
+	for i := range vs {
+		var tx Transaction
+		if err := encoder.DeserializeRaw(vs[i], &tx); err != nil {
+			return []Transaction{}, err
+		}
+		txns = append(txns, tx)
+	}
+
+	return txns, nil
+}
+
+// IsEmpty checks if transaction bucket is empty
+func (txs *transactions) IsEmpty() bool {
+	return txs.bkt.IsEmpty()
+}
+
+// Reset resets the bucekt
+func (txs *transactions) Reset() error {
+	return txs.bkt.Reset()
+}
+
 // GetLastTxs get latest tx hash set.
-func (txs transactions) GetLastTxs() []cipher.SHA256 {
+func (txs *transactions) GetLastTxs() []cipher.SHA256 {
 	return txs.lastTxs
 }
 

--- a/src/visor/historydb/transaction_test.go
+++ b/src/visor/historydb/transaction_test.go
@@ -1,6 +1,3 @@
-// +build ignore
-// These tests need to be rewritten to conform with blockdb changes
-
 package historydb
 
 import (

--- a/src/visor/historydb/transaction_test.go
+++ b/src/visor/historydb/transaction_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/coin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // set rand seed.
@@ -45,6 +46,120 @@ func TestGetLastTxs(t *testing.T) {
 			lastTxHash := txIns.GetLastTxs()
 			assert.Equal(t, txs, lastTxHash)
 		}(uint64(i))
+	}
+}
+
+func TestTransactionGet(t *testing.T) {
+	txs := make([]Transaction, 0, 3)
+	for i := 0; i < 3; i++ {
+		txs = append(txs, makeTransaction())
+	}
+
+	testCases := []struct {
+		name   string
+		hash   cipher.SHA256
+		expect *Transaction
+	}{
+		{
+			"get first",
+			txs[0].Hash(),
+			&txs[0],
+		},
+		{
+			"get second",
+			txs[1].Hash(),
+			&txs[1],
+		},
+		{
+			"not exist",
+			txs[2].Hash(),
+			nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, td, err := setup(t)
+			require.Nil(t, err)
+			defer td()
+			txsBkt, err := newTransactionsBkt(db)
+			require.Nil(t, err)
+
+			// init the bkt
+			for _, tx := range txs[:2] {
+				require.Nil(t, txsBkt.Add(&tx))
+			}
+
+			// get slice
+			ts, err := txsBkt.Get(tc.hash)
+			require.Nil(t, err)
+			require.Equal(t, tc.expect, ts)
+		})
+	}
+}
+
+func TestTransactionGetSlice(t *testing.T) {
+	txs := make([]Transaction, 0, 4)
+	for i := 0; i < 4; i++ {
+		txs = append(txs, makeTransaction())
+	}
+
+	testCases := []struct {
+		name   string
+		hashes []cipher.SHA256
+		expect []Transaction
+	}{
+		{
+			"get one",
+			[]cipher.SHA256{
+				txs[0].Hash(),
+			},
+			txs[:1],
+		},
+		{
+			"get two",
+			[]cipher.SHA256{
+				txs[0].Hash(),
+				txs[1].Hash(),
+			},
+			txs[:2],
+		},
+		{
+			"get all",
+			[]cipher.SHA256{
+				txs[0].Hash(),
+				txs[1].Hash(),
+				txs[2].Hash(),
+			},
+			txs[:3],
+		},
+		{
+			"not exist",
+			[]cipher.SHA256{
+				txs[3].Hash(),
+			},
+			[]Transaction{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, td, err := setup(t)
+			require.Nil(t, err)
+			defer td()
+			txsBkt, err := newTransactionsBkt(db)
+			require.Nil(t, err)
+
+			// init the bkt
+			for _, tx := range txs[:3] {
+				require.Nil(t, txsBkt.Add(&tx))
+			}
+
+			// get slice
+			ts, err := txsBkt.GetSlice(tc.hashes)
+			require.Nil(t, err)
+			require.Equal(t, tc.expect, ts)
+		})
 	}
 }
 

--- a/src/visor/readable.go
+++ b/src/visor/readable.go
@@ -114,7 +114,7 @@ type ReadableTransactionOutput struct {
 	Hash    string `json:"uxid"`
 	Address string `json:"dst"`
 	Coins   string `json:"coins"`
-	Hours   uint64 `json:"hours"`
+	Hours   string `json:"hours"`
 }
 
 // ReadableTransactionInput readable transaction input
@@ -161,7 +161,7 @@ func NewReadableTransactionOutput(t *coin.TransactionOutput, txid cipher.SHA256)
 		Hash:    t.UxID(txid).Hex(),
 		Address: t.Address.String(), //Destination Address
 		Coins:   StrBalance(t.Coins),
-		Hours:   t.Hours,
+		Hours:   strconv.FormatUint(t.Hours, 10),
 	}
 }
 
@@ -179,7 +179,7 @@ type ReadableOutput struct {
 	SourceTransaction string `json:"src_tx"`
 	Address           string `json:"address"`
 	Coins             string `json:"coins"`
-	Hours             uint64 `json:"hours"`
+	Hours             string `json:"hours"`
 }
 
 // ReadableOutputSet records unspent outputs in different status.
@@ -216,7 +216,7 @@ func NewReadableOutput(t coin.UxOut) ReadableOutput {
 		SourceTransaction: t.Body.SrcTransaction.Hex(),
 		Address:           t.Body.Address.String(),
 		Coins:             StrBalance(t.Body.Coins),
-		Hours:             t.Body.Hours,
+		Hours:             strconv.FormatUint(t.Body.Hours, 10),
 	}
 }
 
@@ -380,7 +380,7 @@ type TransactionOutputJSON struct {
 	SourceTransaction string `json:"src_tx"`
 	Address           string `json:"address"` // Address of receiver
 	Coins             string `json:"coins"`   // Number of coins
-	Hours             uint64 `json:"hours"`   // Coin hours
+	Hours             string `json:"hours"`   // Coin hours
 }
 
 // NewTransactionOutputJSON creates transaction output json
@@ -400,7 +400,7 @@ func NewTransactionOutputJSON(ux coin.TransactionOutput, srcTx cipher.SHA256) Tr
 
 	o.Address = ux.Address.String()
 	o.Coins = StrBalance(ux.Coins)
-	o.Hours = ux.Hours
+	o.Hours = strconv.FormatUint(ux.Hours, 10)
 	return o
 }
 
@@ -408,18 +408,17 @@ func NewTransactionOutputJSON(ux coin.TransactionOutput, srcTx cipher.SHA256) Tr
 func TransactionOutputFromJSON(in TransactionOutputJSON) (coin.TransactionOutput, error) {
 	var tx coin.TransactionOutput
 
-	//hash, err := cipher.SHA256FromHex(in.Hash)
-	//if err != nil {
-	//	return coin.TransactionOutput{}, errors.New("Invalid hash")
-	//}
 	addr, err := cipher.DecodeBase58Address(in.Address)
 	if err != nil {
 		return coin.TransactionOutput{}, errors.New("Address decode fail")
 	}
-	//tx.Hash = hash
+
 	tx.Address = addr
 	tx.Coins = StrBalance2(in.Coins)
-	tx.Hours = in.Hours
+	tx.Hours, err = strconv.ParseUint(in.Hours, 10, 64)
+	if err != nil {
+		return coin.TransactionOutput{}, err
+	}
 
 	return tx, nil
 }

--- a/src/visor/readable.go
+++ b/src/visor/readable.go
@@ -380,7 +380,7 @@ type TransactionOutputJSON struct {
 	SourceTransaction string `json:"src_tx"`
 	Address           string `json:"address"` // Address of receiver
 	Coins             string `json:"coins"`   // Number of coins
-	Hours             string `json:"hours"`   // Coin hours
+	Hours             uint64 `json:"hours"`   // Coin hours
 }
 
 // NewTransactionOutputJSON creates transaction output json
@@ -400,7 +400,7 @@ func NewTransactionOutputJSON(ux coin.TransactionOutput, srcTx cipher.SHA256) Tr
 
 	o.Address = ux.Address.String()
 	o.Coins = StrBalance(ux.Coins)
-	o.Hours = strconv.FormatUint(ux.Hours, 10)
+	o.Hours = ux.Hours
 	return o
 }
 
@@ -415,7 +415,7 @@ func TransactionOutputFromJSON(in TransactionOutputJSON) (coin.TransactionOutput
 
 	tx.Address = addr
 	tx.Coins = StrBalance2(in.Coins)
-	tx.Hours, err = strconv.ParseUint(in.Hours, 10, 64)
+	tx.Hours = in.Hours
 	if err != nil {
 		return coin.TransactionOutput{}, err
 	}

--- a/src/visor/readable.go
+++ b/src/visor/readable.go
@@ -114,7 +114,7 @@ type ReadableTransactionOutput struct {
 	Hash    string `json:"uxid"`
 	Address string `json:"dst"`
 	Coins   string `json:"coins"`
-	Hours   string `json:"hours"`
+	Hours   uint64 `json:"hours"`
 }
 
 // ReadableTransactionInput readable transaction input
@@ -161,7 +161,7 @@ func NewReadableTransactionOutput(t *coin.TransactionOutput, txid cipher.SHA256)
 		Hash:    t.UxID(txid).Hex(),
 		Address: t.Address.String(), //Destination Address
 		Coins:   StrBalance(t.Coins),
-		Hours:   strconv.FormatUint(t.Hours, 10),
+		Hours:   t.Hours,
 	}
 }
 
@@ -179,7 +179,7 @@ type ReadableOutput struct {
 	SourceTransaction string `json:"src_tx"`
 	Address           string `json:"address"`
 	Coins             string `json:"coins"`
-	Hours             string `json:"hours"`
+	Hours             uint64 `json:"hours"`
 }
 
 // ReadableOutputSet records unspent outputs in different status.
@@ -216,7 +216,7 @@ func NewReadableOutput(t coin.UxOut) ReadableOutput {
 		SourceTransaction: t.Body.SrcTransaction.Hex(),
 		Address:           t.Body.Address.String(),
 		Coins:             StrBalance(t.Body.Coins),
-		Hours:             strconv.FormatUint(t.Body.Hours, 10),
+		Hours:             t.Body.Hours,
 	}
 }
 

--- a/src/visor/readable.go
+++ b/src/visor/readable.go
@@ -233,19 +233,6 @@ type ReadableTransaction struct {
 	Out  []ReadableTransactionOutput `json:"outputs"`
 }
 
-// ReadableAddressTransaction represents readable address transaction
-type ReadableAddressTransaction struct {
-	Length    uint32 `json:"length"`
-	Type      uint8  `json:"type"`
-	Hash      string `json:"txid"`
-	InnerHash string `json:"inner_hash"`
-	Timestamp uint64 `json:"timestamp,omitempty"`
-
-	Sigs []string                    `json:"sigs"`
-	In   []ReadableTransactionInput  `json:"inputs"`
-	Out  []ReadableTransactionOutput `json:"outputs"`
-}
-
 // ReadableUnconfirmedTxn  represents readable unconfirmed transaction
 type ReadableUnconfirmedTxn struct {
 	Txn       ReadableTransaction `json:"transaction"`
@@ -320,31 +307,6 @@ func NewReadableTransaction(t *Transaction) ReadableTransaction {
 
 		Sigs: sigs,
 		In:   in,
-		Out:  out,
-	}
-}
-
-// NewReadableAddressTransaction creates readable address transaction
-func NewReadableAddressTransaction(t *Transaction, inputs []ReadableTransactionInput) ReadableAddressTransaction {
-	txid := t.Txn.Hash()
-	sigs := make([]string, len(t.Txn.Sigs))
-	for i := range t.Txn.Sigs {
-		sigs[i] = t.Txn.Sigs[i].Hex()
-	}
-	out := make([]ReadableTransactionOutput, len(t.Txn.Out))
-
-	for i := range t.Txn.Out {
-		out[i] = NewReadableTransactionOutput(&t.Txn.Out[i], txid)
-	}
-	return ReadableAddressTransaction{
-		Length:    t.Txn.Length,
-		Type:      t.Txn.Type,
-		Hash:      t.Txn.Hash().Hex(),
-		InnerHash: t.Txn.InnerHash.Hex(),
-		Timestamp: t.Time,
-
-		Sigs: sigs,
-		In:   inputs,
 		Out:  out,
 	}
 }

--- a/src/visor/rpc.go
+++ b/src/visor/rpc.go
@@ -10,6 +10,7 @@ import (
 // TransactionResult represents transaction result
 type TransactionResult struct {
 	Status      TransactionStatus   `json:"status"`
+	Time        uint64              `json:"time"`
 	Transaction ReadableTransaction `json:"txn"`
 }
 
@@ -121,13 +122,14 @@ func (rpc RPC) GetTransaction(v *Visor, txHash cipher.SHA256) (*TransactionResul
 	return &TransactionResult{
 		Transaction: NewReadableTransaction(txn),
 		Status:      txn.Status,
+		Time:        txn.Time,
 	}, nil
 }
 
-// GetAddressTransactions get address transactions
-func (rpc RPC) GetAddressTransactions(v *Visor,
+// GetAddressTxns get address transactions
+func (rpc RPC) GetAddressTxns(v *Visor,
 	addr cipher.Address) (*TransactionResults, error) {
-	addrTxns, err := v.GetAddressTransactions(addr)
+	addrTxns, err := v.GetAddressTxns(addr)
 	if err != nil {
 		return nil, err
 	}
@@ -137,6 +139,7 @@ func (rpc RPC) GetAddressTransactions(v *Visor,
 		txns[i] = TransactionResult{
 			Transaction: NewReadableTransaction(&tx),
 			Status:      tx.Status,
+			Time:        tx.Time,
 		}
 	}
 	return &TransactionResults{

--- a/src/visor/unconfirmed.go
+++ b/src/visor/unconfirmed.go
@@ -109,6 +109,10 @@ func (utb *uncfmTxnBkt) put(v *UnconfirmedTxn) error {
 
 func (utb *uncfmTxnBkt) update(key cipher.SHA256, f func(v *UnconfirmedTxn)) error {
 	updateFun := func(v []byte) ([]byte, error) {
+		if v == nil {
+			return nil, fmt.Errorf("%s is not exist in bucket %s", key.Hex(), utb.txns.Name)
+		}
+
 		var tx UnconfirmedTxn
 		if err := encoder.DeserializeRaw(v, &tx); err != nil {
 			return nil, err

--- a/src/visor/unconfirmed.go
+++ b/src/visor/unconfirmed.go
@@ -110,7 +110,7 @@ func (utb *uncfmTxnBkt) put(v *UnconfirmedTxn) error {
 func (utb *uncfmTxnBkt) update(key cipher.SHA256, f func(v *UnconfirmedTxn)) error {
 	updateFun := func(v []byte) ([]byte, error) {
 		if v == nil {
-			return nil, fmt.Errorf("%s is not exist in bucket %s", key.Hex(), utb.txns.Name)
+			return nil, fmt.Errorf("%s does not exist in bucket %s", key.Hex(), utb.txns.Name)
 		}
 
 		var tx UnconfirmedTxn

--- a/src/visor/unconfirmed.go
+++ b/src/visor/unconfirmed.go
@@ -314,7 +314,6 @@ func (utp *UnconfirmedTxnPool) InjectTxn(bc *Blockchain, t coin.Transaction) (kn
 	// Update if we already have this txn
 	h := t.Hash()
 	// update the time if exist
-	var exist bool
 	utp.Txns.update(h, func(tx *UnconfirmedTxn) {
 		know = true
 		now := utc.Now()
@@ -323,7 +322,7 @@ func (utp *UnconfirmedTxnPool) InjectTxn(bc *Blockchain, t coin.Transaction) (kn
 		tx.IsValid = valid
 	})
 
-	if exist {
+	if know {
 		return
 	}
 

--- a/src/visor/unconfirmed_test.go
+++ b/src/visor/unconfirmed_test.go
@@ -1032,7 +1032,7 @@ func TestUnconfirmTxBktUpdate(t *testing.T) {
 			uctxs[:2],
 			2,
 			time.Now().UnixNano(),
-			fmt.Errorf("%s is not exist in bucket unconfirmed_txns", uctxs[2].Hash().Hex()),
+			fmt.Errorf("%s does not exist in bucket unconfirmed_txns", uctxs[2].Hash().Hex()),
 		},
 	}
 

--- a/src/visor/unconfirmed_test.go
+++ b/src/visor/unconfirmed_test.go
@@ -1032,7 +1032,7 @@ func TestUnconfirmTxBktUpdate(t *testing.T) {
 			uctxs[:2],
 			2,
 			time.Now().UnixNano(),
-			fmt.Errorf("%s not exist in bucket unconfirmed_txns", uctxs[2].Hash().Hex()),
+			fmt.Errorf("%s is not exist in bucket unconfirmed_txns", uctxs[2].Hash().Hex()),
 		},
 	}
 

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -196,17 +196,6 @@ func NewVisor(c Config) (*Visor, VsClose, error) {
 
 // Run starts the visor process
 func (vs *Visor) Run() error {
-	errC := make(chan error, 1)
-
-	go func() {
-		logger.Info("Verify signature...")
-		if err := vs.Blockchain.VerifySigs(vs.Config.BlockchainPubkey, vs.blockSigs); err != nil {
-			errC <- fmt.Errorf("Invalid block signatures: %v", err)
-			return
-		}
-		logger.Info("Signature verify success")
-	}()
-
 	if vs.Blockchain.GetGenesisBlock() == nil {
 		vs.GenesisPreconditions()
 		b, err := vs.Blockchain.CreateGenesisBlock(
@@ -236,6 +225,16 @@ func (vs *Visor) Run() error {
 			}
 		}
 	}
+
+	errC := make(chan error, 1)
+	go func() {
+		logger.Info("Verify signature...")
+		if err := vs.Blockchain.VerifySigs(vs.Config.BlockchainPubkey, vs.blockSigs); err != nil {
+			errC <- fmt.Errorf("Invalid block signatures: %v", err)
+			return
+		}
+		logger.Info("Signature verify success")
+	}()
 
 	go func() {
 		errC <- vs.bcParser.Run()

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -478,33 +478,34 @@ func (vs *Visor) InjectTxn(txn coin.Transaction) (bool, error) {
 	return vs.Unconfirmed.InjectTxn(vs.Blockchain, txn)
 }
 
-// GetAddressTransactions returns the Transactions whose unspents give coins to a cipher.Address.
+// GetAddressTxns returns the Transactions whose unspents give coins to a cipher.Address.
 // This includes unconfirmed txns' predicted unspents.
-func (vs *Visor) GetAddressTransactions(a cipher.Address) ([]Transaction, error) {
+func (vs *Visor) GetAddressTxns(a cipher.Address) ([]Transaction, error) {
 	var txns []Transaction
-	// Look in the blockchain
-	uxs := vs.Blockchain.Unspent().GetUnspentsOfAddr(a)
 
 	mxSeq := vs.HeadBkSeq()
-	var bk *coin.Block
-	for _, ux := range uxs {
-		if bk = vs.GetBlockBySeq(ux.Head.BkSeq); bk == nil {
-			return txns, nil
+	txs, err := vs.history.GetAddrTxns(a)
+	if err != nil {
+		return []Transaction{}, err
+	}
+
+	for _, tx := range txs {
+		h := mxSeq - tx.BlockSeq + 1
+
+		bk := vs.GetBlockBySeq(tx.BlockSeq)
+		if bk == nil {
+			return []Transaction{}, fmt.Errorf("No block exsit in depth:%d", tx.BlockSeq)
 		}
 
-		tx, ok := bk.GetTransaction(ux.Body.SrcTransaction)
-		if ok {
-			h := mxSeq - bk.Head.BkSeq + 1
-			txns = append(txns, Transaction{
-				Txn:    tx,
-				Status: NewConfirmedTransactionStatus(h, bk.Head.BkSeq),
-				Time:   bk.Time(),
-			})
-		}
+		txns = append(txns, Transaction{
+			Txn:    tx.Tx,
+			Status: NewConfirmedTransactionStatus(h, tx.BlockSeq),
+			Time:   bk.Time(),
+		})
 	}
 
 	// Look in the unconfirmed pool
-	uxs = vs.Unconfirmed.Unspent.getAllForAddress(a)
+	uxs := vs.Unconfirmed.Unspent.getAllForAddress(a)
 	for _, ux := range uxs {
 		tx, ok := vs.Unconfirmed.Txns.get(ux.Body.SrcTransaction)
 		if !ok {


### PR DESCRIPTION
* Fix issue #376 , which affect both the history page in wallet and explorer, the old `/explorer/address` api will only return `receive` coins transaction
* Make /wallet/newAddress api able to create multiple address in one api call, and update corresponding client code
* Fix failed test in src/visor/historydb package
* Fix  #416, 'Duplicate transaction' printf
