### PR TITLE
Add /transactions endpoint

### DIFF
--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -476,11 +476,11 @@ func (gw *Gateway) GetUnspent() blockdb.UnspentPool {
 
 // impelemts the wallet.Validator interface
 type spendValidator struct {
-	uncfm   *visor.UnconfirmedTxnPool
+	uncfm   visor.UnconfirmedTxnPooler
 	unspent blockdb.UnspentPool
 }
 
-func newSpendValidator(uncfm *visor.UnconfirmedTxnPool, unspent blockdb.UnspentPool) *spendValidator {
+func newSpendValidator(uncfm visor.UnconfirmedTxnPooler, unspent blockdb.UnspentPool) *spendValidator {
 	return &spendValidator{
 		uncfm:   uncfm,
 		unspent: unspent,

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -397,6 +397,17 @@ func (gw *Gateway) GetAddressTxns(a cipher.Address) (*visor.TransactionResults, 
 	return visor.NewTransactionResults(txs)
 }
 
+// GetTransactionsOfAddrs returns addresses related transactions
+func (gw *Gateway) GetTransactionsOfAddrs(addrs []cipher.Address) (map[cipher.Address][]visor.Transaction, error) {
+	addrTxs := make(map[cipher.Address][]visor.Transaction)
+	var err error
+	gw.strand("GetTransactionsOfAddrs", func() {
+		addrTxs, err = gw.v.GetTransactionsOfAddrs(addrs)
+	})
+
+	return addrTxs, err
+}
+
 // GetUxOutByID gets UxOut by hash id.
 func (gw *Gateway) GetUxOutByID(id cipher.SHA256) (*historydb.UxOut, error) {
 	var uxout *historydb.UxOut

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -397,15 +397,13 @@ func (gw *Gateway) GetAddressTxns(a cipher.Address) (*visor.TransactionResults, 
 	return visor.NewTransactionResults(txs)
 }
 
-// GetTransactionsOfAddrs returns addresses related transactions
-func (gw *Gateway) GetTransactionsOfAddrs(addrs []cipher.Address) (map[cipher.Address][]visor.Transaction, error) {
-	addrTxs := make(map[cipher.Address][]visor.Transaction)
+func (gw *Gateway) GetTransactions(flts ...visor.TxFilter) ([]visor.Transaction, error) {
+	var txns []visor.Transaction
 	var err error
-	gw.strand("GetTransactionsOfAddrs", func() {
-		addrTxs, err = gw.v.GetTransactionsOfAddrs(addrs)
+	gw.strand("GetTransactions", func() {
+		txns, err = gw.v.GetTransactions(flts...)
 	})
-
-	return addrTxs, err
+	return txns, err
 }
 
 // GetUxOutByID gets UxOut by hash id.

--- a/src/gui/transaction.go
+++ b/src/gui/transaction.go
@@ -28,7 +28,7 @@ func RegisterTxHandlers(mux *http.ServeMux, gateway *daemon.Gateway) {
 	// Returns transactions that match the filters.
 	// Method: GET
 	// Args:
-	//     addrs: Comma seperated addresses [optional, returns all transactions if no address provided]
+	//     addrs: Comma seperated addresses [optional, returns all transactions if no address is provided]
 	//     confirmed: Whether the transactions should be confirmed [optional, must be 0 or 1; if not provided, returns all]
 	mux.HandleFunc("/transactions", getTransactions(gateway))
 	//inject a transaction into network

--- a/src/gui/transaction.go
+++ b/src/gui/transaction.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/skycoin/skycoin/src/cipher"
@@ -161,12 +162,12 @@ func getTransactions(gateway *daemon.Gateway) http.HandlerFunc {
 		// Initialize transaction filters
 		flts := []visor.TxFilter{visor.AddrsFilter(addrs)}
 
-		// Gets the "confirmed" parameter value
+		// Gets the 'confirmed' parameter value
 		confirmedStr := r.FormValue("confirmed")
 		if confirmedStr != "" {
-			confirmed, err := parseConfirmedFromStr(confirmedStr)
+			confirmed, err := strconv.ParseBool(confirmedStr)
 			if err != nil {
-				wh.Error400(w, fmt.Sprintf("parse paramenter: 'confirmed' failed: %v", err))
+				wh.Error400(w, fmt.Sprintf("invalid 'confirmed' value: %v", err))
 				return
 			}
 
@@ -215,18 +216,6 @@ func parseAddressesFromStr(addrStr string) ([]cipher.Address, error) {
 	}
 
 	return addrs, nil
-}
-
-// Parses the confirmed string int bool value, must be "0" or "1".
-func parseConfirmedFromStr(confirmedStr string) (bool, error) {
-	switch confirmedStr {
-	case "0":
-		return false, nil
-	case "1":
-		return true, nil
-	default:
-		return false, fmt.Errorf("invalid 'confirmed' value: %v", confirmedStr)
-	}
 }
 
 //Implement

--- a/src/visor/blockchain.go
+++ b/src/visor/blockchain.go
@@ -625,9 +625,14 @@ func (bc *Blockchain) BindListener(ls BlockListener) {
 	bc.blkListener = append(bc.blkListener, ls)
 }
 
-// notifies the listener the new block.
+// Notify notifies the listener the new block.
 func (bc *Blockchain) Notify(b coin.Block) {
 	for _, l := range bc.blkListener {
 		l(b)
 	}
+}
+
+// UpdateDB updates db with given func
+func (bc *Blockchain) UpdateDB(f func(t *bolt.Tx) error) error {
+	return bc.db.Update(f)
 }

--- a/src/visor/blockchain_parser.go
+++ b/src/visor/blockchain_parser.go
@@ -16,7 +16,7 @@ type BlockchainParser struct {
 	blkC      chan coin.Block
 	quit      chan struct{}
 	done      chan struct{}
-	bc        blockchainer
+	bc        Blockchainer
 
 	isStart bool
 }

--- a/src/visor/blockchain_parser.go
+++ b/src/visor/blockchain_parser.go
@@ -12,11 +12,11 @@ type ParserOption func(*BlockchainParser)
 
 // BlockchainParser parses the blockchain and stores the data into historydb.
 type BlockchainParser struct {
-	historyDB *historydb.HistoryDB
+	historyDB historyer
 	blkC      chan coin.Block
 	quit      chan struct{}
 	done      chan struct{}
-	bc        *Blockchain
+	bc        blockchainer
 
 	isStart bool
 }

--- a/src/visor/blockchain_test.go
+++ b/src/visor/blockchain_test.go
@@ -43,7 +43,7 @@ func makeFeeCalc(fee uint64) coin.FeeCalculator {
 	}
 }
 
-func addGenesisBlock(t *testing.T, bc blockchainer) *coin.SignedBlock {
+func addGenesisBlock(t *testing.T, bc Blockchainer) *coin.SignedBlock {
 	// create genesis block
 	gb, err := coin.NewGenesisBlock(genAddress, genCoins, genTime)
 	require.NoError(t, err)
@@ -53,12 +53,12 @@ func addGenesisBlock(t *testing.T, bc blockchainer) *coin.SignedBlock {
 	require.True(t, ok)
 
 	// add genesis block to blockchain
-	bcc.db.Update(func(tx *bolt.Tx) error {
+	require.NoError(t, bcc.db.Update(func(tx *bolt.Tx) error {
 		return bcc.store.AddBlockWithTx(tx, &coin.SignedBlock{
 			Block: *gb,
 			Sig:   gbSig,
 		})
-	})
+	}))
 	return &coin.SignedBlock{
 		Block: *gb,
 		Sig:   gbSig,

--- a/src/visor/blockchain_test.go
+++ b/src/visor/blockchain_test.go
@@ -43,15 +43,18 @@ func makeFeeCalc(fee uint64) coin.FeeCalculator {
 	}
 }
 
-func addGenesisBlock(t *testing.T, bc *Blockchain) *coin.SignedBlock {
+func addGenesisBlock(t *testing.T, bc blockchainer) *coin.SignedBlock {
 	// create genesis block
 	gb, err := coin.NewGenesisBlock(genAddress, genCoins, genTime)
 	require.NoError(t, err)
 	gbSig := cipher.SignHash(gb.HashHeader(), genSecret)
 
+	bcc, ok := bc.(*Blockchain)
+	require.True(t, ok)
+
 	// add genesis block to blockchain
-	bc.db.Update(func(tx *bolt.Tx) error {
-		return bc.store.AddBlockWithTx(tx, &coin.SignedBlock{
+	bcc.db.Update(func(tx *bolt.Tx) error {
+		return bcc.store.AddBlockWithTx(tx, &coin.SignedBlock{
 			Block: *gb,
 			Sig:   gbSig,
 		})

--- a/src/visor/blockchainer_mock_test.go
+++ b/src/visor/blockchainer_mock_test.go
@@ -1,0 +1,354 @@
+/*
+* CODE GENERATED AUTOMATICALLY WITH github.com/ernesto-jimenez/goautomock
+* THIS FILE MUST NEVER BE EDITED MANUALLY
+ */
+
+package visor
+
+import (
+	"fmt"
+	mock "github.com/stretchr/testify/mock"
+
+	bolt "github.com/boltdb/bolt"
+	cipher "github.com/skycoin/skycoin/src/cipher"
+	coin "github.com/skycoin/skycoin/src/coin"
+	blockdb "github.com/skycoin/skycoin/src/visor/blockdb"
+)
+
+// blockchainerMock mock
+type blockchainerMock struct {
+	mock.Mock
+}
+
+func NewBlockchainerMock() *blockchainerMock {
+	return &blockchainerMock{}
+}
+
+// BindListener mocked method
+func (m *blockchainerMock) BindListener(p0 BlockListener) {
+
+	m.Called(p0)
+
+}
+
+// ExecuteBlockWithTx mocked method
+func (m *blockchainerMock) ExecuteBlockWithTx(p0 *bolt.Tx, p1 *coin.SignedBlock) error {
+
+	ret := m.Called(p0, p1)
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// GetBlockByHash mocked method
+func (m *blockchainerMock) GetBlockByHash(p0 cipher.SHA256) (*coin.SignedBlock, error) {
+
+	ret := m.Called(p0)
+
+	var r0 *coin.SignedBlock
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case *coin.SignedBlock:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// GetBlockBySeq mocked method
+func (m *blockchainerMock) GetBlockBySeq(p0 uint64) (*coin.SignedBlock, error) {
+
+	ret := m.Called(p0)
+
+	var r0 *coin.SignedBlock
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case *coin.SignedBlock:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// GetBlocks mocked method
+func (m *blockchainerMock) GetBlocks(p0 uint64, p1 uint64) []coin.SignedBlock {
+
+	ret := m.Called(p0, p1)
+
+	var r0 []coin.SignedBlock
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case []coin.SignedBlock:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// GetGenesisBlock mocked method
+func (m *blockchainerMock) GetGenesisBlock() *coin.SignedBlock {
+
+	ret := m.Called()
+
+	var r0 *coin.SignedBlock
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case *coin.SignedBlock:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// GetLastBlocks mocked method
+func (m *blockchainerMock) GetLastBlocks(p0 uint64) []coin.SignedBlock {
+
+	ret := m.Called(p0)
+
+	var r0 []coin.SignedBlock
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case []coin.SignedBlock:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// Head mocked method
+func (m *blockchainerMock) Head() (*coin.SignedBlock, error) {
+
+	ret := m.Called()
+
+	var r0 *coin.SignedBlock
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case *coin.SignedBlock:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// HeadSeq mocked method
+func (m *blockchainerMock) HeadSeq() uint64 {
+
+	ret := m.Called()
+
+	var r0 uint64
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case uint64:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// Len mocked method
+func (m *blockchainerMock) Len() uint64 {
+
+	ret := m.Called()
+
+	var r0 uint64
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case uint64:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// NewBlock mocked method
+func (m *blockchainerMock) NewBlock(p0 coin.Transactions, p1 uint64) (*coin.Block, error) {
+
+	ret := m.Called(p0, p1)
+
+	var r0 *coin.Block
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case *coin.Block:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// Notify mocked method
+func (m *blockchainerMock) Notify(p0 coin.Block) {
+
+	m.Called(p0)
+
+}
+
+// Time mocked method
+func (m *blockchainerMock) Time() uint64 {
+
+	ret := m.Called()
+
+	var r0 uint64
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case uint64:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// TransactionFee mocked method
+func (m *blockchainerMock) TransactionFee(p0 *coin.Transaction) (uint64, error) {
+
+	ret := m.Called(p0)
+
+	var r0 uint64
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case uint64:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// Unspent mocked method
+func (m *blockchainerMock) Unspent() blockdb.UnspentPool {
+
+	ret := m.Called()
+
+	var r0 blockdb.UnspentPool
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case blockdb.UnspentPool:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// UpdateDB mocked method
+func (m *blockchainerMock) UpdateDB(p0 func(tx *bolt.Tx) error) error {
+
+	ret := m.Called(p0)
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// VerifyTransaction mocked method
+func (m *blockchainerMock) VerifyTransaction(p0 coin.Transaction) error {
+
+	ret := m.Called(p0)
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}

--- a/src/visor/blockchainer_mock_test.go
+++ b/src/visor/blockchainer_mock_test.go
@@ -7,6 +7,7 @@ package visor
 
 import (
 	"fmt"
+
 	mock "github.com/stretchr/testify/mock"
 
 	bolt "github.com/boltdb/bolt"

--- a/src/visor/historydb/historydb.go
+++ b/src/visor/historydb/historydb.go
@@ -106,10 +106,7 @@ func (hd *HistoryDB) reset() error {
 		return err
 	}
 
-	if err := hd.txns.Reset(); err != nil {
-		return err
-	}
-	return nil
+	return hd.txns.Reset()
 }
 
 // GetUxout get UxOut of specific uxID.

--- a/src/visor/historydb/historydb.go
+++ b/src/visor/historydb/historydb.go
@@ -6,9 +6,8 @@ import (
 	"errors"
 
 	"github.com/boltdb/bolt"
-	"github.com/rencatoken/rnc/src/cipher/encoder"
-
 	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/cipher/encoder"
 	"github.com/skycoin/skycoin/src/coin"
 	"github.com/skycoin/skycoin/src/util/logging"
 )

--- a/src/visor/historydb/historydb.go
+++ b/src/visor/historydb/historydb.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"github.com/boltdb/bolt"
+	"github.com/rencatoken/rnc/src/cipher/encoder"
 
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/coin"
@@ -227,4 +228,16 @@ func (hd HistoryDB) GetAddrTxns(address cipher.Address) ([]Transaction, error) {
 	}
 
 	return hd.txns.GetSlice(hashes)
+}
+
+// ForEach traverses the transactions in db
+func (hd HistoryDB) ForEach(f func(tx *Transaction) error) error {
+	return hd.txns.bkt.ForEach(func(k []byte, v []byte) error {
+		var tx Transaction
+		if err := encoder.DeserializeRaw(v, &tx); err != nil {
+			return err
+		}
+
+		return f(&tx)
+	})
 }

--- a/src/visor/historyer_mock_test.go
+++ b/src/visor/historyer_mock_test.go
@@ -1,0 +1,231 @@
+/*
+* CODE GENERATED AUTOMATICALLY WITH github.com/ernesto-jimenez/goautomock
+* THIS FILE MUST NEVER BE EDITED MANUALLY
+ */
+
+package visor
+
+import (
+	"fmt"
+	mock "github.com/stretchr/testify/mock"
+
+	cipher "github.com/skycoin/skycoin/src/cipher"
+	coin "github.com/skycoin/skycoin/src/coin"
+	historydb "github.com/skycoin/skycoin/src/visor/historydb"
+)
+
+// historyerMock mock
+type historyerMock struct {
+	mock.Mock
+}
+
+func NewHistoryerMock() *historyerMock {
+	return &historyerMock{}
+}
+
+// ForEach mocked method
+func (m *historyerMock) ForEach(p0 func(tx *historydb.Transaction) error) error {
+
+	ret := m.Called(p0)
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// GetAddrTxns mocked method
+func (m *historyerMock) GetAddrTxns(p0 cipher.Address) ([]historydb.Transaction, error) {
+
+	ret := m.Called(p0)
+
+	var r0 []historydb.Transaction
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case []historydb.Transaction:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// GetAddrUxOuts mocked method
+func (m *historyerMock) GetAddrUxOuts(p0 cipher.Address) ([]*historydb.UxOut, error) {
+
+	ret := m.Called(p0)
+
+	var r0 []*historydb.UxOut
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case []*historydb.UxOut:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// GetLastTxs mocked method
+func (m *historyerMock) GetLastTxs() ([]*historydb.Transaction, error) {
+
+	ret := m.Called()
+
+	var r0 []*historydb.Transaction
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case []*historydb.Transaction:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// GetTransaction mocked method
+func (m *historyerMock) GetTransaction(p0 cipher.SHA256) (*historydb.Transaction, error) {
+
+	ret := m.Called(p0)
+
+	var r0 *historydb.Transaction
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case *historydb.Transaction:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// GetUxout mocked method
+func (m *historyerMock) GetUxout(p0 cipher.SHA256) (*historydb.UxOut, error) {
+
+	ret := m.Called(p0)
+
+	var r0 *historydb.UxOut
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case *historydb.UxOut:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// ParseBlock mocked method
+func (m *historyerMock) ParseBlock(p0 *coin.Block) error {
+
+	ret := m.Called(p0)
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// ParsedHeight mocked method
+func (m *historyerMock) ParsedHeight() int64 {
+
+	ret := m.Called()
+
+	var r0 int64
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case int64:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// ResetIfNeed mocked method
+func (m *historyerMock) ResetIfNeed() error {
+
+	ret := m.Called()
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}

--- a/src/visor/historyer_mock_test.go
+++ b/src/visor/historyer_mock_test.go
@@ -7,6 +7,7 @@ package visor
 
 import (
 	"fmt"
+
 	mock "github.com/stretchr/testify/mock"
 
 	cipher "github.com/skycoin/skycoin/src/cipher"

--- a/src/visor/unconfirmed.go
+++ b/src/visor/unconfirmed.go
@@ -246,8 +246,8 @@ type UnconfirmedTxnPool struct {
 	unspent *txUnspents
 }
 
-// newUnconfirmedTxnPool creates an UnconfirmedTxnPool instance
-func newUnconfirmedTxnPool(db *bolt.DB) *UnconfirmedTxnPool {
+// NewUnconfirmedTxnPool creates an UnconfirmedTxnPool instance
+func NewUnconfirmedTxnPool(db *bolt.DB) *UnconfirmedTxnPool {
 	return &UnconfirmedTxnPool{
 		txns:    newUncfmTxBkt(db),
 		unspent: newTxUnspents(db),

--- a/src/visor/unconfirmed.go
+++ b/src/visor/unconfirmed.go
@@ -275,7 +275,7 @@ func (utp *UnconfirmedTxnPool) createUnconfirmedTxn(t coin.Transaction) Unconfir
 // InjectTxn adds a coin.Transaction to the pool, or updates an existing one's timestamps
 // Returns an error if txn is invalid, and whether the transaction already
 // existed in the pool.
-func (utp *UnconfirmedTxnPool) InjectTxn(bc blockchainer, t coin.Transaction) (bool, error) {
+func (utp *UnconfirmedTxnPool) InjectTxn(bc Blockchainer, t coin.Transaction) (bool, error) {
 	f, err := bc.TransactionFee(&t)
 	if err != nil {
 		return false, err
@@ -374,7 +374,7 @@ func (utp *UnconfirmedTxnPool) RemoveTransactionsWithTx(tx *bolt.Tx, txns []ciph
 
 // Refresh checks all unconfirmed txns against the blockchain.
 // verify the transaction and returns all those txns that turn to valid.
-func (utp *UnconfirmedTxnPool) Refresh(bc blockchainer) (hashes []cipher.SHA256) {
+func (utp *UnconfirmedTxnPool) Refresh(bc Blockchainer) (hashes []cipher.SHA256) {
 	now := utc.Now()
 	utp.txns.rangeUpdate(func(key cipher.SHA256, tx *UnconfirmedTxn) {
 		tx.Checked = now.UnixNano()

--- a/src/visor/unconfirmed_txn_pooler_mock_test.go
+++ b/src/visor/unconfirmed_txn_pooler_mock_test.go
@@ -1,0 +1,373 @@
+/*
+* CODE GENERATED AUTOMATICALLY WITH github.com/ernesto-jimenez/goautomock
+* THIS FILE MUST NEVER BE EDITED MANUALLY
+ */
+
+package visor
+
+import (
+	"fmt"
+	mock "github.com/stretchr/testify/mock"
+
+	bolt "github.com/boltdb/bolt"
+	cipher "github.com/skycoin/skycoin/src/cipher"
+	coin "github.com/skycoin/skycoin/src/coin"
+	blockdb "github.com/skycoin/skycoin/src/visor/blockdb"
+	time "time"
+)
+
+// UnconfirmedTxnPoolerMock mock
+type UnconfirmedTxnPoolerMock struct {
+	mock.Mock
+}
+
+func NewUnconfirmedTxnPoolerMock() *UnconfirmedTxnPoolerMock {
+	return &UnconfirmedTxnPoolerMock{}
+}
+
+// FilterKnown mocked method
+func (m *UnconfirmedTxnPoolerMock) FilterKnown(p0 []cipher.SHA256) []cipher.SHA256 {
+
+	ret := m.Called(p0)
+
+	var r0 []cipher.SHA256
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case []cipher.SHA256:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// ForEach mocked method
+func (m *UnconfirmedTxnPoolerMock) ForEach(p0 func(cipher.SHA256, *UnconfirmedTxn) error) error {
+
+	ret := m.Called(p0)
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// Get mocked method
+func (m *UnconfirmedTxnPoolerMock) Get(p0 cipher.SHA256) (*UnconfirmedTxn, bool) {
+
+	ret := m.Called(p0)
+
+	var r0 *UnconfirmedTxn
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case *UnconfirmedTxn:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 bool
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case bool:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// GetIncomingOutputs mocked method
+func (m *UnconfirmedTxnPoolerMock) GetIncomingOutputs(p0 coin.BlockHeader) coin.UxArray {
+
+	ret := m.Called(p0)
+
+	var r0 coin.UxArray
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case coin.UxArray:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// GetKnown mocked method
+func (m *UnconfirmedTxnPoolerMock) GetKnown(p0 []cipher.SHA256) coin.Transactions {
+
+	ret := m.Called(p0)
+
+	var r0 coin.Transactions
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case coin.Transactions:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// GetSpendingOutputs mocked method
+func (m *UnconfirmedTxnPoolerMock) GetSpendingOutputs(p0 blockdb.UnspentPool) (coin.UxArray, error) {
+
+	ret := m.Called(p0)
+
+	var r0 coin.UxArray
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case coin.UxArray:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// GetTxHashes mocked method
+func (m *UnconfirmedTxnPoolerMock) GetTxHashes(p0 func(tx UnconfirmedTxn) bool) []cipher.SHA256 {
+
+	ret := m.Called(p0)
+
+	var r0 []cipher.SHA256
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case []cipher.SHA256:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// GetTxns mocked method
+func (m *UnconfirmedTxnPoolerMock) GetTxns(p0 func(tx UnconfirmedTxn) bool) []UnconfirmedTxn {
+
+	ret := m.Called(p0)
+
+	var r0 []UnconfirmedTxn
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case []UnconfirmedTxn:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// GetUnspentsOfAddr mocked method
+func (m *UnconfirmedTxnPoolerMock) GetUnspentsOfAddr(p0 cipher.Address) coin.UxArray {
+
+	ret := m.Called(p0)
+
+	var r0 coin.UxArray
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case coin.UxArray:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// InjectTxn mocked method
+func (m *UnconfirmedTxnPoolerMock) InjectTxn(p0 blockchainer, p1 coin.Transaction) (bool, error) {
+
+	ret := m.Called(p0, p1)
+
+	var r0 bool
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case bool:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// Len mocked method
+func (m *UnconfirmedTxnPoolerMock) Len() int {
+
+	ret := m.Called()
+
+	var r0 int
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case int:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// RawTxns mocked method
+func (m *UnconfirmedTxnPoolerMock) RawTxns() coin.Transactions {
+
+	ret := m.Called()
+
+	var r0 coin.Transactions
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case coin.Transactions:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// RecvOfAddresses mocked method
+func (m *UnconfirmedTxnPoolerMock) RecvOfAddresses(p0 coin.BlockHeader, p1 []cipher.Address) (coin.AddressUxOuts, error) {
+
+	ret := m.Called(p0, p1)
+
+	var r0 coin.AddressUxOuts
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case coin.AddressUxOuts:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// Refresh mocked method
+func (m *UnconfirmedTxnPoolerMock) Refresh(p0 blockchainer) []cipher.SHA256 {
+
+	ret := m.Called(p0)
+
+	var r0 []cipher.SHA256
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case []cipher.SHA256:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// RemoveTransactions mocked method
+func (m *UnconfirmedTxnPoolerMock) RemoveTransactions(p0 []cipher.SHA256) {
+
+	m.Called(p0)
+
+}
+
+// RemoveTransactionsWithTx mocked method
+func (m *UnconfirmedTxnPoolerMock) RemoveTransactionsWithTx(p0 *bolt.Tx, p1 []cipher.SHA256) {
+
+	m.Called(p0, p1)
+
+}
+
+// SetAnnounced mocked method
+func (m *UnconfirmedTxnPoolerMock) SetAnnounced(p0 cipher.SHA256, p1 time.Time) error {
+
+	ret := m.Called(p0, p1)
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// SpendsOfAddresses mocked method
+func (m *UnconfirmedTxnPoolerMock) SpendsOfAddresses(p0 []cipher.Address, p1 blockdb.UnspentGetter) (coin.AddressUxOuts, error) {
+
+	ret := m.Called(p0, p1)
+
+	var r0 coin.AddressUxOuts
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case coin.AddressUxOuts:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}

--- a/src/visor/unconfirmed_txn_pooler_mock_test.go
+++ b/src/visor/unconfirmed_txn_pooler_mock_test.go
@@ -7,13 +7,15 @@ package visor
 
 import (
 	"fmt"
+
 	mock "github.com/stretchr/testify/mock"
+
+	time "time"
 
 	bolt "github.com/boltdb/bolt"
 	cipher "github.com/skycoin/skycoin/src/cipher"
 	coin "github.com/skycoin/skycoin/src/coin"
 	blockdb "github.com/skycoin/skycoin/src/visor/blockdb"
-	time "time"
 )
 
 // UnconfirmedTxnPoolerMock mock

--- a/src/visor/unconfirmed_txn_pooler_mock_test.go
+++ b/src/visor/unconfirmed_txn_pooler_mock_test.go
@@ -208,7 +208,7 @@ func (m *UnconfirmedTxnPoolerMock) GetUnspentsOfAddr(p0 cipher.Address) coin.UxA
 }
 
 // InjectTxn mocked method
-func (m *UnconfirmedTxnPoolerMock) InjectTxn(p0 blockchainer, p1 coin.Transaction) (bool, error) {
+func (m *UnconfirmedTxnPoolerMock) InjectTxn(p0 Blockchainer, p1 coin.Transaction) (bool, error) {
 
 	ret := m.Called(p0, p1)
 
@@ -298,7 +298,7 @@ func (m *UnconfirmedTxnPoolerMock) RecvOfAddresses(p0 coin.BlockHeader, p1 []cip
 }
 
 // Refresh mocked method
-func (m *UnconfirmedTxnPoolerMock) Refresh(p0 blockchainer) []cipher.SHA256 {
+func (m *UnconfirmedTxnPoolerMock) Refresh(p0 Blockchainer) []cipher.SHA256 {
 
 	ret := m.Called(p0)
 

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -175,7 +175,7 @@ type historyer interface {
 }
 
 // Blockchainer is the interface that provides methods for accessing the blockchain data
-type blockchainer interface {
+type Blockchainer interface {
 	GetGenesisBlock() *coin.SignedBlock
 	GetBlocks(start, end uint64) []coin.SignedBlock
 	GetLastBlocks(n uint64) []coin.SignedBlock
@@ -199,11 +199,11 @@ type blockchainer interface {
 // accessing the unconfirmed transaction pool
 type UnconfirmedTxnPooler interface {
 	SetAnnounced(hash cipher.SHA256, t time.Time) error
-	InjectTxn(bc blockchainer, t coin.Transaction) (bool, error)
+	InjectTxn(bc Blockchainer, t coin.Transaction) (bool, error)
 	RawTxns() coin.Transactions
 	RemoveTransactions(txns []cipher.SHA256)
 	RemoveTransactionsWithTx(tx *bolt.Tx, txns []cipher.SHA256)
-	Refresh(bc blockchainer) []cipher.SHA256
+	Refresh(bc Blockchainer) []cipher.SHA256
 	FilterKnown(txns []cipher.SHA256) []cipher.SHA256
 	GetKnown(txns []cipher.SHA256) coin.Transactions
 	RecvOfAddresses(bh coin.BlockHeader, addrs []cipher.Address) (coin.AddressUxOuts, error)
@@ -223,7 +223,7 @@ type Visor struct {
 	Config Config
 	// Unconfirmed transactions, held for relay until we get block confirmation
 	Unconfirmed UnconfirmedTxnPooler
-	Blockchain  blockchainer
+	Blockchain  Blockchainer
 	history     historyer
 	bcParser    *BlockchainParser
 	wallets     *wallet.Service

--- a/src/visor/visor_test.go
+++ b/src/visor/visor_test.go
@@ -384,3 +384,7 @@ func TestVisorCalculatePrecision(t *testing.T) {
 		calculateDivisor(7)
 	})
 }
+
+func TestGetTransctionsOfAddrs(t *testing.T) {
+
+}


### PR DESCRIPTION
Add `/transactions` endpoint, which can be used to query multiple addresses related transactions.
example:
1. Get all addresses related transactions, return all transactions if $addrs is not provided:
```
/transactions?addrs=$addrs
```
2. Get addresses related confirmed transactions:
```
/transactions?addrs=$addrs&confirmed=1
```
3. Get addresses related unconfirmed transactions:
```
/transactions?addrs=$addrs&confirmed=0
```

**TODO:**

- [x] Write test code