### PR TITLE
Timelocked addresses, fixes #476 

### DIFF
--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -24,6 +24,7 @@ import (
 	"github.com/skycoin/skycoin/src/util/cert"
 	"github.com/skycoin/skycoin/src/util/file"
 	"github.com/skycoin/skycoin/src/util/logging"
+	"github.com/skycoin/skycoin/src/visor"
 )
 
 var (
@@ -654,110 +655,6 @@ func main() {
 	Run(&devConfig)
 }
 
-// AddrList for storage of coins
-var AddrList = []string{
-	"R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
-	"2EYM4WFHe4Dgz6kjAdUkM6Etep7ruz2ia6h",
-	"25aGyzypSA3T9K6rgPUv1ouR13efNPtWP5m",
-	"ix44h3cojvN6nqGcdpy62X7Rw6Ahnr3Thk",
-	"AYV8KEBEAPCg8a59cHgqHMqYHP9nVgQDyW",
-	"2Nu5Jv5Wp3RYGJU1EkjWFFHnebxMx1GjfkF",
-	"2THDupTBEo7UqB6dsVizkYUvkKq82Qn4gjf",
-	"tWZ11Nvor9parjg4FkwxNVcby59WVTw2iL",
-	"m2joQiJRZnj3jN6NsoKNxaxzUTijkdRoSR",
-	"8yf8PAQqU2cDj8Yzgz3LgBEyDqjvCh2xR7",
-	"sgB3n11ZPUYHToju6TWMpUZTUcKvQnoFMJ",
-	"2UYPbDBnHUEc67e7qD4eXtQQ6zfU2cyvAvk",
-	"wybwGC9rhm8ZssBuzpy5goXrAdE31MPdsj",
-	"JbM25o7kY7hqJZt3WGYu9pHZFCpA9TCR6t",
-	"2efrft5Lnwjtk7F1p9d7BnPd72zko2hQWNi",
-	"Syzmb3MiMoiNVpqFdQ38hWgffHg86D2J4e",
-	"2g3GUmTQooLrNHaRDhKtLU8rWLz36Beow7F",
-	"D3phtGr9iv6238b3zYXq6VgwrzwvfRzWZQ",
-	"gpqsFSuMCZmsjPc6Rtgy1FmLx424tH86My",
-	"2EUF3GPEUmfocnUc1w6YPtqXVCy3UZA4rAq",
-	"TtAaxB3qGz5zEAhhiGkBY9VPV7cekhvRYS",
-	"2fM5gVpi7XaiMPm4i29zddTNkmrKe6TzhVZ",
-	"ix3NDKgxfYYANKAb5kbmwBYXPrkAsha7uG",
-	"2RkPshpFFrkuaP98GprLtgHFTGvPY5e6wCK",
-	"Ak1qCDNudRxZVvcW6YDAdD9jpYNNStAVqm",
-	"2eZYSbzBKJ7QCL4kd5LSqV478rJQGb4UNkf",
-	"KPfqM6S96WtRLMuSy4XLfVwymVqivdcDoM",
-	"5B98bU1nsedGJBdRD5wLtq7Z8t8ZXio8u5",
-	"2iZWk5tmBynWxj2PpAFyiZzEws9qSnG3a6n",
-	"XUGdPaVnMh7jtzPe3zkrf9FKh5nztFnQU5",
-	"hSNgHgewJme8uaHrEuKubHYtYSDckD6hpf",
-	"2DeK765jLgnMweYrMp1NaYHfzxumfR1PaQN",
-	"orrAssY5V2HuQAbW9K6WktFrGieq2m23pr",
-	"4Ebf4PkG9QEnQTm4MVvaZvJV6Y9av3jhgb",
-	"7Uf5xJ3GkiEKaLxC2WmJ1t6SeekJeBdJfu",
-	"oz4ytDKbCqpgjW3LPc52pW2CaK2gxCcWmL",
-	"2ex5Z7TufQ5Z8xv5mXe53fSQRfUr35SSo7Q",
-	"WV2ap7ZubTxeDdmEZ1Xo7ufGMkekLWikJu",
-	"ckCTV4r1pNuz6j2VBRHhaJN9HsCLY7muLV",
-	"MXJx96ZJVSjktgeYZpVK8vn1H3xWP8ooq5",
-	"wyQVmno9aBJZmQ99nDSLoYWwp7YDJCWsrH",
-	"2cc9wKxCsFNRkoAQDAoHke3ZoyL1mSV14cj",
-	"29k9g3F5AYfVaa1joE1PpZjBED6hQXes8Mm",
-	"2XPLzz4ZLf1A9ykyTCjW5gEmVjnWa8CuatH",
-	"iH7DqqojTgUn2JxmY9hgFp165Nk7wKfan9",
-	"RJzzwUs3c9C8Y7NFYzNfFoqiUKeBhBfPki",
-	"2W2cGyiCRM4nwmmiGPgMuGaPGeBzEm7VZPn",
-	"ALJVNKYL7WGxFBSriiZuwZKWD4b7fbV1od",
-	"tBaeg9zE2sgmw5ZQENaPPYd6jfwpVpGTzS",
-	"2hdTw5Hk3rsgpZjvk8TyKcCZoRVXU5QVrUt",
-	"A1QU6jKq8YgTP79M8fwZNHUZc7hConFKmy",
-	"q9RkXoty3X1fuaypDDRUi78rWgJWYJMmpJ",
-	"2Xvm6is5cAPA85xnSYXDuAqiRyoXiky5RaD",
-	"4CW2CPJEzxhn2PS4JoSLoWGL5QQ7dL2eji",
-	"24EG6uTzL7DHNzcwsygYGRR1nfu5kco7AZ1",
-	"KghGnWw5fppTrqHSERXZf61yf7GkuQdCnV",
-	"2WojewRA3LbpyXTP9ANy8CZqJMgmyNm3MDr",
-	"2BsMfywmGV3M2CoDA112Rs7ZBkiMHfy9X11",
-	"kK1Q4gPyYfVVMzQtAPRzL8qXMqJ67Y7tKs",
-	"28J4mx8xfUtM92DbQ6i2Jmqw5J7dNivfroN",
-	"gQvgyG1djgtftoCVrSZmsRxr7okD4LheKw",
-	"3iFGBKapAWWzbiGFSr5ScbhrEPm6Esyvia",
-	"NFW2akQH2vu7AqkQXxFz2P5vkXTWkSqrSm",
-	"2MQJjLnWRp9eHh6MpCwpiUeshhtmri12mci",
-	"2QjRQUMyL6iodtHP9zKmxCNYZ7k3jxtk49C",
-	"USdfKy7B6oFNoauHWMmoCA7ND9rHqYw2Mf",
-	"cA49et9WtptYHf6wA1F8qqVgH3kS5jJ9vK",
-	"qaJT9TjcMi46sTKcgwRQU8o5Lw2Ea1gC4N",
-	"22pyn5RyhqtTQu4obYjuWYRNNw4i54L8xVr",
-	"22dkmukC6iH4FFLBmHne6modJZZQ3MC9BAT",
-	"z6CJZfYLvmd41GRVE8HASjRcy5hqbpHZvE",
-	"GEBWJ2KpRQDBTCCtvnaAJV2cYurgXS8pta",
-	"oS8fbEm82cprmAeineBeDkaKd7QownDZQh",
-	"rQpAs1LVQdphyj9ipEAuukAoj9kNpSP8cM",
-	"6NSJKsPxmqipGAfFFhUKbkopjrvEESTX3j",
-	"cuC68ycVXmD2EBzYFNYQ6akhKGrh3FGjSf",
-	"bw4wtYU8toepomrhWP2p8UFYfHBbvEV425",
-	"HvgNmDz5jD39Gwmi9VfDY1iYMhZUpZ8GKz",
-	"SbApuZAYquWP3Q6iD51BcMBQjuApYEkRVf",
-	"2Ugii5yxJgLzC59jV1vF8GK7UBZdvxwobeJ",
-	"21N2iJ1qnQRiJWcEqNRxXwfNp8QcmiyhtPy",
-	"9TC4RGs6AtFUsbcVWnSoCdoCpSfM66ALAc",
-	"oQzn55UWG4iMcY9bTNb27aTnRdfiGHAwbD",
-	"2GCdwsRpQhcf8SQcynFrMVDM26Bbj6sgv9M",
-	"2NRFe7REtSmaM2qAgZeG45hC8EtVGV2QjeB",
-	"25RGnhN7VojHUTvQBJA9nBT5y1qTQGULMzR",
-	"26uCBDfF8E2PJU2Dzz2ysgKwv9m4BhodTz9",
-	"Wkvima5cF7DDFdmJQqcdq8Syaq9DuAJJRD",
-	"286hSoJYxvENFSHwG51ZbmKaochLJyq4ERQ",
-	"FEGxF3HPoM2HCWHn82tyeh9o7vEQq5ySGE",
-	"h38DxNxGhWGTq9p5tJnN5r4Fwnn85Krrb6",
-	"2c1UU8J6Y3kL4cmQh21Tj8wkzidCiZxwdwd",
-	"2bJ32KuGmjmwKyAtzWdLFpXNM6t83CCPLq5",
-	"2fi8oLC9zfVVGnzzQtu3Y3rffS65Hiz6QHo",
-	"TKD93RxFr2Am44TntLiJQus4qcEwTtvEEQ",
-	"zMDywYdGEDtTSvWnCyc3qsYHWwj9ogws74",
-	"25NbotTka7TwtbXUpSCQD8RMgHKspyDubXJ",
-	"2ayCELBERubQWH5QxUr3cTxrYpidvUAzsSw",
-	"RMTCwLiYDKEAiJu5ekHL1NQ8UKHi5ozCPg",
-	"ejJjiCwp86ykmFr5iTJ8LxQXJ2wJPTYmkm",
-}
-
 // InitTransaction creates the initialize transaction
 func InitTransaction() coin.Transaction {
 	var tx coin.Transaction
@@ -765,9 +662,20 @@ func InitTransaction() coin.Transaction {
 	output := cipher.MustSHA256FromHex("043836eb6f29aaeb8b9bfce847e07c159c72b25ae17d291f32125e7f1912e2a0")
 	tx.PushInput(output)
 
-	for i := 0; i < 100; i++ {
-		addr := cipher.MustDecodeBase58Address(AddrList[i])
-		tx.PushOutput(addr, 1e12, 1) // 10e6*10e6
+	addrs := visor.GetDistributionAddresses()
+
+	if len(addrs) != 100 {
+		log.Panic("Should have 100 distribution addresses")
+	}
+
+	// 1 million per address, measured in droplets
+	if visor.DistributionAddressInitialBalance != 1e6 {
+		log.Panic("visor.DistributionAddressInitialBalance expected to be 1e6*1e6")
+	}
+
+	for i := range addrs {
+		addr := cipher.MustDecodeBase58Address(addrs[i])
+		tx.PushOutput(addr, visor.DistributionAddressInitialBalance*1e6, 1)
 	}
 	/*
 		seckeys := make([]cipher.SecKey, 1)

--- a/src/coin/block.go
+++ b/src/coin/block.go
@@ -67,11 +67,11 @@ type Block struct {
 */
 
 // NewBlock creates new block.
-func NewBlock(prev Block, currentTime uint64, uxHash cipher.SHA256,
-	txns Transactions, calc FeeCalculator) (*Block, error) {
+func NewBlock(prev Block, currentTime uint64, uxHash cipher.SHA256, txns Transactions, calc FeeCalculator) (*Block, error) {
 	if len(txns) == 0 {
 		return nil, fmt.Errorf("Refusing to create block with no transactions")
 	}
+
 	fee, err := txns.Fees(calc)
 	if err != nil {
 		// This should have been caught earlier
@@ -136,8 +136,7 @@ func (b Block) GetTransaction(txHash cipher.SHA256) (Transaction, bool) {
 }
 
 // NewBlockHeader creates block header
-func NewBlockHeader(prev BlockHeader, uxHash cipher.SHA256, currentTime,
-	fee uint64, body BlockBody) BlockHeader {
+func NewBlockHeader(prev BlockHeader, uxHash cipher.SHA256, currentTime, fee uint64, body BlockBody) BlockHeader {
 	if currentTime <= prev.Time {
 		logger.Panic("Time can only move forward")
 	}

--- a/src/coin/coin_test.go
+++ b/src/coin/coin_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/util/utc"
-	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -19,11 +18,6 @@ var (
 	_genCoins            uint64 = 1000e6
 	_genCoinHours        uint64 = 1000 * 1000
 )
-
-func assertError(t *testing.T, err error, msg string) {
-	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), msg)
-}
 
 func tNow() uint64 {
 	return uint64(utc.UnixNow())

--- a/src/coin/transactions.go
+++ b/src/coin/transactions.go
@@ -82,9 +82,9 @@ func (txn *Transaction) Verify() error {
 	}
 
 	// Check duplicate inputs
-	uxOuts := make(map[cipher.SHA256]int, len(txn.In))
+	uxOuts := make(map[cipher.SHA256]struct{}, len(txn.In))
 	for i := range txn.In {
-		uxOuts[txn.In[i]] = 1
+		uxOuts[txn.In[i]] = struct{}{}
 	}
 	if len(uxOuts) != len(txn.In) {
 		return errors.New("Duplicate spend")
@@ -98,7 +98,7 @@ func (txn *Transaction) Verify() error {
 	}
 
 	// Check for duplicate potential outputs
-	outputs := make(map[cipher.SHA256]int, len(txn.Out))
+	outputs := make(map[cipher.SHA256]struct{}, len(txn.Out))
 	uxb := UxBody{
 		SrcTransaction: txn.Hash(),
 	}
@@ -106,7 +106,7 @@ func (txn *Transaction) Verify() error {
 		uxb.Coins = to.Coins
 		uxb.Hours = to.Hours
 		uxb.Address = to.Address
-		outputs[uxb.Hash()] = 1
+		outputs[uxb.Hash()] = struct{}{}
 	}
 	if len(outputs) != len(txn.Out) {
 		return errors.New("Duplicate output in transaction")
@@ -127,8 +127,7 @@ func (txn *Transaction) Verify() error {
 			return errors.New("Zero coin output")
 		}
 		if txo.Coins%1e6 != 0 {
-			return errors.New("Transaction outputs must be multiple of 1e6 " +
-				"base units")
+			return errors.New("Transaction outputs must be multiple of 1e6 base units")
 		}
 	}
 
@@ -218,7 +217,7 @@ func (txn *Transaction) SignInputs(keys []cipher.SecKey) {
 	sigs := make([]cipher.Sig, len(txn.In))
 	innerHash := txn.HashInner()
 	for i, k := range keys {
-		h := cipher.AddSHA256(innerHash, txn.In[i]) //hash to sign
+		h := cipher.AddSHA256(innerHash, txn.In[i]) // hash to sign
 		sigs[i] = cipher.SignHash(h, k)
 	}
 	txn.Sigs = sigs

--- a/src/daemon/gnet/dispatcher_test.go
+++ b/src/daemon/gnet/dispatcher_test.go
@@ -9,15 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/skycoin/skycoin/src/util/logging"
 )
-
-func init() {
-	if silenceLogger {
-		logging.Disable()
-	}
-}
 
 var (
 	_sendByteMessage = sendByteMessage

--- a/src/daemon/gnet/message_test.go
+++ b/src/daemon/gnet/message_test.go
@@ -5,15 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/stretchr/testify/assert"
 )
-
-func init() {
-	if silenceLogger {
-		logging.Disable()
-	}
-}
 
 func TestNewMessageContext(t *testing.T) {
 	c := &Connection{}

--- a/src/daemon/gnet/pool_test.go
+++ b/src/daemon/gnet/pool_test.go
@@ -12,15 +12,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
+const (
 	addr          = "127.0.0.1:50823"
 	addrb         = "127.0.0.1:50824"
 	addrc         = "127.0.0.1:50825"
 	port          = 50823
 	address       = "127.0.0.1"
-	listener      net.Listener
-	conn          net.Conn
 	silenceLogger = false
+)
+
+var (
+	listener net.Listener
+	conn     net.Conn
 )
 
 func init() {
@@ -29,10 +32,15 @@ func init() {
 	}
 }
 
-func TestNewConnectionPool(t *testing.T) {
+func newTestConfig() Config {
 	cfg := NewConfig()
 	cfg.Port = uint16(port)
 	cfg.Address = address
+	return cfg
+}
+
+func TestNewConnectionPool(t *testing.T) {
+	cfg := newTestConfig()
 	cfg.MaxConnections = 108
 	cfg.DialTimeout = time.Duration(777)
 	p := NewConnectionPool(cfg, nil)
@@ -48,9 +56,7 @@ func TestNewConnectionPool(t *testing.T) {
 
 func TestNewConnection(t *testing.T) {
 	wait()
-	cfg := NewConfig()
-	cfg.Port = uint16(port)
-	cfg.Address = address
+	cfg := newTestConfig()
 	cfg.ConnectionWriteQueueSize = 101
 	p := NewConnectionPool(cfg, nil)
 	defer p.Shutdown()
@@ -73,9 +79,7 @@ func TestNewConnection(t *testing.T) {
 
 func TestNewConnectionAlreadyConnected(t *testing.T) {
 	wait()
-	cfg := NewConfig()
-	cfg.Port = uint16(port)
-	cfg.Address = address
+	cfg := newTestConfig()
 	p := NewConnectionPool(cfg, nil)
 	defer p.Shutdown()
 	go p.Run()
@@ -91,9 +95,7 @@ func TestNewConnectionAlreadyConnected(t *testing.T) {
 
 func TestAcceptConnections(t *testing.T) {
 	wait()
-	cfg := NewConfig()
-	cfg.Port = uint16(port)
-	cfg.Address = address
+	cfg := newTestConfig()
 	called := false
 	cfg.ConnectCallback = func(addr string, solicited bool) {
 		assert.False(t, solicited)
@@ -126,23 +128,9 @@ func TestAcceptConnections(t *testing.T) {
 	assert.True(t, called)
 }
 
-func TestListeningAddress(t *testing.T) {
-	wait()
-	cfg := NewConfig()
-	cfg.Address = ""
-	cfg.Port = 0
-	p := NewConnectionPool(cfg, nil)
-	defer p.Shutdown()
-	go p.Run()
-	wait()
-	t.Log("ListeningAddress: ", addr)
-}
-
 func TestStartListen(t *testing.T) {
 	wait()
-	cfg := NewConfig()
-	cfg.Port = uint16(port)
-	cfg.Address = address
+	cfg := newTestConfig()
 	called := false
 	cfg.ConnectCallback = func(addr string, solicited bool) {
 		assert.False(t, solicited)
@@ -162,9 +150,7 @@ func TestStartListen(t *testing.T) {
 
 func TestStartListenTwice(t *testing.T) {
 	wait()
-	cfg := NewConfig()
-	cfg.Port = uint16(port)
-	cfg.Address = address
+	cfg := newTestConfig()
 	p := NewConnectionPool(cfg, nil)
 	defer p.Shutdown()
 	go p.Run()
@@ -174,9 +160,7 @@ func TestStartListenTwice(t *testing.T) {
 
 func TestStartListenFailed(t *testing.T) {
 	wait()
-	cfg := NewConfig()
-	cfg.Port = uint16(port)
-	cfg.Address = address
+	cfg := newTestConfig()
 	p := NewConnectionPool(cfg, nil)
 	go p.Run()
 	defer p.Shutdown()
@@ -187,9 +171,7 @@ func TestStartListenFailed(t *testing.T) {
 
 func TestStopListen(t *testing.T) {
 	wait()
-	cfg := NewConfig()
-	cfg.Port = uint16(port)
-	cfg.Address = address
+	cfg := newTestConfig()
 	p := NewConnectionPool(cfg, nil)
 	go p.Run()
 	wait()
@@ -215,9 +197,7 @@ func TestStopListen(t *testing.T) {
 
 func TestHandleConnection(t *testing.T) {
 	wait()
-	cfg := NewConfig()
-	cfg.Port = uint16(port)
-	cfg.Address = address
+	cfg := newTestConfig()
 
 	// Unsolicited
 	called := false
@@ -261,9 +241,7 @@ func TestHandleConnection(t *testing.T) {
 
 func TestConnect(t *testing.T) {
 	wait()
-	cfg := NewConfig()
-	cfg.Port = uint16(port)
-	cfg.Address = address
+	cfg := newTestConfig()
 	// cfg.Port
 	p := NewConnectionPool(cfg, nil)
 	go p.Run()
@@ -298,9 +276,7 @@ func TestConnect(t *testing.T) {
 
 func TestConnectNoTimeout(t *testing.T) {
 	wait()
-	cfg := NewConfig()
-	cfg.Port = uint16(port)
-	cfg.Address = address
+	cfg := newTestConfig()
 	cfg.DialTimeout = 0
 	cfg.Port++
 	p := NewConnectionPool(cfg, nil)
@@ -314,9 +290,7 @@ func TestConnectNoTimeout(t *testing.T) {
 
 func TestDisconnect(t *testing.T) {
 	wait()
-	cfg := NewConfig()
-	cfg.Port = uint16(port)
-	cfg.Address = address
+	cfg := newTestConfig()
 	p := NewConnectionPool(cfg, nil)
 	go p.Run()
 	defer p.Shutdown()
@@ -359,7 +333,8 @@ func TestConnectionClose(t *testing.T) {
 
 func TestGetConnections(t *testing.T) {
 	wait()
-	p := NewConnectionPool(NewConfig(), nil)
+	cfg := newTestConfig()
+	p := NewConnectionPool(cfg, nil)
 	c := &Connection{ID: 1}
 	d := &Connection{ID: 2}
 	e := &Connection{ID: 3}
@@ -384,9 +359,7 @@ func TestGetConnections(t *testing.T) {
 
 func TestConnectionReadLoop(t *testing.T) {
 	wait()
-	cfg := NewConfig()
-	cfg.Port = uint16(port)
-	cfg.Address = address
+	cfg := newTestConfig()
 	p := NewConnectionPool(cfg, nil)
 	go p.Run()
 	defer p.Shutdown()
@@ -452,9 +425,7 @@ func TestProcessConnectionBuffers(t *testing.T) {
 	RegisterMessage(DummyPrefix, DummyMessage{})
 	RegisterMessage(ErrorPrefix, ErrorMessage{})
 	VerifyMessages()
-	cfg := NewConfig()
-	cfg.Port = uint16(port)
-	cfg.Address = address
+	cfg := newTestConfig()
 	p := NewConnectionPool(cfg, nil)
 	go p.Run()
 	wait()
@@ -554,9 +525,7 @@ func TestConnectionWriteLoop(t *testing.T) {
 	RegisterMessage(BytePrefix, ByteMessage{})
 	VerifyMessages()
 
-	cfg := NewConfig()
-	cfg.Port = uint16(port)
-	cfg.Address = address
+	cfg := newTestConfig()
 	p := NewConnectionPool(cfg, nil)
 	go p.Run()
 	defer p.Shutdown()
@@ -602,9 +571,7 @@ func TestPoolSendMessage(t *testing.T) {
 	EraseMessages()
 	RegisterMessage(BytePrefix, ByteMessage{})
 	VerifyMessages()
-	cfg := NewConfig()
-	cfg.Address = address
-	cfg.Port = uint16(port)
+	cfg := newTestConfig()
 	cfg.WriteTimeout = time.Second
 	cfg.BroadcastResultSize = 1
 	// cfg.ConnectionWriteQueueSize = 1
@@ -642,9 +609,7 @@ func TestPoolBroadcastMessage(t *testing.T) {
 	EraseMessages()
 	RegisterMessage(BytePrefix, ByteMessage{})
 	VerifyMessages()
-	cfg := NewConfig()
-	cfg.Address = address
-	cfg.Port = uint16(port)
+	cfg := newTestConfig()
 	p := NewConnectionPool(cfg, nil)
 	go p.Run()
 	defer p.Shutdown()
@@ -686,7 +651,8 @@ func TestPoolReceiveMessage(t *testing.T) {
 	// 	Buffer:     &bytes.Buffer{},
 	// 	WriteQueue: make(chan Message),
 	// }
-	p := NewConnectionPool(NewConfig(), nil)
+	cfg := newTestConfig()
+	p := NewConnectionPool(cfg, nil)
 	go p.Run()
 	wait()
 	defer p.Shutdown()

--- a/src/daemon/visor_test.go
+++ b/src/daemon/visor_test.go
@@ -1,1425 +1,301 @@
 package daemon
 
 import (
+	"fmt"
 	"testing"
 
-	"github.com/skycoin/skycoin/src/cipher"
-	"github.com/stretchr/testify/assert"
-)
+	"github.com/boltdb/bolt"
+	"github.com/stretchr/testify/require"
 
-/*
-import (
-	"crypto/rand"
-	"os"
-	"path/filepath"
-	"sort"
-	"testing"
-	"time"
-
-	"github.com/skycoin/skycoin/src/daemon/gnet"
-	"github.com/skycoin/skycoin/src/cipher/encoder"
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/coin"
-	"github.com/skycoin/skycoin/src/util"
+	"github.com/skycoin/skycoin/src/testutil"
 	"github.com/skycoin/skycoin/src/visor"
-	"github.com/skycoin/skycoin/src/wallet"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/assert"
-)
-*/
-
-/*
-
-const (
-	testMasterKeysFile = "testmaster.keys"
-	testWalletFile     = "testwallet.wlt"
-	testWalletDir      = "./"
-	testBlocksigsFile  = "testblockchain.sigs"
-	testBlockchainFile = "testblockchain.bin"
 )
 
 var (
-	fullWalletFile = filepath.Join(testWalletDir, testWalletFile)
+	GenesisPublic, GenesisSecret = cipher.GenerateKeyPair()
+	GenesisAddress               = cipher.AddressFromPubKey(GenesisPublic)
 )
 
-func randBytes(t *testing.T, n int) []byte {
-	b := make([]byte, n)
-	x, err := rand.Read(b)
-	assert.Equal(t, n, x)
-	assert.Nil(t, err)
-	return b
-}
+const (
+	TimeIncrement    uint64 = 3600 * 1000
+	GenesisTime      uint64 = 1000
+	GenesisCoins     uint64 = 1000e6
+	GenesisCoinHours uint64 = 1000 * 1000
+)
 
-func randSHA256(t *testing.T) cipher.SHA256 {
-	return cipher.SumSHA256(randBytes(t, 32))
-}
+func MakeTransactionForChain(t *testing.T, bc *visor.Blockchain, ux coin.UxOut, sec cipher.SecKey, toAddr cipher.Address, amt, hours, fee uint64) coin.Transaction {
+	chrs := ux.CoinHours(bc.Time())
 
-func createGenesisSignature(master wallet.WalletEntry) cipher.Sig {
-	c := visor.NewVisorConfig()
-	bc := coin.NewBlockchain()
-	gb := bc.CreateGenesisBlock(master.Address, c.GenesisTimestamp,
-		c.GenesisCoinVolume)
-	return cipher.SignHash(gb.HashHeader(), master.Secret)
-}
+	require.Equal(t, cipher.AddressFromPubKey(cipher.PubKeyFromSecKey(sec)), ux.Body.Address)
 
-// Returns an appropriate VisorConfig and a master visor
-func setupVisor() (VisorConfig, *visor.Visor) {
-	//cipher.SetAddressVersion("test")
+	knownUx, exists := bc.Unspent().Get(ux.Hash())
+	require.True(t, exists)
+	require.Equal(t, knownUx, ux)
 
-	// Make a new master visor + blockchain
-	// Get the signed genesis block,
-	mw := wallet.NewWalletEntry()
-	mvc := visor.NewVisorConfig()
-	mvc.IsMaster = true
-	mvc.MasterKeys = mw
-	mvc.CoinHourBurnFactor = 0
-	mvc.GenesisSignature = createGenesisSignature(mw)
-	mv := visor.NewVisor(mvc)
+	tx := coin.Transaction{}
+	tx.PushInput(ux.Hash())
 
-	// Use the master values for a client configuration
-	c := NewVisorConfig()
-	c.Config.WalletDirectory = testWalletDir
-	c.Config.IsMaster = false
-	c.Config.MasterKeys = mw
-	c.Config.MasterKeys.Secret = cipher.SecKey{}
-	c.Config.GenesisSignature = mvc.GenesisSignature
-	c.Config.GenesisTimestamp = mvc.GenesisTimestamp
-	return c, mv
-}
+	tx.PushOutput(toAddr, amt, hours)
 
-func setupMasterVisor() VisorConfig {
-	cleanupVisor()
-	cipher.SetAddressVersion("test")
-	c := NewVisorConfig()
-	c.Config.IsMaster = true
-	mw := wallet.NewWalletEntry()
-	c.Config.MasterKeys = mw
-	c.Config.GenesisSignature = createGenesisSignature(mw)
-	return c
-}
-
-func cleanupVisor() {
-	os.Remove(fullWalletFile)
-	os.Remove(testMasterKeysFile)
-	os.Remove(testBlockchainFile)
-	os.Remove(testBlocksigsFile)
-	os.Remove(fullWalletFile + ".tmp")
-	os.Remove(testMasterKeysFile + ".tmp")
-	os.Remove(testBlockchainFile + ".tmp")
-	os.Remove(testBlocksigsFile + ".tmp")
-	os.Remove(fullWalletFile + ".bak")
-	os.Remove(testMasterKeysFile + ".bak")
-	os.Remove(testBlockchainFile + ".bak")
-	os.Remove(testBlocksigsFile + ".bak")
-	wallets, err := filepath.Glob("*." + wallet.WalletExt)
-	if err != nil {
-		logger.Critical("Failed to glob wallet files: %v", err)
-	} else {
-		for _, w := range wallets {
-			os.Remove(w)
-			os.Remove(w + ".bak")
-			os.Remove(w + ".tmp")
-		}
+	// Change output
+	coinsOut := ux.Body.Coins - amt
+	if coinsOut > 0 {
+		tx.PushOutput(GenesisAddress, coinsOut, chrs-hours-fee)
 	}
-}
 
-// Returns a daemon with the visor enabled, but networking disabled
-func newVisorDaemon(vc VisorConfig) (*Daemon, chan int) {
-	quit := make(chan int)
-	c := NewConfig()
-	c.Daemon.DisableNetworking = true
-	c.Visor = vc
-	c.Visor.Config.CoinHourBurnFactor = 0
-	d := NewDaemon(c)
-	return d, quit
-}
+	tx.SignInputs([]cipher.SecKey{sec})
 
-// Writes a wallet entry to disk at filename
-func writeMasterKeysFile() (wallet.WalletEntry, error) {
-	we := wallet.NewWalletEntry()
-	rwe := wallet.NewReadableWalletEntry(&we)
-	err := rwe.Save(testMasterKeysFile)
-	return we, err
-}
+	require.Equal(t, len(tx.Sigs), 1)
 
-func assertFileExists(t *testing.T, filename string) {
-	stat, err := os.Stat(filename)
-	assert.Nil(t, err)
-	assert.NotNil(t, stat)
-	if stat != nil {
-		assert.True(t, stat.Mode().IsRegular())
-	}
-}
+	err := cipher.ChkSig(ux.Body.Address, cipher.AddSHA256(tx.HashInner(), tx.In[0]), tx.Sigs[0])
+	require.NoError(t, err)
 
-func assertFileNotExists(t *testing.T, filename string) {
-	_, err := os.Stat(filename)
-	assert.NotNil(t, err)
-	assert.True(t, os.IsNotExist(err))
-}
+	tx.UpdateHeader()
 
-func createUnconfirmedTxn() visor.UnconfirmedTxn {
-	now := utc.Now()
-	return visor.UnconfirmedTxn{
-		Txn: coin.Transaction{
-			Head: coin.TransactionHeader{
-				Hash: cipher.SumSHA256([]byte("cascas")),
-			},
-		},
-		Received:  now,
-		Checked:   now,
-		Announced: time.Time{},
-	}
-}
+	err = tx.Verify()
+	require.NoError(t, err)
 
-func addUnconfirmedTxn(v *Visor) visor.UnconfirmedTxn {
-	ut := createUnconfirmedTxn()
-	v.Visor.Unconfirmed.Txns[ut.Txn.Hash()] = ut
-	return ut
-}
+	err = bc.VerifyTransaction(tx)
+	require.NoError(t, err)
 
-func makeValidTxn(mv *visor.Visor) (coin.Transaction, error) {
-	we := wallet.NewWalletEntry()
-	return mv.Spend(mv.Wallets[0].GetFilename(), wallet.Balance{10 * 1e6, 0}, 0,
-		we.Address)
-}
-
-func makeValidTxnNoError(t *testing.T, mv *visor.Visor) coin.Transaction {
-	we := wallet.NewWalletEntry()
-	tx, err := mv.Spend(mv.Wallets[0].GetFilename(), wallet.Balance{10 * 1e6, 0}, 0,
-		we.Address)
-	assert.Nil(t, err)
 	return tx
 }
 
-func transferCoins(mv *visor.Visor, v *visor.Visor) error {
-	// Give the nonmaster some money to spend
-	addr := v.Wallets[0].GetAddresses()[0]
-	tx, err := mv.Spend(mv.Wallets[0].GetFilename(), wallet.Balance{10 * 1e6, 0}, 0,
-		addr)
-	if err != nil {
-		return err
-	}
-	mv.InjectTxn(tx)
-	sb, err := mv.CreateAndExecuteBlock()
-	if err != nil {
-		return err
-	}
-	return v.ExecuteSignedBlock(sb)
+func MakeBlockchain(t *testing.T, db *bolt.DB) *visor.Blockchain {
+	b, err := visor.NewBlockchain(db)
+	require.NoError(t, err)
+	b.CreateGenesisBlock(GenesisAddress, GenesisCoins, GenesisTime)
+	return b
 }
 
-func makeMoreBlocks(mv *visor.Visor, n int,
-	now uint64) ([]visor.SignedBlock, error) {
-	dest := wallet.NewWalletEntry()
-	blocks := make([]visor.SignedBlock, n)
-	for i := 0; i < n; i++ {
-		tx, err := mv.Spend(mv.Wallets[0].GetFilename(), wallet.Balance{10 * 1e6, 0},
-			0, dest.Address)
-		if err != nil {
-			return nil, err
-		}
-		mv.InjectTxn(tx)
-		sb, err := mv.CreateBlock(now + uint64(i) + 1)
-		if err != nil {
-			return nil, err
-		}
-		err = mv.ExecuteSignedBlock(sb)
-		if err != nil {
-			return nil, err
-		}
-		blocks[i] = sb
-	}
-	return blocks, nil
+func MakeAddress() (cipher.PubKey, cipher.SecKey, cipher.Address) {
+	p, s := cipher.GenerateKeyPair()
+	a := cipher.AddressFromPubKey(p)
+	return p, s, a
 }
 
-func makeBlocks(mv *visor.Visor, n int) ([]visor.SignedBlock, error) {
-	return makeMoreBlocks(mv, n, uint64(utc.UnixNow()))
+func setupSimpleVisor(db *bolt.DB, bc *visor.Blockchain) *Visor {
+	visorCfg := NewVisorConfig()
+	visorCfg.Disabled = true // disable broadcasting
+	visorCfg.Config.DBPath = db.Path()
+	return &Visor{
+		Config: visorCfg,
+		v: &visor.Visor{
+			Config:      visorCfg.Config,
+			Unconfirmed: visor.NewUnconfirmedTxnPool(db),
+			Blockchain:  bc,
+		},
+	}
 }
 
-// Tests for daemon's loop related to visor
+func createGenesisSpendTransaction(t *testing.T, bc *visor.Blockchain, toAddr cipher.Address, coins, hours, fee uint64) coin.Transaction {
+	uxOuts, err := bc.Unspent().GetAll()
+	require.NoError(t, err)
+	require.Len(t, uxOuts, 1)
 
-func testBlockCreationTicker(t *testing.T, vcfg VisorConfig, master bool,
-	mv *visor.Visor) {
-	vcfg.Config.BlockCreationInterval = 1
-	defer gnet.EraseMessages()
-	c := NewConfig()
-	c.Visor = vcfg
-	c.Daemon.DisableNetworking = false
-	d := NewDaemon(c)
-	if !master {
-		err := transferCoins(mv, d.Visor.Visor)
-		assert.Nil(t, err)
-	}
-	quit := make(chan int)
-	defer closeDaemon(d, quit)
-	gc := setupExistingPool(d.Pool)
-	go d.Pool.Pool.ConnectionWriteLoop(gc)
-	assert.True(t, gc.LastSent.IsZero())
-	assert.Equal(t, len(d.Pool.Pool.Pool), 1)
-	assert.Equal(t, d.Pool.Pool.Pool[gc.Id], gc)
-	assert.Equal(t, len(d.Pool.Pool.Addresses), 1)
-	start := 0
-	if !master {
-		start = 1
-	}
-	assert.Equal(t, d.Visor.Visor.HeadBkSeq(), uint64(start))
-	go d.Start(quit)
-	time.Sleep(time.Second + (time.Millisecond * 50))
-	// Creation should not have occurred, because no transaction
-	assert.Equal(t, d.Visor.Visor.HeadBkSeq(), uint64(start))
-	assert.Equal(t, len(d.Pool.Pool.SendResults), 0)
+	txn := MakeTransactionForChain(t, bc, uxOuts[0], GenesisSecret, toAddr, coins, hours, fee)
+	require.Equal(t, txn.Out[0].Address.String(), toAddr.String())
 
-	// Creation should occur with a transaction, if not a master
-	// Make a transaction
-	assert.False(t, d.Visor.Config.Disabled)
-	assert.True(t, gc.LastSent.IsZero())
-	dest := wallet.NewWalletEntry()
-	tx, err := d.Visor.Spend(d.Visor.Visor.Wallets[0].GetFilename(),
-		wallet.Balance{10 * 1e6, 0}, 0, dest.Address, d.Pool)
-	wait()
-	assert.Nil(t, err)
-	assert.Equal(t, d.Pool.Pool.Pool[gc.Id], gc)
-	assert.Equal(t, len(d.Pool.Pool.DisconnectQueue), 0)
-	assert.Equal(t, len(d.Pool.Pool.Pool), 1)
-	assert.Equal(t, len(d.Pool.Pool.Addresses), 1)
-	// Since the daemon loop is running, it will have processed the SendResult
-	// Instead we can check if the txn was announced
-	assert.Equal(t, len(d.Pool.Pool.SendResults), 0)
-	ut := d.Visor.Visor.Unconfirmed.Txns[tx.Hash()]
-	assert.False(t, ut.Announced.IsZero())
-	assert.False(t, gc.LastSent.IsZero())
-	ls := gc.LastSent
-
-	// Now, block should be created
-	time.Sleep(time.Second + (time.Millisecond * 50))
-	final := start
-	if master {
-		final += 1
-	}
-	assert.Equal(t, len(d.Pool.Pool.Pool), 1)
-	// Again, we can't check SendResults since the daemon loop is running.
-	// We can only check that LastSent was updated, if its the master and it
-	// created the block.
-	if master {
-		assert.True(t, gc.LastSent.After(ls))
+	if coins == GenesisCoins {
+		// No change output
+		require.Len(t, txn.Out, 1)
 	} else {
-		assert.Equal(t, gc.LastSent, ls)
+		require.Len(t, txn.Out, 2)
+		require.Equal(t, txn.Out[1].Address.String(), GenesisAddress.String())
 	}
-	assert.Equal(t, d.Visor.Visor.HeadBkSeq(), uint64(final))
-	assert.False(t, gc.LastSent.IsZero())
+
+	return txn
 }
 
-func TestBlockCreationTicker(t *testing.T) {
-	defer cleanupVisor()
-	vcfg, mv := setupVisor()
-	// No blocks should get created if we are not master
-	testBlockCreationTicker(t, vcfg, false, mv)
+func executeGenesisSpendTransaction(t *testing.T, bc *visor.Blockchain, txn coin.Transaction) coin.UxOut {
+	block, err := bc.NewBlockFromTransactions(coin.Transactions{txn}, GenesisTime+TimeIncrement)
+	require.NoError(t, err)
+
+	err = bc.ExecuteBlock(block)
+	require.NoError(t, err)
+
+	uxOut, err := coin.CreateUnspent(block.Head, txn, 0)
+	require.NoError(t, err)
+
+	return uxOut
 }
 
-func TestBlockCreationTickerMaster(t *testing.T) {
-	defer cleanupVisor()
-	vcfg := setupMasterVisor()
-	// Master should make a block
-	testBlockCreationTicker(t, vcfg, true, nil)
-}
-
-func TestUnconfirmedRefreshTicker(t *testing.T) {
-	defer cleanupVisor()
-	vc, _ := setupVisor()
-	vc.Config.UnconfirmedRefreshRate = time.Millisecond * 10
-	vc.Config.UnconfirmedCheckInterval = time.Nanosecond
-	vc.Config.UnconfirmedMaxAge = time.Nanosecond
-	d, quit := newVisorDaemon(vc)
-	addUnconfirmedTxn(d.Visor)
-	time.Sleep(time.Millisecond)
-	go d.Start(quit)
-	time.Sleep(time.Millisecond * 15)
-	closeDaemon(d, quit)
-	assert.Equal(t, len(d.Visor.Visor.Unconfirmed.Txns), 0)
-}
-
-func TestBlocksRequestTicker(t *testing.T) {
-	defer cleanupVisor()
-	vc, _ := setupVisor()
-	vc.BlocksRequestRate = time.Millisecond * 10
-	d, quit := newVisorDaemon(vc)
-	d.Config.DisableNetworking = false
-	gc := gnetConnection(addr)
-	go d.Pool.Pool.ConnectionWriteLoop(gc)
-	d.Pool.Pool.Pool[gc.Id] = gc
-	d.Pool.Pool.Addresses[gc.Addr()] = gc
-	assert.True(t, gc.LastSent.IsZero())
-	go d.Start(quit)
-	time.Sleep(time.Millisecond * 15)
-	closeDaemon(d, quit)
-	assert.False(t, gc.LastSent.IsZero())
-}
-
-func TestBlocksAnnounceTicker(t *testing.T) {
-	defer cleanupVisor()
-	vc, _ := setupVisor()
-	vc.BlocksAnnounceRate = time.Millisecond * 10
-	d, quit := newVisorDaemon(vc)
-	d.Config.DisableNetworking = false
-	gc := gnetConnection(addr)
-	go d.Pool.Pool.ConnectionWriteLoop(gc)
-	d.Pool.Pool.Pool[gc.Id] = gc
-	d.Pool.Pool.Addresses[gc.Addr()] = gc
-	assert.True(t, gc.LastSent.IsZero())
-	go d.Start(quit)
-	time.Sleep(time.Millisecond * 15)
-	closeDaemon(d, quit)
-	assert.False(t, gc.LastSent.IsZero())
-}
-
-// Tests for daemon.Visor
-
-func TestVisorConfigLoadMasterKeys(t *testing.T) {
-	defer cleanupVisor()
-	c := NewVisorConfig()
-	c.Disabled = true
-	mk := c.Config.MasterKeys
-	// Shouldn't panic, since its disabled. keys should not be loaded
-	assert.NotPanics(t, c.LoadMasterKeys)
-	assert.Equal(t, c.Config.MasterKeys, mk)
-	c.Disabled = false
-	c.MasterKeysFile = testMasterKeysFile
-	// Should panic, since keys not found
-	assert.Panics(t, c.LoadMasterKeys)
-
-	// Shouldn't panic, and keys should be correct
-	we, err := writeMasterKeysFile()
-	assert.Nil(t, err)
-	assert.NotPanics(t, c.LoadMasterKeys)
-	assert.Equal(t, c.Config.MasterKeys, we)
-}
-
-func TestNewVisor(t *testing.T) {
-	defer cleanupVisor()
-	c, _ := setupVisor()
-	v := NewVisor(c)
-	assert.Equal(t, v.Config, c)
-	assert.NotNil(t, v.Visor)
-	assert.Equal(t, len(v.blockchainLengths), 0)
-
-	c.Disabled = true
-	v = NewVisor(c)
-	assert.Equal(t, v.Config, c)
-	assert.Nil(t, v.Visor)
-	assert.Equal(t, len(v.blockchainLengths), 0)
-}
-
-func TestVisorRemoveConnection(t *testing.T) {
-	defer cleanupVisor()
-	c := NewVisorConfig()
-	c.Disabled = true
-	v := NewVisor(c)
-	assert.NotNil(t, v.blockchainLengths)
-	v.blockchainLengths[addr] = 2
-	assert.Equal(t, v.blockchainLengths[addr], uint64(2))
-	assert.Equal(t, len(v.blockchainLengths), 1)
-	v.RemoveConnection(addr)
-	assert.Equal(t, v.blockchainLengths[addr], uint64(0))
-	assert.Equal(t, len(v.blockchainLengths), 0)
-}
-
-func TestVisorShutdown(t *testing.T) {
-	defer cleanupVisor()
-	c, _ := setupVisor()
-	c.Disabled = true
-	c.Config.BlockchainFile = testBlockchainFile
-	c.Config.BlockSigsFile = testBlocksigsFile
-	c.Config.WalletDirectory = testWalletDir
-	v := NewVisor(c)
-	assert.NotPanics(t, v.Shutdown)
-	// Should not save anything
-	assertFileNotExists(t, testBlockchainFile)
-	assertFileNotExists(t, testBlocksigsFile)
-	assertFileNotExists(t, fullWalletFile)
-	wallets, err := filepath.Glob(testWalletDir + "*.wlt")
-	assert.Nil(t, err)
-	assert.Equal(t, len(wallets), 0)
-	cleanupVisor()
-
-	c.Disabled = false
-	v = NewVisor(c)
-	v.Visor.Wallets[0].SetFilename(testWalletFile)
-	assert.NotPanics(t, v.Shutdown)
-	assertFileExists(t, testBlockchainFile)
-	assertFileExists(t, testBlocksigsFile)
-	assertFileExists(t, fullWalletFile)
-	cleanupVisor()
-
-	// If master, no wallet should be saved
-	c = setupMasterVisor()
-	c.Config.BlockchainFile = testBlockchainFile
-	c.Config.BlockSigsFile = testBlocksigsFile
-	c.Config.WalletDirectory = testWalletDir
-	v = NewVisor(c)
-	v.Visor.Wallets[0].SetFilename(testWalletFile)
-	assert.NotPanics(t, v.Shutdown)
-	assertFileExists(t, testBlockchainFile)
-	assertFileExists(t, testBlocksigsFile)
-	assertFileNotExists(t, fullWalletFile)
-	cleanupVisor()
-}
-
-func TestVisorRefreshUnconfirmed(t *testing.T) {
-	defer cleanupVisor()
-	vc, _ := setupVisor()
-	vc.Config.UnconfirmedRefreshRate = time.Millisecond
-	vc.Config.UnconfirmedCheckInterval = time.Nanosecond
-	vc.Config.UnconfirmedMaxAge = time.Nanosecond
-
-	v := NewVisor(vc)
-	addUnconfirmedTxn(v)
-	assert.Equal(t, len(v.Visor.Unconfirmed.Txns), 1)
-	wait()
-
-	v.Config.Disabled = true
-	v.RefreshUnconfirmed()
-	assert.Equal(t, len(v.Visor.Unconfirmed.Txns), 1)
-
-	v.Config.Disabled = false
-	v.RefreshUnconfirmed()
-	assert.Equal(t, len(v.Visor.Unconfirmed.Txns), 0)
-}
-
-func TestVisorRequestBlocks(t *testing.T) {
-	defer cleanupVisor()
-	defer gnet.EraseMessages()
-	p, gc := setupPool()
-	vc, _ := setupVisor()
-	go p.Pool.ConnectionWriteLoop(gc)
-
-	// Disabled
-	vc.Disabled = true
-	v := NewVisor(vc)
-	assert.NotPanics(t, func() { v.RequestBlocks(p) })
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 0)
-	assert.True(t, gc.LastSent.IsZero())
-
-	// Valid
-	vc.Disabled = false
-	gc.Conn = NewDummyConn(addr)
-	v = NewVisor(vc)
-	assert.NotPanics(t, func() { v.RequestBlocks(p) })
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 1)
-	if len(p.Pool.SendResults) == 0 {
-		t.Fatal("SendResults empty, would block")
-	}
-	sr := <-p.Pool.SendResults
-	assert.Nil(t, sr.Error)
-	assert.Equal(t, sr.Connection, gc)
-	_, ok := sr.Message.(*GetBlocksMessage)
-	assert.True(t, ok)
-	assert.False(t, gc.LastSent.IsZero())
-}
-
-func TestVisorAnnounceBlocks(t *testing.T) {
-	defer cleanupVisor()
-	defer gnet.EraseMessages()
-	p, gc := setupPool()
-	vc, _ := setupVisor()
-	go p.Pool.ConnectionWriteLoop(gc)
-
-	// Disabled
-	vc.Disabled = true
-	v := NewVisor(vc)
-	assert.NotPanics(t, func() { v.AnnounceBlocks(p) })
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 0)
-	assert.True(t, gc.LastSent.IsZero())
-
-	// Valid send
-	vc.Disabled = false
-	gc.Conn = NewDummyConn(addr)
-	v = NewVisor(vc)
-	assert.False(t, v.Config.Disabled)
-	assert.NotPanics(t, func() { v.AnnounceBlocks(p) })
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 1)
-	if len(p.Pool.SendResults) == 0 {
-		t.Fatal("SendResults empty, would block")
-	}
-	sr := <-p.Pool.SendResults
-	assert.Nil(t, sr.Error)
-	assert.Equal(t, sr.Connection, gc)
-	_, ok := sr.Message.(*AnnounceBlocksMessage)
-	assert.True(t, ok)
-	assert.False(t, gc.LastSent.IsZero())
-}
-
-func TestVisorRequestBlocksFromAddr(t *testing.T) {
-	defer cleanupVisor()
-	defer gnet.EraseMessages()
-	p, gc := setupPool()
-	vc, _ := setupVisor()
-	go p.Pool.ConnectionWriteLoop(gc)
-
-	// Disabled
-	vc.Disabled = true
-	v := NewVisor(vc)
-	assert.NotPanics(t, func() {
-		err := v.RequestBlocksFromAddr(p, addr)
-		assert.NotNil(t, err)
-		assert.Equal(t, err.Error(), "Visor disabled")
-	})
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 0)
-	assert.True(t, gc.LastSent.IsZero())
-
-	vc.Disabled = false
-	v = NewVisor(vc)
-	assert.NotPanics(t, func() {
-		assert.Nil(t, v.RequestBlocksFromAddr(p, addr))
-	})
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 1)
-	if len(p.Pool.SendResults) == 0 {
-		t.Fatal("SendResults empty, would block")
-	}
-	sr := <-p.Pool.SendResults
-	assert.Nil(t, sr.Error)
-	assert.Equal(t, sr.Connection, gc)
-	_, ok := sr.Message.(*GetBlocksMessage)
-	assert.True(t, ok)
-	assert.False(t, gc.LastSent.IsZero())
-
-	// No connection found for addr
-	gc.LastSent = time.Time{}
-	gc.Conn = NewDummyConn(addr)
-	delete(p.Pool.Pool, gc.Id)
-	delete(p.Pool.Addresses, gc.Addr())
-	assert.NotPanics(t, func() {
-		assert.NotNil(t, v.RequestBlocksFromAddr(p, addr))
-	})
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 0)
-	assert.True(t, gc.LastSent.IsZero())
-}
-
-func TestVisorBroadcastBlock(t *testing.T) {
-	defer cleanupVisor()
-	defer gnet.EraseMessages()
-	p, gc := setupPool()
-	vc, _ := setupVisor()
-	vc.Disabled = true
-	v := NewVisor(vc)
-	// Should not send anything if disabled
-	assert.NotPanics(t, func() {
-		v.broadcastBlock(visor.SignedBlock{}, p)
-	})
-	assert.Equal(t, len(p.Pool.SendResults), 0)
-	assert.True(t, gc.LastSent.IsZero())
-
-	// Sending
-	gc.Conn = NewDummyConn(addr)
-	vc.Disabled = false
-	v = NewVisor(vc)
-	sb := v.Visor.GetGenesisBlock()
-	assert.NotPanics(t, func() {
-		v.broadcastBlock(sb, p)
-	})
-	go p.Pool.ConnectionWriteLoop(gc)
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 1)
-	if len(p.Pool.SendResults) == 0 {
-		t.Fatal("SendResults empty, would block")
-	}
-	sr := <-p.Pool.SendResults
-	assert.Equal(t, sr.Connection, gc)
-	_, ok := sr.Message.(*GiveBlocksMessage)
-	assert.True(t, ok)
-	assert.Nil(t, sr.Error)
-	assert.False(t, gc.LastSent.IsZero())
-}
-
-func TestVisorBroadcastTransaction(t *testing.T) {
-	defer cleanupVisor()
-	defer gnet.EraseMessages()
-	p, gc := setupPool()
-	go p.Pool.ConnectionWriteLoop(gc)
-	vc, _ := setupVisor()
-	vc.Disabled = true
-	v := NewVisor(vc)
-	ut := createUnconfirmedTxn()
-	assert.NotPanics(t, func() {
-		v.BroadcastTransaction(ut.Txn, p)
-	})
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 0)
-	assert.True(t, gc.LastSent.IsZero())
-
-	// Sending
-	vc.Disabled = false
-	gc.Conn = NewDummyConn(addr)
-	v = NewVisor(vc)
-	assert.NotPanics(t, func() {
-		v.BroadcastTransaction(ut.Txn, p)
-	})
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 1)
-	if len(p.Pool.SendResults) == 0 {
-		t.Fatal("SendResults empty, would block")
-	}
-	sr := <-p.Pool.SendResults
-	assert.Nil(t, sr.Error)
-	assert.Equal(t, sr.Connection, gc)
-	_, ok := sr.Message.(*GiveTxnsMessage)
-	assert.True(t, ok)
-	assert.False(t, gc.LastSent.IsZero())
-}
-
-func TestVisorSpend(t *testing.T) {
-	defer cleanupVisor()
-	defer gnet.EraseMessages()
-	p, gc := setupPool()
-	go p.Pool.ConnectionWriteLoop(gc)
-	vc, mv := setupVisor()
-	vc.Disabled = true
-	v := NewVisor(vc)
-	// Spending while disabled
-	_, err := v.Spend("xxx", wallet.Balance{10e6, 0}, 0,
-		mv.Wallets[0].GetAddresses()[0], p)
-	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "Visor disabled")
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 0)
-	assert.True(t, gc.LastSent.IsZero())
-
-	// Spending but spend fails (no money)
-	vc.Disabled = false
-	v = NewVisor(vc)
-	_, err = v.Spend(v.Visor.Wallets[0].GetFilename(),
-		wallet.Balance{1000 * 10e6, 0}, 0, mv.Wallets[0].GetAddresses()[0],
-		p)
-	wait()
-	assert.NotNil(t, err)
-	assert.Equal(t, len(p.Pool.SendResults), 0)
-	assert.Equal(t, len(v.Visor.Unconfirmed.Txns), 0)
-	assert.True(t, gc.LastSent.IsZero())
-
-	// Spending succeeds, and announced
-	vc, mv = setupVisor()
-	vc.Disabled = false
-	gc.Conn = NewDummyConn(addr)
-	v = NewVisor(vc)
-	assert.Nil(t, transferCoins(mv, v.Visor))
-	_, err = v.Spend(v.Visor.Wallets[0].GetFilename(), wallet.Balance{10e6, 0},
-		0, mv.Wallets[0].GetAddresses()[0], p)
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 1)
-	if len(p.Pool.SendResults) == 0 {
-		t.Fatal("SendResults empty, would block")
-	}
-	sr := <-p.Pool.SendResults
-	assert.Equal(t, sr.Connection, gc)
-	assert.Nil(t, sr.Error)
-	_, ok := sr.Message.(*GiveTxnsMessage)
-	assert.True(t, ok)
-	assert.Nil(t, err)
-	assert.Equal(t, len(v.Visor.Unconfirmed.Txns), 1)
-	assert.False(t, gc.LastSent.IsZero())
-}
-
-func TestVisorResendTransaction(t *testing.T) {
-	defer cleanupVisor()
-	defer gnet.EraseMessages()
-	p, gc := setupPool()
-	go p.Pool.ConnectionWriteLoop(gc)
-	vc, mv := setupVisor()
-	v := NewVisor(vc)
-	assert.Equal(t, len(v.Visor.Unconfirmed.Txns), 0)
-
-	// Nothing should happen if txn unknown
-	v.ResendTransaction(cipher.SumSHA256([]byte("garbage")), p)
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 0)
-	assert.Equal(t, len(p.Pool.SendResults), 0)
-	assert.Equal(t, len(v.Visor.Unconfirmed.Txns), 0)
-	assert.True(t, gc.LastSent.IsZero())
-
-	// give the visor some coins, and make a spend to add a txn
-	assert.Nil(t, transferCoins(mv, v.Visor))
-	tx, err := v.Spend(v.Visor.Wallets[0].GetFilename(), wallet.Balance{10e6, 0}, 0,
-		mv.Wallets[0].GetAddresses()[0], p)
-	assert.Nil(t, err)
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 1)
-	if len(p.Pool.SendResults) == 0 {
-		t.Fatal("SendResults empty, would block")
-	}
-	<-p.Pool.SendResults
-	assert.Equal(t, len(v.Visor.Unconfirmed.Txns), 1)
-	h := tx.Hash()
-	ut := v.Visor.Unconfirmed.Txns[h]
-	ut.Announced = time.Time{}
-	v.Visor.Unconfirmed.Txns[h] = ut
-	assert.True(t, v.Visor.Unconfirmed.Txns[h].Announced.IsZero())
-	// Reset the sent timer since we made a successful spend
-	gc.LastSent = time.Time{}
-
-	// Nothing should send if disabled
-	v.Config.Disabled = true
-	v.ResendTransaction(h, p)
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 0)
-	ann := v.Visor.Unconfirmed.Txns[h].Announced
-	assert.True(t, ann.IsZero())
-	assert.True(t, gc.LastSent.IsZero())
-
-	// Should have resent
-	v.Config.Disabled = false
-	gc.Conn = NewDummyConn(addr)
-	v.ResendTransaction(h, p)
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 1)
-	if len(p.Pool.SendResults) == 0 {
-		t.Fatal("SendResults empty, would block")
-	}
-	sr := <-p.Pool.SendResults
-	assert.Nil(t, sr.Error)
-	assert.Equal(t, sr.Connection, gc)
-	_, ok := sr.Message.(*GiveTxnsMessage)
-	assert.True(t, ok)
-	ann = v.Visor.Unconfirmed.Txns[h].Announced
-	// Announced state should not be updated until we process it
-	assert.True(t, ann.IsZero())
-	assert.False(t, gc.LastSent.IsZero())
-}
-
-func TestCreateAndPublishBlock(t *testing.T) {
-	defer cleanupVisor()
-	defer gnet.EraseMessages()
-	p, gc := setupPool()
-	vc, mv := setupVisor()
-	dest := wallet.NewWalletEntry()
-	go p.Pool.ConnectionWriteLoop(gc)
-
-	// Disabled
-	vc.Disabled = true
-	vc.Config = mv.Config
-	v := NewVisor(vc)
-	v.Visor = mv
-	err := v.CreateAndPublishBlock(p)
-	assert.NotNil(t, err)
-	wait()
-	assert.Equal(t, err.Error(), "Visor disabled")
-	assert.Equal(t, len(p.Pool.SendResults), 0)
-	assert.Equal(t, v.Visor.HeadBkSeq(), uint64(0))
-
-	// Created and sent
-	vc.Disabled = false
-	vc.Config.IsMaster = true
-	vc.Config = mv.Config
-	v = NewVisor(vc)
-	gc.Conn = NewDummyConn(addr)
-	_, err = v.Spend(v.Visor.Wallets[0].GetFilename(), wallet.Balance{10 * 1e6, 0}, 0,
-		dest.Address, p)
-	assert.Nil(t, err)
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 1)
-	if len(p.Pool.SendResults) == 0 {
-		t.Fatal("SendResults empty, would block")
-	}
-	<-p.Pool.SendResults
-	err = v.CreateAndPublishBlock(p)
-	wait()
-	assert.Nil(t, err)
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 1)
-	if len(p.Pool.SendResults) == 0 {
-		t.Fatal("SendResults empty, would block")
-	}
-	sr := <-p.Pool.SendResults
-	assert.Nil(t, sr.Error)
-	assert.Equal(t, sr.Connection, gc)
-	_, ok := sr.Message.(*GiveBlocksMessage)
-	assert.True(t, ok)
-	assert.Equal(t, v.Visor.HeadBkSeq(), uint64(1))
-
-	// Can't create, don't have coins
-	// First, spend all of our coins
-	// vc2, _ := setupVisor()
-	// vc2.Config.GenesisSignature = vc.Config.GenesisSignature
-	// vc2.Config.MasterKeys = vc.Config.MasterKeys
-	// vc2.Config.IsMaster = true
-	// vc2.Disabled = false
-	vc.Config.IsMaster = true
-	vc.Disabled = false
-	v = NewVisor(vc)
-	tx, err := v.Spend(v.Visor.Wallets[0].GetFilename(),
-		wallet.Balance{vc.Config.GenesisCoinVolume, 0},
-		vc.Config.GenesisCoinVolume, dest.Address, p)
-	mv.InjectTxn(tx)
-	wait()
-	assert.Nil(t, err)
-	assert.Equal(t, len(p.Pool.SendResults), 1)
-	for len(p.Pool.SendResults) > 0 {
-		<-p.Pool.SendResults
-	}
-	err = v.CreateAndPublishBlock(p)
-	assert.Nil(t, err)
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 1)
-	for len(p.Pool.SendResults) > 0 {
-		<-p.Pool.SendResults
-	}
-	// No coins to spend, fail
-	assert.Equal(t, v.Visor.HeadBkSeq(), uint64(1))
-	_, err = v.Spend(v.Visor.Wallets[0].GetFilename(), wallet.Balance{10 * 1e6, 0}, 0,
-		dest.Address, p)
-	assert.NotNil(t, err)
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 0)
-	err = v.CreateAndPublishBlock(p)
-	assert.NotNil(t, err)
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 0)
-	assert.Equal(t, v.Visor.HeadBkSeq(), uint64(1))
-}
-
-func TestRecordBlockchainLength(t *testing.T) {
-	defer cleanupVisor()
-	vc, _ := setupVisor()
-	v := NewVisor(vc)
-	assert.NotPanics(t, func() { v.recordBlockchainLength(addr, uint64(6)) })
-	assert.Equal(t, v.blockchainLengths[addr], uint64(6))
-	v.blockchainLengths[addr] = uint64(7)
-	assert.NotPanics(t, func() { v.recordBlockchainLength(addr, uint64(5)) })
-	assert.Equal(t, v.blockchainLengths[addr], uint64(5))
-}
-
-func TestEstimateBlockchainLength(t *testing.T) {
-	defer cleanupVisor()
-	vc, mv := setupVisor()
-	v := NewVisor(vc)
-	assert.Nil(t, transferCoins(mv, v.Visor))
-	assert.Equal(t, v.Visor.HeadBkSeq(), uint64(1))
-	// With no peers reporting, returns our own blockchain length
-	assert.Equal(t, v.EstimateBlockchainLength(), uint64(2))
-
-	// With only 1 peer reporting, returns our own blockchain length
-	v.recordBlockchainLength(addr, 1)
-	assert.Equal(t, v.EstimateBlockchainLength(), uint64(2))
-
-	// If the average reported is lower than our own, return our own
-	v.recordBlockchainLength(addr, 1)
-	v.recordBlockchainLength(addrb, 1)
-	assert.Equal(t, v.EstimateBlockchainLength(), uint64(2))
-
-	// Should return the exact median if odd # of them
-	v.recordBlockchainLength(addr, 1)
-	v.recordBlockchainLength(addrb, 5)
-	v.recordBlockchainLength(addrc, 9)
-	assert.Equal(t, v.EstimateBlockchainLength(), uint64(5))
-
-	// Should return the average of the median values, if even # of them
-	v.recordBlockchainLength(addr, 1)
-	v.recordBlockchainLength(addrb, 5)
-	v.recordBlockchainLength(addrc, 9)
-	v.recordBlockchainLength(addrd, 100)
-	assert.Equal(t, v.EstimateBlockchainLength(), uint64(7))
-}
-
-// Visor Messages
-
-func TestGetBlocksMessageHandle(t *testing.T) {
-	d := newDefaultDaemon()
-	defer shutdown(d)
-	m := NewGetBlocksMessage(uint64(1))
-	assert.Equal(t, m.LastBlock, uint64(1))
-	testSimpleMessageHandler(t, d, m)
-
-	// Test serialization
-	m = NewGetBlocksMessage(uint64(106))
-	b := encoder.Serialize(m)
-	m2 := GetBlocksMessage{}
-	assert.Nil(t, encoder.DeserializeRaw(b, &m2))
-	assert.Equal(t, *m, m2)
-}
-
-func TestGetBlocksMessageProcess(t *testing.T) {
-	v, mv := setupVisor()
-	d, _ := newVisorDaemon(v)
-	defer shutdown(d)
-	gc := setupExistingPool(d.Pool)
-	p := d.Pool.Pool
-	go p.ConnectionWriteLoop(gc)
-	assert.Nil(t, transferCoins(mv, d.Visor.Visor))
-	assert.Equal(t, d.Visor.Visor.HeadBkSeq(), uint64(1))
-	m := NewGetBlocksMessage(uint64(7))
-	m.c = messageContext(addr)
-	go p.ConnectionWriteLoop(m.c.Conn)
-	defer m.c.Conn.Close()
-
-	// Disabled
-	d.Visor.Config.Disabled = true
-	m.Process(d)
-	wait()
-	assert.Equal(t, len(p.SendResults), 0)
-	// Disabled should not record a blockchain length
-	assert.Equal(t, len(d.Visor.blockchainLengths), 0)
-
-	// Enabled handler, should record bc length not not send anything since
-	// we have nothing new enough
-	d.Visor.Config.Disabled = false
-	m.Process(d)
-	wait()
-	assert.Equal(t, len(p.SendResults), 0)
-	assert.Equal(t, len(d.Visor.blockchainLengths), 1)
-	assert.Equal(t, d.Visor.blockchainLengths[addr], uint64(7))
-	assert.True(t, m.c.Conn.LastSent.IsZero())
-
-	// Working send
-	m.LastBlock = uint64(0)
-	m.c.Conn.Conn = NewDummyConn(addr)
-	m.Process(d)
-	wait()
-	assert.Equal(t, len(p.SendResults), 1)
-	if len(p.SendResults) == 0 {
-		t.Fatal("SendResults empty, would block")
-	}
-	sr := <-p.SendResults
-	assert.Nil(t, sr.Error)
-	assert.Equal(t, sr.Connection, m.c.Conn)
-	_, ok := sr.Message.(*GiveBlocksMessage)
-	assert.True(t, ok)
-	assert.Equal(t, len(d.Visor.blockchainLengths), 1)
-	assert.Equal(t, d.Visor.blockchainLengths[addr], uint64(0))
-	assert.False(t, m.c.Conn.LastSent.IsZero())
-	assert.True(t, gc.LastSent.IsZero())
-}
-
-func TestGiveBlocksMessageHandle(t *testing.T) {
-	d := newDefaultDaemon()
-	defer shutdown(d)
-	_, mv := setupVisor()
-	blocks := []visor.SignedBlock{mv.GetGenesisBlock()}
-	m := NewGiveBlocksMessage(blocks)
-	assert.Equal(t, m.Blocks, blocks)
-	testSimpleMessageHandler(t, d, m)
-
-	// Test serialization
-	bks, err := makeBlocks(mv, 4)
-	assert.Nil(t, err)
-	blocks = append(blocks, bks...)
-	m = NewGiveBlocksMessage(blocks)
-	b := encoder.Serialize(m)
-	m2 := GiveBlocksMessage{}
-	assert.Nil(t, encoder.DeserializeRaw(b, &m2))
-	assert.Equal(t, *m, m2)
-}
-
-func TestGiveBlocksMessageProcess(t *testing.T) {
-	v, mv := setupVisor()
-	d, _ := newVisorDaemon(v)
-	defer shutdown(d)
-	gc := setupExistingPool(d.Pool)
-	go d.Pool.Pool.ConnectionWriteLoop(gc)
-
-	blocks, err := makeBlocks(mv, 2)
-	assert.Nil(t, err)
-	assert.Equal(t, len(blocks), 2)
-	m := NewGiveBlocksMessage(blocks)
-	m.c = messageContext(addr)
-
-	// Disabled should have nothing happen
-	d.Visor.Config.Disabled = true
-	m.Process(d)
-	wait()
-	assert.Equal(t, len(d.Pool.Pool.SendResults), 0)
-	assert.Equal(t, d.Visor.Visor.HeadBkSeq(), uint64(0))
-	assert.True(t, gc.LastSent.IsZero())
-
-	// Not disabled and blocks were reannounced
-	d.Visor.Config.Disabled = false
-	gc.Conn = NewDummyConn(addr)
-	assert.Equal(t, len(blocks), 2)
-	m = NewGiveBlocksMessage(blocks)
-	assert.Equal(t, len(m.Blocks), 2)
-	m.c = messageContext(addr)
-	m.Process(d)
-	wait()
-	assert.Equal(t, len(d.Pool.Pool.SendResults), 1)
-	if len(d.Pool.Pool.SendResults) == 0 {
-		t.Fatal("SendResults empty, would block")
-	}
-	sr := <-d.Pool.Pool.SendResults
-	assert.Nil(t, sr.Error)
-	assert.Equal(t, sr.Connection, gc)
-	_, ok := sr.Message.(*AnnounceBlocksMessage)
-	assert.True(t, ok)
-	assert.Equal(t, d.Visor.Visor.HeadBkSeq(), uint64(2))
-	assert.False(t, gc.LastSent.IsZero())
-
-	// Send blocks we have and some we dont, as long as they are in order
-	// we can use the ones at the end
-	gc.LastSent = time.Time{}
-	moreBlocks, err := makeMoreBlocks(mv, 2,
-		blocks[len(blocks)-1].Block.Head.Time)
-	assert.Nil(t, err)
-	blocks = append(blocks, moreBlocks...)
-	m = NewGiveBlocksMessage(blocks)
-	m.c = messageContext(addr)
-	m.Process(d)
-	wait()
-	assert.Equal(t, len(d.Pool.Pool.SendResults), 1)
-	if len(d.Pool.Pool.SendResults) == 0 {
-		t.Fatal("SendResults empty, would block")
-	}
-	sr = <-d.Pool.Pool.SendResults
-	assert.Nil(t, sr.Error)
-	assert.Equal(t, sr.Connection, gc)
-	_, ok = sr.Message.(*AnnounceBlocksMessage)
-	assert.True(t, ok)
-	assert.Equal(t, d.Visor.Visor.HeadBkSeq(), uint64(4))
-	assert.False(t, gc.LastSent.IsZero())
-
-	// Send invalid blocks
-	gc.LastSent = time.Time{}
-	bb := visor.SignedBlock{
-		Block: coin.Block{
-			Head: coin.BlockHeader{
-				BkSeq: uint64(7),
-			}}}
-	m = NewGiveBlocksMessage([]visor.SignedBlock{bb})
-	m.c = messageContext(addr)
-	m.Process(d)
-	assert.Equal(t, len(d.Pool.Pool.SendResults), 0)
-	assert.Equal(t, d.Visor.Visor.HeadBkSeq(), uint64(4))
-	assert.True(t, gc.LastSent.IsZero())
-}
-
-func TestAnnounceBlocksMessageHandle(t *testing.T) {
-	d := newDefaultDaemon()
-	defer shutdown(d)
-	m := NewAnnounceBlocksMessage(uint64(7))
-	assert.Equal(t, m.MaxBkSeq, uint64(7))
-	testSimpleMessageHandler(t, d, m)
-
-	// Test serialization
-	m = NewAnnounceBlocksMessage(uint64(101))
-	b := encoder.Serialize(m)
-	m2 := AnnounceBlocksMessage{}
-	assert.Nil(t, encoder.DeserializeRaw(b, &m2))
-	assert.Equal(t, *m, m2)
-}
-
-func TestAnnounceBlocksMessageProcess(t *testing.T) {
-	v, mv := setupVisor()
-	d, _ := newVisorDaemon(v)
-	defer shutdown(d)
-	p := d.Pool
-	gc := setupExistingPool(p)
-	go p.Pool.ConnectionWriteLoop(gc)
-	defer gc.Close()
-	assert.Nil(t, transferCoins(mv, d.Visor.Visor))
-	assert.Equal(t, d.Visor.Visor.HeadBkSeq(), uint64(1))
-
-	// Disabled, nothing should happen
-	d.Visor.Config.Disabled = true
-	m := NewAnnounceBlocksMessage(uint64(2))
-	m.c = messageContext(addr)
-	defer m.c.Conn.Close()
-	go p.Pool.ConnectionWriteLoop(m.c.Conn)
-	assert.NotPanics(t, func() { m.Process(d) })
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 0)
-	assert.True(t, m.c.Conn.LastSent.IsZero())
-	assert.True(t, gc.LastSent.IsZero())
-
-	// We know all the blocks
-	d.Visor.Config.Disabled = false
-	m.MaxBkSeq = uint64(1)
-	assert.NotPanics(t, func() { m.Process(d) })
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 0)
-	assert.True(t, m.c.Conn.LastSent.IsZero())
-	assert.True(t, gc.LastSent.IsZero())
-
-	// We send a GetBlocksMessage in response to a higher MaxBkSeq
-	m.MaxBkSeq = uint64(7)
-	assert.False(t, d.Visor.Visor.HeadBkSeq() >= m.MaxBkSeq)
-	assert.NotPanics(t, func() { m.Process(d) })
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 1)
-	if len(p.Pool.SendResults) == 0 {
-		t.Fatal("SendResults empty, would block")
-	}
-	sr := <-p.Pool.SendResults
-	assert.Nil(t, sr.Error)
-	assert.Equal(t, sr.Connection, m.c.Conn)
-	_, ok := sr.Message.(*GetBlocksMessage)
-	assert.True(t, ok)
-	assert.False(t, m.c.Conn.LastSent.IsZero())
-	assert.True(t, gc.LastSent.IsZero())
-}
-
-func TestAnnounceTxnsMessageHandle(t *testing.T) {
-	d := newDefaultDaemon()
-	defer shutdown(d)
-	tx := createUnconfirmedTxn()
-	txns := []cipher.SHA256{tx.Txn.Hash()}
-	m := NewAnnounceTxnsMessage(txns)
-	assert.Equal(t, m.Txns, txns)
-	testSimpleMessageHandler(t, d, m)
-
-	// Test serialization
-	tx = createUnconfirmedTxn()
-	txns = append(txns, tx.Txn.Hash())
-	tx = createUnconfirmedTxn()
-	txns = append(txns, tx.Txn.Hash())
-	m = NewAnnounceTxnsMessage(txns)
-	assert.Equal(t, len(m.Txns), 3)
-	b := encoder.Serialize(m)
-	m2 := AnnounceTxnsMessage{}
-	assert.Nil(t, encoder.DeserializeRaw(b, &m2))
-	assert.Equal(t, *m, m2)
-}
-
-func TestAnnounceTxnsMessageProcess(t *testing.T) {
-	v, _ := setupVisor()
-	d, _ := newVisorDaemon(v)
-	defer shutdown(d)
-	gc := setupExistingPool(d.Pool)
-	go d.Pool.Pool.ConnectionWriteLoop(gc)
-
-	tx := createUnconfirmedTxn()
-	txns := []cipher.SHA256{tx.Txn.Hash()}
-	m := NewAnnounceTxnsMessage(txns)
-	m.c = messageContext(addr)
-	go d.Pool.Pool.ConnectionWriteLoop(m.c.Conn)
-	defer m.c.Conn.Close()
-
-	// Disabled, nothing should happen
-	d.Visor.Config.Disabled = true
-	assert.NotPanics(t, func() { m.Process(d) })
-	wait()
-	assert.Equal(t, len(d.Pool.Pool.SendResults), 0)
-	assert.True(t, m.c.Conn.LastSent.IsZero())
-	assert.True(t, gc.LastSent.IsZero())
-
-	// We don't know some, request them
-	d.Visor.Config.Disabled = false
-	assert.NotPanics(t, func() { m.Process(d) })
-	wait()
-	assert.Equal(t, len(d.Pool.Pool.SendResults), 1)
-	if len(d.Pool.Pool.SendResults) == 0 {
-		t.Fatal("SendResults empty, would block")
-	}
-	sr := <-d.Pool.Pool.SendResults
-	assert.Equal(t, sr.Connection, m.c.Conn)
-	assert.Nil(t, sr.Error)
-	_, ok := sr.Message.(*GetTxnsMessage)
-	assert.True(t, ok)
-	assert.False(t, m.c.Conn.LastSent.IsZero())
-	// Should not have been broadcast
-	assert.True(t, gc.LastSent.IsZero())
-
-	// We know all the reported txns, nothing should be sent
-	d.Visor.Visor.Unconfirmed.Txns[tx.Txn.Hash()] = tx
-	m.c.Conn.Conn = NewDummyConn(addr)
-	m.c.Conn.LastSent = time.Time{}
-	assert.NotPanics(t, func() { m.Process(d) })
-	wait()
-	assert.Equal(t, len(d.Pool.Pool.SendResults), 0)
-	assert.True(t, m.c.Conn.LastSent.IsZero())
-	assert.True(t, gc.LastSent.IsZero())
-}
-
-func TestGetTxnsMessageHandle(t *testing.T) {
-	d := newDefaultDaemon()
-	defer shutdown(d)
-	tx := createUnconfirmedTxn()
-	txns := []cipher.SHA256{tx.Txn.Hash()}
-	m := NewGetTxnsMessage(txns)
-	assert.Equal(t, m.Txns, txns)
-	testSimpleMessageHandler(t, d, m)
-
-	// Test serialization
-	tx = createUnconfirmedTxn()
-	txns = append(txns, tx.Txn.Hash())
-	tx = createUnconfirmedTxn()
-	txns = append(txns, tx.Txn.Hash())
-	m = NewGetTxnsMessage(txns)
-	assert.Equal(t, len(m.Txns), 3)
-	b := encoder.Serialize(m)
-	m2 := GetTxnsMessage{}
-	assert.Nil(t, encoder.DeserializeRaw(b, &m2))
-	assert.Equal(t, *m, m2)
-}
-
-func TestGetTxnsMessageProcess(t *testing.T) {
-	v, _ := setupVisor()
-	d, _ := newVisorDaemon(v)
-	defer shutdown(d)
-	gc := setupExistingPool(d.Pool)
-	p := d.Pool
-	go p.Pool.ConnectionWriteLoop(gc)
-	tx := createUnconfirmedTxn()
-	tx.Txn.Head.Hash = cipher.SumSHA256([]byte("asdadwadwada"))
-	txns := []cipher.SHA256{tx.Txn.Hash()}
-	m := NewGetTxnsMessage(txns)
-	m.c = messageContext(addr)
-	go p.Pool.ConnectionWriteLoop(m.c.Conn)
-	defer m.c.Conn.Close()
-
-	// We don't have any to reply with
-	assert.NotPanics(t, func() { m.Process(d) })
-	assert.True(t, m.c.Conn.LastSent.IsZero())
-
-	// Disabled, nothing should happen
-	d.Visor.Visor.Unconfirmed.Txns[tx.Txn.Hash()] = tx
-	d.Visor.Config.Disabled = true
-	assert.NotPanics(t, func() { m.Process(d) })
-	assert.True(t, m.c.Conn.LastSent.IsZero())
-
-	// We have some to reply with
-	d.Visor.Config.Disabled = false
-	assert.NotPanics(t, func() { m.Process(d) })
-	wait()
-	assert.Equal(t, len(p.Pool.SendResults), 1)
-	if len(p.Pool.SendResults) == 0 {
-		t.Fatal("SendResults empty, would block")
-	}
-	sr := <-p.Pool.SendResults
-	assert.Equal(t, sr.Connection, m.c.Conn)
-	assert.Nil(t, sr.Error)
-	_, ok := sr.Message.(*GiveTxnsMessage)
-	assert.True(t, ok)
-	assert.False(t, m.c.Conn.LastSent.IsZero())
-	// Should not be broadcast to others
-	assert.True(t, gc.LastSent.IsZero())
-}
-
-func TestGiveTxnsMessageHandle(t *testing.T) {
-	d := newDefaultDaemon()
-	defer shutdown(d)
-	tx := createUnconfirmedTxn()
-	txns := coin.Transactions{tx.Txn}
-	m := NewGiveTxnsMessage(txns)
-	assert.Equal(t, m.Txns, txns)
-	testSimpleMessageHandler(t, d, m)
-
-	// Test serialization
-	tx = createUnconfirmedTxn()
-	txns = append(txns, tx.Txn)
-	tx = createUnconfirmedTxn()
-	txns = append(txns, tx.Txn)
-	m = NewGiveTxnsMessage(txns)
-	assert.Equal(t, len(m.Txns), 3)
-	b := encoder.Serialize(m)
-	m2 := GiveTxnsMessage{}
-	assert.Nil(t, encoder.DeserializeRaw(b, &m2))
-	assert.Equal(t, *m, m2)
-}
-
-func TestGiveTxnsMessageProcess(t *testing.T) {
-	v, mv := setupVisor()
-	d, _ := newVisorDaemon(v)
-	defer shutdown(d)
-	gc := setupExistingPool(d.Pool)
-	go d.Pool.Pool.ConnectionWriteLoop(gc)
-
-	utx := createUnconfirmedTxn()
-	txns := coin.Transactions{utx.Txn}
-	m := NewGiveTxnsMessage(txns)
-	m.c = messageContext(addr)
-
-	// No valid txns, nothing should be sent
-	assert.NotPanics(t, func() { m.Process(d) })
-	wait()
-	assert.Equal(t, len(mv.Unconfirmed.Txns), 0)
-	assert.Equal(t, len(d.Pool.Pool.SendResults), 0)
-	assert.True(t, gc.LastSent.IsZero())
-
-	// Disabled, nothing should happen
-	tx, err := makeValidTxn(mv)
-	assert.Nil(t, err)
-	m.Txns = coin.Transactions{tx}
-	d.Visor.Config.Disabled = true
-	assert.NotPanics(t, func() { m.Process(d) })
-	wait()
-	assert.Equal(t, len(d.Pool.Pool.SendResults), 0)
-	assert.Equal(t, len(mv.Unconfirmed.Txns), 0)
-	assert.True(t, gc.LastSent.IsZero())
-
-	// A valid txn, we should broadcast. Txn's announce state should be updated
-	d.Visor.Config.Disabled = false
-	assert.True(t, gc.LastSent.IsZero())
-	assert.NotPanics(t, func() { m.Process(d) })
-	assert.Equal(t, len(d.Visor.Visor.Unconfirmed.Txns), 1)
-	wait()
-	assert.Equal(t, len(d.Pool.Pool.SendResults), 1)
-	if len(d.Pool.Pool.SendResults) == 0 {
-		t.Fatal("SendResults empty, would block")
-	}
-	sr := <-d.Pool.Pool.SendResults
-	assert.Equal(t, sr.Connection, gc)
-	_, ok := sr.Message.(*AnnounceTxnsMessage)
-	assert.True(t, ok)
-	assert.Nil(t, err)
-	assert.False(t, gc.LastSent.IsZero())
-	_, ok = d.Visor.Visor.Unconfirmed.Txns[tx.Hash()]
-	assert.True(t, ok)
-}
-
-// Misc
-
-func assertSendingTxnsMessageInterface(t *testing.T, i interface{},
-	hashes []cipher.SHA256, isSending bool) {
-	m, ok := i.(SendingTxnsMessage)
-	assert.Equal(t, ok, isSending)
-	if isSending {
-		assert.Equal(t, m.GetTxns(), hashes)
+func TestVerifyTransactionIsLocked(t *testing.T) {
+	for _, addr := range visor.GetLockedDistributionAddresses() {
+		t.Run(fmt.Sprintf("IsLocked: %s", addr), func(t *testing.T) {
+			testVerifyTransactionAddressLocking(t, addr, "Transaction has locked address inputs")
+		})
 	}
 }
 
-func TestSendingTxnsMessageInterface(t *testing.T) {
-	hashes := []cipher.SHA256{randSHA256(t), randSHA256(t)}
-
-	// GetTxnsMessage should not be a SendingTxnsMessage, it is a request for
-	// them
-	getx := NewGetTxnsMessage(hashes)
-	assertSendingTxnsMessageInterface(t, getx, hashes, false)
-
-	// AnnounceTxnsMessage is a SendingTxnsMessage
-	annx := NewAnnounceTxnsMessage(hashes)
-	assertSendingTxnsMessageInterface(t, annx, hashes, true)
-
-	// GiveTxnsMessage is a SendingTxnsMessage
-	defer cleanupVisor()
-	_, v := setupVisor()
-	txns := coin.Transactions{
-		makeValidTxnNoError(t, v),
-		makeValidTxnNoError(t, v),
-	}
-	givx := NewGiveTxnsMessage(txns)
-	assertSendingTxnsMessageInterface(t, givx, txns.Hashes(), true)
-}
-
-func TestBlockchainLengths(t *testing.T) {
-	b := make(BlockchainLengths, 10)
-	for i := 0; i < 10; i++ {
-		b[i] = uint64(9 - i)
-	}
-	assert.Equal(t, b.Len(), 10)
-	assert.True(t, b.Less(4, 3))
-	assert.Equal(t, b[4], uint64(5))
-	assert.Equal(t, b[3], uint64(6))
-	b.Swap(4, 3)
-	assert.Equal(t, b[4], uint64(6))
-	assert.Equal(t, b[3], uint64(5))
-	sort.Sort(b)
-	for i := 0; i < 10; i++ {
-		assert.Equal(t, b[i], uint64(i))
+func TestVerifyTransactionIsUnlocked(t *testing.T) {
+	// Note: we can't sign transactions that spend the outputs of unlocked addresses,
+	// because these are real, hardcoded addresses for which we don't have the secret key.
+	// Validation is expected to fail, but it will fail on invalid header hash, rather than
+	// due to locked address inputs.
+	for _, addr := range visor.GetUnlockedDistributionAddresses() {
+		t.Run(fmt.Sprintf("IsUnlocked: %s", addr), func(t *testing.T) {
+			testVerifyTransactionAddressLocking(t, addr, "Transaction Verification Failed, Invalid header hash")
+		})
 	}
 }
 
-*/
+func testVerifyTransactionAddressLocking(t *testing.T, toAddr, errMsg string) {
+	addr, err := cipher.DecodeBase58Address(toAddr)
+	require.NoError(t, err)
+
+	db, close := testutil.PrepareDB(t)
+	defer close()
+
+	// Setup blockchain
+	bc := MakeBlockchain(t, db)
+
+	// Send coins to the initial address
+	var coins uint64 = GenesisCoins
+	var hours uint64 = 1e6
+	var fee uint64 = 5e8
+
+	txn := createGenesisSpendTransaction(t, bc, addr, coins, hours, fee)
+	uxOut := executeGenesisSpendTransaction(t, bc, txn)
+
+	// Create a transaction that spends from the locked address
+	// The secret key for the locked address is obviously unavailable here,
+	// instead, forge an invalid transaction.
+	// Transaction.Verify() is called after TransactionIsLocked(),
+	// so for this test it doesn't matter if transaction signature is wrong
+	_, _, randomAddress := MakeAddress()
+	txn = coin.Transaction{
+		In: []cipher.SHA256{uxOut.Hash()},
+		Out: []coin.TransactionOutput{
+			{
+				Address: randomAddress,
+				Coins:   uxOut.Body.Coins,
+				Hours:   uxOut.Body.Hours / 2,
+			},
+		},
+	}
+
+	// Setup a minimal visor
+	v := setupSimpleVisor(db, bc)
+
+	// Call verifyTransaction
+	err = v.verifyTransaction(txn)
+	testutil.RequireError(t, err, errMsg)
+}
+
+func TestVerifyTransactionInvalidFee(t *testing.T) {
+	db, close := testutil.PrepareDB(t)
+	defer close()
+
+	// Setup blockchain
+	bc := MakeBlockchain(t, db)
+
+	// Send coins to the initial address, with invalid fee
+	var coins uint64 = GenesisCoins
+	var hours uint64 = GenesisCoinHours * 1e3
+	var fee uint64 = 0
+	_, _, addr := MakeAddress()
+
+	txn := createGenesisSpendTransaction(t, bc, addr, coins, hours, fee)
+
+	// Setup a minimal visor
+	v := setupSimpleVisor(db, bc)
+
+	// Call verifyTransaction
+	err := v.verifyTransaction(txn)
+	testutil.RequireError(t, err, "Transaction coinhour fee minimum not met")
+}
+
+func TestVerifyTransactionInvalidSignature(t *testing.T) {
+	db, close := testutil.PrepareDB(t)
+	defer close()
+
+	// Setup blockchain
+	bc := MakeBlockchain(t, db)
+
+	// Send coins to the initial address, with invalid fee
+	var coins uint64 = GenesisCoins
+	var hours uint64 = 0
+	var fee uint64 = 0
+	_, _, addr := MakeAddress()
+
+	txn := createGenesisSpendTransaction(t, bc, addr, coins, hours, fee)
+
+	// Invalidate signatures
+	txn.Sigs = nil
+
+	// Setup a minimal visor
+	v := setupSimpleVisor(db, bc)
+
+	// Call verifyTransaction
+	err := v.verifyTransaction(txn)
+	testutil.RequireError(t, err, "Transaction Verification Failed, Invalid number of signatures")
+}
+
+func TestInjectValidTransaction(t *testing.T) {
+	db, close := testutil.PrepareDB(t)
+	defer close()
+
+	// Setup blockchain
+	bc := MakeBlockchain(t, db)
+
+	// Send coins to the initial address, with invalid fee
+	var coins uint64 = GenesisCoins
+	var hours uint64 = 0
+	var fee uint64 = 0
+	_, _, addr := MakeAddress()
+
+	txn := createGenesisSpendTransaction(t, bc, addr, coins, hours, fee)
+
+	// Setup a minimal visor
+	v := setupSimpleVisor(db, bc)
+
+	// The unconfirmed pool should be empty
+	txns := v.v.Unconfirmed.RawTxns()
+	require.Len(t, txns, 0)
+
+	// Call injectTransaction
+	err := v.injectTransaction(txn, nil)
+	require.NoError(t, err)
+
+	// The transaction should appear in the unconfirmed pool
+	txns = v.v.Unconfirmed.RawTxns()
+	require.Len(t, txns, 1)
+	require.Equal(t, txns[0], txn)
+}
+
+func TestInjectInvalidTransaction(t *testing.T) {
+	db, close := testutil.PrepareDB(t)
+	defer close()
+
+	// Setup blockchain
+	bc := MakeBlockchain(t, db)
+
+	// Send coins to the initial address, with invalid fee
+	var coins uint64 = GenesisCoins
+	var hours uint64 = GenesisCoinHours * 1e3
+	var fee uint64 = 0
+	_, _, addr := MakeAddress()
+
+	txn := createGenesisSpendTransaction(t, bc, addr, coins, hours, fee)
+
+	// Setup a minimal visor
+	v := setupSimpleVisor(db, bc)
+
+	// The unconfirmed pool should be empty
+	txns := v.v.Unconfirmed.RawTxns()
+	require.Len(t, txns, 0)
+
+	// Call injectTransaction
+	err := v.injectTransaction(txn, nil)
+	testutil.RequireError(t, err, "Transaction coinhour fee minimum not met")
+
+	// The transaction should appear in the unconfirmed pool
+	txns = v.v.Unconfirmed.RawTxns()
+	require.Len(t, txns, 0)
+}
 
 func TestSplitHashes(t *testing.T) {
 	hashes := make([]cipher.SHA256, 10)
@@ -1427,7 +303,7 @@ func TestSplitHashes(t *testing.T) {
 		hashes[i] = cipher.SumSHA256(cipher.RandByte(512))
 	}
 
-	testCasts := []struct {
+	testCases := []struct {
 		name  string
 		init  []cipher.SHA256
 		n     int
@@ -1509,10 +385,10 @@ func TestSplitHashes(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCasts {
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			rlt := divideHashes(tc.init, tc.n)
-			assert.Equal(t, tc.array, rlt)
+			require.Equal(t, tc.array, rlt)
 		})
 	}
 }

--- a/src/gui/README.md
+++ b/src/gui/README.md
@@ -357,3 +357,130 @@ result:
 ```bash
 "3615fc23cc12a5cb9190878a2151d1cf54129ff0cd90e5fc4f4e7debebad6868"
 ```
+
+# Coin supply informations
+
+```bash
+URI: /coinSupply
+Method: GET
+```
+
+example:
+
+```bash
+curl http://127.0.0.1:6420/coinSupply
+```
+
+result:
+
+```json
+{
+    "current_supply": 5847530,
+    "total_supply": 30000000,
+    "max_supply": 100000000,
+    "unlocked_distribution_addresses": [
+        "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
+        "2EYM4WFHe4Dgz6kjAdUkM6Etep7ruz2ia6h",
+        "25aGyzypSA3T9K6rgPUv1ouR13efNPtWP5m",
+        "ix44h3cojvN6nqGcdpy62X7Rw6Ahnr3Thk",
+        "AYV8KEBEAPCg8a59cHgqHMqYHP9nVgQDyW",
+        "2Nu5Jv5Wp3RYGJU1EkjWFFHnebxMx1GjfkF",
+        "2THDupTBEo7UqB6dsVizkYUvkKq82Qn4gjf",
+        "tWZ11Nvor9parjg4FkwxNVcby59WVTw2iL",
+        "m2joQiJRZnj3jN6NsoKNxaxzUTijkdRoSR",
+        "8yf8PAQqU2cDj8Yzgz3LgBEyDqjvCh2xR7",
+        "sgB3n11ZPUYHToju6TWMpUZTUcKvQnoFMJ",
+        "2UYPbDBnHUEc67e7qD4eXtQQ6zfU2cyvAvk",
+        "wybwGC9rhm8ZssBuzpy5goXrAdE31MPdsj",
+        "JbM25o7kY7hqJZt3WGYu9pHZFCpA9TCR6t",
+        "2efrft5Lnwjtk7F1p9d7BnPd72zko2hQWNi",
+        "Syzmb3MiMoiNVpqFdQ38hWgffHg86D2J4e",
+        "2g3GUmTQooLrNHaRDhKtLU8rWLz36Beow7F",
+        "D3phtGr9iv6238b3zYXq6VgwrzwvfRzWZQ",
+        "gpqsFSuMCZmsjPc6Rtgy1FmLx424tH86My",
+        "2EUF3GPEUmfocnUc1w6YPtqXVCy3UZA4rAq",
+        "TtAaxB3qGz5zEAhhiGkBY9VPV7cekhvRYS",
+        "2fM5gVpi7XaiMPm4i29zddTNkmrKe6TzhVZ",
+        "ix3NDKgxfYYANKAb5kbmwBYXPrkAsha7uG",
+        "2RkPshpFFrkuaP98GprLtgHFTGvPY5e6wCK",
+        "Ak1qCDNudRxZVvcW6YDAdD9jpYNNStAVqm",
+        "2eZYSbzBKJ7QCL4kd5LSqV478rJQGb4UNkf",
+        "KPfqM6S96WtRLMuSy4XLfVwymVqivdcDoM",
+        "5B98bU1nsedGJBdRD5wLtq7Z8t8ZXio8u5",
+        "2iZWk5tmBynWxj2PpAFyiZzEws9qSnG3a6n",
+        "XUGdPaVnMh7jtzPe3zkrf9FKh5nztFnQU5"
+    ],
+    "locked_distribution_addresses": [
+        "hSNgHgewJme8uaHrEuKubHYtYSDckD6hpf",
+        "2DeK765jLgnMweYrMp1NaYHfzxumfR1PaQN",
+        "orrAssY5V2HuQAbW9K6WktFrGieq2m23pr",
+        "4Ebf4PkG9QEnQTm4MVvaZvJV6Y9av3jhgb",
+        "7Uf5xJ3GkiEKaLxC2WmJ1t6SeekJeBdJfu",
+        "oz4ytDKbCqpgjW3LPc52pW2CaK2gxCcWmL",
+        "2ex5Z7TufQ5Z8xv5mXe53fSQRfUr35SSo7Q",
+        "WV2ap7ZubTxeDdmEZ1Xo7ufGMkekLWikJu",
+        "ckCTV4r1pNuz6j2VBRHhaJN9HsCLY7muLV",
+        "MXJx96ZJVSjktgeYZpVK8vn1H3xWP8ooq5",
+        "wyQVmno9aBJZmQ99nDSLoYWwp7YDJCWsrH",
+        "2cc9wKxCsFNRkoAQDAoHke3ZoyL1mSV14cj",
+        "29k9g3F5AYfVaa1joE1PpZjBED6hQXes8Mm",
+        "2XPLzz4ZLf1A9ykyTCjW5gEmVjnWa8CuatH",
+        "iH7DqqojTgUn2JxmY9hgFp165Nk7wKfan9",
+        "RJzzwUs3c9C8Y7NFYzNfFoqiUKeBhBfPki",
+        "2W2cGyiCRM4nwmmiGPgMuGaPGeBzEm7VZPn",
+        "ALJVNKYL7WGxFBSriiZuwZKWD4b7fbV1od",
+        "tBaeg9zE2sgmw5ZQENaPPYd6jfwpVpGTzS",
+        "2hdTw5Hk3rsgpZjvk8TyKcCZoRVXU5QVrUt",
+        "A1QU6jKq8YgTP79M8fwZNHUZc7hConFKmy",
+        "q9RkXoty3X1fuaypDDRUi78rWgJWYJMmpJ",
+        "2Xvm6is5cAPA85xnSYXDuAqiRyoXiky5RaD",
+        "4CW2CPJEzxhn2PS4JoSLoWGL5QQ7dL2eji",
+        "24EG6uTzL7DHNzcwsygYGRR1nfu5kco7AZ1",
+        "KghGnWw5fppTrqHSERXZf61yf7GkuQdCnV",
+        "2WojewRA3LbpyXTP9ANy8CZqJMgmyNm3MDr",
+        "2BsMfywmGV3M2CoDA112Rs7ZBkiMHfy9X11",
+        "kK1Q4gPyYfVVMzQtAPRzL8qXMqJ67Y7tKs",
+        "28J4mx8xfUtM92DbQ6i2Jmqw5J7dNivfroN",
+        "gQvgyG1djgtftoCVrSZmsRxr7okD4LheKw",
+        "3iFGBKapAWWzbiGFSr5ScbhrEPm6Esyvia",
+        "NFW2akQH2vu7AqkQXxFz2P5vkXTWkSqrSm",
+        "2MQJjLnWRp9eHh6MpCwpiUeshhtmri12mci",
+        "2QjRQUMyL6iodtHP9zKmxCNYZ7k3jxtk49C",
+        "USdfKy7B6oFNoauHWMmoCA7ND9rHqYw2Mf",
+        "cA49et9WtptYHf6wA1F8qqVgH3kS5jJ9vK",
+        "qaJT9TjcMi46sTKcgwRQU8o5Lw2Ea1gC4N",
+        "22pyn5RyhqtTQu4obYjuWYRNNw4i54L8xVr",
+        "22dkmukC6iH4FFLBmHne6modJZZQ3MC9BAT",
+        "z6CJZfYLvmd41GRVE8HASjRcy5hqbpHZvE",
+        "GEBWJ2KpRQDBTCCtvnaAJV2cYurgXS8pta",
+        "oS8fbEm82cprmAeineBeDkaKd7QownDZQh",
+        "rQpAs1LVQdphyj9ipEAuukAoj9kNpSP8cM",
+        "6NSJKsPxmqipGAfFFhUKbkopjrvEESTX3j",
+        "cuC68ycVXmD2EBzYFNYQ6akhKGrh3FGjSf",
+        "bw4wtYU8toepomrhWP2p8UFYfHBbvEV425",
+        "HvgNmDz5jD39Gwmi9VfDY1iYMhZUpZ8GKz",
+        "SbApuZAYquWP3Q6iD51BcMBQjuApYEkRVf",
+        "2Ugii5yxJgLzC59jV1vF8GK7UBZdvxwobeJ",
+        "21N2iJ1qnQRiJWcEqNRxXwfNp8QcmiyhtPy",
+        "9TC4RGs6AtFUsbcVWnSoCdoCpSfM66ALAc",
+        "oQzn55UWG4iMcY9bTNb27aTnRdfiGHAwbD",
+        "2GCdwsRpQhcf8SQcynFrMVDM26Bbj6sgv9M",
+        "2NRFe7REtSmaM2qAgZeG45hC8EtVGV2QjeB",
+        "25RGnhN7VojHUTvQBJA9nBT5y1qTQGULMzR",
+        "26uCBDfF8E2PJU2Dzz2ysgKwv9m4BhodTz9",
+        "Wkvima5cF7DDFdmJQqcdq8Syaq9DuAJJRD",
+        "286hSoJYxvENFSHwG51ZbmKaochLJyq4ERQ",
+        "FEGxF3HPoM2HCWHn82tyeh9o7vEQq5ySGE",
+        "h38DxNxGhWGTq9p5tJnN5r4Fwnn85Krrb6",
+        "2c1UU8J6Y3kL4cmQh21Tj8wkzidCiZxwdwd",
+        "2bJ32KuGmjmwKyAtzWdLFpXNM6t83CCPLq5",
+        "2fi8oLC9zfVVGnzzQtu3Y3rffS65Hiz6QHo",
+        "TKD93RxFr2Am44TntLiJQus4qcEwTtvEEQ",
+        "zMDywYdGEDtTSvWnCyc3qsYHWwj9ogws74",
+        "25NbotTka7TwtbXUpSCQD8RMgHKspyDubXJ",
+        "2ayCELBERubQWH5QxUr3cTxrYpidvUAzsSw",
+        "RMTCwLiYDKEAiJu5ekHL1NQ8UKHi5ozCPg",
+        "ejJjiCwp86ykmFr5iTJ8LxQXJ2wJPTYmkm"
+    ]
+}
+```

--- a/src/gui/explorer.go
+++ b/src/gui/explorer.go
@@ -2,7 +2,6 @@ package gui
 
 import (
 	"net/http"
-	"strconv"
 
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/daemon"
@@ -15,181 +14,106 @@ func RegisterExplorerHandlers(mux *http.ServeMux, gateway *daemon.Gateway) {
 	// get set of pending transactions
 	mux.HandleFunc("/explorer/address", getTransactionsForAddress(gateway))
 
-	mux.HandleFunc("/explorer/getEffectiveOutputs", getCoinSupply(gateway))
-}
+	mux.HandleFunc("/explorer/getEffectiveOutputs", getEffectiveOutputs(gateway))
 
-const maxCoins = 100000000
-
-var addrList = []string{
-	"R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
-	"2EYM4WFHe4Dgz6kjAdUkM6Etep7ruz2ia6h",
-	"25aGyzypSA3T9K6rgPUv1ouR13efNPtWP5m",
-	"ix44h3cojvN6nqGcdpy62X7Rw6Ahnr3Thk",
-	"AYV8KEBEAPCg8a59cHgqHMqYHP9nVgQDyW",
-	"2Nu5Jv5Wp3RYGJU1EkjWFFHnebxMx1GjfkF",
-	"2THDupTBEo7UqB6dsVizkYUvkKq82Qn4gjf",
-	"tWZ11Nvor9parjg4FkwxNVcby59WVTw2iL",
-	"m2joQiJRZnj3jN6NsoKNxaxzUTijkdRoSR",
-	"8yf8PAQqU2cDj8Yzgz3LgBEyDqjvCh2xR7",
-	"sgB3n11ZPUYHToju6TWMpUZTUcKvQnoFMJ",
-	"2UYPbDBnHUEc67e7qD4eXtQQ6zfU2cyvAvk",
-	"wybwGC9rhm8ZssBuzpy5goXrAdE31MPdsj",
-	"JbM25o7kY7hqJZt3WGYu9pHZFCpA9TCR6t",
-	"2efrft5Lnwjtk7F1p9d7BnPd72zko2hQWNi",
-	"Syzmb3MiMoiNVpqFdQ38hWgffHg86D2J4e",
-	"2g3GUmTQooLrNHaRDhKtLU8rWLz36Beow7F",
-	"D3phtGr9iv6238b3zYXq6VgwrzwvfRzWZQ",
-	"gpqsFSuMCZmsjPc6Rtgy1FmLx424tH86My",
-	"2EUF3GPEUmfocnUc1w6YPtqXVCy3UZA4rAq",
-	"TtAaxB3qGz5zEAhhiGkBY9VPV7cekhvRYS",
-	"2fM5gVpi7XaiMPm4i29zddTNkmrKe6TzhVZ",
-	"ix3NDKgxfYYANKAb5kbmwBYXPrkAsha7uG",
-	"2RkPshpFFrkuaP98GprLtgHFTGvPY5e6wCK",
-	"Ak1qCDNudRxZVvcW6YDAdD9jpYNNStAVqm",
-	"2eZYSbzBKJ7QCL4kd5LSqV478rJQGb4UNkf",
-	"KPfqM6S96WtRLMuSy4XLfVwymVqivdcDoM",
-	"5B98bU1nsedGJBdRD5wLtq7Z8t8ZXio8u5",
-	"2iZWk5tmBynWxj2PpAFyiZzEws9qSnG3a6n",
-	"XUGdPaVnMh7jtzPe3zkrf9FKh5nztFnQU5",
-	"hSNgHgewJme8uaHrEuKubHYtYSDckD6hpf",
-	"2DeK765jLgnMweYrMp1NaYHfzxumfR1PaQN",
-	"orrAssY5V2HuQAbW9K6WktFrGieq2m23pr",
-	"4Ebf4PkG9QEnQTm4MVvaZvJV6Y9av3jhgb",
-	"7Uf5xJ3GkiEKaLxC2WmJ1t6SeekJeBdJfu",
-	"oz4ytDKbCqpgjW3LPc52pW2CaK2gxCcWmL",
-	"2ex5Z7TufQ5Z8xv5mXe53fSQRfUr35SSo7Q",
-	"WV2ap7ZubTxeDdmEZ1Xo7ufGMkekLWikJu",
-	"ckCTV4r1pNuz6j2VBRHhaJN9HsCLY7muLV",
-	"MXJx96ZJVSjktgeYZpVK8vn1H3xWP8ooq5",
-	"wyQVmno9aBJZmQ99nDSLoYWwp7YDJCWsrH",
-	"2cc9wKxCsFNRkoAQDAoHke3ZoyL1mSV14cj",
-	"29k9g3F5AYfVaa1joE1PpZjBED6hQXes8Mm",
-	"2XPLzz4ZLf1A9ykyTCjW5gEmVjnWa8CuatH",
-	"iH7DqqojTgUn2JxmY9hgFp165Nk7wKfan9",
-	"RJzzwUs3c9C8Y7NFYzNfFoqiUKeBhBfPki",
-	"2W2cGyiCRM4nwmmiGPgMuGaPGeBzEm7VZPn",
-	"ALJVNKYL7WGxFBSriiZuwZKWD4b7fbV1od",
-	"tBaeg9zE2sgmw5ZQENaPPYd6jfwpVpGTzS",
-	"2hdTw5Hk3rsgpZjvk8TyKcCZoRVXU5QVrUt",
-	"A1QU6jKq8YgTP79M8fwZNHUZc7hConFKmy",
-	"q9RkXoty3X1fuaypDDRUi78rWgJWYJMmpJ",
-	"2Xvm6is5cAPA85xnSYXDuAqiRyoXiky5RaD",
-	"4CW2CPJEzxhn2PS4JoSLoWGL5QQ7dL2eji",
-	"24EG6uTzL7DHNzcwsygYGRR1nfu5kco7AZ1",
-	"KghGnWw5fppTrqHSERXZf61yf7GkuQdCnV",
-	"2WojewRA3LbpyXTP9ANy8CZqJMgmyNm3MDr",
-	"2BsMfywmGV3M2CoDA112Rs7ZBkiMHfy9X11",
-	"kK1Q4gPyYfVVMzQtAPRzL8qXMqJ67Y7tKs",
-	"28J4mx8xfUtM92DbQ6i2Jmqw5J7dNivfroN",
-	"gQvgyG1djgtftoCVrSZmsRxr7okD4LheKw",
-	"3iFGBKapAWWzbiGFSr5ScbhrEPm6Esyvia",
-	"NFW2akQH2vu7AqkQXxFz2P5vkXTWkSqrSm",
-	"2MQJjLnWRp9eHh6MpCwpiUeshhtmri12mci",
-	"2QjRQUMyL6iodtHP9zKmxCNYZ7k3jxtk49C",
-	"USdfKy7B6oFNoauHWMmoCA7ND9rHqYw2Mf",
-	"cA49et9WtptYHf6wA1F8qqVgH3kS5jJ9vK",
-	"qaJT9TjcMi46sTKcgwRQU8o5Lw2Ea1gC4N",
-	"22pyn5RyhqtTQu4obYjuWYRNNw4i54L8xVr",
-	"22dkmukC6iH4FFLBmHne6modJZZQ3MC9BAT",
-	"z6CJZfYLvmd41GRVE8HASjRcy5hqbpHZvE",
-	"GEBWJ2KpRQDBTCCtvnaAJV2cYurgXS8pta",
-	"oS8fbEm82cprmAeineBeDkaKd7QownDZQh",
-	"rQpAs1LVQdphyj9ipEAuukAoj9kNpSP8cM",
-	"6NSJKsPxmqipGAfFFhUKbkopjrvEESTX3j",
-	"cuC68ycVXmD2EBzYFNYQ6akhKGrh3FGjSf",
-	"bw4wtYU8toepomrhWP2p8UFYfHBbvEV425",
-	"HvgNmDz5jD39Gwmi9VfDY1iYMhZUpZ8GKz",
-	"SbApuZAYquWP3Q6iD51BcMBQjuApYEkRVf",
-	"2Ugii5yxJgLzC59jV1vF8GK7UBZdvxwobeJ",
-	"21N2iJ1qnQRiJWcEqNRxXwfNp8QcmiyhtPy",
-	"9TC4RGs6AtFUsbcVWnSoCdoCpSfM66ALAc",
-	"oQzn55UWG4iMcY9bTNb27aTnRdfiGHAwbD",
-	"2GCdwsRpQhcf8SQcynFrMVDM26Bbj6sgv9M",
-	"2NRFe7REtSmaM2qAgZeG45hC8EtVGV2QjeB",
-	"25RGnhN7VojHUTvQBJA9nBT5y1qTQGULMzR",
-	"26uCBDfF8E2PJU2Dzz2ysgKwv9m4BhodTz9",
-	"Wkvima5cF7DDFdmJQqcdq8Syaq9DuAJJRD",
-	"286hSoJYxvENFSHwG51ZbmKaochLJyq4ERQ",
-	"FEGxF3HPoM2HCWHn82tyeh9o7vEQq5ySGE",
-	"h38DxNxGhWGTq9p5tJnN5r4Fwnn85Krrb6",
-	"2c1UU8J6Y3kL4cmQh21Tj8wkzidCiZxwdwd",
-	"2bJ32KuGmjmwKyAtzWdLFpXNM6t83CCPLq5",
-	"2fi8oLC9zfVVGnzzQtu3Y3rffS65Hiz6QHo",
-	"TKD93RxFr2Am44TntLiJQus4qcEwTtvEEQ",
-	"zMDywYdGEDtTSvWnCyc3qsYHWwj9ogws74",
-	"25NbotTka7TwtbXUpSCQD8RMgHKspyDubXJ",
-	"2ayCELBERubQWH5QxUr3cTxrYpidvUAzsSw",
-	"RMTCwLiYDKEAiJu5ekHL1NQ8UKHi5ozCPg",
-	"ejJjiCwp86ykmFr5iTJ8LxQXJ2wJPTYmkm",
+	mux.HandleFunc("/coinSupply", getCoinSupply(gateway))
 }
 
 // CoinSupply records the coin supply info
 // TODO -- API should export underscore key names e.g. coin_supply
 // Fixing this will require backwards-incompatible API changes
+type DeprecatedCoinSupply struct {
+	DeprecatedCurrentSupply                           uint64   `json:"coinSupply"`
+	DeprecatedCoinCap                                 uint64   `json:"coinCap"`
+	DeprecatedUndistributedLockedCoinBalance          uint64   `json:"UndistributedLockedCoinBalance"`
+	DeprecatedUndistributedLockedCoinHoldingAddresses []string `json:"UndistributedLockedCoinHoldingAddresses"`
+}
+
+// CoinSupply records the coin supply info
 type CoinSupply struct {
-	CurrentSupply                           int      `json:"coinSupply"`
-	CoinCap                                 int      `json:"coinCap"`
-	UndistributedLockedCoinBalance          int      `json:"UndistributedLockedCoinBalance"`
-	UndistributedLockedCoinHoldingAddresses []string `json:"UndistributedLockedCoinHoldingAddresses"`
+	// Coins distributed beyond the project:
+	CurrentSupply uint64 `json:"current_supply"`
+	// TotalSupply is CurrentSupply plus coins held by the distribution addresses that are spendable
+	TotalSupply uint64 `json:"total_supply"`
+	// MaxSupply is the maximum number of coins to be distributed ever
+	MaxSupply uint64 `json:"max_supply"`
+	// Distribution addresses which count towards total supply
+	UnlockedAddresses []string `json:"unlocked_distribution_addresses"`
+	// Distribution addresses which are locked and do not count towards total supply
+	LockedAddresses []string `json:"locked_distribution_addresses"`
 }
 
 func getCoinSupply(gateway *daemon.Gateway) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "GET" {
-			wh.Error405(w)
-			return
+		supply, _ := coinSupply(gateway, w, r)
+		if supply != nil {
+			wh.SendOr404(w, supply)
 		}
-
-		filters := []daemon.OutputsFilter{}
-		filters = append(filters, daemon.FbyAddressesNotIncluded(addrList))
-		outs, err := gateway.GetUnspentOutputs(filters...)
-		if err != nil {
-			wh.Error500(w)
-			return
-		}
-
-		totalSupply := 0
-		for _, u := range outs.HeadOutputs {
-			coin, err := strconv.Atoi(u.Coins)
-			if err != nil {
-				wh.Error500(w)
-				return
-			}
-			totalSupply = totalSupply + coin
-		}
-
-		filtersDevAddresses := []daemon.OutputsFilter{}
-		filtersDevAddresses = append(filtersDevAddresses, daemon.FbyAddresses(addrList))
-		devAddresses, err := gateway.GetUnspentOutputs(filtersDevAddresses...)
-		if err != nil {
-			wh.Error500(w)
-			return
-		}
-
-		totalDevBalance := 0
-		for _, u := range devAddresses.HeadOutputs {
-			coin, err := strconv.Atoi(u.Coins)
-			if err != nil {
-				wh.Error500(w)
-				return
-			}
-			totalDevBalance = totalDevBalance + coin
-		}
-
-		wh.SendOr404(w, CoinSupply{
-			CurrentSupply: totalSupply,
-			CoinCap:       maxCoins,
-			UndistributedLockedCoinHoldingAddresses: addrList,
-			UndistributedLockedCoinBalance:          totalDevBalance,
-		})
 	}
+}
+
+// DEPRECATED
+func getEffectiveOutputs(gateway *daemon.Gateway) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, oldSupply := coinSupply(gateway, w, r)
+		if oldSupply != nil {
+			wh.SendOr404(w, oldSupply)
+		}
+	}
+}
+
+func coinSupply(gateway *daemon.Gateway, w http.ResponseWriter, r *http.Request) (*CoinSupply, *DeprecatedCoinSupply) {
+	if r.Method != http.MethodGet {
+		wh.Error405(w)
+		return nil, nil
+	}
+
+	unlockedAddrs := visor.GetUnlockedDistributionAddresses()
+
+	filterInUnlocked := []daemon.OutputsFilter{}
+	filterInUnlocked = append(filterInUnlocked, daemon.FbyAddresses(unlockedAddrs))
+	unlockedOutputs, err := gateway.GetUnspentOutputs(filterInUnlocked...)
+	if err != nil {
+		wh.Error500(w)
+		return nil, nil
+	}
+
+	var unlockedSupply uint64
+	for _, u := range unlockedOutputs.HeadOutputs {
+		coins, err := visor.StrToBalance(u.Coins)
+		if err != nil {
+			logger.Error("Invalid unlocked output balance string %s: %v", u.Coins, err)
+			wh.Error500(w)
+			return nil, nil
+		}
+		unlockedSupply += coins / 1e6
+	}
+
+	// "total supply" is the number of coins unlocked.
+	// Each distribution address was allocated visor.DistributionAddressInitialBalance coins.
+	totalSupply := uint64(len(unlockedAddrs)) * visor.DistributionAddressInitialBalance
+	// "current supply" is the number of coins distribution from the unlocked pool
+	currentSupply := totalSupply - unlockedSupply
+
+	return &CoinSupply{
+			CurrentSupply:     currentSupply,
+			TotalSupply:       totalSupply,
+			MaxSupply:         visor.MaxCoinSupply,
+			UnlockedAddresses: unlockedAddrs,
+			LockedAddresses:   visor.GetLockedDistributionAddresses(),
+		}, &DeprecatedCoinSupply{
+			DeprecatedCurrentSupply:                           currentSupply,
+			DeprecatedCoinCap:                                 visor.MaxCoinSupply,
+			DeprecatedUndistributedLockedCoinBalance:          unlockedSupply,
+			DeprecatedUndistributedLockedCoinHoldingAddresses: visor.GetDistributionAddresses(),
+		}
 }
 
 // method: GET
 // url: /explorer/address?address=${address}
 func getTransactionsForAddress(gateway *daemon.Gateway) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "GET" {
+		if r.Method != http.MethodGet {
 			wh.Error405(w)
 			return
 		}
@@ -208,8 +132,8 @@ func getTransactionsForAddress(gateway *daemon.Gateway) http.HandlerFunc {
 
 		txns, err := gateway.GetAddressTxns(cipherAddr)
 		if err != nil {
-			wh.Error500(w)
 			logger.Error("Get address transactions failed: %v", err)
+			wh.Error500(w)
 			return
 		}
 
@@ -220,21 +144,21 @@ func getTransactionsForAddress(gateway *daemon.Gateway) http.HandlerFunc {
 			for i := range tx.Transaction.In {
 				id, err := cipher.SHA256FromHex(tx.Transaction.In[i])
 				if err != nil {
-					wh.Error500(w)
 					logger.Error("%v", err)
+					wh.Error500(w)
 					return
 				}
 
 				uxout, err := gateway.GetUxOutByID(id)
 				if err != nil {
-					wh.Error500(w)
 					logger.Error("%v", err)
+					wh.Error500(w)
 					return
 				}
 
 				if uxout == nil {
+					logger.Error("uxout of %d does not exist in history db", id)
 					wh.Error500(w)
-					logger.Error("uxout of %d does not exist in history db")
 					return
 				}
 

--- a/src/testutil/blockchain.go
+++ b/src/testutil/blockchain.go
@@ -1,0 +1,28 @@
+package testutil
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/boltdb/bolt"
+	"github.com/stretchr/testify/require"
+)
+
+func PrepareDB(t *testing.T) (*bolt.DB, func()) {
+	f, err := ioutil.TempFile("", "testdb")
+	require.Nil(t, err)
+
+	db, err := bolt.Open(f.Name(), 0700, nil)
+	require.Nil(t, err)
+
+	return db, func() {
+		db.Close()
+		os.Remove(f.Name())
+	}
+}
+
+func RequireError(t *testing.T, err error, msg string) {
+	require.Error(t, err)
+	require.Equal(t, msg, err.Error())
+}

--- a/src/visor/blockdb/unspent.go
+++ b/src/visor/blockdb/unspent.go
@@ -252,7 +252,7 @@ func (up *UnspentPool) getArray(hashes []cipher.SHA256) (coin.UxArray, error) {
 	return uxs, nil
 }
 
-// Get returns the uxout value of give hash
+// Get returns the uxout value of given hash
 func (up *UnspentPool) Get(h cipher.SHA256) (coin.UxOut, bool) {
 	up.Lock()
 	ux, ok := up.cache.pool[h.Hex()]

--- a/src/visor/bucket/bucket_test.go
+++ b/src/visor/bucket/bucket_test.go
@@ -3,31 +3,21 @@ package bucket
 import (
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 
 	"encoding/json"
 
 	"bytes"
 
-	"github.com/boltdb/bolt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skycoin/src/testutil"
 )
 
 type person struct {
 	Name string
 	Age  int
-}
-
-func prepareDB(t *testing.T) (*bolt.DB, func()) {
-	f := fmt.Sprintf("test%d.db", rand.Intn(1024))
-	db, err := bolt.Open(f, 0700, nil)
-	assert.Nil(t, err)
-	return db, func() {
-		db.Close()
-		os.Remove(f)
-	}
 }
 
 func TestBktUpdate(t *testing.T) {
@@ -47,7 +37,7 @@ func TestBktUpdate(t *testing.T) {
 		},
 	}
 
-	db, cancel := prepareDB(t)
+	db, cancel := testutil.PrepareDB(t)
 	defer cancel()
 
 	for _, tc := range testCases {
@@ -89,7 +79,7 @@ func TestBktUpdate(t *testing.T) {
 }
 
 func TestReset(t *testing.T) {
-	db, cancel := prepareDB(t)
+	db, cancel := testutil.PrepareDB(t)
 	defer cancel()
 
 	bkt, err := New([]byte("tete"), db)
@@ -141,7 +131,7 @@ func TestDelete(t *testing.T) {
 			nil,
 		},
 	}
-	db, cancel := prepareDB(t)
+	db, cancel := testutil.PrepareDB(t)
 	defer cancel()
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
@@ -174,7 +164,7 @@ func TestGetAll(t *testing.T) {
 			},
 		},
 	}
-	db, cancel := prepareDB(t)
+	db, cancel := testutil.PrepareDB(t)
 	defer cancel()
 
 	for _, tc := range testCases {
@@ -211,7 +201,7 @@ func TestRangeUpdate(t *testing.T) {
 			},
 		},
 	}
-	db, cancel := prepareDB(t)
+	db, cancel := testutil.PrepareDB(t)
 	defer cancel()
 
 	for _, tc := range testCases {
@@ -270,7 +260,7 @@ func TestIsExsit(t *testing.T) {
 		},
 	}
 
-	db, cancel := prepareDB(t)
+	db, cancel := testutil.PrepareDB(t)
 	defer cancel()
 
 	for _, tc := range testCases {
@@ -301,7 +291,7 @@ func TestForEach(t *testing.T) {
 			map[string]string{},
 		},
 	}
-	db, cancel := prepareDB(t)
+	db, cancel := testutil.PrepareDB(t)
 	defer cancel()
 	for _, tc := range testCases {
 		bkt, err := New([]byte(fmt.Sprintf("fasd%d", rand.Int31n(1024))), db)
@@ -347,7 +337,7 @@ func TestLen(t *testing.T) {
 		},
 	}
 
-	db, cl := prepareDB(t)
+	db, cl := testutil.PrepareDB(t)
 	defer cl()
 	for _, tc := range testCases {
 		bkt, err := New([]byte(fmt.Sprintf("adsf%d", rand.Int31n(1024))), db)
@@ -361,7 +351,7 @@ func TestLen(t *testing.T) {
 }
 
 func TestBucketIsEmpty(t *testing.T) {
-	db, td := prepareDB(t)
+	db, td := testutil.PrepareDB(t)
 	defer td()
 
 	bkt, err := New([]byte("bkt1"), db)

--- a/src/visor/distribution.go
+++ b/src/visor/distribution.go
@@ -1,0 +1,196 @@
+package visor
+
+import "github.com/skycoin/skycoin/src/coin"
+
+const (
+	// Maximum supply of skycoins
+	MaxCoinSupply uint64 = 1e8 // 100,000,000 million
+
+	// Number of distribution addresses
+	DistributionAddressesTotal uint64 = 100
+
+	DistributionAddressInitialBalance uint64 = MaxCoinSupply / DistributionAddressesTotal
+
+	// Initial number of unlocked addresses
+	InitialUnlockedCount uint64 = 30
+
+	// Number of addresses to unlock per unlock time interval
+	UnlockAddressRate uint64 = 5
+
+	// Unlock time interval, measured in seconds
+	// Once the InitialUnlockedCount is exhausted,
+	// UnlockAddressRate addresses will be unlocked per UnlockTimeInterval
+	UnlockTimeInterval uint64 = 60 * 60 * 24 * 365 // 1 year
+)
+
+func init() {
+	if MaxCoinSupply%DistributionAddressesTotal != 0 {
+		panic("MaxCoinSupply should be perfectly divisible by DistributionAddressesTotal")
+	}
+}
+
+// Returns a copy of the hardcoded distribution addresses array.
+// Each address has 1,000,000 coins. There are 100 addresses.
+func GetDistributionAddresses() []string {
+	addrs := make([]string, len(distributionAddresses))
+	for i := range distributionAddresses {
+		addrs[i] = distributionAddresses[i]
+	}
+	return addrs
+}
+
+// Returns distribution addresses that are unlocked, i.e. they have spendable outputs
+func GetUnlockedDistributionAddresses() []string {
+	// The first InitialUnlockedCount (30) addresses are unlocked by default.
+	// Subsequent addresses will be unlocked at a rate of UnlockAddressRate (5) per year,
+	// after the InitialUnlockedCount (30) addresses have no remaining balance.
+	// The unlock timer will be enabled manually once the
+	// InitialUnlockedCount (30) addresses are distributed.
+
+	// NOTE: To have automatic unlocking, transaction verification would have
+	// to be handled in visor rather than in coin.Transactions.Visor(), because
+	// the coin package is agnostic to the state of the blockchain and cannot reference it.
+	// Instead of automatic unlocking, we can hardcode the timestamp at which the first 30%
+	// is distributed, then compute the unlocked addresses easily here.
+
+	addrs := make([]string, InitialUnlockedCount)
+	for i := range distributionAddresses[:InitialUnlockedCount] {
+		addrs[i] = distributionAddresses[i]
+	}
+	return addrs
+}
+
+// Returns distribution addresses that are locked, i.e. they have unspendable outputs
+func GetLockedDistributionAddresses() []string {
+	addrs := make([]string, DistributionAddressesTotal-InitialUnlockedCount)
+	for i := range distributionAddresses[InitialUnlockedCount:] {
+		addrs[i] = distributionAddresses[InitialUnlockedCount+uint64(i)]
+	}
+	return addrs
+}
+
+// Returns true if the transaction spends locked outputs
+func TransactionIsLocked(bc *Blockchain, t *coin.Transaction) (bool, error) {
+	inUxs, err := bc.Unspent().GetArray(t.In)
+	if err != nil {
+		return false, err
+	}
+
+	lockedAddrs := GetLockedDistributionAddresses()
+	lockedAddrsMap := make(map[string]struct{})
+	for _, a := range lockedAddrs {
+		lockedAddrsMap[a] = struct{}{}
+	}
+
+	for _, o := range inUxs {
+		uxAddr := o.Body.Address.String()
+		if _, ok := lockedAddrsMap[uxAddr]; ok {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+var distributionAddresses = [DistributionAddressesTotal]string{
+	"R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
+	"2EYM4WFHe4Dgz6kjAdUkM6Etep7ruz2ia6h",
+	"25aGyzypSA3T9K6rgPUv1ouR13efNPtWP5m",
+	"ix44h3cojvN6nqGcdpy62X7Rw6Ahnr3Thk",
+	"AYV8KEBEAPCg8a59cHgqHMqYHP9nVgQDyW",
+	"2Nu5Jv5Wp3RYGJU1EkjWFFHnebxMx1GjfkF",
+	"2THDupTBEo7UqB6dsVizkYUvkKq82Qn4gjf",
+	"tWZ11Nvor9parjg4FkwxNVcby59WVTw2iL",
+	"m2joQiJRZnj3jN6NsoKNxaxzUTijkdRoSR",
+	"8yf8PAQqU2cDj8Yzgz3LgBEyDqjvCh2xR7",
+	"sgB3n11ZPUYHToju6TWMpUZTUcKvQnoFMJ",
+	"2UYPbDBnHUEc67e7qD4eXtQQ6zfU2cyvAvk",
+	"wybwGC9rhm8ZssBuzpy5goXrAdE31MPdsj",
+	"JbM25o7kY7hqJZt3WGYu9pHZFCpA9TCR6t",
+	"2efrft5Lnwjtk7F1p9d7BnPd72zko2hQWNi",
+	"Syzmb3MiMoiNVpqFdQ38hWgffHg86D2J4e",
+	"2g3GUmTQooLrNHaRDhKtLU8rWLz36Beow7F",
+	"D3phtGr9iv6238b3zYXq6VgwrzwvfRzWZQ",
+	"gpqsFSuMCZmsjPc6Rtgy1FmLx424tH86My",
+	"2EUF3GPEUmfocnUc1w6YPtqXVCy3UZA4rAq",
+	"TtAaxB3qGz5zEAhhiGkBY9VPV7cekhvRYS",
+	"2fM5gVpi7XaiMPm4i29zddTNkmrKe6TzhVZ",
+	"ix3NDKgxfYYANKAb5kbmwBYXPrkAsha7uG",
+	"2RkPshpFFrkuaP98GprLtgHFTGvPY5e6wCK",
+	"Ak1qCDNudRxZVvcW6YDAdD9jpYNNStAVqm",
+	"2eZYSbzBKJ7QCL4kd5LSqV478rJQGb4UNkf",
+	"KPfqM6S96WtRLMuSy4XLfVwymVqivdcDoM",
+	"5B98bU1nsedGJBdRD5wLtq7Z8t8ZXio8u5",
+	"2iZWk5tmBynWxj2PpAFyiZzEws9qSnG3a6n",
+	"XUGdPaVnMh7jtzPe3zkrf9FKh5nztFnQU5",
+	"hSNgHgewJme8uaHrEuKubHYtYSDckD6hpf",
+	"2DeK765jLgnMweYrMp1NaYHfzxumfR1PaQN",
+	"orrAssY5V2HuQAbW9K6WktFrGieq2m23pr",
+	"4Ebf4PkG9QEnQTm4MVvaZvJV6Y9av3jhgb",
+	"7Uf5xJ3GkiEKaLxC2WmJ1t6SeekJeBdJfu",
+	"oz4ytDKbCqpgjW3LPc52pW2CaK2gxCcWmL",
+	"2ex5Z7TufQ5Z8xv5mXe53fSQRfUr35SSo7Q",
+	"WV2ap7ZubTxeDdmEZ1Xo7ufGMkekLWikJu",
+	"ckCTV4r1pNuz6j2VBRHhaJN9HsCLY7muLV",
+	"MXJx96ZJVSjktgeYZpVK8vn1H3xWP8ooq5",
+	"wyQVmno9aBJZmQ99nDSLoYWwp7YDJCWsrH",
+	"2cc9wKxCsFNRkoAQDAoHke3ZoyL1mSV14cj",
+	"29k9g3F5AYfVaa1joE1PpZjBED6hQXes8Mm",
+	"2XPLzz4ZLf1A9ykyTCjW5gEmVjnWa8CuatH",
+	"iH7DqqojTgUn2JxmY9hgFp165Nk7wKfan9",
+	"RJzzwUs3c9C8Y7NFYzNfFoqiUKeBhBfPki",
+	"2W2cGyiCRM4nwmmiGPgMuGaPGeBzEm7VZPn",
+	"ALJVNKYL7WGxFBSriiZuwZKWD4b7fbV1od",
+	"tBaeg9zE2sgmw5ZQENaPPYd6jfwpVpGTzS",
+	"2hdTw5Hk3rsgpZjvk8TyKcCZoRVXU5QVrUt",
+	"A1QU6jKq8YgTP79M8fwZNHUZc7hConFKmy",
+	"q9RkXoty3X1fuaypDDRUi78rWgJWYJMmpJ",
+	"2Xvm6is5cAPA85xnSYXDuAqiRyoXiky5RaD",
+	"4CW2CPJEzxhn2PS4JoSLoWGL5QQ7dL2eji",
+	"24EG6uTzL7DHNzcwsygYGRR1nfu5kco7AZ1",
+	"KghGnWw5fppTrqHSERXZf61yf7GkuQdCnV",
+	"2WojewRA3LbpyXTP9ANy8CZqJMgmyNm3MDr",
+	"2BsMfywmGV3M2CoDA112Rs7ZBkiMHfy9X11",
+	"kK1Q4gPyYfVVMzQtAPRzL8qXMqJ67Y7tKs",
+	"28J4mx8xfUtM92DbQ6i2Jmqw5J7dNivfroN",
+	"gQvgyG1djgtftoCVrSZmsRxr7okD4LheKw",
+	"3iFGBKapAWWzbiGFSr5ScbhrEPm6Esyvia",
+	"NFW2akQH2vu7AqkQXxFz2P5vkXTWkSqrSm",
+	"2MQJjLnWRp9eHh6MpCwpiUeshhtmri12mci",
+	"2QjRQUMyL6iodtHP9zKmxCNYZ7k3jxtk49C",
+	"USdfKy7B6oFNoauHWMmoCA7ND9rHqYw2Mf",
+	"cA49et9WtptYHf6wA1F8qqVgH3kS5jJ9vK",
+	"qaJT9TjcMi46sTKcgwRQU8o5Lw2Ea1gC4N",
+	"22pyn5RyhqtTQu4obYjuWYRNNw4i54L8xVr",
+	"22dkmukC6iH4FFLBmHne6modJZZQ3MC9BAT",
+	"z6CJZfYLvmd41GRVE8HASjRcy5hqbpHZvE",
+	"GEBWJ2KpRQDBTCCtvnaAJV2cYurgXS8pta",
+	"oS8fbEm82cprmAeineBeDkaKd7QownDZQh",
+	"rQpAs1LVQdphyj9ipEAuukAoj9kNpSP8cM",
+	"6NSJKsPxmqipGAfFFhUKbkopjrvEESTX3j",
+	"cuC68ycVXmD2EBzYFNYQ6akhKGrh3FGjSf",
+	"bw4wtYU8toepomrhWP2p8UFYfHBbvEV425",
+	"HvgNmDz5jD39Gwmi9VfDY1iYMhZUpZ8GKz",
+	"SbApuZAYquWP3Q6iD51BcMBQjuApYEkRVf",
+	"2Ugii5yxJgLzC59jV1vF8GK7UBZdvxwobeJ",
+	"21N2iJ1qnQRiJWcEqNRxXwfNp8QcmiyhtPy",
+	"9TC4RGs6AtFUsbcVWnSoCdoCpSfM66ALAc",
+	"oQzn55UWG4iMcY9bTNb27aTnRdfiGHAwbD",
+	"2GCdwsRpQhcf8SQcynFrMVDM26Bbj6sgv9M",
+	"2NRFe7REtSmaM2qAgZeG45hC8EtVGV2QjeB",
+	"25RGnhN7VojHUTvQBJA9nBT5y1qTQGULMzR",
+	"26uCBDfF8E2PJU2Dzz2ysgKwv9m4BhodTz9",
+	"Wkvima5cF7DDFdmJQqcdq8Syaq9DuAJJRD",
+	"286hSoJYxvENFSHwG51ZbmKaochLJyq4ERQ",
+	"FEGxF3HPoM2HCWHn82tyeh9o7vEQq5ySGE",
+	"h38DxNxGhWGTq9p5tJnN5r4Fwnn85Krrb6",
+	"2c1UU8J6Y3kL4cmQh21Tj8wkzidCiZxwdwd",
+	"2bJ32KuGmjmwKyAtzWdLFpXNM6t83CCPLq5",
+	"2fi8oLC9zfVVGnzzQtu3Y3rffS65Hiz6QHo",
+	"TKD93RxFr2Am44TntLiJQus4qcEwTtvEEQ",
+	"zMDywYdGEDtTSvWnCyc3qsYHWwj9ogws74",
+	"25NbotTka7TwtbXUpSCQD8RMgHKspyDubXJ",
+	"2ayCELBERubQWH5QxUr3cTxrYpidvUAzsSw",
+	"RMTCwLiYDKEAiJu5ekHL1NQ8UKHi5ozCPg",
+	"ejJjiCwp86ykmFr5iTJ8LxQXJ2wJPTYmkm",
+}

--- a/src/visor/distribution_test.go
+++ b/src/visor/distribution_test.go
@@ -1,0 +1,89 @@
+package visor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/coin"
+)
+
+func TestDistributionAddressArrays(t *testing.T) {
+	require.Len(t, GetDistributionAddresses(), 100)
+
+	// At the time of this writing, there should be 25 addresses in the
+	// unlocked pool and 75 in the locked pool.
+	require.Len(t, GetUnlockedDistributionAddresses(), 25)
+	require.Len(t, GetLockedDistributionAddresses(), 75)
+
+	all := GetDistributionAddresses()
+	allMap := make(map[string]struct{})
+	for _, a := range all {
+		// Check no duplicate address in distribution addresses
+		_, ok := allMap[a]
+		require.False(t, ok)
+		allMap[a] = struct{}{}
+	}
+
+	unlocked := GetUnlockedDistributionAddresses()
+	unlockedMap := make(map[string]struct{})
+	for _, a := range unlocked {
+		// Check no duplicate address in unlocked addresses
+		_, ok := unlockedMap[a]
+		require.False(t, ok)
+
+		// Check unlocked address in set of all addresses
+		_, ok = allMap[a]
+		require.True(t, ok)
+
+		unlockedMap[a] = struct{}{}
+	}
+
+	locked := GetLockedDistributionAddresses()
+	lockedMap := make(map[string]struct{})
+	for _, a := range locked {
+		// Check no duplicate address in locked addresses
+		_, ok := lockedMap[a]
+		require.False(t, ok)
+
+		// Check locked address in set of all addresses
+		_, ok = allMap[a]
+		require.True(t, ok)
+
+		// Check locked address not in unlocked addresses
+		_, ok = unlockedMap[a]
+		require.False(t, ok)
+
+		lockedMap[a] = struct{}{}
+	}
+}
+
+func TestTransactionIsLocked(t *testing.T) {
+	test := func(addrStr string, expectedIsLocked bool) {
+		addr := cipher.MustDecodeBase58Address(addrStr)
+
+		uxOut := coin.UxOut{
+			Body: coin.UxBody{
+				Address: addr,
+			},
+		}
+		uxArray := coin.UxArray{uxOut}
+
+		isLocked := TransactionIsLocked(uxArray)
+		require.Equal(t, expectedIsLocked, isLocked)
+	}
+
+	for _, a := range GetLockedDistributionAddresses() {
+		test(a, true)
+	}
+
+	for _, a := range GetUnlockedDistributionAddresses() {
+		test(a, false)
+	}
+
+	// A random address should not be locked
+	pubKey, _ := cipher.GenerateKeyPair()
+	addr := cipher.AddressFromPubKey(pubKey)
+	test(addr.String(), false)
+}

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -117,10 +117,6 @@ type Visor struct {
 	bcParser    *BlockchainParser
 }
 
-func walker(hps []coin.HashPair) cipher.SHA256 {
-	return hps[0].Hash
-}
-
 // open the blockdb.
 func openDB(dbFile string) (*bolt.DB, func(), error) {
 	db, err := bolt.Open(dbFile, 0600, &bolt.Options{
@@ -168,7 +164,7 @@ func NewVisor(c Config) (*Visor, VsClose, error) {
 	}
 
 	// creates blockchain instance
-	bc, err := NewBlockchain(db, walker, Arbitrating(c.Arbitrating))
+	bc, err := NewBlockchain(db, Arbitrating(c.Arbitrating))
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Distribution addresses are hardcoded. They each hold 1 million coins. 

The first 25 of these addresses are spendable at any time. Then, once they are all spent, we will hardcode the timestamp of the block in which they were all spent. Then, 5 more addresses will immediately unlock for spending. Every additional year after this timestamp, another 5 will be unlocked.

In other words, once we reach 25% distribution, then at most another 5% may be spent over the next year, following that time. At each anniversary of this time, another 5% become spendable.

Transactions that contain locked address spends are blocked at the daemon layer.

Also: 

* Create `testutil` package for some common test methods.
* Fix `0.0.0.0` listener in gnet tests
* Refactor some methods to simplify testing
* Add `/coinSupply` endpoint with cleaned up API result, deprecates `/explorer/getEffectiveOutputs`.