### PR TITLE
Fix the misuse of flag -download-peers-list in electron

### DIFF
--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -70,7 +70,7 @@ function startSkycoin() {
     '-gui-dir=' + path.dirname(exe),
     '-color-log=false', // must be disabled or web interface detection
     '-logtofile=true',
-    '-download-peers-list=true'
+    '-download-peerlist=true'
     // will break
     // broken (automatically generated certs do not work):
     // '-web-interface-https=true',


### PR DESCRIPTION
Should be `-download-peerlist`