### PR TITLE
Cleanup address gen cli and api

### DIFF
--- a/cmd/address_gen/address_gen.go
+++ b/cmd/address_gen/address_gen.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/wallet"
 )
 
 // Note: Address_gen generates public keys and addresses
@@ -18,133 +20,37 @@ import (
 // -add option to password the secret key
 // -let people add the key from the command line
 
-var (
-	// HideSeckey whether need hide secret key
-	HideSeckey = false
-	// BitcoinAddress represents if need to generate bitcoin address
-	BitcoinAddress = false
-
-	seed     = ""
-	genCount = 1
-)
-
-func registerFlags() {
-
-	flag.IntVar(&genCount, "n", genCount,
-		"number of addresses to generate")
-
-	flag.BoolVar(&HideSeckey, "s", HideSeckey,
-		"only generate publickey and address, hide seckey")
-
-	flag.BoolVar(&BitcoinAddress, "b", BitcoinAddress,
-		"print seckey address as bitcoin address")
-
-	flag.StringVar(&seed, "seed", seed,
-		"seed for deterministic key generation")
-
-	//flag.StringVar(&outFile, "o", outFile,
-	//    "If present, will create a new wallet entry and write to disk. "+
-	//        "For safety, it will not overwrite an existing keypair")
-	//flag.BoolVar(&printSecret, "print-secret", printSecret,
-	//    "Print the wallet entry's secret key")
-	//flag.StringVar(&inFile, "i", inFile,
-	//    "Will read a wallet entry from this file for printing info")
-}
-
-func parseFlags() {
-	flag.Parse()
-}
-
-// Wallet represents the wallet
-type Wallet struct {
-	Meta    map[string]string `json:"meta"`
-	Entries []KeyEntry        `json:"entries"`
-}
-
-// KeyEntry represents the key entry in wallet
-type KeyEntry struct {
-	Address string `json:"address"`
-	Public  string `json:"public_key"`
-	Secret  string `json:"secret_key"`
-}
-
-func getKeyEntry(pub cipher.PubKey, sec cipher.SecKey) KeyEntry {
-
-	var e KeyEntry
-
-	//skycoin address
-	if BitcoinAddress == false {
-		e = KeyEntry{
-			Address: cipher.AddressFromPubKey(pub).String(),
-			Public:  pub.Hex(),
-			Secret:  sec.Hex(),
-		}
-	}
-
-	//bitcoin address
-	if BitcoinAddress == true {
-		e = KeyEntry{
-			Address: cipher.BitcoinAddressFromPubkey(pub),
-			Public:  pub.Hex(),
-			Secret:  cipher.BitcoinWalletImportFormatFromSeckey(sec),
-		}
-	}
-
-	//hide the secret key
-	if HideSeckey == true {
-		e.Secret = ""
-	}
-
-	return e
-}
-
 func main() {
-	registerFlags()
-	parseFlags()
+	genCount := flag.Int("n", 1, "Number of addresses to generate")
+	hideSecKey := flag.Bool("s", false, "Hide the secret key from the output")
+	isBitcoin := flag.Bool("b", false, "Print address as a bitcoin address")
+	seed := flag.String("seed", "", "Seed for deterministic key generation. Will generate a random 1024-byte CSPRNG-generated seed if not provided.")
+	flag.Parse()
 
-	w := Wallet{
-		Meta:    make(map[string]string), //map[string]string
-		Entries: make([]KeyEntry, genCount),
-	}
-
-	if BitcoinAddress == false {
-		w.Meta = map[string]string{"coin": "skycoin"}
+	var coinType wallet.CoinType
+	if *isBitcoin {
+		coinType = wallet.CoinTypeBitcoin
 	} else {
-		w.Meta = map[string]string{"coin": "bitcoin"}
+		coinType = wallet.CoinTypeSkycoin
 	}
 
-	if seed == "" { //generate a new seed, as hex string
-		seed = cipher.SumSHA256(cipher.RandByte(1024)).Hex()
+	if *seed == "" {
+		// generate a new seed, as hex string
+		*seed = cipher.SumSHA256(cipher.RandByte(1024)).Hex()
 	}
 
-	w.Meta["seed"] = seed
+	w, err := wallet.CreateAddresses(coinType, *seed, *genCount, *hideSecKey)
 
-	seckeys := cipher.GenerateDeterministicKeyPairs([]byte(seed), genCount)
-
-	for i, sec := range seckeys {
-		pub := cipher.PubKeyFromSecKey(sec)
-		w.Entries[i] = getKeyEntry(pub, sec)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
 
 	output, err := json.MarshalIndent(w, "", "    ")
 	if err != nil {
-		fmt.Printf("Error formating wallet to JSON. Error : %s\n", err.Error())
-		return
+		fmt.Println("Error formating wallet to JSON. Error:", err)
+		os.Exit(1)
 	}
-	fmt.Printf("%s\n", string(output))
 
+	fmt.Println(string(output))
 }
-
-/*
-   if outFile != "" {
-       w := createWalletEntry(outFile, testNetwork)
-       if w != nil {
-           printWalletEntry(w, labelStdout, PrintAddress, printPublic,
-               printSecret)
-       }
-   }
-   if inFile != "" {
-       printWalletEntryFromFile(inFile, labelStdout, PrintAddress,
-           printPublic, printSecret)
-   }
-*/

--- a/src/wallet/addresses.go
+++ b/src/wallet/addresses.go
@@ -1,0 +1,69 @@
+package wallet
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/skycoin/skycoin/src/cipher"
+)
+
+// Creates genCount addresses deterministically from seed.  coinType is either CoinTypeBitcoin or CoinTypeSkycoin.
+// hideSecretKey will hide the secret key from the output.
+func CreateAddresses(coinType CoinType, seed string, genCount int, hideSecretKey bool) (*ReadableWallet, error) {
+	if genCount < 1 {
+		return nil, errors.New("genCount must be > 0")
+	}
+
+	if seed == "" {
+		return nil, errors.New("seed must not be the empty string")
+	}
+
+	wallet := &ReadableWallet{
+		Meta: map[string]string{
+			"coin": string(coinType),
+			"seed": seed,
+		},
+	}
+
+	seckeys := cipher.GenerateDeterministicKeyPairs([]byte(seed), genCount)
+
+	for _, sec := range seckeys {
+		pub := cipher.PubKeyFromSecKey(sec)
+
+		var entry ReadableEntry
+		switch coinType {
+		case CoinTypeBitcoin:
+			entry = GetBitcoinWalletEntry(pub, sec)
+		case CoinTypeSkycoin:
+			entry = GetSkycoinWalletEntry(pub, sec)
+		default:
+			return nil, fmt.Errorf(`unknown coinType "%s"`, coinType)
+		}
+
+		if hideSecretKey {
+			entry.Secret = ""
+		}
+
+		wallet.Entries = append(wallet.Entries, entry)
+	}
+
+	return wallet, nil
+}
+
+// Returns a ReadableEntry in Skycoin format
+func GetSkycoinWalletEntry(pub cipher.PubKey, sec cipher.SecKey) ReadableEntry {
+	return ReadableEntry{
+		Address: cipher.AddressFromPubKey(pub).String(),
+		Public:  pub.Hex(),
+		Secret:  sec.Hex(),
+	}
+}
+
+// Returns a ReadableEntry in Bitcoin format
+func GetBitcoinWalletEntry(pub cipher.PubKey, sec cipher.SecKey) ReadableEntry {
+	return ReadableEntry{
+		Address: cipher.BitcoinAddressFromPubkey(pub),
+		Public:  pub.Hex(),
+		Secret:  cipher.BitcoinWalletImportFormatFromSeckey(sec),
+	}
+}

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -23,11 +23,18 @@ var (
 	logger = logging.MustGetLogger("wallet")
 )
 
-// WalletExt  wallet file extension
-const WalletExt = "wlt"
+type CoinType string
 
-// WalletTimestampFormat  wallet timestamp layout
-const WalletTimestampFormat = "2006_01_02"
+const (
+	// WalletExt  wallet file extension
+	WalletExt = "wlt"
+
+	// WalletTimestampFormat  wallet timestamp layout
+	WalletTimestampFormat = "2006_01_02"
+
+	CoinTypeSkycoin CoinType = "skycoin"
+	CoinTypeBitcoin CoinType = "bitcoin"
+)
 
 // NewWalletFilename check for collisions and retry if failure
 func NewWalletFilename() string {
@@ -76,7 +83,8 @@ func NewWallet(wltName string, opts ...Option) (*Wallet, error) {
 			"lastSeed": seed,
 			"tm":       fmt.Sprintf("%v", time.Now().Unix()),
 			"type":     "deterministic",
-			"coin":     "sky"},
+			"coin":     string(CoinTypeSkycoin),
+		},
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
* Removes some globals in package gui.
* Removes copy/paste code that was in both `cmd/address_gen/address_gen.go` and `src/gui/api.go` and partially in `src/wallet/readable.go`.  Address gen in json wallet format is moved to `src/wallet/addresses.go`.
* Improve error handling in `/api/create-address`; if invalid value is provided in the request query/form, return 400 instead of using default value