### PR TITLE
Bug fix: /wallet/newAddress doesn't save new generated address

### DIFF
--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -126,7 +126,7 @@ func (serv *Service) GetAddresses(wltID string) ([]cipher.Address, error) {
 func (serv *Service) GetWallet(wltID string) (Wallet, bool) {
 	serv.RLock()
 	defer serv.RUnlock()
-	return serv.wallets.Get(wltID)
+	return serv.wallets.Get(wltID).Copy()
 }
 
 // GetWallets returns all wallet

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -126,7 +126,11 @@ func (serv *Service) GetAddresses(wltID string) ([]cipher.Address, error) {
 func (serv *Service) GetWallet(wltID string) (Wallet, bool) {
 	serv.RLock()
 	defer serv.RUnlock()
-	return serv.wallets.Get(wltID).Copy()
+	w, ok := serv.wallets.Get(wltID)
+	if !ok {
+		return Wallet{}, false
+	}
+	return w.Copy(), true
 }
 
 // GetWallets returns all wallet

--- a/src/wallet/wallets.go
+++ b/src/wallet/wallets.go
@@ -138,7 +138,7 @@ func (wlts Wallets) Remove(id string) {
 // Get returns wallet by wallet id
 func (wlts Wallets) Get(wltID string) (Wallet, bool) {
 	if w, ok := wlts[wltID]; ok {
-		return w.Copy(), true
+		return *w, true
 	}
 	return Wallet{}, false
 }


### PR DESCRIPTION
Fix the bug that the api /wallet/newAddress will always return the same address