### PR TITLE
Make block execute process atomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Skycoin is small part of OP Redecentralize and OP Darknet Plan.
 
 ### Prerequisites
 
-Install go1.8+.
+[Install go1.8+](https://golang.org/doc/install)
 
 *Note: In China, use `--source=https://github.com/golang/go` to bypass firewall when fetching golang source.*
 

--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -652,7 +652,6 @@ func Run(c *Config) {
 	if rpc != nil {
 		rpc.Shutdown()
 	}
-
 	gui.Shutdown()
 	d.Shutdown()
 	closelog()

--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -286,9 +286,7 @@ type MessageEvent struct {
 // before calling this function.
 func (dm *Daemon) Shutdown() {
 	// close the daemon loop first
-	q := make(chan struct{}, 1)
-	dm.quitC <- q
-	<-q
+	close(dm.quitC)
 
 	if !dm.Config.DisableNetworking {
 		dm.Pool.Shutdown()
@@ -351,8 +349,7 @@ func (dm *Daemon) Run() (err error) {
 		select {
 		case err = <-errC:
 			return
-		case qc := <-dm.quitC:
-			qc <- struct{}{}
+		case <-dm.quitC:
 			return
 		// Remove connections that failed to complete the handshake
 		case <-cullInvalidTicker:

--- a/src/gui/transaction.go
+++ b/src/gui/transaction.go
@@ -48,7 +48,8 @@ func getPendingTxs(gateway *daemon.Gateway) http.HandlerFunc {
 	}
 }
 
-// getLastTxs get the last confirmed txs.
+// DEPRECATED: last txs can't recover from db when restart
+// , and it's not used actually
 func getLastTxs(gateway *daemon.Gateway) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {

--- a/src/visor/blockchain_parser.go
+++ b/src/visor/blockchain_parser.go
@@ -36,8 +36,8 @@ func NewBlockchainParser(hisDB *historydb.HistoryDB, bc *Blockchain, ops ...Pars
 	return bp
 }
 
-// BlockListener when new block appended to blockchain, this method will b invoked
-func (bcp *BlockchainParser) BlockListener(b coin.Block) {
+// FeedBlock feeds block to the parser
+func (bcp *BlockchainParser) FeedBlock(b coin.Block) {
 	bcp.blkC <- b
 }
 
@@ -62,8 +62,14 @@ func (bcp *BlockchainParser) Run() error {
 			cc <- struct{}{}
 			return nil
 		case b := <-bcp.blkC:
-			if err := bcp.parseTo(b.Head.BkSeq); err != nil {
+			parsedHeight := bcp.historyDB.ParsedHeight()
+
+			if err := bcp.historyDB.ParseBlock(&b); err != nil {
 				return err
+			}
+
+			if b.Seq() > uint64(parsedHeight) {
+				bcp.historyDB.SetParsedHeight(b.Seq())
 			}
 		}
 	}

--- a/src/visor/blockdb/blocksigs.go
+++ b/src/visor/blockdb/blocksigs.go
@@ -53,3 +53,10 @@ func (bs *BlockSigs) Add(sb *coin.SignedBlock) error {
 
 	return bs.Sigs.Put(hash[:], encoder.Serialize(sb.Sig))
 }
+
+// AddWithTx add signed block with bolt.Tx
+func (bs *BlockSigs) AddWithTx(tx *bolt.Tx, sb *coin.SignedBlock) error {
+	hash := sb.Block.HashHeader()
+
+	return bs.Sigs.PutWithTx(tx, hash[:], encoder.Serialize(sb.Sig))
+}

--- a/src/visor/blockdb/blocksigs.go
+++ b/src/visor/blockdb/blocksigs.go
@@ -1,8 +1,6 @@
 package blockdb
 
 import (
-	"fmt"
-
 	"github.com/boltdb/bolt"
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/cipher/encoder"
@@ -37,16 +35,16 @@ func NewBlockSigs(db *bolt.DB) (*BlockSigs, error) {
 }
 
 // Get returns signature of specific block
-func (bs BlockSigs) Get(hash cipher.SHA256) (cipher.Sig, error) {
+func (bs BlockSigs) Get(hash cipher.SHA256) (cipher.Sig, bool, error) {
 	bin := bs.Sigs.Get(hash[:])
 	if bin == nil {
-		return cipher.Sig{}, fmt.Errorf("no sig for %v", hash.Hex())
+		return cipher.Sig{}, false, nil
 	}
 	var sig cipher.Sig
 	if err := encoder.DeserializeRaw(bin, &sig); err != nil {
-		return cipher.Sig{}, err
+		return cipher.Sig{}, false, err
 	}
-	return sig, nil
+	return sig, true, nil
 }
 
 // Add stores the signed block into db.

--- a/src/visor/bucket/bucket.go
+++ b/src/visor/bucket/bucket.go
@@ -2,6 +2,7 @@ package bucket
 
 import (
 	"encoding/binary"
+	"fmt"
 
 	"github.com/boltdb/bolt"
 )
@@ -86,6 +87,16 @@ func (b Bucket) Put(key []byte, value []byte) error {
 	})
 }
 
+// PutWithTx put key value with bolt.Tx
+func (b Bucket) PutWithTx(tx *bolt.Tx, key []byte, value []byte) error {
+	bkt := tx.Bucket(b.Name)
+	if bkt == nil {
+		return fmt.Errorf("bucket %s does not exist", b.Name)
+	}
+
+	return bkt.Put(key, value)
+}
+
 // Find find value that match the filter in the bucket.
 func (b Bucket) Find(filter func(key, value []byte) bool) []byte {
 	var value []byte
@@ -122,6 +133,16 @@ func (b *Bucket) Delete(key []byte) error {
 	return b.db.Update(func(tx *bolt.Tx) error {
 		return tx.Bucket(b.Name).Delete(key)
 	})
+}
+
+// DeleteWithTx remove from bucket with tx
+func (b *Bucket) DeleteWithTx(tx *bolt.Tx, key []byte) error {
+	bkt := tx.Bucket(b.Name)
+	if bkt == nil {
+		return fmt.Errorf("bucket %s doesn't exist", b.Name)
+	}
+
+	return bkt.Delete(key)
 }
 
 // RangeUpdate updates range of the values

--- a/src/visor/historydb/history_meta.go
+++ b/src/visor/historydb/history_meta.go
@@ -31,7 +31,7 @@ func (hm *historyMeta) ParsedHeight() int64 {
 }
 
 // SetParsedHeight updates history parsed height
-func (hm *historyMeta) setParsedHeight(h uint64) error {
+func (hm *historyMeta) SetParsedHeight(h uint64) error {
 	return hm.v.Put(parsedHeightKey, bucket.Itob(h))
 }
 

--- a/src/visor/historydb/history_meta_test.go
+++ b/src/visor/historydb/history_meta_test.go
@@ -54,10 +54,10 @@ func TestHistoryMetaSetParsedHeight(t *testing.T) {
 
 	hm, err := newHistoryMeta(db)
 	assert.Nil(t, err)
-	assert.Nil(t, hm.setParsedHeight(0))
+	assert.Nil(t, hm.SetParsedHeight(0))
 	assert.Equal(t, uint64(0), bucket.Btoi(hm.v.Get(parsedHeightKey)))
 
 	// set 10
-	hm.setParsedHeight(10)
+	hm.SetParsedHeight(10)
 	assert.Equal(t, uint64(10), bucket.Btoi(hm.v.Get(parsedHeightKey)))
 }

--- a/src/visor/historydb/historydb.go
+++ b/src/visor/historydb/historydb.go
@@ -116,21 +116,29 @@ func (hd *HistoryDB) GetUxout(uxID cipher.SHA256) (*UxOut, error) {
 	return hd.outputs.Get(uxID)
 }
 
-// ProcessBlock will index the transaction, outputs,etc.
+// ProcessBlock parses the block and update parsed block height
 func (hd *HistoryDB) ProcessBlock(b *coin.Block) error {
+	if err := hd.ParseBlock(b); err != nil {
+		return err
+	}
+
+	return hd.SetParsedHeight(b.Seq())
+}
+
+// ParseBlock will index the transaction, outputs,etc.
+func (hd *HistoryDB) ParseBlock(b *coin.Block) error {
 	if b == nil {
 		return errors.New("process nil block")
 	}
 
 	// index the transactions
-	for _, t := range b.Body.Transactions {
-		txn := Transaction{
-			Tx:       t,
-			BlockSeq: b.Seq(),
-		}
-
-		if err := hd.db.Update(func(tx *bolt.Tx) error {
-			// all updates will rollback if return error is not nil
+	return hd.db.Update(func(tx *bolt.Tx) error {
+		// all updates will rollback if return error is not nil
+		for _, t := range b.Body.Transactions {
+			txn := Transaction{
+				Tx:       t,
+				BlockSeq: b.Seq(),
+			}
 
 			txnsBkt := tx.Bucket(hd.txns.bkt.Name)
 			outputsBkt := tx.Bucket(hd.outputs.bkt.Name)
@@ -180,17 +188,10 @@ func (hd *HistoryDB) ProcessBlock(b *coin.Block) error {
 					return err
 				}
 			}
-
-			return nil
-		}); err != nil {
-			return err
 		}
 
-		// update the last tx hash in transaction
-		hd.txns.updateLastTxs(t.Hash())
-	}
-
-	return hd.setParsedHeight(b.Seq())
+		return nil
+	})
 }
 
 // GetTransaction get transaction by hash.

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -246,10 +246,9 @@ func (vs *Visor) Run() error {
 			return
 		}
 
-		for _, seq := range noSigBlockSeqs {
-			logger.Warning("no signature found in block %d, parse the block again", seq)
-			b := vs.GetBlockBySeq(seq)
-			vs.bcParser.FeedBlock(*b)
+		if len(noSigBlockSeqs) > 0 {
+			errC <- fmt.Errorf("no signature found in block %d", noSigBlockSeqs)
+			return
 		}
 
 		logger.Info("Signature verify success")

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -249,7 +249,7 @@ func (vs *Visor) Run() error {
 		}
 
 		if len(noSigBlockSeqs) > 0 {
-			errC <- fmt.Errorf("no signature found in block %d", noSigBlockSeqs)
+			errC <- fmt.Errorf("no signature found in block %v", noSigBlockSeqs)
 			return
 		}
 


### PR DESCRIPTION
Our block execute process is not atomic, if the node closed unexpectedly when synchronizing the blocks, we might lost block signature or leaving used unconfirmed transaction in the pool. Make the execute block process atomic, and avoid #509 issue in the future. 