### PR TITLE
Fix base58 leading invalid chars verification

### DIFF
--- a/src/cipher/address_test.go
+++ b/src/cipher/address_test.go
@@ -3,7 +3,7 @@ package cipher
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/skycoin/skycoin/src/cipher/base58"
 )
@@ -11,52 +11,97 @@ import (
 func TestMustDecodeBase58Address(t *testing.T) {
 	p, _ := GenerateKeyPair()
 	a := AddressFromPubKey(p)
-	assert.Nil(t, a.Verify(p))
+	require.NoError(t, a.Verify(p))
 
-	assert.Panics(t, func() { MustDecodeBase58Address("") })
-	assert.Panics(t, func() { MustDecodeBase58Address("cascs") })
+	require.Panics(t, func() { MustDecodeBase58Address("") })
+	require.Panics(t, func() { MustDecodeBase58Address("cascs") })
 	b := a.Bytes()
 	h := string(base58.Hex2Base58(b[:len(b)/2]))
-	assert.Panics(t, func() { MustDecodeBase58Address(h) })
+	require.Panics(t, func() { MustDecodeBase58Address(h) })
 	h = string(base58.Hex2Base58(b))
-	assert.NotPanics(t, func() { MustDecodeBase58Address(h) })
+	require.NotPanics(t, func() { MustDecodeBase58Address(h) })
 	a2 := MustDecodeBase58Address(h)
-	assert.Equal(t, a, a2)
+	require.Equal(t, a, a2)
+
+	require.NotPanics(t, func() { MustDecodeBase58Address(a.String()) })
+	a2 = MustDecodeBase58Address(a.String())
+	require.Equal(t, a, a2)
+
+	// preceding whitespace is invalid
+	badAddr := " " + a.String()
+	require.Panics(t, func() { MustDecodeBase58Address(badAddr) })
+
+	// preceding zeroes are invalid
+	badAddr = "000" + a.String()
+	require.Panics(t, func() { MustDecodeBase58Address(badAddr) })
+
+	// trailing whitespace is invalid
+	badAddr = a.String() + " "
+	require.Panics(t, func() { MustDecodeBase58Address(badAddr) })
+
+	// trailing zeroes are invalid
+	badAddr = a.String() + "000"
+	require.Panics(t, func() { MustDecodeBase58Address(badAddr) })
 }
 
 func TestDecodeBase58Address(t *testing.T) {
 	p, _ := GenerateKeyPair()
 	a := AddressFromPubKey(p)
-	assert.Nil(t, a.Verify(p))
+	require.NoError(t, a.Verify(p))
 
 	a2, err := DecodeBase58Address("")
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	a2, err = DecodeBase58Address("cascs")
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	b := a.Bytes()
 	h := string(base58.Hex2Base58(b[:len(b)/2]))
 	a2, err = DecodeBase58Address(h)
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	h = string(base58.Hex2Base58(b))
 	a2, err = DecodeBase58Address(h)
-	assert.Nil(t, err)
-	assert.Equal(t, a, a2)
+	require.NoError(t, err)
+	require.Equal(t, a, a2)
+
+	as := a.String()
+	a2, err = DecodeBase58Address(as)
+	require.NoError(t, err)
+	require.Equal(t, a, a2)
+
+	// preceding whitespace is invalid
+	as2 := " " + as
+	_, err = DecodeBase58Address(as2)
+	require.Error(t, err)
+
+	// preceding zeroes are invalid
+	as2 = "000" + as
+	_, err = DecodeBase58Address(as2)
+	require.Error(t, err)
+
+	// trailing whitespace is invalid
+	as2 = as + " "
+	_, err = DecodeBase58Address(as2)
+	require.Error(t, err)
+
+	// trailing zeroes are invalid
+	as2 = as + "000"
+	_, err = DecodeBase58Address(as2)
+	require.Error(t, err)
 }
 
 func TestAddressFromBytes(t *testing.T) {
 	p, _ := GenerateKeyPair()
 	a := AddressFromPubKey(p)
 	a2, err := addressFromBytes(a.Bytes())
-	assert.Nil(t, err)
-	assert.Equal(t, a2, a)
+	require.NoError(t, err)
+	require.Equal(t, a2, a)
 	// Invalid number of bytes
 	b := a.Bytes()
 	_, err = addressFromBytes(b[:len(b)-2])
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	// Invalid checksum
 	b[len(b)-1] += byte(1)
 	_, err = addressFromBytes(b)
-	assert.NotNil(t, err)
+	require.Error(t, err)
 }
 
 //encode and decode
@@ -64,23 +109,23 @@ func TestAddressRoundtrip(t *testing.T) {
 	p, _ := GenerateKeyPair()
 	a := AddressFromPubKey(p)
 	a2, err := addressFromBytes(a.Bytes())
-	assert.Nil(t, err)
-	assert.Equal(t, a, a2)
-	assert.Equal(t, a.String(), a2.String())
+	require.NoError(t, err)
+	require.Equal(t, a, a2)
+	require.Equal(t, a.String(), a2.String())
 }
 
 func TestAddressVerify(t *testing.T) {
 	p, _ := GenerateKeyPair()
 	a := AddressFromPubKey(p)
 	// Valid pubkey+address
-	assert.Nil(t, a.Verify(p))
+	require.NoError(t, a.Verify(p))
 	// Invalid pubkey
-	assert.NotNil(t, a.Verify(PubKey{}))
+	require.Error(t, a.Verify(PubKey{}))
 	p2, _ := GenerateKeyPair()
-	assert.NotNil(t, a.Verify(p2))
+	require.Error(t, a.Verify(p2))
 	// Bad version
 	a.Version = 0x01
-	assert.NotNil(t, a.Verify(p))
+	require.Error(t, a.Verify(p))
 }
 
 func TestAddressString(t *testing.T) {
@@ -88,42 +133,42 @@ func TestAddressString(t *testing.T) {
 	a := AddressFromPubKey(p)
 	s := a.String()
 	a2, err := DecodeBase58Address(s)
-	assert.Nil(t, err)
-	assert.Equal(t, a2, a)
+	require.NoError(t, err)
+	require.Equal(t, a2, a)
 	s2 := a2.String()
 	a3, err := DecodeBase58Address(s2)
-	assert.Nil(t, err)
-	assert.Equal(t, a2, a3)
+	require.NoError(t, err)
+	require.Equal(t, a2, a3)
 }
 
 func TestBitcoinAddress1(t *testing.T) {
 	seckey := MustSecKeyFromHex("1111111111111111111111111111111111111111111111111111111111111111")
 	pubkey := PubKeyFromSecKey(seckey)
 	pubkeyStr := "034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa"
-	assert.Equal(t, pubkeyStr, pubkey.Hex())
+	require.Equal(t, pubkeyStr, pubkey.Hex())
 	bitcoinStr := "1Q1pE5vPGEEMqRcVRMbtBK842Y6Pzo6nK9"
 	bitcoinAddr := BitcoinAddressFromPubkey(pubkey)
-	assert.Equal(t, bitcoinStr, bitcoinAddr)
+	require.Equal(t, bitcoinStr, bitcoinAddr)
 }
 
 func TestBitcoinAddress2(t *testing.T) {
 	seckey := MustSecKeyFromHex("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
 	pubkey := PubKeyFromSecKey(seckey)
 	pubkeyStr := "02ed83704c95d829046f1ac27806211132102c34e9ac7ffa1b71110658e5b9d1bd"
-	assert.Equal(t, pubkeyStr, pubkey.Hex())
+	require.Equal(t, pubkeyStr, pubkey.Hex())
 	bitcoinStr := "1NKRhS7iYUGTaAfaR5z8BueAJesqaTyc4a"
 	bitcoinAddr := BitcoinAddressFromPubkey(pubkey)
-	assert.Equal(t, bitcoinStr, bitcoinAddr)
+	require.Equal(t, bitcoinStr, bitcoinAddr)
 }
 
 func TestBitcoinAddress3(t *testing.T) {
 	seckey := MustSecKeyFromHex("47f7616ea6f9b923076625b4488115de1ef1187f760e65f89eb6f4f7ff04b012")
 	pubkey := PubKeyFromSecKey(seckey)
 	pubkeyStr := "032596957532fc37e40486b910802ff45eeaa924548c0e1c080ef804e523ec3ed3"
-	assert.Equal(t, pubkeyStr, pubkey.Hex())
+	require.Equal(t, pubkeyStr, pubkey.Hex())
 	bitcoinStr := "19ck9VKC6KjGxR9LJg4DNMRc45qFrJguvV"
 	bitcoinAddr := BitcoinAddressFromPubkey(pubkey)
-	assert.Equal(t, bitcoinStr, bitcoinAddr)
+	require.Equal(t, bitcoinStr, bitcoinAddr)
 }
 
 func TestBitcoinWIPRoundTrio(t *testing.T) {
@@ -133,10 +178,10 @@ func TestBitcoinWIPRoundTrio(t *testing.T) {
 	seckey2, err := SecKeyFromWalletImportFormat(wip1)
 	wip2 := BitcoinWalletImportFormatFromSeckey(seckey2)
 
-	assert.Nil(t, err)
-	assert.Equal(t, seckey1, seckey2)
-	assert.Equal(t, seckey1.Hex(), seckey2.Hex())
-	assert.Equal(t, wip1, wip2)
+	require.NoError(t, err)
+	require.Equal(t, seckey1, seckey2)
+	require.Equal(t, seckey1.Hex(), seckey2.Hex())
+	require.Equal(t, wip1, wip2)
 
 }
 
@@ -162,22 +207,22 @@ func TestBitcoinWIP(t *testing.T) {
 
 	for i := range wip {
 		seckey, err := SecKeyFromWalletImportFormat(wip[i])
-		assert.Equal(t, nil, err)
+		require.Equal(t, nil, err)
 		_ = MustSecKeyFromWalletImportFormat(wip[i])
 		pubkey := PubKeyFromSecKey(seckey)
-		assert.Equal(t, pub[i], pubkey.Hex())
+		require.Equal(t, pub[i], pubkey.Hex())
 		bitcoinAddr := BitcoinAddressFromPubkey(pubkey)
-		assert.Equal(t, addr[i], bitcoinAddr)
+		require.Equal(t, addr[i], bitcoinAddr)
 	}
 
 	/*
 		seckey := MustSecKeyFromHex("47f7616ea6f9b923076625b4488115de1ef1187f760e65f89eb6f4f7ff04b012")
 		pubkey := PubKeyFromSecKey(seckey)
 		pubkey_str := "032596957532fc37e40486b910802ff45eeaa924548c0e1c080ef804e523ec3ed3"
-		assert.Equal(t, pubkey_str, pubkey.Hex())
+		require.Equal(t, pubkey_str, pubkey.Hex())
 		bitcoin_str := "19ck9VKC6KjGxR9LJg4DNMRc45qFrJguvV"
 		bitcoin_addr := BitcoinAddressFromPubkey(pubkey)
-		assert.Equal(t, bitcoin_str, bitcoin_addr)
+		require.Equal(t, bitcoin_str, bitcoin_addr)
 	*/
 }
 
@@ -187,11 +232,11 @@ func TestAddressBulk(t *testing.T) {
 		pub, _ := GenerateDeterministicKeyPair(RandByte(32))
 
 		a := AddressFromPubKey(pub)
-		assert.Nil(t, a.Verify(pub))
+		require.NoError(t, a.Verify(pub))
 		s := a.String()
 		a2, err := DecodeBase58Address(s)
-		assert.Nil(t, err)
-		assert.Equal(t, a2, a)
+		require.NoError(t, err)
+		require.Equal(t, a2, a)
 
 	}
 }

--- a/src/cipher/base58/base58.go
+++ b/src/cipher/base58/base58.go
@@ -51,28 +51,39 @@ func String2Hex(s string) []byte {
 }
 
 // ToBig convert base58 to big.Int
-func (b Base58) ToBig() *big.Int {
+func (b Base58) ToBig() (*big.Int, error) {
 	answer := new(big.Int)
 	for i := 0; i < len(b); i++ {
-		answer.Mul(answer, big.NewInt(58))                              //multiply current value by 58
-		answer.Add(answer, big.NewInt(int64(revalp[string(b[i:i+1])]))) //add value of the current letter
+		answer.Mul(answer, big.NewInt(58)) //multiply current value by 58
+		c, ok := revalp[string(b[i:i+1])]
+		if !ok {
+			return nil, errors.New("Invalid base58 character")
+		}
+		answer.Add(answer, big.NewInt(int64(c))) //add value of the current letter
 	}
-	return answer
+	return answer, nil
 }
 
 // ToInt converts base58 to int
-func (b Base58) ToInt() int {
+func (b Base58) ToInt() (int, error) {
 	answer := 0
 	for i := 0; i < len(b); i++ {
-		answer *= 58                       //multiply current value by 58
-		answer += revalp[string(b[i:i+1])] //add value of the current letter
+		answer *= 58 //multiply current value by 58
+		c, ok := revalp[string(b[i:i+1])]
+		if !ok {
+			return 0, errors.New("Invalid base58 character")
+		}
+		answer += c //add value of the current letter
 	}
-	return answer
+	return answer, nil
 }
 
 //ToHex converts base58 to hex bytes
 func (b Base58) ToHex() ([]byte, error) {
-	value := b.ToBig() //convert to big.Int
+	value, err := b.ToBig() //convert to big.Int
+	if err != nil {
+		return nil, err
+	}
 	oneCount := 0
 	bs := string(b)
 	if len(bs) == 0 {
@@ -89,23 +100,31 @@ func (b Base58) ToHex() ([]byte, error) {
 }
 
 // Base582Big converts base58 to big
-func (b Base58) Base582Big() *big.Int {
+func (b Base58) Base582Big() (*big.Int, error) {
 	answer := new(big.Int)
 	for i := 0; i < len(b); i++ {
-		answer.Mul(answer, big.NewInt(58))                              //multiply current value by 58
-		answer.Add(answer, big.NewInt(int64(revalp[string(b[i:i+1])]))) //add value of the current letter
+		answer.Mul(answer, big.NewInt(58)) //multiply current value by 58
+		c, ok := revalp[string(b[i:i+1])]
+		if !ok {
+			return nil, errors.New("Invalid base58 character")
+		}
+		answer.Add(answer, big.NewInt(int64(c))) //add value of the current letter
 	}
-	return answer
+	return answer, nil
 }
 
 // Base582Int converts base58 to int
-func (b Base58) Base582Int() int {
+func (b Base58) Base582Int() (int, error) {
 	answer := 0
 	for i := 0; i < len(b); i++ {
-		answer *= 58                       //multiply current value by 58
-		answer += revalp[string(b[i:i+1])] //add value of the current letter
+		answer *= 58 //multiply current value by 58
+		c, ok := revalp[string(b[i:i+1])]
+		if !ok {
+			return 0, errors.New("Invalid base58 character")
+		}
+		answer += c //add value of the current letter
 	}
-	return answer
+	return answer, nil
 }
 
 // Base582Hex converts base58 to hex bytes
@@ -114,20 +133,23 @@ func Base582Hex(b string) ([]byte, error) {
 }
 
 // BitHex converts base58 to hexes used by Bitcoins (keeping the zeroes on the front, 25 bytes long)
-func (b Base58) BitHex() []byte {
-	value := b.ToBig() //convert to big.Int
+func (b Base58) BitHex() ([]byte, error) {
+	value, err := b.ToBig() //convert to big.Int
+	if err != nil {
+		return nil, err
+	}
 
 	tmp := value.Bytes() //convert to hex bytes
 	if len(tmp) == 25 {  //if it is exactly 25 bytes, return
-		return tmp
+		return tmp, nil
 	} else if len(tmp) > 25 { //if it is longer than 25, return nothing
-		return nil
+		return nil, errors.New("base58 invalid length")
 	}
 	answer := make([]byte, 25)      //make 25 byte container
 	for i := 0; i < len(tmp); i++ { //copy converted bytes
 		answer[24-i] = tmp[len(tmp)-1-i]
 	}
-	return answer
+	return answer, nil
 }
 
 // Big2Base58 encodes big.Int to base58 string
@@ -201,48 +223,4 @@ func Hex2Base58String(val []byte) string {
 // Hex2Base58Str converts hex to Base58 string
 func Hex2Base58Str(val []byte) string {
 	return string(Hex2Base58(val))
-}
-
-// StringHex2Base58 converts string to base58
-//encodes string stored hex bytes into base58
-func StringHex2Base58(val string) Base58 {
-	tmp := Big2Base58(Hex2Big(String2Hex(val))) //encoding of the number without zeroes in front
-
-	//looking for zeros at the beginning
-	i := 0
-	for i = 0; val[i:i+2] == string("00") && i < len(val)-2; i += 2 {
-	}
-	i /= 2
-	answer := ""
-	for j := 0; j < i; j++ {
-		answer += alphabet[0:1]
-	}
-	answer += string(tmp)
-
-	return Base58(answer)
-}
-
-// StrHex2Base58 converts string hex to base58
-func StrHex2Base58(val string) Base58 {
-	return StringHex2Base58(val)
-}
-
-// String2Base58 converts string to base58
-func String2Base58(val string) Base58 {
-	var answer Base58
-	for i := 0; i < len(val); i++ {
-		_, err := revalp[val[i:i+1]]
-		if err == false {
-			return answer
-		}
-	}
-
-	answer = Base58(val)
-
-	return answer
-}
-
-// Str2Hex58 converts string to hex58
-func Str2Hex58(val string) Base58 {
-	return String2Base58(val)
 }


### PR DESCRIPTION
Fixes #760 

base58 library did not check if a character was in the reverse mapping or not, so treated all invalid base58 characters as a leading `0` character (only `1` is a valid leading `0` character)