### PR TITLE
Use -gcflags=-trimpath, -asmflags=-trimpath

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,7 @@ install:
   - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
   - go version
   - go env
-  - go get github.com/mitchellh/gox
+  - go get github.com/gz-c/gox
   - ps: Install-Product node 8 x64
 
 build_script:
@@ -39,13 +39,13 @@ after_build:
 
 test: off
 
-artifacts: 
+artifacts:
   - path: skycoin.zip
     name: published
 
 deploy:
   provider: S3
-  access_key_id: $(AWS_ACCESS_KEY_ID) 
+  access_key_id: $(AWS_ACCESS_KEY_ID)
   secret_access_key: $(AWS_SECRET_ACCESS_KEY)
   bucket: $(AWS_BUCKET)
   region: $(AWS_REGION)

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
 
 install:
   # Install gox
-  - go get github.com/mitchellh/gox
+  - go get github.com/gz-c/gox
   # Install dependences for building wallet
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_PULL_REQUEST" == false ]]; then sudo apt-get install --no-install-recommends -y icnsutils graphicsmagick xz-utils  &&nvm install 8; fi
   # for test

--- a/electron/README.md
+++ b/electron/README.md
@@ -13,7 +13,7 @@ gox (go cross compiler), node and npm.
 To install gox:
 
 ```sh
-go get github.com/mitchellh/gox
+go get github.com/gz-c/gox
 ```
 
 ### NPM

--- a/electron/gox.sh
+++ b/electron/gox.sh
@@ -44,6 +44,8 @@ fi
 COMMIT=`git rev-parse HEAD`
 
 gox -osarch="$OSARCH" \
+    -gcflags="-trimpath=${HOME}" \
+    -asmflags="-trimpath=${HOME}" \
     -ldflags="-X main.Version=${APP_VERSION} -X main.Commit=${COMMIT}" \
     -output="${OUTPUT}{{.Dir}}_{{.OS}}_{{.Arch}}" \
     "${CMDDIR}/${CMD}"


### PR DESCRIPTION
Fixes #719 as much as possible (still leaves the build machine's full build directory somewhere in the binary, but removes them from `runtime` info)