### PR TITLE
Update /wallet apis to support encrypted wallets

### DIFF
--- a/src/api/cli/add_private_key.go
+++ b/src/api/cli/add_private_key.go
@@ -86,7 +86,7 @@ func AddPrivateKey(wlt *wallet.Wallet, key string) error {
 	return wlt.AddEntry(entry)
 }
 
-// Adds a private key to a wallet based on filename.  Will save the wallet after modifying.
+// AddPrivateKeyToFile adds a private key to a wallet based on filename.  Will save the wallet after modifying.
 func AddPrivateKeyToFile(walletFile, key string) error {
 	wlt, err := wallet.Load(walletFile)
 	if err != nil {
@@ -102,7 +102,7 @@ func AddPrivateKeyToFile(walletFile, key string) error {
 		return err
 	}
 
-	if err := wlt.Save(dir); err != nil {
+	if err := wallet.Save(dir, wlt); err != nil {
 		return WalletSaveError(err)
 	}
 

--- a/src/api/cli/generate_addrs.go
+++ b/src/api/cli/generate_addrs.go
@@ -89,13 +89,17 @@ func generateAddrs(c *gcli.Context) error {
 	return nil
 }
 
+// GenerateAddressesInFile generates addresses in given wallet file
 func GenerateAddressesInFile(walletFile string, num uint64) ([]cipher.Address, error) {
 	wlt, err := wallet.Load(walletFile)
 	if err != nil {
 		return nil, WalletLoadError(err)
 	}
 
-	addrs := wlt.GenerateAddresses(num)
+	addrs, err := wlt.GenerateAddresses(num)
+	if err != nil {
+		return nil, err
+	}
 
 	dir, err := filepath.Abs(filepath.Dir(walletFile))
 	if err != nil {

--- a/src/api/cli/generate_addrs.go
+++ b/src/api/cli/generate_addrs.go
@@ -102,7 +102,7 @@ func GenerateAddressesInFile(walletFile string, num uint64) ([]cipher.Address, e
 		return nil, err
 	}
 
-	if err := wlt.Save(dir); err != nil {
+	if err := wallet.Save(dir, wlt); err != nil {
 		return nil, WalletSaveError(err)
 	}
 

--- a/src/api/cli/generate_wallet.go
+++ b/src/api/cli/generate_wallet.go
@@ -123,17 +123,16 @@ func generateWallet(c *gcli.Context) error {
 	if err != nil {
 		return err
 	}
-
 	wlt, err := GenerateWallet(wltName, label, sd, num)
 	if err != nil {
 		return err
 	}
 
-	if err := wlt.Save(cfg.WalletDir); err != nil {
+	if err := wallet.Save(cfg.WalletDir, wlt); err != nil {
 		return err
 	}
 
-	return printJson(wallet.NewReadableWallet(*wlt))
+	return printJson(wallet.NewReadableWallet(wlt))
 }
 
 func makeSeed(s string, r, rd bool) (string, error) {
@@ -175,7 +174,9 @@ func GenerateWallet(walletFile, label, seed string, numAddrs uint64) (*wallet.Wa
 		return nil, err
 	}
 
-	wlt.GenerateAddresses(numAddrs)
+	if _, err := wlt.GenerateAddresses(numAddrs); err != nil {
+		return nil, err
+	}
 
 	return wlt, nil
 }

--- a/src/api/cli/list_wallets.go
+++ b/src/api/cli/list_wallets.go
@@ -54,7 +54,7 @@ func listWallets(c *gcli.Context) error {
 			}
 			wlts.Wallets = append(wlts.Wallets, walletEntry{
 				Name:       name,
-				Label:      w.GetLabel(),
+				Label:      w.Label(),
 				AddressNum: len(w.Entries),
 			})
 		}

--- a/src/cipher/encrypt.go
+++ b/src/cipher/encrypt.go
@@ -144,14 +144,14 @@ func Decrypt(data []byte, password []byte) ([]byte, error) {
 		return nil, ErrInvalidPassword
 	}
 
-	if l > uint64(len(decodeData[lenPrefixSize:])) {
+	if l > uint64(len(decodeData[lenPrefixSize:])) || l < 32 {
 		return nil, ErrInvalidPassword
 	}
 
 	var dataHash SHA256
 	copy(dataHash[:], decodeData[lenPrefixSize:lenPrefixSize+32])
 	rawData := decodeData[lenPrefixSize+32 : lenPrefixSize+l]
-	if dataHash.Hex() != SumSHA256(rawData).Hex() {
+	if dataHash != SumSHA256(rawData) {
 		return nil, ErrInvalidPassword
 	}
 

--- a/src/cipher/encrypt.go
+++ b/src/cipher/encrypt.go
@@ -17,20 +17,26 @@ const (
 )
 
 // Encrypt encrypts the data with password
-// 1> Add 32 bits length prefix to indicate the length of data
-// 2> Split data into 256 bits(32 bytes) blocks (pad to 32 bytes with nulls at end)
-// 3> Each block is encrypted by XORing the unencrypted block with SHA256(SHA256(password), SHA256(index, SHA256(nonce))
+// 1> SHA256 the data
+// 2> Add 32 bits length prefix to indicate the length of data, including the data hash
+// 3> Split data into 256 bits(32 bytes) blocks (pad to 32 bytes with nulls at end)
+// 4> Each block is encrypted by XORing the unencrypted block with SHA256(SHA256(password), SHA256(index, SHA256(nonce))
 // 	  - index is 0 for the first block of 32 bytes, 1 for the second block of 32 bytes, 2 for third block
-// 4> SHA256 the nonce with comma seperated, hex encoded blocks of 32 bytes(256 bits)
-// 5> Encode <checksum(32 bytes)><nonce(32 bytes)><block0.Hex(), block1.Hex()...> with base64
+// 5> SHA256 the nonce with comma seperated, hex encoded blocks of 32 bytes(256 bits)
+// 6> Encode <checksum(32 bytes)><nonce(32 bytes)><block0.Hex(), block1.Hex()...> with base64
 func Encrypt(data []byte, password []byte) ([]byte, error) {
 	// set data length prefix
-	prefix := make([]byte, lenPrefixSize)
-	binary.PutUvarint(prefix, uint64(len(data)))
-	pdata := append(prefix, data...)
+	dataHash := SumSHA256(data)
+	length := make([]byte, lenPrefixSize)
+	binary.PutUvarint(length, uint64(len(data)+32)) // the length including the data hash
+	var pbuf bytes.Buffer
+	pbuf.Write(length)
+	pbuf.Write(dataHash[:])
+	pbuf.Write(data)
+	pdata := pbuf.Bytes()
 
 	// split the data into 256 bit blocks(pad with null to 32 bytes)
-	l := len(pdata)
+	l := len(pdata) // hash length + data length
 	n := l / blockSize
 	var blocks [][blockSize]byte
 	for i := 0; i < n; i++ {
@@ -131,14 +137,21 @@ func Decrypt(data []byte, password []byte) ([]byte, error) {
 	buf = bytes.NewBuffer(decodeData)
 	l, err := binary.ReadUvarint(bytes.NewReader(decodeData[:lenPrefixSize]))
 	if err != nil {
-		return nil, fmt.Errorf("read prefix length failed: %v", err)
+		return nil, fmt.Errorf("invalid password, read prefix length failed: %v", err)
 	}
 
-	if l > uint64(len(decodeData[4:])) {
-		return nil, fmt.Errorf("prefix length > data length")
+	if l > uint64(len(decodeData[lenPrefixSize:])) {
+		return nil, errors.New("invalid password, prefix length > data length")
 	}
 
-	return decodeData[lenPrefixSize : l+lenPrefixSize], nil
+	var dataHash SHA256
+	copy(dataHash[:], decodeData[lenPrefixSize:lenPrefixSize+32])
+	rawData := decodeData[lenPrefixSize+32 : lenPrefixSize+l]
+	if dataHash.Hex() != SumSHA256(rawData).Hex() {
+		return nil, errors.New("decrypt data failed, invalid password")
+	}
+
+	return rawData, nil
 }
 
 // hash(password, hash(index, hash(nonce)))

--- a/src/cipher/encrypt_test.go
+++ b/src/cipher/encrypt_test.go
@@ -1,4 +1,4 @@
-package wallet
+package cipher
 
 import (
 	"testing"

--- a/src/cipher/encrypt_test.go
+++ b/src/cipher/encrypt_test.go
@@ -59,10 +59,10 @@ func TestEncryptAndDecrypt(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			enData, err := encrypt([]byte(tc.data), []byte(tc.key))
+			enData, err := Encrypt([]byte(tc.data), []byte(tc.key))
 			require.NoError(t, err)
 
-			d, err := decrypt(enData, []byte(tc.key))
+			d, err := Decrypt(enData, []byte(tc.key))
 			require.NoError(t, err)
 			require.Equal(t, tc.data, string(d))
 		})

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -488,8 +488,9 @@ func (sv spendValidator) HasUnconfirmedSpendTx(addr []cipher.Address) (bool, err
 }
 
 // Spend spends coins from given wallet and broadcast it,
+// set password as nil if wallet is not encrypted, otherwise the password must be provied.
 // return transaction or error.
-func (gw *Gateway) Spend(wltID string, password string, coins uint64, dest cipher.Address) (*coin.Transaction, error) {
+func (gw *Gateway) Spend(wltID string, password []byte, coins uint64, dest cipher.Address) (*coin.Transaction, error) {
 	var tx *coin.Transaction
 	var err error
 	gw.strand("Spend", func() {
@@ -513,8 +514,8 @@ func (gw *Gateway) Spend(wltID string, password string, coins uint64, dest ciphe
 }
 
 // CreateWallet creates wallet
-func (gw *Gateway) CreateWallet(wltName string, options wallet.Options) (wallet.Wallet, error) {
-	var wlt wallet.Wallet
+func (gw *Gateway) CreateWallet(wltName string, options wallet.Options) (*wallet.Wallet, error) {
+	var wlt *wallet.Wallet
 	var err error
 	gw.strand("CreateWallet", func() {
 		wlt, err = gw.vrpc.CreateWallet(wltName, options)
@@ -523,21 +524,22 @@ func (gw *Gateway) CreateWallet(wltName string, options wallet.Options) (wallet.
 }
 
 // ScanAheadWalletAddresses loads wallet from given seed and scan ahead N addresses
-func (gw *Gateway) ScanAheadWalletAddresses(wltName string, scanN uint64) (wallet.Wallet, error) {
-	var wlt wallet.Wallet
+// Set password as nil if the wallet is not encrypted, otherwise the password must be provided
+func (gw *Gateway) ScanAheadWalletAddresses(wltName string, password []byte, scanN uint64) (*wallet.Wallet, error) {
+	var wlt *wallet.Wallet
 	var err error
 	gw.strand("ScanAheadWalletAddresses", func() {
-		wlt, err = gw.v.ScanAheadWalletAddresses(wltName, scanN)
+		wlt, err = gw.v.ScanAheadWalletAddresses(wltName, password, scanN)
 	})
 	return wlt, err
 }
 
 // EncryptWallet encrypts the wallet
-func (gw *Gateway) EncryptWallet(wltName, password string) (*wallet.Wallet, error) {
+func (gw *Gateway) EncryptWallet(wltName string, password []byte) (*wallet.Wallet, error) {
 	var wlt *wallet.Wallet
 	var err error
 	gw.strand("EncryptWallet", func() {
-		wlt, err = gw.v.Wallets.Encrypt(wltName, password)
+		wlt, err = gw.v.Wallets.EncryptWallet(wltName, password)
 	})
 	return wlt, err
 }
@@ -596,7 +598,7 @@ func (gw *Gateway) GetWalletDir() string {
 }
 
 // NewAddresses generate addresses in given wallet
-func (gw *Gateway) NewAddresses(wltID string, password string, n uint64) ([]cipher.Address, error) {
+func (gw *Gateway) NewAddresses(wltID string, password []byte, n uint64) ([]cipher.Address, error) {
 	var addrs []cipher.Address
 	var err error
 	gw.strand("NewAddresses", func() {
@@ -615,8 +617,8 @@ func (gw *Gateway) UpdateWalletLabel(wltID, label string) error {
 }
 
 // GetWallet returns wallet by id
-func (gw *Gateway) GetWallet(wltID string) (wallet.Wallet, error) {
-	var w wallet.Wallet
+func (gw *Gateway) GetWallet(wltID string) (*wallet.Wallet, error) {
+	var w *wallet.Wallet
 	var err error
 	gw.strand("GetWallet", func() {
 		w, err = gw.vrpc.GetWallet(wltID)

--- a/src/daemon/visor.go
+++ b/src/daemon/visor.go
@@ -470,11 +470,12 @@ func (vs *Visor) EstimateBlockchainHeight() uint64 {
 }
 
 // ScanAheadWalletAddresses loads wallet from seeds and scan ahead N addresses
-func (vs *Visor) ScanAheadWalletAddresses(wltName string, scanN uint64) (wallet.Wallet, error) {
-	var wlt wallet.Wallet
+// Set password as nil if the wallet is not encrypted, otherwise the password must be provided.
+func (vs *Visor) ScanAheadWalletAddresses(wltName string, password []byte, scanN uint64) (*wallet.Wallet, error) {
+	var wlt *wallet.Wallet
 	var err error
 	vs.strand("ScanAheadWalletAddresses", func() error {
-		wlt, err = vs.v.ScanAheadWalletAddresses(wltName, scanN)
+		wlt, err = vs.v.ScanAheadWalletAddresses(wltName, password, scanN)
 		return nil
 	})
 

--- a/src/gui/wallet.go
+++ b/src/gui/wallet.go
@@ -29,7 +29,7 @@ func Spend(gateway *daemon.Gateway, walletID string, coins uint64, dest cipher.A
 	var b wallet.BalancePair
 	var err error
 	for {
-		tx, err = gateway.Spend(walletID, coins, dest)
+		tx, err = gateway.Spend(walletID, nil, coins, dest)
 		if err != nil {
 			break
 		}
@@ -198,7 +198,7 @@ func walletCreate(gateway *daemon.Gateway) http.HandlerFunc {
 			return
 		}
 
-		wlt, err = gateway.ScanAheadWalletAddresses(wlt.GetFilename(), scanN-1)
+		wlt, err = gateway.ScanAheadWalletAddresses(wlt.Filename(), nil, scanN-1)
 		if err != nil {
 			logger.Error("gateway.ScanAheadWalletAddresses failed: %v", err)
 			wh.Error500(w)
@@ -240,7 +240,7 @@ func walletNewAddresses(gateway *daemon.Gateway) http.HandlerFunc {
 			}
 		}
 
-		addrs, err := gateway.NewAddresses(wltID, n)
+		addrs, err := gateway.NewAddresses(wltID, nil, n)
 		if err != nil {
 			wh.Error400(w, err.Error())
 			return
@@ -405,6 +405,10 @@ func RegisterWalletHandlers(mux *http.ServeMux, gateway *daemon.Gateway) {
 	//     scan: the number of addresses to scan ahead for balances [optional, must be > 0]
 	mux.HandleFunc("/wallet/create", walletCreate(gateway))
 
+	// Generates new addresses in specific wallet
+	// POST Arguments:
+	//         id: wallet id.
+	//         num: the number of address want to generate
 	mux.HandleFunc("/wallet/newAddress", walletNewAddresses(gateway))
 
 	// Returns the confirmed and predicted balance for a specific wallet.

--- a/src/visor/rpc.go
+++ b/src/visor/rpc.go
@@ -139,44 +139,44 @@ func (rpc RPC) GetAddressTxns(v *Visor,
 }
 
 // CreateWallet creates new wallet
-func (rpc *RPC) CreateWallet(wltName string, options wallet.Options) (wallet.Wallet, error) {
-	return rpc.v.wallets.CreateWallet(wltName, options)
+func (rpc *RPC) CreateWallet(wltName string, options wallet.Options) (*wallet.Wallet, error) {
+	return rpc.v.Wallets.CreateWallet(wltName, options)
 }
 
 // NewAddresses generates new addresses in given wallet
 func (rpc *RPC) NewAddresses(wltName string, num uint64) ([]cipher.Address, error) {
-	return rpc.v.wallets.NewAddresses(wltName, num)
+	return rpc.v.Wallets.NewAddresses(wltName, nil, num)
 }
 
 // GetWalletAddresses returns all addresses in given wallet
 func (rpc *RPC) GetWalletAddresses(wltID string) ([]cipher.Address, error) {
-	return rpc.v.wallets.GetAddresses(wltID)
+	return rpc.v.Wallets.GetAddresses(wltID)
 }
 
 // CreateAndSignTransaction creates and sign transaction from wallet
-func (rpc *RPC) CreateAndSignTransaction(wltID string, vld wallet.Validator, unspent blockdb.UnspentGetter,
+func (rpc *RPC) CreateAndSignTransaction(wltID string, password []byte, vld wallet.Validator, unspent blockdb.UnspentGetter,
 	headTime, coins uint64, dest cipher.Address) (*coin.Transaction, error) {
-	return rpc.v.wallets.CreateAndSignTransaction(wltID, vld, unspent, headTime, coins, dest)
+	return rpc.v.Wallets.CreateAndSignTransaction(wltID, password, vld, unspent, headTime, coins, dest)
 }
 
 // UpdateWalletLabel updates wallet label
 func (rpc *RPC) UpdateWalletLabel(wltID, label string) error {
-	return rpc.v.wallets.UpdateWalletLabel(wltID, label)
+	return rpc.v.Wallets.UpdateWalletLabel(wltID, label)
 }
 
 // GetWallet returns wallet by id
-func (rpc *RPC) GetWallet(wltID string) (wallet.Wallet, error) {
-	return rpc.v.wallets.GetWallet(wltID)
+func (rpc *RPC) GetWallet(wltID string) (*wallet.Wallet, error) {
+	return rpc.v.Wallets.GetWallet(wltID)
 }
 
 // GetWallets returns all wallet
 func (rpc *RPC) GetWallets() wallet.Wallets {
-	return rpc.v.wallets.GetWallets()
+	return rpc.v.Wallets.GetWallets()
 }
 
 // ReloadWallets reloads all wallet from files
 func (rpc *RPC) ReloadWallets() error {
-	return rpc.v.wallets.ReloadWallets()
+	return rpc.v.Wallets.ReloadWallets()
 }
 
 // GetBuildInfo returns node build info, including version, build time, etc.

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -168,7 +168,7 @@ type Visor struct {
 	// blockSigs   *blockdb.BlockSigs
 	history  *historydb.HistoryDB
 	bcParser *BlockchainParser
-	wallets  *wallet.Service
+	Wallets  *wallet.Service
 	db       *bolt.DB
 }
 
@@ -210,7 +210,7 @@ func NewVisor(c Config, db *bolt.DB) (*Visor, error) {
 		Unconfirmed: NewUnconfirmedTxnPool(db),
 		history:     history,
 		bcParser:    bp,
-		wallets:     wltServ,
+		Wallets:     wltServ,
 	}
 
 	return v, nil
@@ -769,6 +769,5 @@ func (vs Visor) GetBalanceOfAddrs(addrs []cipher.Address) ([]wallet.BalancePair,
 
 		bps = append(bps, bp)
 	}
-
 	return bps, nil
 }

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -723,8 +723,8 @@ func (vs Visor) GetAddrUxOuts(address cipher.Address) ([]*historydb.UxOut, error
 }
 
 // ScanAheadWalletAddresses scans ahead N addresses in a wallet, looking for a non-empty balance
-func (vs Visor) ScanAheadWalletAddresses(wltName string, scanN uint64) (wallet.Wallet, error) {
-	return vs.wallets.ScanAheadWalletAddresses(wltName, scanN, vs)
+func (vs Visor) ScanAheadWalletAddresses(wltName string, password []byte, scanN uint64) (*wallet.Wallet, error) {
+	return vs.Wallets.ScanAheadWalletAddresses(wltName, password, scanN, vs)
 }
 
 // GetBalanceOfAddrs returns balance pairs of given addreses

--- a/src/wallet/encrypt.go
+++ b/src/wallet/encrypt.go
@@ -1,0 +1,27 @@
+package wallet
+
+import (
+	"encoding/base64"
+
+	"github.com/skycoin/skycoin/src/cipher"
+)
+
+// cipher.Encrypt the data, then encode the result into base64 string
+func encrypt(data []byte, password []byte) (string, error) {
+	encData, err := cipher.Encrypt(data, password)
+	if err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(encData), nil
+}
+
+// base64 decode the string, then cipher.Decrypt the data
+func decrypt(data string, password []byte) ([]byte, error) {
+	base64DecodedData, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return cipher.Decrypt(base64DecodedData, password)
+}

--- a/src/wallet/encrypt.go
+++ b/src/wallet/encrypt.go
@@ -1,0 +1,131 @@
+package wallet
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"strings"
+
+	"github.com/skycoin/skycoin/src/cipher"
+)
+
+const blockSize = 32
+
+// encrypt encrypts the data with password
+// 1> Split data into 256 bits(32 bytes) blocks (pad to 32 bytes with nulls at end)
+// 2> Each block is encrypted by XORing the unencrypted block with SHA256(SHA256(password), SHA256(index, SHA256(nonce))
+// 	  - index is 0 for the first block of 32 bytes, 1 for the second block of 32 bytes, 2 for third block
+// 3> SHA256 the nonce with comma seperated, hex encoded blocks of 32 bytes(256 bits)
+// 4> Encode <checksum(32 bytes)><nonce(32 bytes)><block0.Hex(), block1.Hex()...> with base64
+func encrypt(data []byte, password []byte) (string, error) {
+	// split the data into 256 bit blocks(pad with null to 32 bytes)
+	l := len(data)
+	n := l / blockSize
+	var blocks [][blockSize]byte
+	for i := 0; i < n; i++ {
+		var b [blockSize]byte
+		copy(b[:], data[i*blockSize:(i+1)*blockSize])
+		blocks = append(blocks, b)
+	}
+
+	// append last block if exist
+	if l%blockSize > 0 {
+		b := [blockSize]byte{}
+		copy(b[:], data[n*blockSize:])
+		blocks = append(blocks, b)
+	}
+
+	nonce := cipher.RandByte(blockSize)
+	var encryptedBlocks []string
+	// encode the blocks
+	for i := range blocks {
+		h := hashPwdIndexNonce(password, int64(i), nonce)
+		bh := cipher.SHA256(blocks[i])
+		encryptedBlocks = append(encryptedBlocks, bh.Xor(h).Hex())
+	}
+
+	encryptedData := strings.Join(encryptedBlocks, ",")
+	nonceAndDataBytes := append(nonce, []byte(encryptedData)...)
+	checkSum := cipher.SumSHA256(nonceAndDataBytes)
+	var buf bytes.Buffer
+	_, err := buf.Write(checkSum[:])
+	if err != nil {
+		return "", err
+	}
+
+	_, err = buf.Write(nonceAndDataBytes)
+	if err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}
+
+func decrypt(data string, password []byte) ([]byte, error) {
+	// decode with base64
+	dataBytes, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := bytes.NewBuffer(dataBytes)
+
+	checkSumBytes := make([]byte, blockSize)
+	n, err := buf.Read(checkSumBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	if n != blockSize {
+		return nil, errors.New("decode checksum failed")
+	}
+
+	var checkSum cipher.SHA256
+	copy(checkSum[:], checkSumBytes)
+
+	// verify the checksum
+	csh := cipher.SumSHA256(buf.Bytes())
+	if csh.Hex() != checkSum.Hex() {
+		return nil, errors.New("invalid checksum")
+	}
+
+	nonce := make([]byte, blockSize)
+	n, err = buf.Read(nonce)
+	if err != nil {
+		return nil, err
+	}
+
+	if n != blockSize {
+		return nil, errors.New("decode nonce failed")
+	}
+
+	encryptedBlocks := strings.Split(buf.String(), ",")
+	var decodeData []byte
+	for i := range encryptedBlocks {
+		bh, err := cipher.SHA256FromHex(encryptedBlocks[i])
+		if err != nil {
+			return nil, err
+		}
+
+		dataHash := bh.Xor(hashPwdIndexNonce(password, int64(i), nonce))
+		decodeData = append(decodeData, dataHash[:]...)
+	}
+
+	// remove the padding null
+	return bytes.TrimRight(decodeData, "\x00"), nil
+}
+
+// hash(password, hash(index, hash(nonce)))
+func hashPwdIndexNonce(password []byte, index int64, nonce []byte) cipher.SHA256 {
+	// convert index to 256bit number
+	indexBytes := make([]byte, 32)
+	binary.PutVarint(indexBytes, index)
+
+	// hash(index, hash(nonce))
+	nonceHash := cipher.SumSHA256(nonce)
+	indexNonceHash := cipher.SumSHA256(append(indexBytes, nonceHash[:]...))
+
+	// hash(hash(password), indexNonceHash)
+	return cipher.AddSHA256(cipher.SumSHA256(password), indexNonceHash)
+}

--- a/src/wallet/encrypt.go
+++ b/src/wallet/encrypt.go
@@ -6,8 +6,8 @@ import (
 	"github.com/skycoin/skycoin/src/cipher"
 )
 
-// cipher.Encrypt the data, then encode the result into base64 string
-func encrypt(data []byte, password []byte) (string, error) {
+// Encrypt cipher.Encrypt the data, then encode the result into base64 string
+func Encrypt(data []byte, password []byte) (string, error) {
 	encData, err := cipher.Encrypt(data, password)
 	if err != nil {
 		return "", err
@@ -16,8 +16,8 @@ func encrypt(data []byte, password []byte) (string, error) {
 	return base64.StdEncoding.EncodeToString(encData), nil
 }
 
-// base64 decode the string, then cipher.Decrypt the data
-func decrypt(data string, password []byte) ([]byte, error) {
+// Decrypt base64 decodes the string, then cipher.Decrypt the data
+func Decrypt(data string, password []byte) ([]byte, error) {
 	base64DecodedData, err := base64.StdEncoding.DecodeString(data)
 	if err != nil {
 		return nil, err

--- a/src/wallet/encrypt_test.go
+++ b/src/wallet/encrypt_test.go
@@ -1,0 +1,72 @@
+package wallet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncryptAndDecrypt(t *testing.T) {
+	tt := []struct {
+		name string
+		data string
+		key  string
+		err  error
+	}{
+		{
+			"one byte with empty key",
+			"1",
+			"",
+			nil,
+		},
+		{
+			"one byte, with key",
+			"1",
+			"key",
+			nil,
+		},
+		{
+			"encrypt data size < 32, with key",
+			"hello,world",
+			"pwd",
+			nil,
+		},
+		{
+			"encrypt data size = 32, with key",
+			"22Be3vk9nSbXHYJ8JMkCPphe73NQvGhm",
+			"pwd",
+			nil,
+		},
+		{
+			"encrypt data size > 32, with key",
+			"22Be3vk9nSbXHYJ8JMkCPphe73NQvGhmabc",
+			"pwd13",
+			nil,
+		},
+		{
+			"encrypt data size > 32, with key",
+			"22Be3vk9nSbXHYJ8JMkCPphe73NQvGhmabc",
+			"pwd13",
+			nil,
+		},
+		{
+			"encrypt data size > 2*32, with key",
+			"9d4a8e0b9fe800e40790cab00710ef2a49dbdb6be2b0e0950c739fe0799d0",
+			"8JMkCPphe73NQvGhmab",
+			nil,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			enData, err := encrypt([]byte(tc.data), []byte(tc.key))
+			require.NoError(t, err)
+			str := string(enData)
+
+			d, err := decrypt(str, []byte(tc.key))
+			require.NoError(t, err)
+			require.Equal(t, tc.data, string(d))
+		})
+	}
+
+}

--- a/src/wallet/encrypt_test.go
+++ b/src/wallet/encrypt_test.go
@@ -61,9 +61,8 @@ func TestEncryptAndDecrypt(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			enData, err := encrypt([]byte(tc.data), []byte(tc.key))
 			require.NoError(t, err)
-			str := string(enData)
 
-			d, err := decrypt(str, []byte(tc.key))
+			d, err := decrypt(enData, []byte(tc.key))
 			require.NoError(t, err)
 			require.Equal(t, tc.data, string(d))
 		})

--- a/src/wallet/entry.go
+++ b/src/wallet/entry.go
@@ -1,56 +1,41 @@
 package wallet
 
 import (
-	"errors"
-
 	"github.com/skycoin/skycoin/src/cipher"
 )
 
 // Entry represents the wallet entry
 type Entry struct {
-	Address cipher.Address
-	Public  cipher.PubKey
-	Secret  cipher.SecKey
-}
-
-// NewEntryFromReadable creates WalletEntry base one ReadableWalletEntry
-func NewEntryFromReadable(w *ReadableEntry) (*Entry, error) {
-	if w.Secret == "" {
-		return nil, errors.New("secret field is empty")
-	}
-
-	s, err := cipher.SecKeyFromHex(w.Secret)
-	if err != nil {
-		return nil, err
-	}
-
-	a := cipher.AddressFromSecKey(s)
-	if w.Address != "" {
-		if a.String() != w.Address {
-			return nil, errors.New("address does not match the secret")
-		}
-	}
-
-	return &Entry{
-		Address: a,
-		Public:  cipher.PubKeyFromSecKey(s),
-		Secret:  s,
-	}, nil
+	Address         cipher.Address
+	Public          cipher.PubKey
+	Secret          cipher.SecKey
+	EncryptedSeckey string
 }
 
 // Verify checks that the public key is derivable from the secret key,
 // and that the public key is associated with the address
-func (we *Entry) Verify() error {
-	if cipher.PubKeyFromSecKey(we.Secret) != we.Public {
-		return errors.New("invalid public key for secret key")
-	}
-	return we.VerifyPublic()
-}
+// func (we *Entry) Verify(password []byte) error {
+// 	var seckey cipher.SecKey
+// 	if password == nil {
+
+// 	}
+// 	ds, err := decrypt(we.Secret, password)
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	copy(seckey[:], ds[:])
+
+// 	if cipher.PubKeyFromSecKey(seckey) != we.Public {
+// 		return errors.New("invalid public key for secret key")
+// 	}
+// 	return we.VerifyPublic()
+// }
 
 // VerifyPublic checks that the public key is associated with the address
-func (we *Entry) VerifyPublic() error {
-	if err := we.Public.Verify(); err != nil {
-		return err
-	}
-	return we.Address.Verify(we.Public)
-}
+// func (we *Entry) VerifyPublic() error {
+// 	if err := we.Public.Verify(); err != nil {
+// 		return err
+// 	}
+// 	return we.Address.Verify(we.Public)
+// }

--- a/src/wallet/readable.go
+++ b/src/wallet/readable.go
@@ -135,7 +135,7 @@ func (bt ByTm) Swap(i, j int) {
 }
 
 // NewReadableWallet creates readable wallet
-func NewReadableWallet(w Wallet) *ReadableWallet {
+func NewReadableWallet(w *Wallet) *ReadableWallet {
 	readable := make(ReadableEntries, len(w.Entries))
 	for i, e := range w.Entries {
 		readable[i] = NewReadableEntry(e, w.Version())

--- a/src/wallet/readable.go
+++ b/src/wallet/readable.go
@@ -134,14 +134,11 @@ func (bt ByTm) Swap(i, j int) {
 	bt[i], bt[j] = bt[j], bt[i]
 }
 
-// ReadableWalletCtor readable wallet creator
-type ReadableWalletCtor func(w Wallet) *ReadableWallet
-
 // NewReadableWallet creates readable wallet
 func NewReadableWallet(w Wallet) *ReadableWallet {
 	readable := make(ReadableEntries, len(w.Entries))
 	for i, e := range w.Entries {
-		readable[i] = NewReadableEntry(e, w.GetVersion())
+		readable[i] = NewReadableEntry(e, w.version())
 	}
 
 	meta := make(map[string]string, len(w.Meta))
@@ -174,8 +171,8 @@ func (rw *ReadableWallet) toWallet() (*Wallet, error) {
 		Entries: ets,
 	}
 
-	if err := w.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid wallet %s: %v", w.GetFilename(), err)
+	if err := w.validate(); err != nil {
+		return nil, fmt.Errorf("invalid wallet %s: %v", w.Filename(), err)
 	}
 
 	return w, nil

--- a/src/wallet/readable.go
+++ b/src/wallet/readable.go
@@ -24,7 +24,7 @@ func NewReadableEntry(w Entry, v string) ReadableEntry {
 	switch v {
 	case "0.1":
 		secret = w.Secret.Hex()
-	case wltVersion:
+	case Version:
 		secret = w.EncryptedSeckey
 	}
 	return ReadableEntry{
@@ -102,7 +102,7 @@ func newEntryFromReadable(w *ReadableEntry, v string) (*Entry, error) {
 			Public:  p,
 			Secret:  s,
 		}, nil
-	case wltVersion:
+	case Version:
 		return &Entry{
 			Address:         a,
 			Public:          p,
@@ -138,7 +138,7 @@ func (bt ByTm) Swap(i, j int) {
 func NewReadableWallet(w Wallet) *ReadableWallet {
 	readable := make(ReadableEntries, len(w.Entries))
 	for i, e := range w.Entries {
-		readable[i] = NewReadableEntry(e, w.version())
+		readable[i] = NewReadableEntry(e, w.Version())
 	}
 
 	meta := make(map[string]string, len(w.Meta))

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -12,10 +12,6 @@ import (
 	"github.com/skycoin/skycoin/src/visor/blockdb"
 )
 
-func errWalletNotExist(wltName string) error {
-	return fmt.Errorf("wallet %s doesn't exist", wltName)
-}
-
 // BalanceGetter interface for getting the balance of given addresses
 type BalanceGetter interface {
 	GetBalanceOfAddrs(addrs []cipher.Address) ([]BalancePair, error)
@@ -54,7 +50,7 @@ func NewService(walletDir string) (*Service, error) {
 			return nil, err
 		}
 
-		// create default wallet
+		// Create default wallet
 		w, err := serv.CreateWallet("", Options{
 			Label: "Your Wallet",
 			Seed:  seed,
@@ -63,7 +59,7 @@ func NewService(walletDir string) (*Service, error) {
 			return nil, err
 		}
 
-		if err := w.Save(serv.WalletDirectory); err != nil {
+		if err := Save(serv.WalletDirectory, w); err != nil {
 			return nil, fmt.Errorf("failed to save wallets to %s: %v", serv.WalletDirectory, err)
 		}
 	}
@@ -72,7 +68,7 @@ func NewService(walletDir string) (*Service, error) {
 }
 
 // CreateWallet creates a wallet with one address
-func (serv *Service) CreateWallet(wltName string, options Options) (Wallet, error) {
+func (serv *Service) CreateWallet(wltName string, options Options) (*Wallet, error) {
 	serv.Lock()
 	defer serv.Unlock()
 
@@ -85,79 +81,105 @@ func (serv *Service) CreateWallet(wltName string, options Options) (Wallet, erro
 
 // ScanAheadWalletAddresses scans n addresses for a balance, and sets the wallet's entry list to the highest
 // address with a non-zero coins balance.
-func (serv *Service) ScanAheadWalletAddresses(wltName string, scanN uint64, bg BalanceGetter) (Wallet, error) {
+// Set password as nil if the wallet is not encrypted, otherwise the password must be provided.
+func (serv *Service) ScanAheadWalletAddresses(wltName string, password []byte, scanN uint64, bg BalanceGetter) (*Wallet, error) {
 	serv.Lock()
 	defer serv.Unlock()
 
 	w, err := serv.getWallet(wltName)
 	if err != nil {
-		return Wallet{}, err
+		return nil, err
 	}
 
-	if err := w.ScanAddresses(scanN, bg); err != nil {
-		return Wallet{}, err
+	f := func(wlt *Wallet) error {
+		return wlt.ScanAddresses(scanN, bg)
 	}
 
-	if err := Save(serv.WalletDirectory); err != nil {
-		return Wallet{}, err
+	if w.IsEncrypted() {
+		if err := w.guard(password, f); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := f(w); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := Save(serv.WalletDirectory, w); err != nil {
+		return nil, err
 	}
 
 	serv.wallets.set(w)
 
-	return w.Copy(), nil
+	return w.clone(), nil
 }
 
 // loadWallet loads wallet from seed and scan the first N addresses
-func (serv *Service) loadWallet(wltName string, options Options, scanN uint64, bg BalanceGetter) (Wallet, error) {
+func (serv *Service) loadWallet(wltName string, options Options, scanN uint64, bg BalanceGetter) (*Wallet, error) {
 	w, err := NewWallet(wltName, options)
 	if err != nil {
-		return Wallet{}, err
+		return nil, err
 	}
 
-	// Generate a default address
-	w.GenerateAddresses(1)
+	f := func(wlt *Wallet) error {
+		if len(wlt.Entries) == 0 {
+			// Generate a default address
+			wlt.GenerateAddresses(1)
+		}
 
-	// Check for duplicate wallets by initial seed
-	if id, ok := serv.firstAddrIDMap[w.Entries[0].Address.String()]; ok {
-		return Wallet{}, fmt.Errorf("duplicate wallet with %v", id)
+		// Check for duplicate wallets by initial seed
+		if id, ok := serv.firstAddrIDMap[wlt.Entries[0].Address.String()]; ok {
+			return fmt.Errorf("duplicate wallet with %v", id)
+		}
+
+		// Scan for addresses with balances
+		if scanN > 1 && bg != nil {
+			if err := wlt.ScanAddresses(scanN-1, bg); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
-	// Scan for addresses with balances
-	if scanN > 1 && bg != nil {
-		if err := w.ScanAddresses(scanN-1, bg); err != nil {
-			return Wallet{}, err
+	if w.IsEncrypted() {
+		if err := w.guard(options.Password, f); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := f(w); err != nil {
+			return nil, err
 		}
 	}
 
-	if err := serv.wallets.Add(*w); err != nil {
-		return Wallet{}, err
+	if err := serv.wallets.Add(w); err != nil {
+		return nil, err
 	}
 
-	if err := w.Save(serv.WalletDirectory); err != nil {
+	if err := Save(serv.WalletDirectory, w); err != nil {
 		// If save fails, remove the added wallet
-		serv.wallets.Remove(w.GetID())
-		return Wallet{}, err
+		serv.wallets.Remove(w.Filename())
+		return nil, err
 	}
 
 	serv.firstAddrIDMap[w.Entries[0].Address.String()] = w.Filename()
 
-	return w.Copy(), nil
+	return w.clone(), nil
 }
 
 func (serv *Service) generateUniqueWalletFilename() string {
-	wltName := NewWalletFilename()
+	wltName := newWalletFilename()
 	for {
 		if _, ok := serv.wallets.Get(wltName); !ok {
 			break
 		}
-		wltName = NewWalletFilename()
+		wltName = newWalletFilename()
 	}
 
 	return wltName
 }
 
-// Encrypt encrypts wallet by given password
-func (serv *Service) Encrypt(wltID, password string) (*Wallet, error) {
+// EncryptWallet encrypts wallet with password
+func (serv *Service) EncryptWallet(wltID string, password []byte) (*Wallet, error) {
 	serv.Lock()
 	defer serv.Unlock()
 	w, ok := serv.wallets.Get(wltID)
@@ -165,43 +187,19 @@ func (serv *Service) Encrypt(wltID, password string) (*Wallet, error) {
 		return nil, ErrWalletNotExist{wltID}
 	}
 
-	oldVersion := w.Version()
+	isEncrypted := w.IsEncrypted()
 
-	// Update version to lastest
-	w.setVersion(Version)
-
-	// encrypt seed
-	sseed, err := Encrypt([]byte(w.seed()), []byte(password))
-	if err != nil {
+	if err := w.lock(password); err != nil {
 		return nil, err
-	}
-	w.setSeed(sseed)
-
-	// encrypt lastSeed
-	lsseed, err := Encrypt([]byte(w.lastSeed()), []byte(password))
-	if err != nil {
-		return nil, err
-	}
-	w.setLastSeed(lsseed)
-
-	// encrypts private keys in entries
-	for i := range w.Entries {
-		sk, err := Encrypt(w.Entries[i].Secret[:], []byte(password))
-		if err != nil {
-			return nil, err
-		}
-
-		w.Entries[i].EncryptedSeckey = sk
-		w.Entries[i].Secret = cipher.SecKey{}
 	}
 
 	if err := Save(serv.WalletDirectory, w); err != nil {
 		return nil, err
 	}
 
-	// Delete the .bak file if the previous version is 0.1,
+	// Delete the .bak file if the previous version was not encrypted
 	// othewise it would expose the plaintext seeds and private keys.
-	if oldVersion == "0.1" {
+	if !isEncrypted {
 		fn := w.Filename() + ".bak"
 		path := filepath.Join(serv.WalletDirectory, fn)
 		if e, err := os.Stat(path); !os.IsNotExist(err) {
@@ -213,14 +211,13 @@ func (serv *Service) Encrypt(wltID, password string) (*Wallet, error) {
 		}
 	}
 
-	nw := w.clone()
-
-	return nw, nil
+	return w.clone(), nil
 }
 
 // NewAddresses generate address entries in given wallet,
 // return nil if wallet does not exist.
-func (serv *Service) NewAddresses(wltID string, num uint64) ([]cipher.Address, error) {
+// Set password as nil if the wallet is not encrypted, otherwise the password must be provided.
+func (serv *Service) NewAddresses(wltID string, password []byte, num uint64) ([]cipher.Address, error) {
 	serv.Lock()
 	defer serv.Unlock()
 	w, ok := serv.wallets.Get(wltID)
@@ -228,9 +225,21 @@ func (serv *Service) NewAddresses(wltID string, num uint64) ([]cipher.Address, e
 		return []cipher.Address{}, ErrWalletNotExist{wltID}
 	}
 
-	addrs, err := w.GenerateAddresses(num)
-	if err != nil {
-		return nil, err
+	var addrs []cipher.Address
+	f := func(wlt *Wallet) error {
+		var err error
+		addrs, err = wlt.GenerateAddresses(num)
+		return err
+	}
+
+	if w.IsEncrypted() {
+		if err := w.guard(password, f); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := f(w); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := Save(serv.WalletDirectory, w); err != nil {
@@ -253,17 +262,17 @@ func (serv *Service) GetAddresses(wltID string) ([]cipher.Address, error) {
 }
 
 // GetWallet returns wallet by id
-func (serv *Service) GetWallet(wltID string) (Wallet, error) {
+func (serv *Service) GetWallet(wltID string) (*Wallet, error) {
 	serv.RLock()
 	defer serv.RUnlock()
 
 	return serv.getWallet(wltID)
 }
 
-func (serv *Service) getWallet(wltID string) (Wallet, error) {
+func (serv *Service) getWallet(wltID string) (*Wallet, error) {
 	w, ok := serv.wallets.Get(wltID)
 	if !ok {
-		return Wallet{}, errWalletNotExist(wltID)
+		return nil, ErrWalletNotExist{wltID}
 	}
 	return w.clone(), nil
 }
@@ -274,8 +283,7 @@ func (serv *Service) GetWallets() Wallets {
 	defer serv.RUnlock()
 	wlts := make(Wallets, len(serv.wallets))
 	for k, w := range serv.wallets {
-		nw := w.clone()
-		wlts[k] = nw
+		wlts[k] = w.clone()
 	}
 	return wlts
 }
@@ -295,7 +303,8 @@ func (serv *Service) ReloadWallets() error {
 }
 
 // CreateAndSignTransaction creates and sign transaction from wallet
-func (serv *Service) CreateAndSignTransaction(wltID string, vld Validator, unspent blockdb.UnspentGetter,
+// Set password as nil if the wallet is not encrypted, otherwise the password must be provided
+func (serv *Service) CreateAndSignTransaction(wltID string, password []byte, vld Validator, unspent blockdb.UnspentGetter,
 	headTime, coins uint64, dest cipher.Address) (*coin.Transaction, error) {
 	serv.RLock()
 	defer serv.RUnlock()
@@ -304,7 +313,23 @@ func (serv *Service) CreateAndSignTransaction(wltID string, vld Validator, unspe
 		return nil, ErrWalletNotExist{wltID}
 	}
 
-	return w.CreateAndSignTransaction(vld, unspent, headTime, coins, dest)
+	var tx *coin.Transaction
+	f := func(wlt *Wallet) error {
+		var err error
+		tx, err = wlt.CreateAndSignTransaction(vld, unspent, headTime, coins, dest)
+		return err
+	}
+
+	if w.IsEncrypted() {
+		if err := w.guard(password, f); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := f(w); err != nil {
+			return nil, err
+		}
+	}
+	return tx, nil
 }
 
 // UpdateWalletLabel updates the wallet label

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -157,7 +157,7 @@ func (serv *Service) generateUniqueWalletFilename() string {
 
 // NewAddresses generate address entries in given wallet,
 // return nil if wallet does not exist.
-func (serv *Service) NewAddresses(wltID string, num int, password string) ([]cipher.Address, error) {
+func (serv *Service) NewAddresses(wltID string, password string, num int) ([]cipher.Address, error) {
 	serv.Lock()
 	defer serv.Unlock()
 	w, ok := serv.wallets.Get(wltID)
@@ -165,7 +165,7 @@ func (serv *Service) NewAddresses(wltID string, num int, password string) ([]cip
 		return []cipher.Address{}, errWalletNotExist(wltID)
 	}
 
-	addrs, err := w.GenerateAddresses(num, password)
+	addrs, err := w.GenerateAddresses(password, num)
 	if err != nil {
 		return nil, err
 	}
@@ -232,8 +232,8 @@ func (serv *Service) ReloadWallets() error {
 }
 
 // CreateAndSignTransaction creates and sign transaction from wallet
-func (serv *Service) CreateAndSignTransaction(wltID string, vld Validator, unspent blockdb.UnspentGetter,
-	headTime, coins uint64, dest cipher.Address, password string) (*coin.Transaction, error) {
+func (serv *Service) CreateAndSignTransaction(wltID string, password string, vld Validator, unspent blockdb.UnspentGetter,
+	headTime, coins uint64, dest cipher.Address) (*coin.Transaction, error) {
 	serv.RLock()
 	defer serv.RUnlock()
 	w, ok := serv.wallets.Get(wltID)
@@ -241,7 +241,7 @@ func (serv *Service) CreateAndSignTransaction(wltID string, vld Validator, unspe
 		return nil, errWalletNotExist(wltID)
 	}
 
-	return w.CreateAndSignTransaction(vld, unspent, headTime, coins, dest, password)
+	return w.CreateAndSignTransaction(password, vld, unspent, headTime, coins, dest)
 }
 
 // UpdateWalletLabel updates the wallet label

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -157,7 +157,7 @@ func (serv *Service) generateUniqueWalletFilename() string {
 
 // NewAddresses generate address entries in given wallet,
 // return nil if wallet does not exist.
-func (serv *Service) NewAddresses(wltID string, num int, password []byte) ([]cipher.Address, error) {
+func (serv *Service) NewAddresses(wltID string, num int, password string) ([]cipher.Address, error) {
 	serv.Lock()
 	defer serv.Unlock()
 	w, ok := serv.wallets.Get(wltID)
@@ -233,7 +233,7 @@ func (serv *Service) ReloadWallets() error {
 
 // CreateAndSignTransaction creates and sign transaction from wallet
 func (serv *Service) CreateAndSignTransaction(wltID string, vld Validator, unspent blockdb.UnspentGetter,
-	headTime, coins uint64, dest cipher.Address, password []byte) (*coin.Transaction, error) {
+	headTime, coins uint64, dest cipher.Address, password string) (*coin.Transaction, error) {
 	serv.RLock()
 	defer serv.RUnlock()
 	w, ok := serv.wallets.Get(wltID)

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -170,7 +170,7 @@ func (serv *Service) NewAddresses(wltID string, password string, num int) ([]cip
 		return nil, err
 	}
 
-	if err := Save(w, serv.WalletDirectory); err != nil {
+	if err := Save(serv.WalletDirectory, w); err != nil {
 		return []cipher.Address{}, err
 	}
 
@@ -257,7 +257,7 @@ func (serv *Service) UpdateWalletLabel(wltID, label string) error {
 		return err
 	}
 
-	return Save(&wlt, serv.WalletDirectory)
+	return Save(serv.WalletDirectory, &wlt)
 }
 
 func (serv *Service) removeDup(wlts Wallets) Wallets {

--- a/src/wallet/service_test.go
+++ b/src/wallet/service_test.go
@@ -270,14 +270,15 @@ func TestServiceCreateAndScanWallet(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, seed, w.Meta["seed"])
 			require.NoError(t, w.validate())
 
 			w, err = s.ScanAheadWalletAddresses(wltName, tc.scanN, tc.balGetter)
 			require.NoError(t, err)
 
 			require.Len(t, w.Entries, tc.expect.entryNum)
-			require.Equal(t, tc.expect.lastSeed, w.lastSeed())
+			for i := range w.Entries {
+				require.Equal(t, addrsOfSeed1[i], w.Entries[i].Address.String())
+			}
 		})
 	}
 }
@@ -303,7 +304,7 @@ func TestServiceNewAddress(t *testing.T) {
 
 	// wallet doesn't exist
 	_, err = s.NewAddresses("not_exist_id.wlt", pwd, 1)
-	require.Equal(t, errWalletNotExist("not_exist_id.wlt"), err)
+	require.Equal(t, ErrWalletNotExist{"not_exist_id.wlt"}, err)
 }
 
 func TestServiceGetAddress(t *testing.T) {
@@ -321,7 +322,7 @@ func TestServiceGetAddress(t *testing.T) {
 	// test none exist wallet
 	notExistID := "not_exist_id.wlt"
 	_, err = s.GetAddresses(notExistID)
-	require.Equal(t, errWalletNotExist(notExistID), err)
+	require.Equal(t, ErrWalletNotExist{notExistID}, err)
 }
 
 func TestServiceGetWallet(t *testing.T) {

--- a/src/wallet/service_test.go
+++ b/src/wallet/service_test.go
@@ -293,7 +293,7 @@ func TestServiceNewAddress(t *testing.T) {
 	require.NoError(t, err)
 
 	// get the default wallet id
-	addrs, err := s.NewAddresses(w.Filename(), 1, pwd)
+	addrs, err := s.NewAddresses(w.Filename(), pwd, 1)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(addrs))
 
@@ -302,7 +302,7 @@ func TestServiceNewAddress(t *testing.T) {
 	require.NoError(t, err)
 
 	// wallet doesn't exist
-	_, err = s.NewAddresses("not_exist_id.wlt", 1, pwd)
+	_, err = s.NewAddresses("not_exist_id.wlt", pwd, 1)
 	require.Equal(t, errWalletNotExist("not_exist_id.wlt"), err)
 }
 
@@ -605,7 +605,7 @@ func TestServiceCreateAndSignTx(t *testing.T) {
 				unspents.unspents[ux.Hash()] = ux
 			}
 
-			tx, err := s.CreateAndSignTransaction(w.Filename(), tc.vld, unspents, uint64(headTime), tc.coins, tc.dest, tc.pwd)
+			tx, err := s.CreateAndSignTransaction(w.Filename(), tc.pwd, tc.vld, unspents, uint64(headTime), tc.coins, tc.dest)
 			require.Equal(t, tc.err, err)
 			if err != nil {
 				return

--- a/src/wallet/service_test.go
+++ b/src/wallet/service_test.go
@@ -287,7 +287,7 @@ func TestServiceNewAddress(t *testing.T) {
 	s, err := NewService(dir)
 	require.NoError(t, err)
 
-	pwd := []byte("pwd")
+	pwd := "pwd"
 	wltName := "test.wlt"
 	w, err := s.CreateWallet(wltName, pwd)
 	require.NoError(t, err)
@@ -311,7 +311,7 @@ func TestServiceGetAddress(t *testing.T) {
 	s, err := NewService(dir)
 	require.NoError(t, err)
 
-	w, err := s.CreateWallet("test.wlt", []byte("pwd"))
+	w, err := s.CreateWallet("test.wlt", "pwd")
 	require.NoError(t, err)
 
 	addrs, err := s.GetAddresses(w.Filename())
@@ -330,7 +330,7 @@ func TestServiceGetWallet(t *testing.T) {
 	s, err := NewService(dir)
 	require.NoError(t, err)
 
-	w, err := s.CreateWallet("test.wlt", []byte("pwd"))
+	w, err := s.CreateWallet("test.wlt", "pwd")
 	require.NoError(t, err)
 
 	w, err := s.GetWallet(id)
@@ -351,7 +351,7 @@ func TestServiceReloadWallets(t *testing.T) {
 	s, err := NewService(dir)
 	require.NoError(t, err)
 
-	pwd := []byte("pwd")
+	pwd := "pwd"
 	w, err := s.CreateWallet("test.wlt", pwd)
 	require.NoError(t, err)
 
@@ -456,7 +456,7 @@ func TestServiceCreateAndSignTx(t *testing.T) {
 		vld        Validator
 		coins      uint64
 		dest       cipher.Address
-		pwd        []byte
+		pwd        string
 		err        error
 	}{
 		{

--- a/src/wallet/service_test.go
+++ b/src/wallet/service_test.go
@@ -1,3 +1,5 @@
+// build ignore
+
 package wallet
 
 import (
@@ -26,54 +28,6 @@ func prepareWltDir() string {
 	return dir
 }
 
-type mockBalanceGetter map[cipher.Address]BalancePair
-
-// 10 addresses of seed1
-var addrsOfSeed1 = []string{
-	"2GBifzJEehbDX7Mkk63Prfa4MQQQyRzBLfe",
-	"q2kU13X8XsAg8cS8BuSeSVzjPF9AT9ghAa",
-	"2WXvTagXtrc1Qq71yjNXw86TC6SRgfVRH1B",
-	"2NUNw748b9mT2FHRxgJL5KjBHasLfdP32Sh",
-	"2V1CnVzWoXDaCX6wHU4tLJkWaFmLcQBb2q4",
-	"wBkMr936thcr57wxyrH6ffvA99JN2Q1MN1",
-	"2f92Wht7VQefAyoJUz3SEnfwT6wTdeAcq3L",
-	"27UM5jPFYVuve3ceEHAYGaJSmkynQYmwPcH",
-	"xjWbVN7ihReasVFwXJSSYYWF7rgQa22auC",
-	"2LyanokLYFeBfBsNkRYHp2qtN8naGFJqeUw",
-}
-
-var childSeedsOfSeed1 = []string{
-	"22b826c586039f8078433be26618ca1024e883d97de2267313bb78068f634c5a",
-	"68efbbdf8aa06368cfc55e252d1e782bbd7651e590ee59e94ab579d2e44c20ad",
-	"8894c818732375680284be4509d153272726f42296b85ecac1fb66b9dc7484b9",
-	"6603375ee19c1e9fffe369e3f62e9deaa6931c1183d7da7f24ecbbd591061502",
-	"91a63f939149d423ea39701d8ed16cfb16a3554c184d214d2289018ddb9e73de",
-	"f0f4f008aa3e7cd32ee953507856fb46e37b734fd289dc01449133d7e37a1f07",
-	"6b194da58a5ba5660cf2b00076cf6a2962fe8fe0523abca5647c87df3352866a",
-	"b47a2678f7e797d3ada86e7e36855f572a18ab78dcbe54ed0613bba69fd76f8d",
-	"fe064533108dadbef13be3a95f547ba03423aa6a701c40aaaed775cb783b12b3",
-	"d554da211321a437e4d08f2a57e3ef255cffa89dd182e0fd52a4fd5bdfcab1ae",
-}
-
-func fromAddrString(t *testing.T, addrStrs []string) []cipher.Address {
-	addrs := make([]cipher.Address, 0, len(addrStrs))
-	for _, addr := range addrStrs {
-		a, err := cipher.DecodeBase58Address(addr)
-		require.NoError(t, err)
-		addrs = append(addrs, a)
-	}
-	return addrs
-}
-
-func (mb mockBalanceGetter) GetBalanceOfAddrs(addrs []cipher.Address) ([]BalancePair, error) {
-	var bals []BalancePair
-	for _, addr := range addrs {
-		bal := mb[addr]
-		bals = append(bals, bal)
-	}
-	return bals, nil
-}
-
 func TestNewService(t *testing.T) {
 	dir := prepareWltDir()
 	s, err := NewService(dir)
@@ -85,7 +39,7 @@ func TestNewService(t *testing.T) {
 
 	require.Equal(t, dir, s.WalletDirectory)
 
-	require.Equal(t, 0, len(s.wallets))
+	require.Equal(t, 1, len(s.wallets))
 
 	// test load wallets
 	s, err = NewService("./testdata")
@@ -103,7 +57,6 @@ func TestNewService(t *testing.T) {
 
 func TestServiceCreateWallet(t *testing.T) {
 	dir := prepareWltDir()
-	fmt.Println("dir:", dir)
 	s, err := NewService(dir)
 	require.NoError(t, err)
 
@@ -113,7 +66,6 @@ func TestServiceCreateWallet(t *testing.T) {
 		Seed: seed,
 	})
 	require.NoError(t, err)
-	require.Equal(t, seed, string(sd))
 	require.NoError(t, w.validate())
 
 	// create wallet with dup wallet name
@@ -135,176 +87,251 @@ func TestServiceCreateWallet(t *testing.T) {
 	require.True(t, os.IsNotExist(err))
 }
 
-func TestServiceCreateAndScanWallet(t *testing.T) {
-	bg := make(mockBalanceGetter, len(addrsOfSeed1))
-	addrs := fromAddrString(t, addrsOfSeed1)
-	for _, a := range addrs {
-		bg[a] = BalancePair{}
-	}
-
-	type exp struct {
-		seed             string
-		lastSeed         string
-		entryNum         int
-		confirmedBalance uint64
-		predictedBalance uint64
+func TestServiceLoadWallet(t *testing.T) {
+	// Prepare addresss
+	seed := "seed"
+	_, seckeys := cipher.GenerateDeterministicKeyPairsSeed([]byte(seed), 10)
+	var addrs []cipher.Address
+	for _, s := range seckeys {
+		addrs = append(addrs, cipher.AddressFromSecKey(s))
 	}
 
 	tt := []struct {
-		name      string
-		scanN     uint64
-		balGetter BalanceGetter
-		expect    exp
+		name          string
+		opts          Options
+		scanN         uint64
+		bg            BalanceGetter
+		err           error
+		expectAddrNum int
+		expectAddrs   []cipher.Address
 	}{
 		{
-			"no coins and scan 0",
-			0,
-			bg,
-			exp{
-				seed:             "seed1",
-				lastSeed:         childSeedsOfSeed1[0],
-				entryNum:         1,
-				confirmedBalance: 0,
-				predictedBalance: 0,
+			"raw wallet, one address",
+			Options{
+				Seed:  "seed",
+				Label: "wallet",
 			},
-		},
-		{
-			"no coins and scan 1",
+			5,
+			mockBalanceGetter{
+				addrs[0]: BalancePair{Confirmed: Balance{Coins: 1e6, Hours: 100}},
+			},
+			nil,
 			1,
-			bg,
-			exp{
-				seed:             "seed1",
-				lastSeed:         childSeedsOfSeed1[0],
-				entryNum:         1,
-				confirmedBalance: 0,
-				predictedBalance: 0,
-			},
+			addrs[:1],
 		},
 		{
-			"no coins and scan 10",
-			10,
-			bg,
-			exp{
-				seed:             "seed1",
-				lastSeed:         childSeedsOfSeed1[0],
-				entryNum:         1,
-				confirmedBalance: 0,
-				predictedBalance: 0,
+			"raw wallet, two address",
+			Options{
+				Seed:  "seed",
+				Label: "wallet",
 			},
-		},
-		{
-			"scan 5 get 5",
 			5,
 			mockBalanceGetter{
-				addrs[5]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+				addrs[1]: BalancePair{Confirmed: Balance{Coins: 1e6, Hours: 100}},
 			},
-			exp{
-				seed:             "seed1",
-				lastSeed:         childSeedsOfSeed1[5],
-				entryNum:         5 + 1,
-				confirmedBalance: 10,
-				predictedBalance: 0,
-			},
+			nil,
+			2,
+			addrs[:2],
 		},
 		{
-			"scan 5 get 4",
+			"encrypted wallet, one address",
+			Options{
+				Seed:     "seed",
+				Label:    "wallet",
+				Encrypt:  true,
+				Password: []byte("pwd"),
+			},
 			5,
 			mockBalanceGetter{
-				addrs[3]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
-				addrs[4]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+				addrs[0]: BalancePair{Confirmed: Balance{Coins: 1e6, Hours: 100}},
 			},
-			exp{
-				seed:             "seed1",
-				lastSeed:         childSeedsOfSeed1[4],
-				entryNum:         4 + 1,
-				confirmedBalance: 20,
-				predictedBalance: 0,
-			},
+			nil,
+			1,
+			addrs[:1],
 		},
 		{
-			"scan 5 get 4 have 6",
+			"encrypted wallet, two address",
+			Options{
+				Seed:     "seed",
+				Label:    "wallet",
+				Encrypt:  true,
+				Password: []byte("pwd"),
+			},
 			5,
 			mockBalanceGetter{
-				addrs[3]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
-				addrs[4]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
-				addrs[6]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+				addrs[1]: BalancePair{Confirmed: Balance{Coins: 1e6, Hours: 100}},
 			},
-			exp{
-				seed:             "seed1",
-				lastSeed:         childSeedsOfSeed1[4],
-				entryNum:         4 + 1,
-				confirmedBalance: 20,
-				predictedBalance: 0,
-			},
-		},
-
-		{
-			"confirmed and predicted",
-			5,
-			mockBalanceGetter{
-				addrs[3]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
-				addrs[4]: BalancePair{Predicted: Balance{Coins: 10, Hours: 100}},
-			},
-			exp{
-				seed:             "seed1",
-				lastSeed:         childSeedsOfSeed1[4],
-				entryNum:         4 + 1,
-				confirmedBalance: 20,
-				predictedBalance: 0,
-			},
+			nil,
+			2,
+			addrs[:2],
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := prepareWltDir()
-
 			s, err := NewService(dir)
 			require.NoError(t, err)
+			wltName := newWalletFilename()
+			w, err := s.loadWallet(wltName, tc.opts, tc.scanN, tc.bg)
+			require.Equal(t, tc.err, err)
+			if err != nil {
+				return
+			}
 
-			wltName := "t1.wlt"
-			seed := "seed1"
-			w, err := s.CreateWallet(wltName, Options{
-				Seed:  seed,
-				Label: "foo",
-			})
-			require.NoError(t, err)
-
-			require.NoError(t, w.validate())
-
-			w, err = s.ScanAheadWalletAddresses(wltName, tc.scanN, tc.balGetter)
-			require.NoError(t, err)
-
-			require.Len(t, w.Entries, tc.expect.entryNum)
-			for i := range w.Entries {
-				require.Equal(t, addrsOfSeed1[i], w.Entries[i].Address.String())
+			require.Len(t, w.Entries, tc.expectAddrNum)
+			for i, a := range tc.expectAddrs {
+				require.Equal(t, a, w.Entries[i].Address)
 			}
 		})
 	}
+
 }
 
 func TestServiceNewAddress(t *testing.T) {
-	dir := prepareWltDir()
-	s, err := NewService(dir)
-	require.NoError(t, err)
+	seed := []byte("seed")
+	// Generate adddresses from the seed
+	var addrs []cipher.Address
+	_, seckeys := cipher.GenerateDeterministicKeyPairsSeed(seed, 10)
+	for _, s := range seckeys {
+		addrs = append(addrs, cipher.AddressFromSecKey(s))
+	}
 
-	pwd := "pwd"
-	wltName := "test.wlt"
-	w, err := s.CreateWallet(wltName, pwd)
-	require.NoError(t, err)
+	tt := []struct {
+		name          string
+		opts          Options
+		n             uint64
+		pwd           []byte
+		err           error
+		expectAddrNum int
+		expectAddrs   []cipher.Address
+	}{
+		{
+			"not encrypted, 0 address",
+			Options{
+				Label: "label",
+				Seed:  string(seed),
+			},
+			0,
+			nil,
+			nil,
+			0,
+			nil, // CreateWallet will generate a default address, so check from new address
+		},
+		{
+			"not encrypted, 1 addresses",
+			Options{
+				Label: "label",
+				Seed:  string(seed),
+			},
+			2,
+			nil,
+			nil,
+			2,
+			addrs[1:3], // CreateWallet will generate a default address, so check from new address
+		},
+		{
+			"not encrypted, 2 addresses",
+			Options{
+				Label: "label",
+				Seed:  string(seed),
+			},
+			2,
+			nil,
+			nil,
+			2,
+			addrs[1:3], // CreateWallet will generate a default address, so check from new address
+		},
+		{
+			"encrypted, 1 addresses",
+			Options{
+				Label:    "label",
+				Seed:     string(seed),
+				Encrypt:  true,
+				Password: []byte("pwd"),
+			},
+			1,
+			[]byte("pwd"),
+			nil,
+			1,
+			addrs[1:2], // CreateWallet will generate a default address, so check from new address
+		},
+		{
+			"encrypted, 2 addresses",
+			Options{
+				Label:    "label",
+				Seed:     string(seed),
+				Encrypt:  true,
+				Password: []byte("pwd"),
+			},
+			2,
+			[]byte("pwd"),
+			nil,
+			2,
+			addrs[1:3], // CreateWallet will generate a default address, so check from new address
+		},
+		{
+			"encrypted, wrong password",
+			Options{
+				Label:    "label",
+				Seed:     string(seed),
+				Encrypt:  true,
+				Password: []byte("pwd"),
+			},
+			1,
+			[]byte("wrong password"),
+			errors.New("unlock wallet failed: invalid password"),
+			1,
+			nil,
+		},
+	}
 
-	// get the default wallet id
-	addrs, err := s.NewAddresses(w.Filename(), pwd, 1)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(addrs))
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
 
-	// check if the wallet file is created
-	_, err = os.Stat(filepath.Join(dir, w.Filename()))
-	require.NoError(t, err)
+			dir := prepareWltDir()
+			s, err := NewService(dir)
+			require.NoError(t, err)
 
-	// wallet doesn't exist
-	_, err = s.NewAddresses("not_exist_id.wlt", pwd, 1)
-	require.Equal(t, ErrWalletNotExist{"not_exist_id.wlt"}, err)
+			wltName := newWalletFilename()
+			w, err := s.CreateWallet(wltName, tc.opts)
+			require.NoError(t, err)
+
+			naddrs, err := s.NewAddresses(w.Filename(), tc.pwd, tc.n)
+			require.Equal(t, tc.err, err)
+			if err != nil {
+				return
+			}
+
+			require.Len(t, naddrs, tc.expectAddrNum)
+			for i, a := range tc.expectAddrs {
+				require.Equal(t, a, naddrs[i])
+			}
+
+			// Check the wallet again
+			w, ok := s.wallets[wltName]
+			require.True(t, ok)
+			require.Len(t, w.Entries, int(tc.n+1))
+
+			// Wallet has a default address, so need to start from the second address
+			for i, a := range tc.expectAddrs {
+				require.Equal(t, a, w.Entries[i+1].Address)
+			}
+
+			// Load wallet from file and check
+			_, err = os.Stat(filepath.Join(dir, w.Filename()))
+			require.NoError(t, err)
+
+			lw, err := Load(filepath.Join(dir, w.Filename()))
+			require.NoError(t, err)
+			require.Equal(t, lw, w)
+
+			// Wallet doesn't exist
+			_, err = s.NewAddresses("wallet_not_exist.wlt", tc.pwd, 1)
+			require.Equal(t, ErrWalletNotExist{"wallet_not_exist.wlt"}, err)
+		})
+	}
+
 }
 
 func TestServiceGetAddress(t *testing.T) {
@@ -312,8 +339,10 @@ func TestServiceGetAddress(t *testing.T) {
 	s, err := NewService(dir)
 	require.NoError(t, err)
 
-	w, err := s.CreateWallet("test.wlt", "pwd")
-	require.NoError(t, err)
+	// get the defaut wallet
+	var w *Wallet
+	for _, w = range s.wallets {
+	}
 
 	addrs, err := s.GetAddresses(w.Filename())
 	require.NoError(t, err)
@@ -331,19 +360,54 @@ func TestServiceGetWallet(t *testing.T) {
 	s, err := NewService(dir)
 	require.NoError(t, err)
 
-	w, err := s.CreateWallet("test.wlt", "pwd")
+	// Get the defaut wallet
+	var w *Wallet
+	for _, w = range s.wallets {
+	}
 	require.NoError(t, err)
 
-	w, err := s.GetWallet(id)
+	w1, err := s.GetWallet(w.Filename())
 	require.NoError(t, err)
 
-	// modify the returned wallet won't affect the wallet in service
-	w1.setLabel("new_label")
+	// Check if change original wallet would change the returned wallet
+	w.setLabel("new_label")
 
-	w1, err := s.GetWallet(id)
+	require.NotEqual(t, "new_label", w1.Label())
+
+	// Get wallet doesn't exist
+	wltName := "does_not_exist.wlt"
+	_, err = s.GetWallet(wltName)
+	require.Equal(t, ErrWalletNotExist{wltName}, err)
+}
+
+func TestServiceGetWallets(t *testing.T) {
+	dir := prepareWltDir()
+	s, err := NewService(dir)
 	require.NoError(t, err)
 
-	require.NotEqual(t, "new_label", w2.Label())
+	var wallets []*Wallet
+	// Get the default wallet
+	var w1 *Wallet
+	for _, w1 = range s.wallets {
+	}
+	wallets = append(wallets, w1)
+
+	// Create a new wallet
+	wltName := newWalletFilename()
+	w2, err := s.CreateWallet(wltName, Options{
+		Seed:  "seed",
+		Label: "label",
+	})
+	require.NoError(t, err)
+	wallets = append(wallets, w2)
+
+	ws := s.GetWallets()
+	for _, w := range wallets {
+		ww, ok := ws[w.Filename()]
+		require.True(t, ok)
+		require.Equal(t, w, ww)
+	}
+
 }
 
 func TestServiceReloadWallets(t *testing.T) {
@@ -352,9 +416,9 @@ func TestServiceReloadWallets(t *testing.T) {
 	s, err := NewService(dir)
 	require.NoError(t, err)
 
-	pwd := "pwd"
-	w, err := s.CreateWallet("test.wlt", pwd)
-	require.NoError(t, err)
+	var w *Wallet
+	for _, w = range s.wallets {
+	}
 
 	defaultWltID := w.Filename()
 
@@ -364,8 +428,10 @@ func TestServiceReloadWallets(t *testing.T) {
 	}
 
 	wltName := "t1.wlt"
-	w, err := s.CreateWallet(wltName, Options{Seed: "seed1"})
+	w1, err := s.CreateWallet(wltName, Options{Seed: "seed1"})
 	require.NoError(t, err)
+
+	fmt.Println(dir, w1.Filename())
 
 	err = s.ReloadWallets()
 	require.NoError(t, err)
@@ -383,6 +449,680 @@ func TestServiceReloadWallets(t *testing.T) {
 
 	_, ok = s.firstAddrIDMap[w1.Entries[0].Address.String()]
 	require.True(t, ok)
+}
+
+func TestServiceCreateAndSignTx(t *testing.T) {
+	headTime := time.Now().UTC().Unix()
+	seed := []byte("seed")
+
+	// Generate first keys
+	_, secKeys := cipher.GenerateDeterministicKeyPairsSeed(seed, 1)
+	secKey := secKeys[0]
+	addr := cipher.AddressFromSecKey(secKey)
+
+	// Create unspent outptus
+	var uxouts []coin.UxOut
+	addrs := []cipher.Address{}
+	for i := 0; i < 10; i++ {
+		uxout := makeUxOut(t, secKey, 2e6, 100)
+		uxouts = append(uxouts, uxout)
+
+		p, _ := cipher.GenerateKeyPair()
+		a := cipher.AddressFromPubKey(p)
+		addrs = append(addrs, a)
+	}
+
+	// Create unspent outputs with no hours
+	var uxoutsNoHours []coin.UxOut
+	addrsNoHours := []cipher.Address{}
+	for i := 0; i < 10; i++ {
+		uxout := makeUxOut(t, secKey, 2e6, 100)
+		uxout.Body.Hours = 0
+		uxout.Head.Time = uint64(headTime)
+		uxoutsNoHours = append(uxoutsNoHours, uxout)
+
+		p, _ := cipher.GenerateKeyPair()
+		a := cipher.AddressFromPubKey(p)
+		addrsNoHours = append(addrsNoHours, a)
+	}
+
+	tt := []struct {
+		name     string
+		opts     Options
+		pwd      []byte
+		unspents []coin.UxOut
+		vld      Validator
+		coins    uint64
+		dest     cipher.Address
+		err      error
+	}{
+		{
+			"ok with no change, unencrypted",
+			Options{
+				Seed:       string(seed),
+				AddressNum: 1,
+			},
+			nil,
+			uxouts[:],
+			&dummyValidator{
+				ok: false,
+			},
+			2e6,
+			addrs[0],
+			nil,
+		},
+		{
+			"ok with no change, encrypted",
+			Options{
+				Seed:       string(seed),
+				AddressNum: 1,
+				Encrypt:    true,
+				Password:   []byte("pwd"),
+			},
+			[]byte("pwd"),
+			uxouts[:],
+			&dummyValidator{
+				ok: false,
+			},
+			2e6,
+			addrs[0],
+			nil,
+		},
+		{
+			"ok with change, unencrypted",
+			Options{
+				Seed:       string(seed),
+				AddressNum: 1,
+			},
+			nil,
+			uxouts[:],
+			&dummyValidator{
+				ok: false,
+			},
+			1e6,
+			addrs[0],
+			nil,
+		},
+		{
+			"has unconfirmed spending transaction, unencrypted",
+			Options{
+				Seed:       string(seed),
+				AddressNum: 1,
+			},
+			nil,
+			uxouts[:],
+			&dummyValidator{
+				ok: true,
+			},
+			2e6,
+			addrs[0],
+			errors.New("please spend after your pending transaction is confirmed"),
+		},
+		{
+			"check unconfirmed spend failed, unencrypted",
+			Options{
+				Seed:       string(seed),
+				AddressNum: 1,
+			},
+			nil,
+			uxouts[:],
+			&dummyValidator{
+				ok:  false,
+				err: errors.New("fail intentionally"),
+			},
+			2e6,
+			addrs[0],
+			errors.New("checking unconfirmed spending failed: fail intentionally"),
+		},
+		{
+			"spend zero, unencrypted",
+			Options{
+				Seed:       string(seed),
+				AddressNum: 1,
+			},
+			nil,
+			uxouts[:],
+			&dummyValidator{
+				ok: false,
+			},
+			0,
+			addrs[0],
+			errors.New("zero spend amount"),
+		},
+		{
+			"spend fractional coins, unencrypted",
+			Options{
+				Seed:       string(seed),
+				AddressNum: 1,
+			},
+			nil,
+			uxouts[:],
+			&dummyValidator{
+				ok: false,
+			},
+			1e3,
+			addrs[0],
+			nil,
+		},
+		{
+			"not enough confirmed coins, unencrypted",
+			Options{
+				Seed:       string(seed),
+				AddressNum: 1,
+			},
+			nil,
+			uxouts[:],
+			&dummyValidator{
+				ok: false,
+			},
+			100e6,
+			addrs[0],
+			ErrInsufficientBalance,
+		},
+		{
+			"no coin hours in inputs, unencrypted",
+			Options{
+				Seed:       string(seed),
+				AddressNum: 1,
+			},
+			nil,
+			uxoutsNoHours[:],
+			&dummyValidator{
+				ok: false,
+			},
+			1e6,
+			addrsNoHours[0],
+			fee.ErrTxnNoFee,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			unspents := &dummyUnspentGetter{
+				addrUnspents: coin.AddressUxOuts{
+					addr: tc.unspents,
+				},
+				unspents: map[cipher.SHA256]coin.UxOut{},
+			}
+
+			for _, ux := range tc.unspents {
+				unspents.unspents[ux.Hash()] = ux
+			}
+
+			dir := prepareWltDir()
+			s, err := NewService(dir)
+			require.NoError(t, err)
+
+			wltName := newWalletFilename()
+
+			w, err := s.CreateWallet(wltName, tc.opts)
+			require.NoError(t, err)
+
+			tx, err := s.CreateAndSignTransaction(w.Filename(), tc.pwd, tc.vld, unspents, uint64(headTime), tc.coins, tc.dest)
+			require.Equal(t, tc.err, err)
+			if err != nil {
+				return
+			}
+
+			// check the IN of tx
+			for _, inUxid := range tx.In {
+				_, ok := unspents.unspents[inUxid]
+				require.True(t, ok)
+			}
+
+			err = tx.Verify()
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestServiceUpdateWalletLabel(t *testing.T) {
+	tt := []struct {
+		name          string
+		wltName       string
+		opts          Options
+		updateWltName string
+		label         string
+		err           error
+	}{
+		{
+			"ok",
+			"t.wlt",
+			Options{
+				Seed:  "seed",
+				Label: "label",
+			},
+			"t.wlt",
+			"new-label",
+			nil,
+		},
+		{
+			"wallet doesn't exist",
+			"t.wlt",
+			Options{
+				Seed:  "seed",
+				Label: "label",
+			},
+			"t1.wlt",
+			"new-label",
+			ErrWalletNotExist{"t1.wlt"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create the wallet service
+			dir := prepareWltDir()
+			s, err := NewService(dir)
+			require.NoError(t, err)
+
+			// Create a new wallet
+			w, err := s.CreateWallet(tc.wltName, tc.opts)
+			require.NoError(t, err)
+
+			err = s.UpdateWalletLabel(tc.updateWltName, tc.label)
+			require.Equal(t, tc.err, err)
+
+			if err != nil {
+				return
+			}
+
+			nw, err := s.GetWallet(w.Filename())
+			require.NoError(t, err)
+			require.NotEqual(t, w.Label(), nw.Label())
+
+			require.Equal(t, tc.label, nw.Label())
+		})
+	}
+}
+
+func TestServiceEncryptWallet(t *testing.T) {
+	tt := []struct {
+		name       string
+		wltName    string
+		opts       Options
+		encWltName string
+		pwd        []byte
+		err        error
+	}{
+		{
+			"ok",
+			"t.wlt",
+			Options{
+				Seed: "seed",
+			},
+			"t.wlt",
+			[]byte("pwd"),
+			nil,
+		},
+		{
+			"wallet doesn't exist",
+			"t.wlt",
+			Options{
+				Seed: "seed",
+			},
+			"t2.wlt",
+			nil,
+			ErrWalletNotExist{"t2.wlt"},
+		},
+		{
+			"wallet already encrypted",
+			"t.wlt",
+			Options{
+				Seed:     "seed",
+				Encrypt:  true,
+				Password: []byte("pwd"),
+			},
+			"t.wlt",
+			[]byte("pwd"),
+			ErrWalletEncrypted,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := prepareWltDir()
+			// Create the wallet service
+			s, err := NewService(dir)
+			require.NoError(t, err)
+
+			// Create a new wallet
+			w, err := s.CreateWallet(tc.wltName, tc.opts)
+			require.NoError(t, err)
+
+			// Encrypt the wallet
+			encWlt, err := s.EncryptWallet(tc.encWltName, tc.pwd)
+			require.Equal(t, tc.err, err)
+			if err != nil {
+				return
+			}
+
+			// Check the encrypted wallet
+			require.True(t, encWlt.IsEncrypted())
+			require.Equal(t, cipher.SecKey{}, encWlt.Entries[0].Secret)
+			require.NotEqual(t, w.seed(), encWlt.seed())
+			require.NotEqual(t, w.lastSeed(), encWlt.lastSeed())
+
+			// Check the decrypted seeds
+			decWlt, err := encWlt.unlock(tc.pwd)
+			require.NoError(t, err)
+			require.Equal(t, w.seed(), decWlt.seed())
+			require.Equal(t, w.lastSeed(), decWlt.lastSeed())
+
+			// Check if the wallet file exist
+			path := filepath.Join(dir, w.Filename())
+			_, err = os.Stat(path)
+			require.True(t, !os.IsNotExist(err))
+
+			// Check if the backup wallet file, which should not exist
+			bakPath := path + ".bak"
+			_, err = os.Stat(bakPath)
+			require.True(t, os.IsNotExist(err))
+		})
+	}
+}
+
+func TestServiceScanAheadWalletAddresses(t *testing.T) {
+	bg := make(mockBalanceGetter, len(addrsOfSeed1))
+	addrs := fromAddrString(t, addrsOfSeed1)
+	for _, a := range addrs {
+		bg[a] = BalancePair{}
+	}
+
+	type exp struct {
+		err              error
+		seed             string
+		lastSeed         string
+		entryNum         int
+		confirmedBalance uint64
+		predictedBalance uint64
+	}
+
+	tt := []struct {
+		name      string
+		opts      Options
+		pwd       []byte
+		scanN     uint64
+		balGetter BalanceGetter
+		expect    exp
+	}{
+		{
+			"no coins and scan 0, unencrypted",
+			Options{
+				Seed: "seed1",
+			},
+			nil,
+			0,
+			bg,
+			exp{
+				err:              nil,
+				seed:             "seed1",
+				lastSeed:         childSeedsOfSeed1[0],
+				entryNum:         1,
+				confirmedBalance: 0,
+				predictedBalance: 0,
+			},
+		},
+		{
+			"no coins and scan 0, encrypted",
+			Options{
+				Seed:     "seed1",
+				Encrypt:  true,
+				Password: []byte("pwd"),
+			},
+			[]byte("pwd"),
+			0,
+			bg,
+			exp{
+				err:              nil,
+				seed:             "seed1",
+				lastSeed:         childSeedsOfSeed1[0],
+				entryNum:         1,
+				confirmedBalance: 0,
+				predictedBalance: 0,
+			},
+		},
+		{
+			"no coins and scan 1, unencrypted",
+			Options{
+				Seed: "seed1",
+			},
+			nil,
+			1,
+			bg,
+			exp{
+				err:              nil,
+				seed:             "seed1",
+				lastSeed:         childSeedsOfSeed1[0],
+				entryNum:         1,
+				confirmedBalance: 0,
+				predictedBalance: 0,
+			},
+		},
+		{
+			"no coins and scan 1, encrypted",
+			Options{
+				Seed:     "seed1",
+				Encrypt:  true,
+				Password: []byte("pwd"),
+			},
+			[]byte("pwd"),
+			1,
+			bg,
+			exp{
+				err:              nil,
+				seed:             "seed1",
+				lastSeed:         childSeedsOfSeed1[0],
+				entryNum:         1,
+				confirmedBalance: 0,
+				predictedBalance: 0,
+			},
+		},
+		{
+			"no coins and scan 10, unencrypted",
+			Options{
+				Seed: "seed1",
+			},
+			nil,
+			10,
+			bg,
+			exp{
+				err:              nil,
+				seed:             "seed1",
+				lastSeed:         childSeedsOfSeed1[0],
+				entryNum:         1,
+				confirmedBalance: 0,
+				predictedBalance: 0,
+			},
+		},
+		{
+			"scan 5 get 5, unencrypted",
+			Options{
+				Seed: "seed1",
+			},
+			nil,
+			5,
+			mockBalanceGetter{
+				addrs[4]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+			},
+			exp{
+				err:              nil,
+				seed:             "seed1",
+				lastSeed:         childSeedsOfSeed1[5],
+				entryNum:         5,
+				confirmedBalance: 10,
+				predictedBalance: 0,
+			},
+		},
+		{
+			"scan 5 get 5, encrypted",
+			Options{
+				Seed:     "seed1",
+				Encrypt:  true,
+				Password: []byte("pwd"),
+			},
+			[]byte("pwd"),
+			5,
+			mockBalanceGetter{
+				addrs[4]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+			},
+			exp{
+				err:              nil,
+				seed:             "seed1",
+				lastSeed:         childSeedsOfSeed1[5],
+				entryNum:         5,
+				confirmedBalance: 10,
+				predictedBalance: 0,
+			},
+		},
+		{
+			"scan 5 get 4, unencrypted",
+			Options{
+				Seed: "seed1",
+			},
+			nil,
+			5,
+			mockBalanceGetter{
+				addrs[2]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+				addrs[3]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+			},
+			exp{
+				err:              nil,
+				seed:             "seed1",
+				lastSeed:         childSeedsOfSeed1[4],
+				entryNum:         4,
+				confirmedBalance: 20,
+				predictedBalance: 0,
+			},
+		},
+		{
+			"scan 5 get 4, encrypted",
+			Options{
+				Seed:     "seed1",
+				Encrypt:  true,
+				Password: []byte("pwd"),
+			},
+			[]byte("pwd"),
+			5,
+			mockBalanceGetter{
+				addrs[2]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+				addrs[3]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+			},
+			exp{
+				err:              nil,
+				seed:             "seed1",
+				lastSeed:         childSeedsOfSeed1[4],
+				entryNum:         4,
+				confirmedBalance: 20,
+				predictedBalance: 0,
+			},
+		},
+		{
+			"scan 5 get 4 have 6, unencrypted",
+			Options{
+				Seed: "seed1",
+			},
+			nil,
+			5,
+			mockBalanceGetter{
+				addrs[2]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+				addrs[3]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+				addrs[6]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+			},
+			exp{
+				err:              nil,
+				seed:             "seed1",
+				lastSeed:         childSeedsOfSeed1[4],
+				entryNum:         4,
+				confirmedBalance: 20,
+				predictedBalance: 0,
+			},
+		},
+		{
+			"confirmed and predicted, unencrypted",
+			Options{
+				Seed: "seed1",
+			},
+			nil,
+			5,
+			mockBalanceGetter{
+				addrs[2]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+				addrs[3]: BalancePair{Predicted: Balance{Coins: 10, Hours: 100}},
+			},
+			exp{
+				err:              nil,
+				seed:             "seed1",
+				lastSeed:         childSeedsOfSeed1[4],
+				entryNum:         4,
+				confirmedBalance: 20,
+				predictedBalance: 0,
+			},
+		},
+		{
+			"confirmed and predicted, encrypted",
+			Options{
+				Seed:     "seed1",
+				Encrypt:  true,
+				Password: []byte("pwd"),
+			},
+			[]byte("pwd"),
+			5,
+			mockBalanceGetter{
+				addrs[2]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+				addrs[3]: BalancePair{Predicted: Balance{Coins: 10, Hours: 100}},
+			},
+			exp{
+				err:              nil,
+				seed:             "seed1",
+				lastSeed:         childSeedsOfSeed1[4],
+				entryNum:         4,
+				confirmedBalance: 20,
+				predictedBalance: 0,
+			},
+		},
+		{
+			"confirmed and predicted, wrong password",
+			Options{
+				Seed:     "seed1",
+				Encrypt:  true,
+				Password: []byte("pwd"),
+			},
+			[]byte("wrong password"),
+			5,
+			mockBalanceGetter{
+				addrs[2]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+				addrs[3]: BalancePair{Predicted: Balance{Coins: 10, Hours: 100}},
+			},
+			exp{
+				err: errors.New("unlock wallet failed: invalid password"),
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := prepareWltDir()
+			s, err := NewService(dir)
+			require.NoError(t, err)
+
+			wltName := newWalletFilename()
+			w, err := s.CreateWallet(wltName, tc.opts)
+			require.NoError(t, err)
+
+			require.NoError(t, w.validate())
+
+			w1, err := s.ScanAheadWalletAddresses(wltName, tc.pwd, tc.scanN, tc.balGetter)
+			require.Equal(t, tc.expect.err, err)
+			if err != nil {
+				return
+			}
+
+			require.Len(t, w1.Entries, tc.expect.entryNum)
+			for i := range w1.Entries {
+				require.Equal(t, addrsOfSeed1[i], w1.Entries[i].Address.String())
+			}
+		})
+	}
 }
 
 type dummyValidator struct {
@@ -408,234 +1148,8 @@ func (dug dummyUnspentGetter) Get(uxid cipher.SHA256) (coin.UxOut, bool) {
 	return uxout, ok
 }
 
-func TestServiceCreateAndSignTx(t *testing.T) {
-	dir := prepareWltDir()
-
-	s, err := NewService(dir)
-	require.NoError(t, err)
-	var id string
-	for id = range s.wallets {
-		break
-	}
-
-	headTime := time.Now().UTC().Unix()
-
-	wlt, err := s.GetWallet(id)
-	require.NoError(t, err)
-
-	secKey := wlt.Entries[0].Secret
-	addr := wlt.Entries[0].Address
-
-	var uxouts []coin.UxOut
-	addrs := []cipher.Address{}
-	for i := 0; i < 10; i++ {
-		uxout := makeUxOut(t, seckeys[0])
-		uxouts = append(uxouts, uxout)
-
-		p, _ := cipher.GenerateKeyPair()
-		a := cipher.AddressFromPubKey(p)
-		addrs = append(addrs, a)
-	}
-
-	var uxoutsNoHours []coin.UxOut
-	addrsNoHours := []cipher.Address{}
-	for i := 0; i < 10; i++ {
-		uxout := makeUxOut(t, seckeys[0])
-		uxout.Body.Hours = 0
-		uxout.Head.Time = uint64(headTime)
-		uxoutsNoHours = append(uxoutsNoHours, uxout)
-
-		p, _ := cipher.GenerateKeyPair()
-		a := cipher.AddressFromPubKey(p)
-		addrsNoHours = append(addrsNoHours, a)
-	}
-
-	tt := []struct {
-		name       string
-		unspents   []coin.UxOut
-		addrUxouts coin.AddressUxOuts
-		vld        Validator
-		coins      uint64
-		dest       cipher.Address
-		pwd        string
-		err        error
-	}{
-		{
-			"ok with no change",
-			uxouts[:],
-			coin.AddressUxOuts{
-				addr: uxouts,
-			},
-			&dummyValidator{
-				ok: false,
-			},
-			2e6,
-			addrs[0],
-			pwd,
-			nil,
-		},
-		{
-			"ok with change",
-			uxouts[:],
-			coin.AddressUxOuts{
-				addr: uxouts,
-			},
-			&dummyValidator{
-				ok: false,
-			},
-			1e6,
-			addrs[0],
-			pwd,
-			nil,
-		},
-		{
-			"has unconfirmed spending transaction",
-			uxouts[:],
-			coin.AddressUxOuts{
-				addr: uxouts,
-			},
-			&dummyValidator{
-				ok: true,
-			},
-			2e6,
-			addrs[0],
-			pwd,
-			errors.New("please spend after your pending transaction is confirmed"),
-		},
-		{
-			"check unconfirmed spend failed",
-			uxouts[:],
-			coin.AddressUxOuts{
-				addr: uxouts,
-			},
-			&dummyValidator{
-				ok:  false,
-				err: errors.New("fail intentionally"),
-			},
-			2e6,
-			addrs[0],
-			pwd,
-			errors.New("checking unconfirmed spending failed: fail intentionally"),
-		},
-		{
-			"spend zero",
-			uxouts[:],
-			coin.AddressUxOuts{
-				addr: uxouts,
-			},
-			&dummyValidator{
-				ok: false,
-			},
-			0,
-			addrs[0],
-			pwd,
-			errors.New("zero spend amount"),
-		},
-		{
-			"spend fractional coins",
-			uxouts[:],
-			coin.AddressUxOuts{
-				addr: uxouts,
-			},
-			&dummyValidator{
-				ok: false,
-			},
-			1e3,
-			addrs[0],
-			pwd,
-			nil,
-		},
-		{
-			"not enough confirmed coins",
-			uxouts[:],
-			coin.AddressUxOuts{
-				addr: uxouts,
-			},
-			&dummyValidator{
-				ok: false,
-			},
-			100e6,
-			addrs[0],
-			pwd,
-			ErrInsufficientBalance,
-		},
-		{
-			"no coin hours in inputs",
-			uxoutsNoHours[:],
-			coin.AddressUxOuts{
-				addr: uxoutsNoHours,
-			},
-			&dummyValidator{
-				ok: false,
-			},
-			1e6,
-			addrsNoHours[0],
-			pwd,
-			fee.ErrTxnNoFee,
-		},
-		{
-			"wrong password",
-			uxouts[:],
-			coin.AddressUxOuts{
-				addr: uxouts,
-			},
-			&dummyValidator{
-				ok: false,
-			},
-			2e6,
-			addrs[0],
-			pwd,
-			cipher.ErrInvalidPassword,
-		},
-	}
-
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			dir := prepareWltDir()
-			s, err := NewService(dir)
-			require.NoError(t, err)
-			w, err := s.CreateWallet("test.wlt", pwd, OptSeed(string(seed)))
-			require.NoError(t, err)
-
-			unspents := &dummyUnspentGetter{
-				addrUnspents: tc.addrUxouts,
-				unspents:     map[cipher.SHA256]coin.UxOut{},
-			}
-
-			for _, ux := range tc.unspents {
-				unspents.unspents[ux.Hash()] = ux
-			}
-
-			tx, err := s.CreateAndSignTransaction(w.Filename(), tc.pwd, tc.vld, unspents, uint64(headTime), tc.coins, tc.dest)
-			require.Equal(t, tc.err, err)
-			if err != nil {
-				return
-			}
-
-			// check the IN of tx
-			for _, inUxid := range tx.In {
-				_, ok := unspents.unspents[inUxid]
-				require.True(t, ok)
-			}
-
-			err = tx.Verify()
-			require.NoError(t, err)
-		})
-	}
-}
-
-func makeUxBody(t *testing.T, s cipher.SecKey) coin.UxBody {
-	p := cipher.PubKeyFromSecKey(s)
-	return coin.UxBody{
-		SrcTransaction: cipher.SumSHA256(testutil.RandBytes(t, 128)),
-		Address:        cipher.AddressFromPubKey(p),
-		Coins:          2e6,
-		Hours:          100,
-	}
-}
-
-func makeUxOut(t *testing.T, s cipher.SecKey) coin.UxOut {
-	body := makeUxBody(t, s)
+func makeUxOut(t *testing.T, s cipher.SecKey, coins, hours uint64) coin.UxOut {
+	body := makeUxBody(t, s, coins, hours)
 	tm := rand.Int31n(1000)
 	seq := rand.Int31n(100)
 	return coin.UxOut{
@@ -644,5 +1158,15 @@ func makeUxOut(t *testing.T, s cipher.SecKey) coin.UxOut {
 			BkSeq: uint64(seq),
 		},
 		Body: body,
+	}
+}
+
+func makeUxBody(t *testing.T, s cipher.SecKey, coins, hours uint64) coin.UxBody {
+	p := cipher.PubKeyFromSecKey(s)
+	return coin.UxBody{
+		SrcTransaction: cipher.SumSHA256(testutil.RandBytes(t, 128)),
+		Address:        cipher.AddressFromPubKey(p),
+		Coins:          coins,
+		Hours:          hours,
 	}
 }

--- a/src/wallet/testdata/v2.wlt
+++ b/src/wallet/testdata/v2.wlt
@@ -1,0 +1,19 @@
+{
+    "meta": {
+        "coin": "skycoin",
+        "filename": "t1.wlt",
+        "label": "",
+        "lastSeed": "pYCzcK5exEqBS+bnePDkGs7U2UXIPhPrNdrkp81I2hyCJyJtL122GzsBBtRJpiX+3yvOnmTQZJ7+7m8wZ/qq6nluejE4bzdFSzA3WEtVODdkQi9iUlRGbGdHZWJ6WXlHSlZvOHp3YTVleTA9LEFCaGxpWFlFbVhEVUdHTDJRd2w3VmdVTEJseWVkSzFQMjN6VHBRVVVUMDA9LERmUzRPMGVGS2t0UjU4Y01rbndVcWh2cjlCN1JWZFRueFU3UkFjUkZ3RW89",
+        "seed": "g8slU58evVZtiO4ouxY5QeC6ZsMXprLAQYY9nls/JFyIYQvBxufxZvSlppyiO6X0dK8MzHaEFg0wpHUgbm8WsTd3VXBmR1dMVXVsaE03UkVmY3U3QU0vOWVhallJWDhJN1N6QzcycjFtUlU9LExtSUxVbHMzNkxwbnZFR1FjT0YrdHUyRHJaQ3NqaWdQMDhuTUVFdjhZNzA9",
+        "tm": "1511856544",
+        "type": "deterministic",
+        "version": "0.2"
+    },
+    "entries": [
+        {
+            "address": "2GBifzJEehbDX7Mkk63Prfa4MQQQyRzBLfe",
+            "public_key": "03d395b3f7b7cf8780e4bde41f72c930b44f3465da94313e564b04d0f37dd12d9d",
+            "secret_key": "JJMcA/ymhBnk7G1FstgdCPYmXOwy0DqYNznPRJ2F0TdCQ7cUEi0s4pEaPIOrZW4msGj8/rKonrAUEf/jFx1isDFPSmxVaHREakdCbHpWRDFNSVd6RUlSUFNXV2xDQXYzd2JTRmIvRGE0RlU9LDNKQmlUaWtUQkRNT0lvUGc3cEhiRDJCTCswK20rQVR1SmwyZm9CWUtzWmc9LFAxaDlBRTVKclAwZ3dpS25oSUlGcFg4Qk82ODN3bWUwdEllWXJnc3VjOWM9"
+        }
+    ]
+}

--- a/src/wallet/testdata/v2.wlt
+++ b/src/wallet/testdata/v2.wlt
@@ -7,7 +7,8 @@
         "seed": "g8slU58evVZtiO4ouxY5QeC6ZsMXprLAQYY9nls/JFyIYQvBxufxZvSlppyiO6X0dK8MzHaEFg0wpHUgbm8WsTd3VXBmR1dMVXVsaE03UkVmY3U3QU0vOWVhallJWDhJN1N6QzcycjFtUlU9LExtSUxVbHMzNkxwbnZFR1FjT0YrdHUyRHJaQ3NqaWdQMDhuTUVFdjhZNzA9",
         "tm": "1511856544",
         "type": "deterministic",
-        "version": "0.2"
+        "version": "0.2",
+        "encrypted": "true"
     },
     "entries": [
         {

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -217,12 +217,12 @@ func (w *Wallet) GenerateAddresses(num uint64) []cipher.Address {
 	return wlt.newAddressesInUnencryptedWallet(num)
 }
 
-func (wlt *Wallet) newAddressesInEncryptedWallet(num int, password []byte) ([]cipher.Address, error) {
+func (wlt *Wallet) newAddressesInEncryptedWallet(num int, password string) ([]cipher.Address, error) {
 	var seckeys []cipher.SecKey
 	var sd []byte
 	var err error
 
-	lastSeed, err := decrypt(wlt.lastSeed(), password)
+	lastSeed, err := decrypt(wlt.lastSeed(), []byte(password))
 	if err != nil {
 		return nil, fmt.Errorf("decrypt last seed failed: %v", err)
 	}

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -24,6 +24,12 @@ var (
 
 	// ErrInsufficientBalance is returned if a wallet does not have enough balance for a spend
 	ErrInsufficientBalance = errors.New("balance is not sufficient")
+	// ErrInvalidEncryptedField is returned if a wallet's Meta.encrypted value is invalid.
+	ErrInvalidEncryptedField = errors.New(`encrypted field value is not valid, must be "true", "false" or ""`)
+	// ErrWalletEncrypted is returned when trying to generate addresses or sign tx in encrypted wallet
+	ErrWalletEncrypted = errors.New("wallet is encrypted")
+	// ErrWalletNotEncrypted is returned when trying to decrypt unencrypted wallet
+	ErrWalletNotEncrypted = errors.New("wallet is not encrypted")
 )
 
 // CoinType represents the wallet coin type
@@ -44,13 +50,20 @@ const (
 
 var (
 	// ErrNoPassword find no password when creating wallet
-	ErrNoPassword = errors.New("password is required when creating wallet")
+	ErrNoPassword = errors.New("password is required")
 	// ErrInvalidWalletVersion represents invalid wallet version erro
 	ErrInvalidWalletVersion = errors.New("invalid wallet version")
 
 	// Version represents the current wallet version
 	Version = "0.2"
 )
+
+// Options are wallet constructor options
+type Options struct {
+	Coin  CoinType
+	Label string
+	Seed  string
+}
 
 // Option NewWallet optional arguments type
 type Option func(w *Wallet)
@@ -69,6 +82,7 @@ func NewWalletFilename() string {
 //      filename
 //      version
 //      label
+// 		encrypted - whether this wallet is encrypted
 //      seed
 //      lastSeed - seed for generating next address
 //      tm - timestamp when creating the wallet
@@ -109,8 +123,92 @@ func NewWallet(wltName string, opts Options) (*Wallet, error) {
 			"tm":       fmt.Sprintf("%v", time.Now().Unix()),
 			"type":     "deterministic",
 			"coin":     string(coin),
+			"encrypted": "false",
 		},
 	}
+
+	return w, nil
+}
+
+// Lock encrypts the wallet with password
+func (wlt *Wallet) Lock(password []byte) error {
+	if password == nil {
+		return errors.New("password is requried to encrypt wallet")
+	}
+
+	if wlt.IsEncrypted() {
+		return ErrWalletEncrypted
+	}
+
+	// encrypt the seed
+	ss, err := Encrypt([]byte(wlt.seed()), password)
+	if err != nil {
+		return err
+	}
+
+	wlt.setSeed(ss)
+
+	// encrypt the last seed
+	sls, err := Encrypt([]byte(wlt.lastSeed()), password)
+	if err != nil {
+		return err
+	}
+
+	wlt.setLastSeed(sls)
+
+	// encrypt private keys in entries
+	for i, e := range wlt.Entries {
+		se, err := Encrypt(e.Secret[:], password)
+		if err != nil {
+			return err
+		}
+
+		e.EncryptedSeckey = se
+		// clear the entry.Secret
+		wlt.Entries[i].Secret = cipher.SecKey{}
+	}
+
+	return nil
+}
+
+// Unlock decrypts the wallet into a temporary decrypted copy of the wallet
+// It returns an error if decryption fails
+// The temporary decrypted wallet should be erased from memory when done.
+func (wlt *Wallet) Unlock(password []byte) (*Wallet, error) {
+	if password == nil {
+		return nil, errors.New("password is required to decrypt wallet")
+	}
+
+	if !wlt.IsEncrypted() {
+		return nil, ErrWalletNotEncrypted
+	}
+
+	w := wlt.clone()
+
+	// decrypt the seed
+	s, err := Decrypt(w.seed(), password)
+	if err != nil {
+		return nil, err
+	}
+	w.setSeed(string(s))
+
+	// decrypt lastSeed
+	ls, err := Decrypt(w.lastSeed(), password)
+	if err != nil {
+		return nil, err
+	}
+	w.setLastSeed(string(ls))
+
+	// decrypt the entries
+	for i, e := range w.Entries {
+		sk, err := Decrypt(e.EncryptedSeckey, password)
+		if err != nil {
+			return nil, err
+		}
+		copy(w.Entries[i].Secret[:], sk[:])
+		w.Entries[i].EncryptedSeckey = ""
+	}
+	w.setEncrypted(false)
 
 	return w, nil
 }
@@ -133,12 +231,18 @@ func Load(wltFile string) (*Wallet, error) {
 
 // Save saves the wallet to given dir
 func Save(dir string, w *Wallet) error {
-	r := NewReadableWallet(*w)
+	r := NewReadableWallet(w)
 	return r.Save(filepath.Join(dir, w.Filename()))
 }
 
+// Reset resets the wallet entries and move the lastSeed to origin
+func (wlt *Wallet) Reset() {
+	wlt.Entries = []Entry{}
+	wlt.setLastSeed(wlt.seed())
+}
+
 // Validate validates the wallet
-func (w *Wallet) Validate() error {
+func (w *Wallet) validate() error {
 	if _, ok := w.Meta["filename"]; !ok {
 		return errors.New("filename not set")
 	}
@@ -158,22 +262,32 @@ func (w *Wallet) Validate() error {
 		return errors.New("coin field not set")
 	}
 
+	switch wlt.Meta["encrypted"] {
+	case "true", "false", "":
+	default:
+		return ErrInvalidEncryptedField
+	}
+
 	return nil
 }
 
 // Type gets the wallet type
-func (wlt Wallet) Type() string {
+func (wlt *Wallet) Type() string {
 	return wlt.Meta["type"]
-}
-
-// Filename gets the wallet filename
-func (wlt Wallet) Filename() string {
-	return wlt.Meta["filename"]
 }
 
 // Version gets the wallet version
 func (wlt *Wallet) Version() string {
 	return wlt.Meta["version"]
+}
+
+func (wlt *Wallet) setVersion(v string) {
+	wlt.Meta["version"] = v
+}
+
+// Filename gets the wallet filename
+func (wlt *Wallet) Filename() string {
+	return wlt.Meta["filename"]
 }
 
 // setFilename sets the wallet filename
@@ -182,7 +296,7 @@ func (wlt *Wallet) setFilename(fn string) {
 }
 
 // Label gets the wallet label
-func (wlt Wallet) Label() string {
+func (wlt *Wallet) Label() string {
 	return wlt.Meta["label"]
 }
 
@@ -192,7 +306,7 @@ func (wlt *Wallet) setLabel(label string) {
 }
 
 // lastSeed returns the last seed
-func (wlt Wallet) lastSeed() string {
+func (wlt *Wallet) lastSeed() string {
 	return wlt.Meta["lastSeed"]
 }
 
@@ -208,68 +322,21 @@ func (wlt *Wallet) setSeed(seed string) {
 	wlt.Meta["seed"] = seed
 }
 
-// Version gets the wallet version
-func (wlt *Wallet) version() string {
-	return wlt.Meta["version"]
+// GenerateAddresses generates addresses
+func (wlt *Wallet) GenerateAddresses(num uint64) ([]cipher.Address, error) {
+	if wlt.IsEncrypted() {
+		return nil, ErrWalletEncrypted
+	}
+
+	return wlt.generateAddresses(num)
 }
 
-// GenerateAddresses generate addresses of given number and adds them to the wallet
-func (w *Wallet) GenerateAddresses(num uint64) []cipher.Address {
-	if num == 0 {
-		return []cipher.Address{}
-	}
-
-	return wlt.newAddressesInUnencryptedWallet(num)
-}
-
-func (wlt *Wallet) newAddressesInEncryptedWallet(password string, num int) ([]cipher.Address, error) {
-	var seckeys []cipher.SecKey
-	var sd []byte
-	var err error
-
-	lastSeed, err := Decrypt(wlt.lastSeed(), []byte(password))
-	if err != nil {
-		return nil, fmt.Errorf("decrypt last seed failed: %v", err)
-	}
-
-	sd, seckeys = cipher.GenerateDeterministicKeyPairsSeed(lastSeed, num)
-
-	// encrypt the last seed
-	newLastSeed, err := Encrypt(sd, []byte(password))
-	if err != nil {
-		return nil, err
-	}
-
-	// update the last seed
-	wlt.setLastSeed(newLastSeed)
-
-	addrs := make([]cipher.Address, len(seckeys))
-	for i, s := range seckeys {
-		p := cipher.PubKeyFromSecKey(s)
-		a := cipher.AddressFromPubKey(p)
-		addrs[i] = a
-
-		// encrypt seckey
-		ss, err := Encrypt(s[:], []byte(password))
-		if err != nil {
-			return nil, fmt.Errorf("encrypt private key failed: %v", err)
-		}
-
-		wlt.Entries = append(wlt.Entries, Entry{
-			Address:         a,
-			EncryptedSeckey: ss,
-			Public:          p,
-		})
-	}
-	return addrs, nil
-}
-
-func (wlt *Wallet) newAddressesInUnencryptedWallet(num int) ([]cipher.Address, error) {
+func (wlt *Wallet) generateAddresses(num uint64) ([]cipher.Address, error) {
 	var seckeys []cipher.SecKey
 	var sd []byte
 	var err error
 	if len(wlt.Entries) == 0 {
-		sd, seckeys = cipher.GenerateDeterministicKeyPairsSeed([]byte(wlt.lastSeed()), num)
+		sd, seckeys = cipher.GenerateDeterministicKeyPairsSeed([]byte(wlt.lastSeed()), int(num))
 	} else {
 		sd, err = hex.DecodeString(wlt.lastSeed())
 		if err != nil {
@@ -328,6 +395,34 @@ func (w *Wallet) ScanAddresses(scanN uint64, bg BalanceGetter) error {
 	}
 
 	return nil
+// GenerateAddressesEncrypted generates addresses in encrypted wallet with password
+func (wlt *Wallet) GenerateAddressesEncrypted(num uint64, password []byte) (addrs []cipher.Address, err error) {
+	if !wlt.IsEncrypted() {
+		return nil, errors.New("wallet is not encrypted")
+	}
+
+	if password == nil {
+		return nil, errors.New("password is required for generating addresses in encrypted wallet")
+	}
+
+	// Unlock the wallet
+	w, err := wlt.Unlock(password)
+	if err != nil {
+		return nil, fmt.Errorf("unlock wallet failed: %v", err)
+	}
+
+	// Lock the wallet when done
+	defer func() {
+		if lockErr := w.Lock(password); lockErr != nil {
+			addrs = nil
+			err = fmt.Errorf("lock wallet failed after generating addresses: %v", err)
+			return
+		}
+
+		wlt = w
+	}()
+
+	return w.generateAddresses(num)
 }
 
 // GetAddresses returns all addresses in wallet
@@ -397,7 +492,7 @@ func (w *Wallet) Load(wltFile string) error {
 }
 
 // clone returns the clone of self
-func (wlt *Wallet) clone() Wallet {
+func (wlt *Wallet) clone() *Wallet {
 	w := Wallet{Meta: make(map[string]string)}
 	for k, v := range wlt.Meta {
 		w.Meta[k] = v
@@ -407,7 +502,7 @@ func (wlt *Wallet) clone() Wallet {
 		wlt.Entries = append(wlt.Entries, e)
 	}
 
-	return wlt
+	return &w
 }
 
 // Validator validate if the wallet be able to create spending transaction
@@ -420,8 +515,41 @@ type Validator interface {
 // spending coins and hours from wallet
 func (w *Wallet) CreateAndSignTransaction(vld Validator, unspent blockdb.UnspentGetter,
 	headTime, coins uint64, dest cipher.Address) (*coin.Transaction, error) {
+	if wlt.IsEncrypted() {
+		return nil, ErrWalletEncrypted
+	}
 
-	addrs := w.GetAddresses()
+	return wlt.createAndSignTransaction(vld, unspent, headTime, coins, dest)
+}
+
+// CreateAndSignTransactionEncrypted creates and signs the transaction
+func (wlt *Wallet) CreateAndSignTransactionEncrypted(vld Validator, unspent blockdb.UnspentGetter,
+	headTime, coins uint64, dest cipher.Address, password []byte) (tx *coin.Transaction, err error) {
+	if !wlt.IsEncrypted() {
+		return nil, ErrWalletNotEncrypted
+	}
+
+	w, err := wlt.Unlock(password)
+	if err != nil {
+		return nil, fmt.Errorf("unlock wallet failed: %v", err)
+	}
+
+	defer func() {
+		if lockErr := w.Lock(password); lockErr != nil {
+			tx = nil
+			err = fmt.Errorf("lock wallet failed after signing tx: %v", err)
+			return
+		}
+	}()
+
+	return w.createAndSignTransaction(vld, unspent, headTime, coins, dest)
+}
+
+// createAndSignTransaction Creates a Transaction
+// spending coins and hours from wallet
+func (wlt *Wallet) createAndSignTransaction(vld Validator, unspent blockdb.UnspentGetter,
+	headTime, coins uint64, dest cipher.Address) (*coin.Transaction, error) {
+	addrs := wlt.GetAddresses()
 	ok, err := vld.HasUnconfirmedSpendTx(addrs)
 	if err != nil {
 		return nil, fmt.Errorf("checking unconfirmed spending failed: %v", err)
@@ -454,18 +582,12 @@ func (w *Wallet) CreateAndSignTransaction(vld Validator, unspent blockdb.Unspent
 
 		txn.PushInput(au.Hash)
 
-		switch wlt.Version() {
-		case "0.1":
-			toSign[i] = entry.Secret
-		case Version:
-			// decrypt the private key
-			s, err := Decrypt(entry.EncryptedSeckey, []byte(password))
-			if err != nil {
-				return nil, err
-			}
-
-			copy(toSign[i][:], s[:])
+		if wlt.IsEncrypted() {
+			return nil, ErrWalletEncrypted
 		}
+
+		toSign[i] = entry.Secret
+
 		spending.Coins += au.Coins
 		spending.Hours += au.Hours
 	}
@@ -496,6 +618,31 @@ func (w *Wallet) CreateAndSignTransaction(vld Validator, unspent blockdb.Unspent
 	txn.UpdateHeader()
 
 	return &txn, nil
+}
+
+func (wlt *Wallet) setEncrypted(encrypt bool) {
+	if encrypt {
+		wlt.Meta["encrypted"] = "true"
+	} else {
+		wlt.Meta["encrypted"] = "false"
+	}
+}
+
+// IsEncrypted checks whether the wallet is encrypted.
+// Check the "encrypted" meta field:
+//     - return true if "true".
+//     - return false if "false" or "".
+func (wlt *Wallet) IsEncrypted() bool {
+	switch wlt.Meta["encrypted"] {
+	// return false if it's value is "false" or empty string, cause old wallets do
+	// not have this field.
+	case "true":
+		return true
+	case "false", "":
+		return false
+	default:
+		panic(ErrInvalidEncryptedField)
+	}
 }
 
 // DistributeSpendHours calculates how many coin hours to transfer to the change address and how

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -144,7 +144,7 @@ func NewWallet(wltName string, opts Options) (*Wallet, error) {
 
 // lock encrypts the wallet with password
 func (w *Wallet) lock(password []byte) error {
-	if password == nil {
+	if len(password) == 0 {
 		return ErrRequirePassword
 	}
 
@@ -238,7 +238,7 @@ func (w *Wallet) guard(password []byte, f func(w *Wallet) error) (err error) {
 		return ErrWalletNotEncrypted
 	}
 
-	if password == nil {
+	if len(password) == 0 {
 		return ErrRequirePassword
 	}
 

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -227,7 +227,7 @@ func (wlt *Wallet) newAddressesInEncryptedWallet(password string, num int) ([]ci
 	var sd []byte
 	var err error
 
-	lastSeed, err := decrypt(wlt.lastSeed(), []byte(password))
+	lastSeed, err := Decrypt(wlt.lastSeed(), []byte(password))
 	if err != nil {
 		return nil, fmt.Errorf("decrypt last seed failed: %v", err)
 	}
@@ -235,7 +235,7 @@ func (wlt *Wallet) newAddressesInEncryptedWallet(password string, num int) ([]ci
 	sd, seckeys = cipher.GenerateDeterministicKeyPairsSeed(lastSeed, num)
 
 	// encrypt the last seed
-	newLastSeed, err := encrypt(sd, []byte(password))
+	newLastSeed, err := Encrypt(sd, []byte(password))
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +250,7 @@ func (wlt *Wallet) newAddressesInEncryptedWallet(password string, num int) ([]ci
 		addrs[i] = a
 
 		// encrypt seckey
-		ss, err := encrypt(s[:], []byte(password))
+		ss, err := Encrypt(s[:], []byte(password))
 		if err != nil {
 			return nil, fmt.Errorf("encrypt private key failed: %v", err)
 		}
@@ -459,7 +459,7 @@ func (w *Wallet) CreateAndSignTransaction(vld Validator, unspent blockdb.Unspent
 			toSign[i] = entry.Secret
 		case Version:
 			// decrypt the private key
-			s, err := decrypt(entry.EncryptedSeckey, []byte(password))
+			s, err := Decrypt(entry.EncryptedSeckey, []byte(password))
 			if err != nil {
 				return nil, err
 			}

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -217,7 +217,7 @@ func (w *Wallet) GenerateAddresses(num uint64) []cipher.Address {
 	return wlt.newAddressesInUnencryptedWallet(num)
 }
 
-func (wlt *Wallet) newAddressesInEncryptedWallet(num int, password string) ([]cipher.Address, error) {
+func (wlt *Wallet) newAddressesInEncryptedWallet(password string, num int) ([]cipher.Address, error) {
 	var seckeys []cipher.SecKey
 	var sd []byte
 	var err error

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -20,20 +20,24 @@ import (
 )
 
 var (
+	// Version represents the current wallet version
+	Version = "0.2"
+
 	logger = logging.MustGetLogger("wallet")
 
 	// ErrInsufficientBalance is returned if a wallet does not have enough balance for a spend
 	ErrInsufficientBalance = errors.New("balance is not sufficient")
-	// ErrInvalidEncryptedField is returned if a wallet's Meta.encrypted value is invalid.
-	ErrInvalidEncryptedField = errors.New(`encrypted field value is not valid, must be "true", "false" or ""`)
+	// ErrInvalidEncryptedFieldValue is returned if a wallet's Meta.encrypted value is invalid.
+	ErrInvalidEncryptedFieldValue = errors.New(`encrypted field value is not valid, must be "true", "false" or ""`)
 	// ErrWalletEncrypted is returned when trying to generate addresses or sign tx in encrypted wallet
 	ErrWalletEncrypted = errors.New("wallet is encrypted")
 	// ErrWalletNotEncrypted is returned when trying to decrypt unencrypted wallet
 	ErrWalletNotEncrypted = errors.New("wallet is not encrypted")
+	// ErrRequirePassword find no password when creating wallet
+	ErrRequirePassword = errors.New("password is required")
+	// ErrInvalidWalletVersion represents invalid wallet version erro
+	ErrInvalidWalletVersion = errors.New("invalid wallet version")
 )
-
-// CoinType represents the wallet coin type
-type CoinType string
 
 const (
 	// WalletExt  wallet file extension
@@ -48,28 +52,24 @@ const (
 	CoinTypeBitcoin CoinType = "bitcoin"
 )
 
-var (
-	// ErrNoPassword find no password when creating wallet
-	ErrNoPassword = errors.New("password is required")
-	// ErrInvalidWalletVersion represents invalid wallet version erro
-	ErrInvalidWalletVersion = errors.New("invalid wallet version")
-
-	// Version represents the current wallet version
-	Version = "0.2"
-)
+// CoinType represents the wallet coin type
+type CoinType string
 
 // Options are wallet constructor options
 type Options struct {
-	Coin  CoinType
-	Label string
-	Seed  string
+	Coin       CoinType
+	Label      string
+	Seed       string
+	Encrypt    bool
+	Password   []byte
+	AddressNum uint64 // Generate N addresses when create wallet
 }
 
 // Option NewWallet optional arguments type
 type Option func(w *Wallet)
 
-// NewWalletFilename check for collisions and retry if failure
-func NewWalletFilename() string {
+// newWalletFilename check for collisions and retry if failure
+func newWalletFilename() string {
 	timestamp := time.Now().Format(WalletTimestampFormat)
 	// should read in wallet files and make sure does not exist
 	padding := hex.EncodeToString((cipher.RandByte(2)))
@@ -93,13 +93,6 @@ type Wallet struct {
 	Entries []Entry
 }
 
-// Options are wallet constructor options
-type Options struct {
-	Coin  CoinType
-	Label string
-	Seed  string
-}
-
 // NewWallet generates Deterministic Wallet
 // generates a random seed if seed is ""
 func NewWallet(wltName string, opts Options) (*Wallet, error) {
@@ -116,101 +109,159 @@ func NewWallet(wltName string, opts Options) (*Wallet, error) {
 	w := &Wallet{
 		Meta: map[string]string{
 			"filename": wltName,
-			"version":  wltVersion,
+			"version":  Version,
 			"label":    opts.Label,
 			"seed":     seed,
 			"lastSeed": seed,
 			"tm":       fmt.Sprintf("%v", time.Now().Unix()),
 			"type":     "deterministic",
 			"coin":     string(coin),
-			"encrypted": "false",
 		},
 	}
+
+	// Generate addresses
+	if _, err := w.GenerateAddresses(opts.AddressNum); err != nil {
+		return nil, fmt.Errorf("generate addresses failed when creating wallets: %v", err)
+	}
+
+	if !opts.Encrypt {
+		return w, nil
+	}
+
+	if opts.Password == nil {
+		return nil, errors.New("password is required for creating wallet with encryption")
+	}
+
+	if err := w.lock(opts.Password); err != nil {
+		return nil, fmt.Errorf("lock wallet failed: %v", err)
+	}
+
+	// Update the encrypted meta field
+	w.setEncrypted(true)
 
 	return w, nil
 }
 
-// Lock encrypts the wallet with password
-func (wlt *Wallet) Lock(password []byte) error {
+// lock encrypts the wallet with password
+func (w *Wallet) lock(password []byte) error {
 	if password == nil {
-		return errors.New("password is requried to encrypt wallet")
+		return ErrRequirePassword
 	}
 
-	if wlt.IsEncrypted() {
+	if w.IsEncrypted() {
 		return ErrWalletEncrypted
 	}
 
-	// encrypt the seed
-	ss, err := Encrypt([]byte(wlt.seed()), password)
+	// Encrypt the seed
+	ss, err := Encrypt([]byte(w.seed()), password)
 	if err != nil {
 		return err
 	}
 
-	wlt.setSeed(ss)
+	w.setSeed(ss)
 
-	// encrypt the last seed
-	sls, err := Encrypt([]byte(wlt.lastSeed()), password)
+	// Encrypt the last seed
+	sls, err := Encrypt([]byte(w.lastSeed()), password)
 	if err != nil {
 		return err
 	}
 
-	wlt.setLastSeed(sls)
+	w.setLastSeed(sls)
 
 	// encrypt private keys in entries
-	for i, e := range wlt.Entries {
+	for i, e := range w.Entries {
 		se, err := Encrypt(e.Secret[:], password)
 		if err != nil {
 			return err
 		}
 
-		e.EncryptedSeckey = se
-		// clear the entry.Secret
-		wlt.Entries[i].Secret = cipher.SecKey{}
+		// Set the encrypted seckey value
+		w.Entries[i].EncryptedSeckey = se
+		// Clear the entry.Secret
+		w.Entries[i].Secret = cipher.SecKey{}
 	}
+
+	w.setEncrypted(true)
 
 	return nil
 }
 
-// Unlock decrypts the wallet into a temporary decrypted copy of the wallet
+// unlock decrypts the wallet into a temporary decrypted copy of the wallet
 // It returns an error if decryption fails
 // The temporary decrypted wallet should be erased from memory when done.
-func (wlt *Wallet) Unlock(password []byte) (*Wallet, error) {
+func (w *Wallet) unlock(password []byte) (*Wallet, error) {
+	if !w.IsEncrypted() {
+		return nil, ErrWalletNotEncrypted
+	}
+
 	if password == nil {
 		return nil, errors.New("password is required to decrypt wallet")
 	}
 
-	if !wlt.IsEncrypted() {
-		return nil, ErrWalletNotEncrypted
-	}
-
-	w := wlt.clone()
+	wlt := w.clone()
 
 	// decrypt the seed
-	s, err := Decrypt(w.seed(), password)
+	s, err := Decrypt(wlt.seed(), password)
 	if err != nil {
 		return nil, err
 	}
-	w.setSeed(string(s))
+	wlt.setSeed(string(s))
 
 	// decrypt lastSeed
-	ls, err := Decrypt(w.lastSeed(), password)
+	ls, err := Decrypt(wlt.lastSeed(), password)
 	if err != nil {
 		return nil, err
 	}
-	w.setLastSeed(string(ls))
+	wlt.setLastSeed(string(ls))
 
 	// decrypt the entries
-	for i, e := range w.Entries {
-		sk, err := Decrypt(e.EncryptedSeckey, password)
+	for i := range wlt.Entries {
+		sk, err := Decrypt(wlt.Entries[i].EncryptedSeckey, password)
 		if err != nil {
 			return nil, err
 		}
-		copy(w.Entries[i].Secret[:], sk[:])
-		w.Entries[i].EncryptedSeckey = ""
+		copy(wlt.Entries[i].Secret[:], sk[:])
+		wlt.Entries[i].EncryptedSeckey = ""
 	}
-	w.setEncrypted(false)
+	wlt.setEncrypted(false)
 
-	return w, nil
+	return wlt, nil
+}
+
+// guard will do:
+// 1. unlock the encrypted wallet
+// 2. process with the decrypted wallet by calling the callback function
+// 3. lock the wallet at the end again
+// If the wallet is not encrypted, it would return ErrWalletNotEncrypted error
+func (w *Wallet) guard(password []byte, f func(w *Wallet) error) (err error) {
+	if !w.IsEncrypted() {
+		return ErrWalletNotEncrypted
+	}
+
+	if password == nil {
+		return ErrRequirePassword
+	}
+
+	var wlt *Wallet
+	wlt, err = w.unlock(password)
+	if err != nil {
+		return fmt.Errorf("unlock wallet failed: %v", err)
+	}
+
+	defer func() {
+		if lockErr := wlt.lock(password); lockErr != nil {
+			err = fmt.Errorf("lock wallet failed: %v", lockErr)
+			return
+		}
+
+		*w = *wlt
+	}()
+
+	if err := f(wlt); err != nil {
+		return fmt.Errorf("process wallet failed: %v", err)
+	}
+
+	return
 }
 
 // Load loads wallet from given file
@@ -235,10 +286,10 @@ func Save(dir string, w *Wallet) error {
 	return r.Save(filepath.Join(dir, w.Filename()))
 }
 
-// Reset resets the wallet entries and move the lastSeed to origin
-func (wlt *Wallet) Reset() {
-	wlt.Entries = []Entry{}
-	wlt.setLastSeed(wlt.seed())
+// reset resets the wallet entries and move the lastSeed to origin
+func (w *Wallet) reset() {
+	w.Entries = []Entry{}
+	w.setLastSeed(w.seed())
 }
 
 // Validate validates the wallet
@@ -262,83 +313,83 @@ func (w *Wallet) validate() error {
 		return errors.New("coin field not set")
 	}
 
-	switch wlt.Meta["encrypted"] {
+	switch w.Meta["encrypted"] {
 	case "true", "false", "":
 	default:
-		return ErrInvalidEncryptedField
+		return ErrInvalidEncryptedFieldValue
 	}
 
 	return nil
 }
 
 // Type gets the wallet type
-func (wlt *Wallet) Type() string {
-	return wlt.Meta["type"]
+func (w *Wallet) Type() string {
+	return w.Meta["type"]
 }
 
 // Version gets the wallet version
-func (wlt *Wallet) Version() string {
-	return wlt.Meta["version"]
+func (w *Wallet) Version() string {
+	return w.Meta["version"]
 }
 
-func (wlt *Wallet) setVersion(v string) {
-	wlt.Meta["version"] = v
+func (w *Wallet) setVersion(v string) {
+	w.Meta["version"] = v
 }
 
 // Filename gets the wallet filename
-func (wlt *Wallet) Filename() string {
-	return wlt.Meta["filename"]
+func (w *Wallet) Filename() string {
+	return w.Meta["filename"]
 }
 
 // setFilename sets the wallet filename
-func (wlt *Wallet) setFilename(fn string) {
-	wlt.Meta["filename"] = fn
+func (w *Wallet) setFilename(fn string) {
+	w.Meta["filename"] = fn
 }
 
 // Label gets the wallet label
-func (wlt *Wallet) Label() string {
-	return wlt.Meta["label"]
+func (w *Wallet) Label() string {
+	return w.Meta["label"]
 }
 
 // setLabel sets the wallet label
-func (wlt *Wallet) setLabel(label string) {
-	wlt.Meta["label"] = label
+func (w *Wallet) setLabel(label string) {
+	w.Meta["label"] = label
 }
 
 // lastSeed returns the last seed
-func (wlt *Wallet) lastSeed() string {
-	return wlt.Meta["lastSeed"]
+func (w *Wallet) lastSeed() string {
+	return w.Meta["lastSeed"]
 }
 
 func (w *Wallet) setLastSeed(lseed string) {
 	w.Meta["lastSeed"] = lseed
 }
 
-func (wlt *Wallet) seed() string {
-	return wlt.Meta["seed"]
+func (w *Wallet) seed() string {
+	return w.Meta["seed"]
 }
 
-func (wlt *Wallet) setSeed(seed string) {
-	wlt.Meta["seed"] = seed
+func (w *Wallet) setSeed(seed string) {
+	w.Meta["seed"] = seed
 }
 
 // GenerateAddresses generates addresses
-func (wlt *Wallet) GenerateAddresses(num uint64) ([]cipher.Address, error) {
-	if wlt.IsEncrypted() {
+func (w *Wallet) GenerateAddresses(num uint64) ([]cipher.Address, error) {
+	if w.IsEncrypted() {
 		return nil, ErrWalletEncrypted
 	}
 
-	return wlt.generateAddresses(num)
-}
+	if num == 0 {
+		return nil, nil
+	}
 
-func (wlt *Wallet) generateAddresses(num uint64) ([]cipher.Address, error) {
 	var seckeys []cipher.SecKey
-	var sd []byte
+	var seed []byte
 	var err error
-	if len(wlt.Entries) == 0 {
-		sd, seckeys = cipher.GenerateDeterministicKeyPairsSeed([]byte(wlt.lastSeed()), int(num))
+	if len(w.Entries) == 0 {
+		seed, seckeys = cipher.GenerateDeterministicKeyPairsSeed([]byte(w.lastSeed()), int(num))
 	} else {
-		sd, err = hex.DecodeString(wlt.lastSeed())
+		seed, err = hex.DecodeString(w.lastSeed())
 		if err != nil {
 			return nil, fmt.Errorf("decode hex seed failed: %v", err)
 		}
@@ -361,16 +412,23 @@ func (wlt *Wallet) generateAddresses(num uint64) ([]cipher.Address, error) {
 	return addrs, nil
 }
 
-// ScanAddresses scans ahead N addresses to find one with non-zero coins
+// ScanAddresses scans ahead N addresses to find one with none-zero coins.
 func (w *Wallet) ScanAddresses(scanN uint64, bg BalanceGetter) error {
+	if w.IsEncrypted() {
+		return ErrWalletEncrypted
+	}
+
 	if scanN <= 0 {
 		return nil
 	}
 
-	nExistingAddrs := uint64(w.NumEntries())
+	nExistingAddrs := uint64(len(w.Entries))
 
 	// Generate the addresses to scan
-	addrs := w.GenerateAddresses(scanN)
+	addrs, err := w.GenerateAddresses(scanN)
+	if err != nil {
+		return err
+	}
 
 	// Get these addresses' balances
 	bals, err := bg.GetBalanceOfAddrs(addrs)
@@ -390,39 +448,11 @@ func (w *Wallet) ScanAddresses(scanN uint64, bg BalanceGetter) error {
 	// Regenerate addresses up to keepNum.
 	// This is necessary to keep the lastSeed updated.
 	if keepNum != uint64(len(bals)) {
-		w.Reset()
+		w.reset()
 		w.GenerateAddresses(nExistingAddrs + keepNum)
 	}
 
 	return nil
-// GenerateAddressesEncrypted generates addresses in encrypted wallet with password
-func (wlt *Wallet) GenerateAddressesEncrypted(num uint64, password []byte) (addrs []cipher.Address, err error) {
-	if !wlt.IsEncrypted() {
-		return nil, errors.New("wallet is not encrypted")
-	}
-
-	if password == nil {
-		return nil, errors.New("password is required for generating addresses in encrypted wallet")
-	}
-
-	// Unlock the wallet
-	w, err := wlt.Unlock(password)
-	if err != nil {
-		return nil, fmt.Errorf("unlock wallet failed: %v", err)
-	}
-
-	// Lock the wallet when done
-	defer func() {
-		if lockErr := w.Lock(password); lockErr != nil {
-			addrs = nil
-			err = fmt.Errorf("lock wallet failed after generating addresses: %v", err)
-			return
-		}
-
-		wlt = w
-	}()
-
-	return w.generateAddresses(num)
 }
 
 // GetAddresses returns all addresses in wallet
@@ -457,52 +487,18 @@ func (w *Wallet) AddEntry(entry Entry) error {
 	return nil
 }
 
-// Reset resets the wallet entries and move the lastSeed to origin
-func (w *Wallet) Reset() {
-	w.Entries = []Entry{}
-	w.Meta["lastSeed"] = w.Meta["seed"]
-}
-
-// Save persists wallet to disk
-func (w *Wallet) Save(dir string) error {
-	r := NewReadableWallet(*w)
-	return r.Save(filepath.Join(dir, w.GetFilename()))
-}
-
-// Load loads wallets from given wallet file
-func (w *Wallet) Load(wltFile string) error {
-	if _, err := os.Stat(wltFile); os.IsNotExist(err) {
-		return fmt.Errorf("load wallet file failed, wallet %s doesn't exist", wltFile)
-	}
-
-	r := &ReadableWallet{}
-	if err := r.Load(wltFile); err != nil {
-		return err
-	}
-
-	// update filename meta info with the real filename
-	r.Meta["filename"] = filepath.Base(wltFile)
-	var err error
-	w, err := r.toWallet()
-	if err != nil {
-		return err
-	}
-	*wlt = *w
-	return nil
-}
-
 // clone returns the clone of self
-func (wlt *Wallet) clone() *Wallet {
-	w := Wallet{Meta: make(map[string]string)}
-	for k, v := range wlt.Meta {
-		w.Meta[k] = v
+func (w *Wallet) clone() *Wallet {
+	wlt := Wallet{Meta: make(map[string]string)}
+	for k, v := range w.Meta {
+		wlt.Meta[k] = v
 	}
 
 	for _, e := range w.Entries {
 		wlt.Entries = append(wlt.Entries, e)
 	}
 
-	return &w
+	return &wlt
 }
 
 // Validator validate if the wallet be able to create spending transaction
@@ -511,45 +507,44 @@ type Validator interface {
 	HasUnconfirmedSpendTx(addr []cipher.Address) (bool, error)
 }
 
+// // CreateAndSignTransaction Creates a Transaction
+// // spending coins and hours from wallet
+// func (w *Wallet) CreateAndSignTransaction(vld Validator, unspent blockdb.UnspentGetter,
+// 	headTime, coins uint64, dest cipher.Address) (*coin.Transaction, error) {
+// 	if w.IsEncrypted() {
+// 		return nil, ErrWalletEncrypted
+// 	}
+
+// 	return w.createAndSignTransaction(vld, unspent, headTime, coins, dest)
+// }
+
+// // CreateAndSignTransactionEncrypted creates and signs the transaction
+// func (w *Wallet) CreateAndSignTransactionEncrypted(vld Validator, unspent blockdb.UnspentGetter,
+// 	headTime, coins uint64, dest cipher.Address, password []byte) (*coin.Transaction, error) {
+// 	var tx *coin.Transaction
+// 	if err := w.guard(password, func(wlt *Wallet) error {
+// 		var err error
+// 		tx, err = wlt.createAndSignTransaction(vld, unspent, headTime, coins, dest)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		return nil
+// 	}); err != nil {
+// 		return nil, err
+// 	}
+
+// 	return tx, nil
+// }
+
 // CreateAndSignTransaction Creates a Transaction
 // spending coins and hours from wallet
 func (w *Wallet) CreateAndSignTransaction(vld Validator, unspent blockdb.UnspentGetter,
 	headTime, coins uint64, dest cipher.Address) (*coin.Transaction, error) {
-	if wlt.IsEncrypted() {
+	if w.IsEncrypted() {
 		return nil, ErrWalletEncrypted
 	}
 
-	return wlt.createAndSignTransaction(vld, unspent, headTime, coins, dest)
-}
-
-// CreateAndSignTransactionEncrypted creates and signs the transaction
-func (wlt *Wallet) CreateAndSignTransactionEncrypted(vld Validator, unspent blockdb.UnspentGetter,
-	headTime, coins uint64, dest cipher.Address, password []byte) (tx *coin.Transaction, err error) {
-	if !wlt.IsEncrypted() {
-		return nil, ErrWalletNotEncrypted
-	}
-
-	w, err := wlt.Unlock(password)
-	if err != nil {
-		return nil, fmt.Errorf("unlock wallet failed: %v", err)
-	}
-
-	defer func() {
-		if lockErr := w.Lock(password); lockErr != nil {
-			tx = nil
-			err = fmt.Errorf("lock wallet failed after signing tx: %v", err)
-			return
-		}
-	}()
-
-	return w.createAndSignTransaction(vld, unspent, headTime, coins, dest)
-}
-
-// createAndSignTransaction Creates a Transaction
-// spending coins and hours from wallet
-func (wlt *Wallet) createAndSignTransaction(vld Validator, unspent blockdb.UnspentGetter,
-	headTime, coins uint64, dest cipher.Address) (*coin.Transaction, error) {
-	addrs := wlt.GetAddresses()
+	addrs := w.GetAddresses()
 	ok, err := vld.HasUnconfirmedSpendTx(addrs)
 	if err != nil {
 		return nil, fmt.Errorf("checking unconfirmed spending failed: %v", err)
@@ -577,12 +572,12 @@ func (wlt *Wallet) createAndSignTransaction(vld Validator, unspent blockdb.Unspe
 	for i, au := range spends {
 		entry, exists := w.GetEntry(au.Address)
 		if !exists {
-			return nil, fmt.Errorf("address:%v does not exist in wallet:%v", au.Address, wlt.Filename())
+			return nil, fmt.Errorf("address:%v does not exist in wallet:%v", au.Address, w.Filename())
 		}
 
 		txn.PushInput(au.Hash)
 
-		if wlt.IsEncrypted() {
+		if w.IsEncrypted() {
 			return nil, ErrWalletEncrypted
 		}
 
@@ -620,11 +615,11 @@ func (wlt *Wallet) createAndSignTransaction(vld Validator, unspent blockdb.Unspe
 	return &txn, nil
 }
 
-func (wlt *Wallet) setEncrypted(encrypt bool) {
+func (w *Wallet) setEncrypted(encrypt bool) {
 	if encrypt {
-		wlt.Meta["encrypted"] = "true"
+		w.Meta["encrypted"] = "true"
 	} else {
-		wlt.Meta["encrypted"] = "false"
+		w.Meta["encrypted"] = "false"
 	}
 }
 
@@ -632,8 +627,12 @@ func (wlt *Wallet) setEncrypted(encrypt bool) {
 // Check the "encrypted" meta field:
 //     - return true if "true".
 //     - return false if "false" or "".
-func (wlt *Wallet) IsEncrypted() bool {
-	switch wlt.Meta["encrypted"] {
+func (w *Wallet) IsEncrypted() bool {
+	return checkEncrypted(w.Meta["encrypted"])
+}
+
+func checkEncrypted(v string) bool {
+	switch v {
 	// return false if it's value is "false" or empty string, cause old wallets do
 	// not have this field.
 	case "true":
@@ -641,7 +640,7 @@ func (wlt *Wallet) IsEncrypted() bool {
 	case "false", "":
 		return false
 	default:
-		panic(ErrInvalidEncryptedField)
+		panic(ErrInvalidEncryptedFieldValue)
 	}
 }
 

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -48,8 +48,8 @@ var (
 	// ErrInvalidWalletVersion represents invalid wallet version erro
 	ErrInvalidWalletVersion = errors.New("invalid wallet version")
 
-	// wallet version
-	wltVersion = "0.2"
+	// Version represents the current wallet version
+	Version = "0.2"
 )
 
 // Option NewWallet optional arguments type
@@ -132,7 +132,7 @@ func Load(wltFile string) (*Wallet, error) {
 }
 
 // Save saves the wallet to given dir
-func Save(w *Wallet, dir string) error {
+func Save(dir string, w *Wallet) error {
 	r := NewReadableWallet(*w)
 	return r.Save(filepath.Join(dir, w.Filename()))
 }
@@ -169,6 +169,11 @@ func (wlt Wallet) Type() string {
 // Filename gets the wallet filename
 func (wlt Wallet) Filename() string {
 	return wlt.Meta["filename"]
+}
+
+// Version gets the wallet version
+func (wlt *Wallet) Version() string {
+	return wlt.Meta["version"]
 }
 
 // setFilename sets the wallet filename
@@ -449,10 +454,10 @@ func (w *Wallet) CreateAndSignTransaction(vld Validator, unspent blockdb.Unspent
 
 		txn.PushInput(au.Hash)
 
-		switch wlt.version() {
+		switch wlt.Version() {
 		case "0.1":
 			toSign[i] = entry.Secret
-		case wltVersion:
+		case Version:
 			// decrypt the private key
 			s, err := decrypt(entry.EncryptedSeckey, []byte(password))
 			if err != nil {

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -42,6 +42,13 @@ const (
 	CoinTypeBitcoin CoinType = "bitcoin"
 )
 
+var (
+	// ErrNoPassword find no password when creating wallet
+	ErrNoPassword = errors.New("password is required when creating wallet")
+	// ErrInvalidWalletVersion represents invalid wallet version erro
+	ErrInvalidWalletVersion = errors.New("invalid wallet version")
+)
+
 // NewWalletFilename check for collisions and retry if failure
 func NewWalletFilename() string {
 	timestamp := time.Now().Format(WalletTimestampFormat)
@@ -61,7 +68,8 @@ type Wallet struct {
 	Entries []Entry
 }
 
-var version = "0.1"
+// wallet version
+var wltVersion = "0.2"
 
 // Options are wallet constructor options
 type Options struct {
@@ -86,7 +94,7 @@ func NewWallet(wltName string, opts Options) (*Wallet, error) {
 	w := &Wallet{
 		Meta: map[string]string{
 			"filename": wltName,
-			"version":  version,
+			"version":  wltVersion,
 			"label":    opts.Label,
 			"seed":     seed,
 			"lastSeed": seed,
@@ -104,25 +112,6 @@ func Load(wltFile string) (*Wallet, error) {
 	w := Wallet{}
 	if err := w.Load(wltFile); err != nil {
 		return nil, err
-	}
-
-	return &w, nil
-}
-
-// newWalletFromReadable creates wallet from readable wallet
-func newWalletFromReadable(r *ReadableWallet) (*Wallet, error) {
-	ets, err := r.Entries.ToWalletEntries()
-	if err != nil {
-		return nil, err
-	}
-
-	w := Wallet{
-		Meta:    r.Meta,
-		Entries: ets,
-	}
-
-	if err := w.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid wallet %s: %v", w.GetFilename(), err)
 	}
 
 	return &w, nil
@@ -190,6 +179,14 @@ func (w *Wallet) setLastSeed(lseed string) {
 	w.Meta["lastSeed"] = lseed
 }
 
+func (wlt *Wallet) seed() string {
+	return wlt.Meta["seed"]
+}
+
+func (wlt *Wallet) setSeed(seed string) {
+	wlt.Meta["seed"] = seed
+}
+
 // GetVersion gets the wallet version
 func (w *Wallet) GetVersion() string {
 	return w.Meta["version"]
@@ -205,7 +202,52 @@ func (w *Wallet) GenerateAddresses(num uint64) []cipher.Address {
 	if num == 0 {
 		return []cipher.Address{}
 	}
+	return nil, ErrInvalidWalletVersion
+}
 
+func (wlt *Wallet) newAddressesInEncryptedWallet(num int, password []byte) ([]cipher.Address, error) {
+	var seckeys []cipher.SecKey
+	var sd []byte
+	var err error
+
+	lastSeed, err := decrypt(wlt.getLastSeed(), password)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt last seed failed: %v", err)
+	}
+
+	sd, seckeys = cipher.GenerateDeterministicKeyPairsSeed(lastSeed, num)
+
+	// encrypt the last seed
+	newLastSeed, err := encrypt(sd, []byte(password))
+	if err != nil {
+		return nil, err
+	}
+
+	// update the last seed
+	wlt.setLastSeed(newLastSeed)
+
+	addrs := make([]cipher.Address, len(seckeys))
+	for i, s := range seckeys {
+		p := cipher.PubKeyFromSecKey(s)
+		a := cipher.AddressFromPubKey(p)
+		addrs[i] = a
+
+		// encrypt seckey
+		ss, err := encrypt(s[:], []byte(password))
+		if err != nil {
+			return nil, fmt.Errorf("encrypt private key failed: %v", err)
+		}
+
+		wlt.Entries = append(wlt.Entries, Entry{
+			Address:         a,
+			EncryptedSeckey: ss,
+			Public:          p,
+		})
+	}
+	return addrs, nil
+}
+
+func (wlt *Wallet) newAddressesInUnencryptedWallet(num int) ([]cipher.Address, error) {
 	var seckeys []cipher.SecKey
 	var seed []byte
 	if len(w.Entries) == 0 {
@@ -214,7 +256,7 @@ func (w *Wallet) GenerateAddresses(num uint64) []cipher.Address {
 		var err error
 		seed, err = hex.DecodeString(w.getLastSeed())
 		if err != nil {
-			logger.Panicf("decode hex seed failed: %v", err)
+			return nil, fmt.Errorf("decode hex seed failed: %v", err)
 		}
 		seed, seckeys = cipher.GenerateDeterministicKeyPairsSeed(seed, int(num))
 	}
@@ -232,7 +274,7 @@ func (w *Wallet) GenerateAddresses(num uint64) []cipher.Address {
 			Public:  p,
 		})
 	}
-	return addrs
+	return addrs, nil
 }
 
 // ScanAddresses scans ahead N addresses to find one with non-zero coins
@@ -328,12 +370,12 @@ func (w *Wallet) Load(wltFile string) error {
 
 	// update filename meta info with the real filename
 	r.Meta["filename"] = filepath.Base(wltFile)
-	wlt, err := newWalletFromReadable(r)
+	var err error
+	w, err := r.toWallet()
 	if err != nil {
 		return err
 	}
-
-	*w = *wlt
+	*wlt = *w
 	return nil
 }
 
@@ -394,7 +436,19 @@ func (w *Wallet) CreateAndSignTransaction(vld Validator, unspent blockdb.Unspent
 		}
 
 		txn.PushInput(au.Hash)
-		toSign[i] = entry.Secret
+
+		switch wlt.GetVersion() {
+		case "0.1":
+			toSign[i] = entry.Secret
+		case wltVersion:
+			// decrypt the private key
+			s, err := decrypt(entry.EncryptedSeckey, []byte(password))
+			if err != nil {
+				return nil, err
+			}
+
+			copy(toSign[i][:], s[:])
+		}
 		spending.Coins += au.Coins
 		spending.Hours += au.Hours
 	}

--- a/src/wallet/wallet_test.go
+++ b/src/wallet/wallet_test.go
@@ -22,6 +22,54 @@ var _ = func() int64 {
 	return t
 }()
 
+type mockBalanceGetter map[cipher.Address]BalancePair
+
+func (mb mockBalanceGetter) GetBalanceOfAddrs(addrs []cipher.Address) ([]BalancePair, error) {
+	var bals []BalancePair
+	for _, addr := range addrs {
+		bal := mb[addr]
+		bals = append(bals, bal)
+	}
+	return bals, nil
+}
+
+// 10 addresses of seed1
+var addrsOfSeed1 = []string{
+	"2GBifzJEehbDX7Mkk63Prfa4MQQQyRzBLfe",
+	"q2kU13X8XsAg8cS8BuSeSVzjPF9AT9ghAa",
+	"2WXvTagXtrc1Qq71yjNXw86TC6SRgfVRH1B",
+	"2NUNw748b9mT2FHRxgJL5KjBHasLfdP32Sh",
+	"2V1CnVzWoXDaCX6wHU4tLJkWaFmLcQBb2q4",
+	"wBkMr936thcr57wxyrH6ffvA99JN2Q1MN1",
+	"2f92Wht7VQefAyoJUz3SEnfwT6wTdeAcq3L",
+	"27UM5jPFYVuve3ceEHAYGaJSmkynQYmwPcH",
+	"xjWbVN7ihReasVFwXJSSYYWF7rgQa22auC",
+	"2LyanokLYFeBfBsNkRYHp2qtN8naGFJqeUw",
+}
+
+var childSeedsOfSeed1 = []string{
+	"22b826c586039f8078433be26618ca1024e883d97de2267313bb78068f634c5a",
+	"68efbbdf8aa06368cfc55e252d1e782bbd7651e590ee59e94ab579d2e44c20ad",
+	"8894c818732375680284be4509d153272726f42296b85ecac1fb66b9dc7484b9",
+	"6603375ee19c1e9fffe369e3f62e9deaa6931c1183d7da7f24ecbbd591061502",
+	"91a63f939149d423ea39701d8ed16cfb16a3554c184d214d2289018ddb9e73de",
+	"f0f4f008aa3e7cd32ee953507856fb46e37b734fd289dc01449133d7e37a1f07",
+	"6b194da58a5ba5660cf2b00076cf6a2962fe8fe0523abca5647c87df3352866a",
+	"b47a2678f7e797d3ada86e7e36855f572a18ab78dcbe54ed0613bba69fd76f8d",
+	"fe064533108dadbef13be3a95f547ba03423aa6a701c40aaaed775cb783b12b3",
+	"d554da211321a437e4d08f2a57e3ef255cffa89dd182e0fd52a4fd5bdfcab1ae",
+}
+
+func fromAddrString(t *testing.T, addrStrs []string) []cipher.Address {
+	addrs := make([]cipher.Address, 0, len(addrStrs))
+	for _, addr := range addrStrs {
+		a, err := cipher.DecodeBase58Address(addr)
+		require.NoError(t, err)
+		addrs = append(addrs, a)
+	}
+	return addrs
+}
+
 func TestNewWallet(t *testing.T) {
 	type expect struct {
 		meta map[string]string
@@ -47,7 +95,7 @@ func TestNewWallet(t *testing.T) {
 					"coin":     "skycoin",
 					"type":     "deterministic",
 					"seed":     "testseed123",
-					"version":  wltVersion,
+					"version":  Version,
 				},
 				err: nil,
 			},
@@ -66,7 +114,7 @@ func TestNewWallet(t *testing.T) {
 					"coin":     "skycoin",
 					"type":     "deterministic",
 					"seed":     "testseed123",
-					"version":  wltVersion,
+					"version":  Version,
 				},
 				err: nil,
 			},
@@ -90,6 +138,84 @@ func TestNewWallet(t *testing.T) {
 				err: nil,
 			},
 		},
+		{
+			"ok with label, seed and coin set, encrypted",
+			"test.wlt",
+			Options{
+				Label:    "wallet1",
+				Coin:     CoinTypeSkycoin,
+				Seed:     "testseed123",
+				Encrypt:  true,
+				Password: []byte("pwd"),
+			},
+			expect{
+				meta: map[string]string{
+					"label":     "wallet1",
+					"coin":      string(CoinTypeSkycoin),
+					"type":      "deterministic",
+					"encrypted": "true",
+				},
+				err: nil,
+			},
+		},
+		{
+			"encrypt without password",
+			"test.wlt",
+			Options{
+				Label:   "wallet1",
+				Coin:    CoinTypeSkycoin,
+				Seed:    "testseed123",
+				Encrypt: true,
+			},
+			expect{
+				meta: map[string]string{
+					"label":     "wallet1",
+					"coin":      string(CoinTypeSkycoin),
+					"type":      "deterministic",
+					"encrypted": "true",
+				},
+				err: errors.New("password is required for creating wallet with encryption"),
+			},
+		},
+		{
+			"create with no seed",
+			"test.wlt",
+			Options{
+				Label:    "wallet1",
+				Coin:     CoinTypeSkycoin,
+				Encrypt:  true,
+				Password: []byte("pwd"),
+			},
+			expect{
+				meta: map[string]string{
+					"label":     "wallet1",
+					"coin":      string(CoinTypeSkycoin),
+					"type":      "deterministic",
+					"encrypted": "true",
+				},
+				err: errors.New("seed required"),
+			},
+		},
+		{
+			"generate addresses",
+			"test.wlt",
+			Options{
+				Label:      "wallet1",
+				Coin:       CoinTypeSkycoin,
+				Encrypt:    true,
+				Password:   []byte("pwd"),
+				AddressNum: 2,
+			},
+			expect{
+				meta: map[string]string{
+					"label":     "wallet1",
+					"coin":      string(CoinTypeSkycoin),
+					"type":      "deterministic",
+					"encrypted": "true",
+				},
+				err: errors.New("seed required"),
+			},
+		},
 	}
 
 	for _, tc := range tt {
@@ -100,22 +226,172 @@ func TestNewWallet(t *testing.T) {
 				return
 			}
 
-			_, err = w.GenerateAddresses("pwd", 1)
+			// Checks the generated addresses
+			require.Len(t, w.Entries, int(tc.ops.AddressNum))
+
+			require.Equal(t, tc.ops.Encrypt, w.IsEncrypted())
+
+			if w.IsEncrypted() {
+				// decrypt the seed and genearte the first address
+				seed, err := Decrypt(w.seed(), tc.ops.Password)
+				require.NoError(t, err)
+				require.Equal(t, tc.ops.Seed, string(seed))
+
+				// decrypt last seed
+				lastSeed, err := Decrypt(w.lastSeed(), tc.ops.Password)
+				require.NoError(t, err)
+				require.Equal(t, lastSeed, seed)
+
+				// check the entries, the seckeys must be erased.
+				for _, e := range w.Entries {
+					require.Empty(t, e.Secret)
+					require.NotEmpty(t, e.EncryptedSeckey)
+				}
+			}
+		})
+	}
+}
+
+func TestWalletLock(t *testing.T) {
+	tt := []struct {
+		name    string
+		opts    Options
+		lockPwd []byte
+		err     error
+	}{
+		{
+			"ok",
+			Options{
+				Seed: "seed",
+			},
+			[]byte("pwd"),
+			nil,
+		},
+		{
+			"password is nil",
+			Options{
+				Seed: "seed",
+			},
+			nil,
+			ErrRequirePassword,
+		},
+		{
+			"wallet already encrypted",
+			Options{
+				Seed:     "seed",
+				Encrypt:  true,
+				Password: []byte("pwd"),
+			},
+			[]byte("pwd"),
+			ErrWalletEncrypted,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			wltName := newWalletFilename()
+			w, err := NewWallet(wltName, tc.opts)
 			require.NoError(t, err)
-			require.NoError(t, w.validate())
-			for k, v := range tc.expect.meta {
-				vv, ok := w.Meta[k]
-				require.True(t, ok)
-				require.Equal(t, v, vv)
+
+			if !w.IsEncrypted() {
+				_, err = w.GenerateAddresses(2)
+				require.NoError(t, err)
 			}
 
-			if w.seed() != "" {
-				// decrypt the seed and genearte the first address
-				seed, err := Decrypt(w.seed(), []byte("pwd"))
-				require.NoError(t, err)
-				_, seckeys := cipher.GenerateDeterministicKeyPairsSeed(seed, 1)
-				addr := cipher.AddressFromSecKey(seckeys[0])
-				require.Equal(t, w.Entries[0].Address.String(), addr.String())
+			err = w.lock(tc.lockPwd)
+			require.Equal(t, tc.err, err)
+			if err != nil {
+				return
+			}
+
+			// Checks if the seeds are encrypted
+			require.NotEqual(t, w.seed(), tc.opts.Seed)
+			require.NotEqual(t, w.lastSeed(), tc.opts.Seed)
+
+			// Checks if the entries are encrypted
+			for i := range w.Entries {
+				require.Equal(t, cipher.SecKey{}, w.Entries[i].Secret)
+				require.NotEmpty(t, w.Entries[i].EncryptedSeckey)
+			}
+		})
+	}
+
+}
+
+func TestWalletUnlock(t *testing.T) {
+	tt := []struct {
+		name      string
+		opts      Options
+		unlockPwd []byte
+		err       error
+	}{
+		{
+			"ok",
+			Options{
+				Seed:       "seed",
+				Encrypt:    true,
+				Password:   []byte("pwd"),
+				AddressNum: 2,
+			},
+			[]byte("pwd"),
+			nil,
+		},
+		{
+			"unlock with nil password",
+			Options{
+				Seed:       "seed",
+				Encrypt:    true,
+				Password:   []byte("pwd"),
+				AddressNum: 2,
+			},
+			nil,
+			errors.New("password is required to decrypt wallet"),
+		},
+		{
+			"unlock undecrypted wallet",
+			Options{
+				Seed:    "seed",
+				Encrypt: false,
+			},
+			[]byte("pwd"),
+			ErrWalletNotEncrypted,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			w, err := NewWallet("t.wlt", tc.opts)
+			require.NoError(t, err)
+
+			wlt, err := w.unlock(tc.unlockPwd)
+			require.Equal(t, tc.err, err)
+
+			if err != nil {
+				return
+			}
+
+			require.False(t, wlt.IsEncrypted())
+
+			// Checks the seeds
+			require.Equal(t, tc.opts.Seed, wlt.seed())
+
+			// Checks the generated addresses
+			sd, sks := cipher.GenerateDeterministicKeyPairsSeed([]byte(wlt.seed()), int(tc.opts.AddressNum))
+			require.NotEqual(t, sd, []byte(wlt.lastSeed()))
+
+			require.Equal(t, tc.opts.AddressNum, uint64(len(wlt.Entries)))
+
+			for i := range wlt.Entries {
+				addr := cipher.AddressFromSecKey(sks[i])
+				require.Equal(t, addr, wlt.Entries[i].Address)
+			}
+
+			// Checks the original seeds
+			require.NotEqual(t, tc.opts.Seed, w.seed())
+
+			// Checks if the seckeys in entries of original wallet are empty
+			for i := range w.Entries {
+				require.Equal(t, cipher.SecKey{}, w.Entries[i].Secret)
 			}
 		})
 	}
@@ -227,60 +503,71 @@ func TestLoadWallet(t *testing.T) {
 func TestWalletGenerateAddress(t *testing.T) {
 	tt := []struct {
 		name               string
-		seed               []byte
-		pwd                []byte
+		opts               Options
 		num                uint64
 		oneAddressEachTime bool
 		err                error
 	}{
 		{
 			"ok with one address",
-			[]byte("seed"),
-			[]byte("pwd"),
+			Options{
+				Seed: "seed",
+			},
 			1,
 			false,
 			nil,
 		},
 		{
 			"ok with two address",
-			[]byte("seed"),
-			[]byte("pwd"),
+			Options{
+				Seed: "seed",
+			},
 			2,
 			false,
 			nil,
 		},
 		{
 			"ok with three address and generate one address each time",
-			[]byte("seed"),
-			[]byte("pwd"),
+			Options{
+				Seed: "seed",
+			},
 			2,
 			true,
 			nil,
 		},
 		{
-			"invalid password",
-			[]byte("seed"),
-			[]byte("pwd1"),
-			0,
-			false,
-			cipher.ErrInvalidPassword,
+			"wallet is encrypted",
+			Options{
+				Seed:     "seed",
+				Encrypt:  true,
+				Password: []byte("pwd"),
+			},
+			2,
+			true,
+			ErrWalletEncrypted,
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			// create wallet
-			w, err := NewWallet("test.wlt", "pwd", OptSeed(string(tc.seed)))
+			w, err := NewWallet("test.wlt", tc.opts)
 			require.NoError(t, err)
 
 			// generate addresses
 			if tc.oneAddressEachTime {
-				_, err = w.GenerateAddresses(string(tc.pwd), tc.num)
-				require.NoError(t, err)
+				_, err = w.GenerateAddresses(tc.num)
+				require.Equal(t, tc.err, err)
+				if err != nil {
+					return
+				}
 			} else {
 				for i := uint64(0); i < tc.num; i++ {
-					_, err := w.GenerateAddresses(string(tc.pwd), 1)
-					require.NoError(t, err)
+					_, err := w.GenerateAddresses(1)
+					require.Equal(t, tc.err, err)
+					if err != nil {
+						return
+					}
 				}
 			}
 
@@ -289,7 +576,7 @@ func TestWalletGenerateAddress(t *testing.T) {
 
 			addrs := w.GetAddresses()
 
-			_, keys := cipher.GenerateDeterministicKeyPairsSeed(tc.seed, int(tc.num))
+			_, keys := cipher.GenerateDeterministicKeyPairsSeed([]byte(tc.opts.Seed), int(tc.num))
 			for i, k := range keys {
 				a := cipher.AddressFromSecKey(k)
 				require.Equal(t, a.String(), addrs[i].String())
@@ -383,6 +670,9 @@ func TestWalletAddEntry(t *testing.T) {
 			}))
 		})
 	}
+}
+
+func TestScanAddresses(t *testing.T) {
 }
 
 type distributeSpendHoursTestCase struct {

--- a/src/wallet/wallet_test.go
+++ b/src/wallet/wallet_test.go
@@ -229,7 +229,7 @@ func TestWalletGenerateAddress(t *testing.T) {
 		name               string
 		seed               []byte
 		pwd                []byte
-		num                int
+		num                uint64
 		oneAddressEachTime bool
 		err                error
 	}{
@@ -278,18 +278,18 @@ func TestWalletGenerateAddress(t *testing.T) {
 				_, err = w.GenerateAddresses(string(tc.pwd), tc.num)
 				require.NoError(t, err)
 			} else {
-				for i := 0; i < tc.num; i++ {
+				for i := uint64(0); i < tc.num; i++ {
 					_, err := w.GenerateAddresses(string(tc.pwd), 1)
 					require.NoError(t, err)
 				}
 			}
 
 			// check the entry number
-			require.Equal(t, tc.num, len(w.Entries))
+			require.Equal(t, int(tc.num), len(w.Entries))
 
 			addrs := w.GetAddresses()
 
-			_, keys := cipher.GenerateDeterministicKeyPairsSeed(tc.seed, tc.num)
+			_, keys := cipher.GenerateDeterministicKeyPairsSeed(tc.seed, int(tc.num))
 			for i, k := range keys {
 				a := cipher.AddressFromSecKey(k)
 				require.Equal(t, a.String(), addrs[i].String())

--- a/src/wallet/wallet_test.go
+++ b/src/wallet/wallet_test.go
@@ -100,7 +100,7 @@ func TestNewWallet(t *testing.T) {
 				return
 			}
 
-			_, err = w.GenerateAddresses(1, []byte("pwd"))
+			_, err = w.GenerateAddresses(1, "pwd")
 			require.NoError(t, err)
 			require.NoError(t, w.validate())
 			for k, v := range tc.expect.meta {
@@ -270,16 +270,16 @@ func TestWalletGenerateAddress(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			// create wallet
-			w, err := NewWallet("test.wlt", []byte("pwd"), OptSeed(string(tc.seed)))
+			w, err := NewWallet("test.wlt", "pwd", OptSeed(string(tc.seed)))
 			require.NoError(t, err)
 
 			// generate addresses
 			if tc.oneAddressEachTime {
-				_, err = w.GenerateAddresses(tc.num, tc.pwd)
+				_, err = w.GenerateAddresses(tc.num, string(tc.pwd))
 				require.NoError(t, err)
 			} else {
 				for i := 0; i < tc.num; i++ {
-					_, err := w.GenerateAddresses(1, tc.pwd)
+					_, err := w.GenerateAddresses(1, string(tc.pwd))
 					require.NoError(t, err)
 				}
 			}

--- a/src/wallet/wallet_test.go
+++ b/src/wallet/wallet_test.go
@@ -100,7 +100,7 @@ func TestNewWallet(t *testing.T) {
 				return
 			}
 
-			_, err = w.GenerateAddresses(1, "pwd")
+			_, err = w.GenerateAddresses("pwd", 1)
 			require.NoError(t, err)
 			require.NoError(t, w.validate())
 			for k, v := range tc.expect.meta {
@@ -275,11 +275,11 @@ func TestWalletGenerateAddress(t *testing.T) {
 
 			// generate addresses
 			if tc.oneAddressEachTime {
-				_, err = w.GenerateAddresses(tc.num, string(tc.pwd))
+				_, err = w.GenerateAddresses(string(tc.pwd), tc.num)
 				require.NoError(t, err)
 			} else {
 				for i := 0; i < tc.num; i++ {
-					_, err := w.GenerateAddresses(1, string(tc.pwd))
+					_, err := w.GenerateAddresses(string(tc.pwd), 1)
 					require.NoError(t, err)
 				}
 			}

--- a/src/wallet/wallet_test.go
+++ b/src/wallet/wallet_test.go
@@ -111,7 +111,7 @@ func TestNewWallet(t *testing.T) {
 
 			if w.seed() != "" {
 				// decrypt the seed and genearte the first address
-				seed, err := decrypt(w.seed(), []byte("pwd"))
+				seed, err := Decrypt(w.seed(), []byte("pwd"))
 				require.NoError(t, err)
 				_, seckeys := cipher.GenerateDeterministicKeyPairsSeed(seed, 1)
 				addr := cipher.AddressFromSecKey(seckeys[0])

--- a/src/wallet/wallet_test.go
+++ b/src/wallet/wallet_test.go
@@ -102,7 +102,7 @@ func TestNewWallet(t *testing.T) {
 
 			_, err = w.GenerateAddresses(1, []byte("pwd"))
 			require.NoError(t, err)
-			require.NoError(t, w.Validate())
+			require.NoError(t, w.validate())
 			for k, v := range tc.expect.meta {
 				vv, ok := w.Meta[k]
 				require.True(t, ok)
@@ -210,8 +210,7 @@ func TestLoadWallet(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			w := Wallet{}
-			err := w.Load(tc.file)
+			w, err := Load(tc.file)
 			require.Equal(t, tc.expect.err, err)
 			if err != nil {
 				return
@@ -328,8 +327,8 @@ func TestWalletGetEntry(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			w := Wallet{}
-			require.NoError(t, w.Load(tc.wltFile))
+			w, err := Load(tc.wltFile)
+			require.NoError(t, err)
 			a, err := cipher.DecodeBase58Address(tc.address)
 			require.NoError(t, err)
 			e, ok := w.GetEntry(a)
@@ -373,8 +372,8 @@ func TestWalletAddEntry(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			w := Wallet{}
-			require.NoError(t, w.Load(tc.wltFile))
+			w, err := Load(tc.wltFile)
+			require.NoError(t, err)
 			a := cipher.AddressFromSecKey(tc.secKey)
 			p := cipher.PubKeyFromSecKey(tc.secKey)
 			require.Equal(t, tc.err, w.AddEntry(Entry{

--- a/src/wallet/wallets.go
+++ b/src/wallet/wallets.go
@@ -152,7 +152,7 @@ func (wlts Wallets) Update(wltID string, updateFunc func(Wallet) Wallet) error {
 // NewAddresses creates num addresses in given wallet
 func (wlts *Wallets) NewAddresses(id string, num int, password string) ([]cipher.Address, error) {
 	if w, ok := (*wlts)[id]; ok {
-		return w.GenerateAddresses(num, password)
+		return w.GenerateAddresses(password, num)
 	}
 	return nil, fmt.Errorf("wallet: %v does not exist", id)
 }

--- a/src/wallet/wallets.go
+++ b/src/wallet/wallets.go
@@ -93,7 +93,7 @@ func backupWltFile(src, dst string) error {
 // Add add walet to current wallet
 func (wlts Wallets) Add(w *Wallet) error {
 	if _, dup := wlts[w.Filename()]; dup {
-		return errors.New("wallet name would conflict with existing wallet, renaming")
+		return ErrWalletNameConflict
 	}
 
 	wlts[w.Filename()] = w
@@ -110,23 +110,23 @@ func (wlts Wallets) Get(id string) (*Wallet, bool) {
 	if w, ok := wlts[id]; ok {
 		return w, true
 	}
-	return &Wallet{}, false
+	return nil, false
 }
 
 // set sets a wallet into the map
-func (wlts Wallets) set(w Wallet) {
-	wlts[w.GetFilename()] = &w
+func (wlts Wallets) set(w *Wallet) {
+	wlts[w.Filename()] = w
 }
 
 // Update updates the given wallet, return error if not exist
-func (wlts Wallets) Update(wltID string, updateFunc func(Wallet) Wallet) error {
+func (wlts Wallets) Update(wltID string, updateFunc func(*Wallet) *Wallet) error {
 	w, ok := wlts[wltID]
 	if !ok {
-		return errWalletNotExist(wltID)
+		return ErrWalletNotExist{wltID}
 	}
 
-	newWlt := updateFunc(*w)
-	wlts[wltID] = &newWlt
+	newWlt := updateFunc(w.clone())
+	wlts[wltID] = newWlt
 	return nil
 }
 

--- a/src/wallet/wallets.go
+++ b/src/wallet/wallets.go
@@ -150,7 +150,7 @@ func (wlts Wallets) Update(wltID string, updateFunc func(Wallet) Wallet) error {
 }
 
 // NewAddresses creates num addresses in given wallet
-func (wlts *Wallets) NewAddresses(id string, num int, password []byte) ([]cipher.Address, error) {
+func (wlts *Wallets) NewAddresses(id string, num int, password string) ([]cipher.Address, error) {
 	if w, ok := (*wlts)[id]; ok {
 		return w.GenerateAddresses(num, password)
 	}

--- a/src/wallet/wallets.go
+++ b/src/wallet/wallets.go
@@ -162,7 +162,7 @@ func (wlts *Wallets) NewAddresses(id string, num int, password string) ([]cipher
 func (wlts Wallets) Save(dir string) map[string]error {
 	errs := make(map[string]error)
 	for id, w := range wlts {
-		if err := Save(w, dir); err != nil {
+		if err := Save(dir, w); err != nil {
 			errs[id] = err
 		}
 	}


### PR DESCRIPTION
1. Add "encrypt" and "password" paraments in /wallet/create api. "encrypt" value must be 0 or 1, and "password" must be provided if "encrypt" is 1.
2. Add "password" paramenter in the following apis:
        /wallet/newAddress
        /wallet/spend
3. Reorder the api handler functions, the same as they are registered in RegisterWalletHandlers function.
4. Update api comments

Fix #665 