### PR TITLE
Fix /wallet/newAddress bug

### DIFF
--- a/src/wallet/wallets.go
+++ b/src/wallet/wallets.go
@@ -136,11 +136,11 @@ func (wlts Wallets) Remove(id string) {
 }
 
 // Get returns wallet by wallet id
-func (wlts Wallets) Get(wltID string) (Wallet, bool) {
+func (wlts Wallets) Get(wltID string) (*Wallet, bool) {
 	if w, ok := wlts[wltID]; ok {
-		return *w, true
+		return w, true
 	}
-	return Wallet{}, false
+	return &Wallet{}, false
 }
 
 // Update updates the given wallet, return error if not exist


### PR DESCRIPTION
Only the first generated address is saved since wallet start