### PR TITLE
Add /wallet/load endpoint to load wallet from seed and scan ahead N addresses

### DIFF
--- a/src/api/cli/generate_addrs.go
+++ b/src/api/cli/generate_addrs.go
@@ -50,7 +50,7 @@ func generateAddrs(c *gcli.Context) error {
 	cfg := ConfigFromContext(c)
 
 	// get number of address that are need to be generated.
-	num := c.Uint("n")
+	num := c.Uint64("n")
 	if num == 0 {
 		return errors.New("-n must > 0")
 	}
@@ -62,7 +62,7 @@ func generateAddrs(c *gcli.Context) error {
 		return err
 	}
 
-	addrs, err := GenerateAddressesInFile(w, int(num))
+	addrs, err := GenerateAddressesInFile(w, num)
 
 	switch err.(type) {
 	case nil:
@@ -88,7 +88,7 @@ func generateAddrs(c *gcli.Context) error {
 	return nil
 }
 
-func GenerateAddressesInFile(walletFile string, num int) ([]cipher.Address, error) {
+func GenerateAddressesInFile(walletFile string, num uint64) ([]cipher.Address, error) {
 	wlt, err := wallet.Load(walletFile)
 	if err != nil {
 		return nil, WalletLoadError(err)

--- a/src/api/cli/generate_wallet.go
+++ b/src/api/cli/generate_wallet.go
@@ -107,7 +107,7 @@ func generateWallet(c *gcli.Context) error {
 	}
 
 	// get number of address that are need to be generated, if m is 0, set to 1.
-	num := c.Uint("n")
+	num := c.Uint64("n")
 	if num == 0 {
 		return errors.New("-n must > 0")
 	}
@@ -125,7 +125,7 @@ func generateWallet(c *gcli.Context) error {
 		return err
 	}
 
-	wlt, err := GenerateWallet(wltName, label, sd, int(num))
+	wlt, err := GenerateWallet(wltName, label, sd, num)
 	if err != nil {
 		return err
 	}
@@ -163,9 +163,9 @@ func makeSeed(s string, r, rd bool) (string, error) {
 
 // PUBLIC
 
-// Generates a new wallet with filename walletFile, label, seed and number of addresses.
+// GenerateWallet generates a new wallet with filename walletFile, label, seed and number of addresses.
 // Caller should save the wallet file to its chosen directory
-func GenerateWallet(walletFile, label, seed string, numAddrs int) (*wallet.Wallet, error) {
+func GenerateWallet(walletFile, label, seed string, numAddrs uint64) (*wallet.Wallet, error) {
 	walletFile = filepath.Base(walletFile)
 
 	wlt, err := wallet.NewWallet(walletFile, wallet.OptLabel(label), wallet.OptSeed(seed))

--- a/src/coin/outputs.go
+++ b/src/coin/outputs.go
@@ -159,14 +159,23 @@ func (ua UxArray) Swap(i, j int) {
 	ua[i], ua[j] = ua[j], ua[i]
 }
 
-// CoinHours returns the total coins and hours
-func (ua UxArray) CoinHours(headTime uint64) (coins uint64, hours uint64) {
+// Coins returns the total coins
+func (ua UxArray) Coins() uint64 {
+	var coins uint64
 	for _, ux := range ua {
 		coins += ux.Body.Coins
-		hours += ux.CoinHours(headTime)
 	}
 
-	return
+	return coins
+}
+
+// CoinHours returns the total coin hours
+func (ua UxArray) CoinHours(headTime uint64) uint64 {
+	var hours uint64
+	for _, ux := range ua {
+		hours += ux.CoinHours(headTime)
+	}
+	return hours
 }
 
 // AddressUxOuts maps address with uxarray

--- a/src/coin/outputs.go
+++ b/src/coin/outputs.go
@@ -159,6 +159,16 @@ func (ua UxArray) Swap(i, j int) {
 	ua[i], ua[j] = ua[j], ua[i]
 }
 
+// CoinHours returns the total coins and hours
+func (ua UxArray) CoinHours(headTime uint64) (coins uint64, hours uint64) {
+	for _, ux := range ua {
+		coins += ux.Body.Coins
+		hours += ux.CoinHours(headTime)
+	}
+
+	return
+}
+
 // AddressUxOuts maps address with uxarray
 type AddressUxOuts map[cipher.Address]UxArray
 

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -525,6 +525,16 @@ func (gw *Gateway) NewWallet(wltName string, options ...wallet.Option) (wallet.W
 	return wlt, err
 }
 
+// LoadAndScanWallet loads wallet from given seed and scan ahead N addresses
+func (gw *Gateway) LoadAndScanWallet(wltName string, seed string, scanN uint64, options ...wallet.Option) (wallet.Wallet, error) {
+	var wlt wallet.Wallet
+	var err error
+	gw.strand("LoadAndScanWallet", func() {
+		wlt, err = gw.vrpc.LoadAndScanWallet(wltName, seed, scanN, &gw.vrpc, options...)
+	})
+	return wlt, err
+}
+
 // CreateSpendingTransaction creates spending transactions
 func (gw *Gateway) CreateSpendingTransaction(wlt wallet.Wallet, amt wallet.Balance, dest cipher.Address) (*coin.Transaction, error) {
 	var tx *coin.Transaction
@@ -578,37 +588,15 @@ func (gw *Gateway) GetWalletBalance(wltID string) (wallet.BalancePair, error) {
 	return balance, err
 }
 
-// GetAddressesBalance gets balance of given addresses
-func (gw *Gateway) GetAddressesBalance(addrs []cipher.Address) (wallet.BalancePair, error) {
-	var balance wallet.BalancePair
+// GetBalanceOfAddrs gets balance of given addresses
+func (gw *Gateway) GetBalanceOfAddrs(addrs []cipher.Address) ([]wallet.BalancePair, error) {
+	var bps []wallet.BalancePair
 	var err error
-	gw.strand("GetAddressBalance", func() {
-		auxs := gw.vrpc.GetUnspent(gw.v).GetUnspentsOfAddrs(addrs)
-		var spendUxs coin.AddressUxOuts
-		spendUxs, err = gw.vrpc.GetUnconfirmedSpends(gw.v, addrs)
-		if err != nil {
-			err = fmt.Errorf("get unconfirmed spending failed when checking addresses balance: %v", err)
-			return
-		}
-
-		var recvUxs coin.AddressUxOuts
-		recvUxs, err = gw.vrpc.GetUnconfirmedReceiving(gw.v, addrs)
-		if err != nil {
-			err = fmt.Errorf("get unconfirmed receiving failed when checking addresses balance: %v", err)
-			return
-		}
-
-		uxs := auxs.Sub(spendUxs)
-		uxs = uxs.Add(recvUxs)
-		coins1, hours1 := gw.v.AddressBalance(auxs)
-		coins2, hours2 := gw.v.AddressBalance(auxs.Sub(spendUxs).Add(recvUxs))
-		balance = wallet.BalancePair{
-			Confirmed: wallet.Balance{Coins: coins1, Hours: hours1},
-			Predicted: wallet.Balance{Coins: coins2, Hours: hours2},
-		}
+	gw.strand("GetBalanceOfAddrs", func() {
+		bps, err = gw.vrpc.GetBalanceOfAddrs(addrs)
 	})
 
-	return balance, err
+	return bps, err
 }
 
 // GetWalletDir returns path for storing wallet files
@@ -617,7 +605,7 @@ func (gw *Gateway) GetWalletDir() string {
 }
 
 // NewAddresses generate addresses in given wallet
-func (gw *Gateway) NewAddresses(wltID string, n int) ([]cipher.Address, error) {
+func (gw *Gateway) NewAddresses(wltID string, n uint64) ([]cipher.Address, error) {
 	var addrs []cipher.Address
 	var err error
 	gw.strand("NewAddresses", func() {

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -530,7 +530,7 @@ func (gw *Gateway) LoadAndScanWallet(wltName string, seed string, scanN uint64, 
 	var wlt wallet.Wallet
 	var err error
 	gw.strand("LoadAndScanWallet", func() {
-		wlt, err = gw.vrpc.LoadAndScanWallet(wltName, seed, scanN, &gw.vrpc, options...)
+		wlt, err = gw.v.LoadAndScanWallet(wltName, seed, scanN, options...)
 	})
 	return wlt, err
 }
@@ -593,7 +593,7 @@ func (gw *Gateway) GetBalanceOfAddrs(addrs []cipher.Address) ([]wallet.BalancePa
 	var bps []wallet.BalancePair
 	var err error
 	gw.strand("GetBalanceOfAddrs", func() {
-		bps, err = gw.vrpc.GetBalanceOfAddrs(addrs)
+		bps, err = gw.v.GetBalanceOfAddrs(addrs)
 	})
 
 	return bps, err

--- a/src/daemon/visor.go
+++ b/src/daemon/visor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/skycoin/skycoin/src/daemon/strand"
 	"github.com/skycoin/skycoin/src/util/utc"
 	"github.com/skycoin/skycoin/src/visor"
+	"github.com/skycoin/skycoin/src/wallet"
 )
 
 //TODO
@@ -464,6 +465,18 @@ func (vs *Visor) EstimateBlockchainHeight() uint64 {
 		return nil
 	})
 	return maxLen
+}
+
+// LoadAndScanWallet loads wallet from seeds and scan ahead N addresses
+func (vs *Visor) LoadAndScanWallet(wltName string, seed string, scanN uint64, ops ...wallet.Option) (wallet.Wallet, error) {
+	var wlt wallet.Wallet
+	var err error
+	vs.strand("LoadAndScanWallet", func() error {
+		wlt, err = vs.v.LoadAndScanWallet(wltName, seed, scanN, ops...)
+		return nil
+	})
+
+	return wlt, err
 }
 
 // PeerBlockchainHeight is a peer's IP address with their reported blockchain height

--- a/src/gui/README.md
+++ b/src/gui/README.md
@@ -168,6 +168,27 @@ result:
 }
 ```
 
+### Load wallet from seed and scan ahead N address
+
+```bash
+URI: /wallet/load
+Method: GET/POST
+Args:
+    seed: wallet seed
+    label: wallet label
+    scan-num: the number of ahead addresses that we are going to scan(if not specified, the default num: 100 will be used)
+```
+
+example:
+
+```bash
+curl http://127.0.0.1:6420/wallet/load?seed=$seed&label=$label&scan-num=100
+```
+
+result:
+
+The result is the same format as `wallet/create`, excpet it returns all entries that contains coins.
+
 ### Generate new address in wallet
 
 ```bash

--- a/src/gui/http.go
+++ b/src/gui/http.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/daemon"
+	"github.com/skycoin/skycoin/src/wallet"
 
 	"github.com/skycoin/skycoin/src/util/file"
 	wh "github.com/skycoin/skycoin/src/util/http" //http,json helpers
@@ -235,14 +236,20 @@ func getBalanceHandler(gateway *daemon.Gateway) http.HandlerFunc {
 			addrs = append(addrs, a)
 		}
 
-		bal, err := gateway.GetAddressesBalance(addrs)
+		bals, err := gateway.GetBalanceOfAddrs(addrs)
 		if err != nil {
 			logger.Error("Get balance failed: %v", err)
 			wh.Error500(w)
 			return
 		}
 
-		wh.SendOr404(w, bal)
+		var balance wallet.BalancePair
+		for _, bal := range bals {
+			balance.Confirmed = balance.Confirmed.Add(bal.Confirmed)
+			balance.Predicted = balance.Predicted.Add(bal.Predicted)
+		}
+
+		wh.SendOr404(w, balance)
 	}
 }
 

--- a/src/gui/wallet.go
+++ b/src/gui/wallet.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/skycoin/skycoin/src/cipher"
 	bip39 "github.com/skycoin/skycoin/src/cipher/go-bip39"
@@ -178,7 +177,7 @@ func walletCreate(gateway *daemon.Gateway) http.HandlerFunc {
 		for {
 			wlt, err = gateway.NewWallet(wltName, wallet.OptSeed(seed), wallet.OptLabel(label))
 			if err != nil {
-				if strings.Contains(err.Error(), "renaming") {
+				if err == wallet.ErrWalletNameConflict {
 					wltName = wallet.NewWalletFilename()
 					continue
 				}
@@ -228,7 +227,7 @@ func walletLoad(gateway *daemon.Gateway) http.HandlerFunc {
 		for {
 			wlt, err = gateway.LoadAndScanWallet(wltName, seed, scanN, wallet.OptLabel(label))
 			if err != nil {
-				if strings.Contains(err.Error(), "renaming") {
+				if err == wallet.ErrWalletNameConflict {
 					wltName = wallet.NewWalletFilename()
 					continue
 				}

--- a/src/visor/rpc.go
+++ b/src/visor/rpc.go
@@ -1,8 +1,6 @@
 package visor
 
 import (
-	"fmt"
-
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/coin"
 	"github.com/skycoin/skycoin/src/visor/blockdb"
@@ -145,11 +143,6 @@ func (rpc *RPC) NewWallet(wltName string, ops ...wallet.Option) (wallet.Wallet, 
 	return rpc.v.wallets.CreateWallet(wltName, ops...)
 }
 
-// LoadAndScanWallet create wallet and scan ahead N address in the wallet
-func (rpc *RPC) LoadAndScanWallet(wltName string, seed string, scanN uint64, bg wallet.BalanceGetter, ops ...wallet.Option) (wallet.Wallet, error) {
-	return rpc.v.wallets.LoadAndScanWallet(wltName, seed, scanN, bg, ops...)
-}
-
 // NewAddresses generates new addresses in given wallet
 func (rpc *RPC) NewAddresses(wltName string, num uint64) ([]cipher.Address, error) {
 	return rpc.v.wallets.NewAddresses(wltName, num)
@@ -197,43 +190,4 @@ func (rpc *RPC) ReloadWallets() error {
 // GetBuildInfo returns node build info, including version, build time, etc.
 func (rpc *RPC) GetBuildInfo() BuildInfo {
 	return rpc.v.Config.BuildInfo
-}
-
-// GetBalanceOfAddrs gets balance of given addresses
-func (rpc *RPC) GetBalanceOfAddrs(addrs []cipher.Address) ([]wallet.BalancePair, error) {
-	var bps []wallet.BalancePair
-	auxs := rpc.GetUnspent(rpc.v).GetUnspentsOfAddrs(addrs)
-	spendUxs, err := rpc.GetUnconfirmedSpends(rpc.v, addrs)
-	if err != nil {
-		return nil, fmt.Errorf("get unconfirmed spending failed when checking addresses balance: %v", err)
-	}
-
-	recvUxs, err := rpc.GetUnconfirmedReceiving(rpc.v, addrs)
-	if err != nil {
-		return nil, fmt.Errorf("get unconfirmed receiving failed when checking addresses balance: %v", err)
-	}
-
-	headTime := rpc.v.Blockchain.Time()
-	for _, addr := range addrs {
-		uxs, ok := auxs[addr]
-		if !ok {
-			bps = append(bps, wallet.BalancePair{})
-			continue
-		}
-
-		outUxs := spendUxs[addr]
-		inUxs := recvUxs[addr]
-		predictedUxs := uxs.Sub(outUxs).Add(inUxs)
-
-		coins, hours := uxs.CoinHours(headTime)
-		pcoins, phours := predictedUxs.CoinHours(headTime)
-		bp := wallet.BalancePair{
-			Confirmed: wallet.Balance{Coins: coins, Hours: hours},
-			Predicted: wallet.Balance{Coins: pcoins, Hours: phours},
-		}
-
-		bps = append(bps, bp)
-	}
-
-	return bps, nil
 }

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -667,11 +667,13 @@ func (vs Visor) GetBalanceOfAddrs(addrs []cipher.Address) ([]wallet.BalancePair,
 		inUxs := recvUxs[addr]
 		predictedUxs := uxs.Sub(outUxs).Add(inUxs)
 
-		coins, hours := uxs.CoinHours(headTime)
-		pcoins, phours := predictedUxs.CoinHours(headTime)
+		coins := uxs.Coins()
+		coinHours := uxs.CoinHours(headTime)
+		pcoins := predictedUxs.Coins()
+		pcoinHours := predictedUxs.CoinHours(headTime)
 		bp := wallet.BalancePair{
-			Confirmed: wallet.Balance{Coins: coins, Hours: hours},
-			Predicted: wallet.Balance{Coins: pcoins, Hours: phours},
+			Confirmed: wallet.Balance{Coins: coins, Hours: coinHours},
+			Predicted: wallet.Balance{Coins: pcoins, Hours: pcoinHours},
 		}
 
 		bps = append(bps, bp)

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -139,7 +139,6 @@ func (serv *Service) LoadAndScanWallet(wltName string, seed string, scanN uint64
 
 	// reset the wallet if scan number > 1 and not equal to the keep number
 	if scanN > 1 && keepNum != scanN {
-		// reset wallet and
 		w.Reset()
 		w.GenerateAddresses(uint64(keepNum))
 	}

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -10,6 +10,11 @@ import (
 	"github.com/skycoin/skycoin/src/visor/blockdb"
 )
 
+// BalanceGetter interface for getting the balance of given addresses
+type BalanceGetter interface {
+	GetBalanceOfAddrs(addrs []cipher.Address) ([]BalancePair, error)
+}
+
 // Service wallet service struct
 type Service struct {
 	sync.RWMutex
@@ -92,9 +97,71 @@ func (serv *Service) CreateWallet(wltName string, options ...Option) (Wallet, er
 	return *w, nil
 }
 
+// LoadAndScanWallet loads wallet from seed and scan the first N address
+func (serv *Service) LoadAndScanWallet(wltName string, seed string, scanN uint64, bg BalanceGetter, options ...Option) (Wallet, error) {
+	ops := make([]Option, 0, len(serv.options)+len(options))
+	ops = append(ops, serv.options...)
+	ops = append(ops, options...)
+	ops = append(ops, OptSeed(seed))
+	w, err := NewWallet(wltName, ops...)
+	if err != nil {
+		return Wallet{}, err
+	}
+
+	// generate a default address
+	w.GenerateAddresses(1)
+
+	serv.Lock()
+	defer serv.Unlock()
+	// check dup
+	if id, ok := serv.firstAddrIDMap[w.Entries[0].Address.String()]; ok {
+		return Wallet{}, fmt.Errorf("duplicate wallet with %v", id)
+	}
+
+	// generate the remaining addresses that are need to scan
+	w.GenerateAddresses(scanN - 1)
+
+	// check balance from the last one till we find the
+	// address that has coins
+	addrs := w.GetAddresses()
+	bals, err := bg.GetBalanceOfAddrs(addrs)
+	if err != nil {
+		return Wallet{}, err
+	}
+
+	var keepNum uint64 = 1
+	for i := len(bals) - 1; i >= 0; i-- {
+		if bals[i].Confirmed.Coins > 0 || bals[i].Predicted.Coins > 0 {
+			keepNum = uint64(i + 1)
+			break
+		}
+	}
+
+	// reset the wallet if scan number > 1 and not equal to the keep number
+	if scanN > 1 && keepNum != scanN {
+		// reset wallet and
+		w.Reset()
+		w.GenerateAddresses(uint64(keepNum))
+	}
+
+	if err := serv.wallets.Add(*w); err != nil {
+		return Wallet{}, err
+	}
+
+	if err := w.Save(serv.WalletDirectory); err != nil {
+		// remove the added wallet from serv.wallets.
+		serv.wallets.Remove(w.GetID())
+		return Wallet{}, err
+	}
+
+	serv.firstAddrIDMap[w.Entries[0].Address.String()] = w.GetID()
+
+	return *w, nil
+}
+
 // NewAddresses generate address entries in given wallet,
 // return nil if wallet does not exist.
-func (serv *Service) NewAddresses(wltID string, num int) ([]cipher.Address, error) {
+func (serv *Service) NewAddresses(wltID string, num uint64) ([]cipher.Address, error) {
 	serv.Lock()
 	defer serv.Unlock()
 	w, ok := serv.wallets.Get(wltID)

--- a/src/wallet/service_test.go
+++ b/src/wallet/service_test.go
@@ -124,7 +124,7 @@ func TestServiceCreateWallet(t *testing.T) {
 
 	// create walelt with dup wallet name
 	_, err = s.CreateWallet(wltName)
-	require.EqualError(t, err, "wallet name would conflict with existing wallet, renaming")
+	require.EqualError(t, err, ErrWalletNameConflict)
 
 	// create wallet with dup seed
 	dupWlt := "dup_wallet.wlt"

--- a/src/wallet/service_test.go
+++ b/src/wallet/service_test.go
@@ -124,7 +124,7 @@ func TestServiceCreateWallet(t *testing.T) {
 
 	// create walelt with dup wallet name
 	_, err = s.CreateWallet(wltName)
-	require.EqualError(t, err, ErrWalletNameConflict)
+	require.Equal(t, err, ErrWalletNameConflict)
 
 	// create wallet with dup seed
 	dupWlt := "dup_wallet.wlt"

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -289,7 +289,7 @@ func (wlt *Wallet) AddEntry(entry Entry) error {
 
 // Reset resets the wallet entries and move the lastSeed to origin
 func (wlt *Wallet) Reset() {
-	wlt.Entries = wlt.Entries[0:0]
+	wlt.Entries = []Entry{}
 	wlt.Meta["lastSeed"] = wlt.Meta["seed"]
 }
 

--- a/src/wallet/wallets.go
+++ b/src/wallet/wallets.go
@@ -156,7 +156,7 @@ func (wlts Wallets) Update(wltID string, updateFunc func(Wallet) Wallet) error {
 }
 
 // NewAddresses creates num addresses in given wallet
-func (wlts *Wallets) NewAddresses(wltID string, num int) ([]cipher.Address, error) {
+func (wlts *Wallets) NewAddresses(wltID string, num uint64) ([]cipher.Address, error) {
 	if w, ok := (*wlts)[wltID]; ok {
 		return w.GenerateAddresses(num), nil
 	}

--- a/src/wallet/wallets.go
+++ b/src/wallet/wallets.go
@@ -20,6 +20,11 @@ import (
 // Wallets wallets map
 type Wallets map[string]*Wallet
 
+var (
+	// ErrWalletNameConflict represents the wallet name conflict error
+	ErrWalletNameConflict = errors.New("wallet name would conflict with existing wallet, renaming")
+)
+
 // LoadWallets Loads all wallets contained in wallet dir.  If any regular file in wallet
 // dir fails to load, loading is aborted and error returned.  Only files with
 // extension WalletExt are considered. If encounter old wallet file, then backup
@@ -123,7 +128,7 @@ func mustUpdateWallet(wlt *Wallet, dir string, tm int64) {
 // Add add walet to current wallet
 func (wlts Wallets) Add(w Wallet) error {
 	if _, dup := wlts[w.GetFilename()]; dup {
-		return errors.New("wallet name would conflict with existing wallet, renaming")
+		return ErrWalletNameConflict
 	}
 
 	wlts[w.GetFilename()] = &w


### PR DESCRIPTION
Add `/wallet/load` endpoint, which will load wallet from given seed and scan ahead N addresses to check balance. 

Arguments:
    `seed`: wallet seed
    `label`: wallet label
    `scan-num`: the ahead number of address that will scan, if not specified, we will use 100 by default.

Fixes #597