### PR TITLE
Added travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: required
+dist: trusty
+language:
+  - go
+before_install:
+  - sudo apt-get install curl git mercurial make binutils gcc bzr bison libgmp3-dev screen -y
+  - bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
+  - source $HOME/.gvm/scripts/gvm
+  - gvm install go1.4 --source=https://github.com/golang/go
+  - gvm use go1.4
+  - gvm install go1.8
+  - gvm use go1.8 --default
+
+install:
+  - go get -v github.com/skycoin/skycoin/...
+
+script:
+  - go build cmd/skycoin/skycoin.go
+
+notifications:
+  email: false


### PR DESCRIPTION
Added travis CI to build  skycoin node and running uni-test for every push commit done for the project.
To make the CI running need to do the following:
 1. Login with github account of the maintainer that has admin permissions for the Skycoin repository on  https://travis-ci.org/ . 
2. AT Travis profile page need to enable the repository -flick the switch to turn it on.
All set.
3. Next time anyone does push in the repository the CI will be initiated , and log file from this run can be viewed in the profile by going to "build history" there.  