### PR TITLE
Do not allow user to press send button if form is not valid.

### DIFF
--- a/src/gui/static/karma.conf.js
+++ b/src/gui/static/karma.conf.js
@@ -4,12 +4,13 @@
 module.exports = function (config) {
   config.set({
     basePath: '',
-    frameworks: ['jasmine', '@angular/cli'],
+    frameworks: ['jasmine', '@angular/cli', 'sinon'],
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
+      require('karma-sinon'),
       require('@angular/cli/plugins/karma')
     ],
     client:{

--- a/src/gui/static/package.json
+++ b/src/gui/static/package.json
@@ -47,7 +47,9 @@
     "karma-coverage-istanbul-reporter": "^1.2.1",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
+    "karma-sinon": "1.0.5",
     "protractor": "~5.1.2",
+    "sinon": "4.1.4",
     "ts-node": "~3.2.0",
     "tslint": "~5.7.0",
     "typescript": "~2.4.2"

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-skycoin.component.spec.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-skycoin.component.spec.ts
@@ -1,25 +1,155 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import * as sinon from 'sinon';
+import { async, inject, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { HttpModule, XHRBackend } from '@angular/http';
+import { MdCardModule, MdMenuModule, MdSelectModule, MdSnackBarModule, MdTooltipModule } from '@angular/material';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MockBackend } from '@angular/http/testing';
 
+import { NgxDatatableModule } from '@swimlane/ngx-datatable';
+import { ButtonComponent } from '../../layout/button/button.component';
+import { HeaderComponent } from '../../layout/header/header.component';
+import { NavBarComponent } from '../../layout/header/nav-bar/nav-bar.component';
+import { TopBarComponent } from '../../layout/header/top-bar/top-bar.component';
 import { SendSkycoinComponent } from './send-skycoin.component';
+import { DateTimePipe } from '../../../pipes/date-time.pipe';
+import { ApiService } from '../../../services/api.service';
+import { PriceService } from '../../../price.service';
+import { WalletService } from '../../../services/wallet.service';
 
 describe('SendSkycoinComponent', () => {
   let component: SendSkycoinComponent;
+  let mockBackend: MockBackend;
   let fixture: ComponentFixture<SendSkycoinComponent>;
+  let sendButton: any;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SendSkycoinComponent ]
+      declarations: [
+        ButtonComponent,
+        DateTimePipe,
+        HeaderComponent,
+        NavBarComponent,
+        SendSkycoinComponent,
+        TopBarComponent
+      ],
+      imports: [
+        HttpModule,
+        MdCardModule,
+        MdMenuModule,
+        MdSelectModule,
+        MdSnackBarModule,
+        MdTooltipModule,
+        NgxDatatableModule,
+        NoopAnimationsModule,
+        ReactiveFormsModule,
+        RouterTestingModule
+      ],
+      providers: [
+        ApiService,
+        PriceService,
+        WalletService,
+        { provide: XHRBackend, useClass: MockBackend }
+      ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
-  beforeEach(() => {
+  beforeEach(inject([XHRBackend], (backend: MockBackend) => {
+    mockBackend = backend;
     fixture = TestBed.createComponent(SendSkycoinComponent);
     component = fixture.componentInstance;
+    component.ngOnInit();
     fixture.detectChanges();
+
+    sendButton = fixture.debugElement.nativeElement.querySelector('app-button');
+  }));
+
+  afterEach(() => {
+    fixture.destroy();
   });
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('send should not make any backend call if wallet is not chosen', () => {
+    const backendCallSpy = sinon.spy();
+    mockBackend.connections.subscribe(backendCallSpy);
+
+    fixture.detectChanges();
+    component.button.onClick();
+
+    sinon.assert.notCalled(backendCallSpy);
+  });
+
+  it('send should not make any backend call if address is not set', () => {
+    const backendCallSpy = sinon.spy();
+    mockBackend.connections.subscribe(backendCallSpy);
+
+    component.form.controls.wallet.setValue({
+      meta: { filename: 'test' },
+      balance: 1000000
+    });
+
+    fixture.detectChanges();
+    component.button.onClick();
+
+    sinon.assert.notCalled(backendCallSpy);
+  });
+
+  it('send should not make any backend call if amount is not set', () => {
+    const backendCallSpy = sinon.spy();
+    mockBackend.connections.subscribe(backendCallSpy);
+
+    component.form.controls.wallet.setValue({
+      meta: { filename: 'test' },
+      balance: 1000000
+    });
+    component.form.controls.address.setValue('0xABC');
+
+    fixture.detectChanges();
+    component.button.onClick();
+
+    sinon.assert.notCalled(backendCallSpy);
+  });
+
+  it('send should not make any backend call if amount exceeds balance', () => {
+    const backendCallSpy = sinon.spy();
+    mockBackend.connections.subscribe(backendCallSpy);
+
+    component.form.controls.wallet.setValue({
+      meta: { filename: 'test' },
+      balance: 1000000
+    });
+    component.form.controls.address.setValue('0xABC');
+    component.form.controls.amount.setValue(2);
+
+    fixture.detectChanges();
+    component.button.onClick();
+
+    sinon.assert.notCalled(backendCallSpy);
+  });
+
+  it('send should make backend call if send form is valid', () => {
+    let request;
+    mockBackend.connections.subscribe((connection) => {
+      request = connection.request;
+    });
+
+    component.form.controls.wallet.setValue({
+      filename: 'test',
+      coins: 100000
+    });
+    component.form.controls.address.setValue('0xABC');
+    component.form.controls.amount.setValue(1);
+
+    fixture.detectChanges();
+    component.button.onClick();
+
+    expect(request).toBeDefined();
+    expect(request.url).toBe('http://127.0.0.1:6420/wallet/spend?');
+    expect(request.getBody()).toBe('id=test&dst=0xABC&coins=1000000');
   });
 });

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-skycoin.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-skycoin.component.ts
@@ -29,8 +29,12 @@ export class SendSkycoinComponent implements OnInit {
   }
 
   send() {
+    const wallet = this.form.value.wallet;
+    const addressToSend = this.form.value.address;
+    const amountToSend = this.form.value.amount * 1000000;
+
     this.button.setLoading();
-    this.walletService.sendSkycoin(this.form.value.wallet, this.form.value.address, this.form.value.amount * 1000000)
+    this.walletService.sendSkycoin(wallet, addressToSend, amountToSend)
       .delay(1000)
       .subscribe(
         () => {

--- a/src/gui/static/src/app/components/pages/wallets/load-wallet/load-wallet.component.spec.ts
+++ b/src/gui/static/src/app/components/pages/wallets/load-wallet/load-wallet.component.spec.ts
@@ -1,20 +1,20 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { CreateWalletComponent } from './create-wallet.component';
+import { LoadWalletComponent } from './load-wallet.component';
 
-describe('CreateWalletComponent', () => {
-  let component: CreateWalletComponent;
-  let fixture: ComponentFixture<CreateWalletComponent>;
+describe('LoadWalletComponent', () => {
+  let component: LoadWalletComponent;
+  let fixture: ComponentFixture<LoadWalletComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ CreateWalletComponent ]
+      declarations: [ LoadWalletComponent ]
     })
     .compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(CreateWalletComponent);
+    fixture = TestBed.createComponent(LoadWalletComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });


### PR DESCRIPTION
@gz-c, currently user is able to press send button even if it looks like disabled + user can press send button once again even if previous send operation hasn't completed yet that may have quite bad consequences. `Send` is one of the critical parts of any crypto wallet so here shouldn't be any confusion at all.

I've fixed existing `SendSkycoinComponent` test and added few more. Most of the GUI tests  in Sky Wallet are red now, I'm planing to revive them if it's useful for you, let me know if it's.

---
_Donation is not required, but highly appreciated (in case you find PR useful of course)._

_Skycoin Wallet:_ `JFNp1Dt82L3mZe2xuzjpmEvGNuVBoCZFRv`