### PR TITLE
advanced spend builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- #864, Add `advancedSend` cli command
 - #800, Add entropy parameter to `/wallet/newSeed` endpoint
 - #877, Add -disable-wallet-api CLI option
 - Add `total_coinhour_supply` and `current_coinhour_supply` to `/coinSupply` endpoint
 - Remove `/logs` and log buffering due to possible crash
 - Add `Host` header check to localhost HTTP interfaces to prevent DNS rebinding attacks
 - #866, Include coins and hours in `/explorer/address` inputs
-- #864, Add `advancedSend` cli command
-
->>>>>>> Update changelog and readme
 
 ## [0.21.1] - 2017-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Remove `/logs` and log buffering due to possible crash
 - Add `Host` header check to localhost HTTP interfaces to prevent DNS rebinding attacks
 - #866, Include coins and hours in `/explorer/address` inputs
+- #864, Add `advancedSend` cli command
+
+>>>>>>> Update changelog and readme
 
 ## [0.21.1] - 2017-12-14
 

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -143,16 +143,29 @@ Use `skycoin-cli send -h` to see the subcommand usage.
 ### Advanced send
 
 ```bash
-$ skycoin-cli advancedSend -s $coinhours_distribute -u $unspent_hash $recipient_address $amount
+$ skycoin-cli advancedSend -$a $from_address $recipient_address $amount $hours
 ```
 
-The above `advancedSend` command will send coins from your node's default wallet: `$HOME/.skycoin/wallets/skycoin_cli.wlt` if it has `$unspent_hash`. 
-It willt send `$coinhours_distribute` to `$recipient_address`
+The above `advancedSend` command will send `$amount` coins and `$hours` coinhours from your node's default wallet: `$HOME/.skycoin/wallets/skycoin_cli.wlt`
+
 You can also send from the wallet as you want, just use the `-f` option flag, example:
-
 ```bash
-$ skycoin-cli advancedSend -f $WALLET_PATH -a $from_address -s $coinhours_distribute -u $unspent_hash $recipient_address $amount
+$ skycoin-cli advancedSend -f $WALLET_PATH -a $from_addresses -u $unspent_hashes $recipient_address $amount $hours
 ```
+
+The above `advancedSend` command will send `$amount` coins and `$hours` coinhours from wallet defined by `$WALLET_PATH`
+if the `$from_addresses` have an unspent hash from `$unspent_hashes`. 
+
+
+To send to multiple addresses use the `-m` flag, example:
+```bash
+$ skycoin-cli advancedSend -f $WALLET_PATH -a $from_addresses -u $unspent_hashes -m '[{"addr":"$addr1", "coins": "$amt1", "hours": "$hours1"}, {"addr":"$addr1", "coins": "$amt2"}]'
+```
+
+The above `advancedSend` command will send the coins and hours as defined by the `-m` flag
+if the `$from_addresses` have an unspent hash from `$unspent_hashes`. 
+
+#####Note: default value for `hours` is 0
 
 Use `skycoin-cli advancedSend -h` to see the subcommand usage.
 

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -86,32 +86,37 @@ USAGE:
    skycoin-cli [global options] command [command options] [arguments...]
 
 VERSION:
-   0.1
+   0.21.1
 
 COMMANDS:
      addPrivateKey         Add a private key to specific wallet
+     addressBalance        Check the balance of specific addresses
+     addressGen            Generate skycoin or bitcoin addresses
+     addressOutputs        Display outputs of specific addresses
      blocks                Lists the content of a single block or a range of blocks
      broadcastTransaction  Broadcast a raw transaction to the network
-     walletBalance         Check the balance of a wallet
-     walletOutputs         Display outputs of specific wallet
-     addressBalance        Check the balance of specific addresses
-     addressOutputs        Display outputs of specific addresses
      createRawTransaction  Create a raw transaction to be broadcast to the network later
+     decodeRawTransaction  Decode raw transaction
      generateAddresses     Generate additional addresses for a wallet
      generateWallet        Generate a new wallet
      lastBlocks            Displays the content of the most recently N generated blocks
      listAddresses         Lists all addresses in a given wallet
-     listWallets           Lists all wallets stored in the default wallet directory
+     listWallets           Lists all wallets stored in the wallet directory
      send                  Send skycoin from a wallet or an address to a recipient address
+     advancedSend          Create a custom send transaction from a wallet or address to a recipient address
      status                Check the status of current skycoin node
      transaction           Show detail info of specific transaction
      version
+     walletBalance         Check the balance of a wallet
      walletDir             Displays wallet folder address
-     walletHistory         Display the transaction history of specific wallet
+     walletHistory         Display the transaction history of specific wallet. Requires skycoin node rpc.
+     walletOutputs         Display outputs of specific wallet
+     checkdb               Verify the database
+     verifyAddress         Verify a skycoin address
      help, h               Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --help, -h     show help, can also be used to show subcommand help
+   --help, -h     show help
    --version, -v  print the version
 ENVIRONMENT VARIABLES:
     RPC_ADDR: Address of RPC node. Default "127.0.0.1:6430"
@@ -134,6 +139,22 @@ $ skycoin-cli send -f $WALLET_PATH $recipient_address $amount
 ```
 
 Use `skycoin-cli send -h` to see the subcommand usage.
+
+### Advanced send
+
+```bash
+$ skycoin-cli advancedSend -s $coinhours_distribute -u $unspent_hash $recipient_address $amount
+```
+
+The above `advancedSend` command will send coins from your node's default wallet: `$HOME/.skycoin/wallets/skycoin_cli.wlt` if it has `$unspent_hash`. 
+It willt send `$coinhours_distribute` to `$recipient_address`
+You can also send from the wallet as you want, just use the `-f` option flag, example:
+
+```bash
+$ skycoin-cli advancedSend -f $WALLET_PATH -a $from_address -s $coinhours_distribute -u $unspent_hash $recipient_address $amount
+```
+
+Use `skycoin-cli advancedSend -h` to see the subcommand usage.
 
 ### Check address balance
 

--- a/src/api/cli/cli.go
+++ b/src/api/cli/cli.go
@@ -220,6 +220,7 @@ func NewApp(cfg Config) *App {
 		listAddressesCmd(),
 		listWalletsCmd(),
 		sendCmd(),
+		advancedSendCmd(),
 		statusCmd(),
 		transactionCmd(),
 		versionCmd(),

--- a/src/api/cli/cli.go
+++ b/src/api/cli/cli.go
@@ -213,6 +213,7 @@ func NewApp(cfg Config) *App {
 		blocksCmd(),
 		broadcastTxCmd(),
 		createRawTxCmd(cfg),
+		createAdvancedRawTxCmd(cfg),
 		decodeRawTxCmd(),
 		generateAddrsCmd(cfg),
 		generateWalletCmd(cfg),

--- a/src/api/cli/create_advanced_rawtx.go
+++ b/src/api/cli/create_advanced_rawtx.go
@@ -327,10 +327,7 @@ func advancedCreateRawTx(uxouts visor.ReadableOutputSet, wlt *wallet.Wallet, chg
 		return nil, err
 	}
 
-	tx, err := NewTransaction(outs, keys, txOuts)
-	if err != nil {
-		return nil, err
-	}
+	tx := NewTransaction(outs, keys, txOuts)
 
 	return tx, nil
 }

--- a/src/api/cli/create_advanced_rawtx.go
+++ b/src/api/cli/create_advanced_rawtx.go
@@ -1,0 +1,386 @@
+package cli
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/skycoin/skycoin/src/util/droplet"
+	"github.com/skycoin/skycoin/src/util/fee"
+
+	"github.com/skycoin/skycoin/src/api/webrpc"
+	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/coin"
+	"github.com/skycoin/skycoin/src/visor"
+	"github.com/skycoin/skycoin/src/wallet"
+
+	"strconv"
+
+	gcli "github.com/urfave/cli"
+)
+
+// AdvancedSendAmount represents the coins and hours to send to an address
+type AdvancedSendAmount struct {
+	Addr  string
+	Coins uint64
+	Hours uint64
+}
+
+type advancedSendAmountJSON struct {
+	Addr  string `json:"addr"`
+	Coins string `json:"coins"`
+	Hours string `json:"hours"`
+}
+
+type walletAddresses struct {
+	Wallet  string
+	Address []string
+}
+
+func fromWalletOrAddresses(c *gcli.Context) (walletAddresses, error) {
+	cfg := ConfigFromContext(c)
+
+	wlt, err := resolveWalletPath(cfg, c.String("f"))
+	if err != nil {
+		return walletAddresses{}, err
+	}
+
+	wltAddr := walletAddresses{
+		Wallet: wlt,
+	}
+
+	addrs := c.String("a")
+	if addrs == "" {
+		return wltAddr, nil
+	}
+
+	wltAddr.Address = strings.Split(addrs, ",")
+	for _, addr := range wltAddr.Address {
+		_, err := cipher.DecodeBase58Address(addr)
+		if err != nil {
+			return walletAddresses{}, fmt.Errorf("invalid address: %s", addr)
+		}
+	}
+	return wltAddr, nil
+}
+
+func createAdvancedRawTxCmd(cfg Config) gcli.Command {
+	name := "createAdvancedRawTransaction"
+	return gcli.Command{
+		Name:      name,
+		Usage:     "Create an advanced raw transaction to be broadcast to the network later",
+		ArgsUsage: "[to address] [amount]",
+		Description: `
+		Note: the [amount] argument is the coins you will spend, 1 coins = 1e6 droplets.`,
+		Flags: []gcli.Flag{
+			gcli.StringFlag{
+				Name:  "f",
+				Usage: "[wallet file or path] From wallet. If no path is specified your default wallet path will be used.",
+			},
+			gcli.StringFlag{
+				Name: "a",
+				Usage: `[address] From address(es)
+				example: -a cGPHG23We5otc5ME7EqPNKnzZe7CVm3Fjx,2E88wjND2uLGM6QCXpEDEJ29RuScXZVRLJW`,
+			},
+			gcli.StringFlag{
+				Name:  "c",
+				Usage: `[changeAddress] Specify change address, by default the from address with most coins is used`,
+			},
+			gcli.StringFlag{
+				Name: "u",
+				Usage: `[unspent address hashes] hash of unspent address(es) to use in the transaction, for multiple separate using a comma
+				example: -u "7a1555d60ec1d2a8861376d4b028b321dd9c7d6b438fb628d0ec2e675d91afcb, 4e905cffbbfe0f0f4b7c62bb6c1419ad74fc923eb2d60c239d1f4cf92dce3c5e"`,
+			},
+			gcli.StringFlag{
+				Name: "m",
+				Usage: `[send to many] use JSON string to set multiple recive addresses and coins,
+				example: -m '[{"addr":"$addr1", "coins": "10.2", "hours": "2"}, {"addr":"$addr2", "coins": "20"}]'`,
+			},
+			gcli.BoolFlag{
+				Name:  "json,j",
+				Usage: "Returns the results in JSON format.",
+			},
+		},
+		OnUsageError: onCommandUsageError(name),
+		Action: func(c *gcli.Context) error {
+			tx, err := createAdvancedRawTxCmdHandler(c)
+			if err != nil {
+				errorWithHelp(c, err)
+				return nil
+			}
+
+			rawTx := hex.EncodeToString(tx.Serialize())
+
+			if c.Bool("json") {
+				return printJson(struct {
+					RawTx string `json:"rawtx"`
+				}{
+					RawTx: rawTx,
+				})
+			}
+
+			fmt.Println(rawTx)
+			return nil
+		},
+	}
+	// Commands = append(Commands, cmd)
+}
+
+func createAdvancedRawTxCmdHandler(c *gcli.Context) (*coin.Transaction, error) {
+	rpcClient := RpcClientFromContext(c)
+
+	wltAddr, err := fromWalletOrAddresses(c)
+	if err != nil {
+		return nil, err
+	}
+
+	chgAddr, err := getChangeAddress(wltAddr, c.String("c"))
+	if err != nil {
+		return nil, err
+	}
+
+	toAddrs, err := advancedGetToAddresses(c)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validateSendAmounts(toAddrs); err != nil {
+		return nil, err
+	}
+
+	// hashes of unspent outputs to spend from
+	var uxOutHashes = c.String("u")
+	var allowedUxOuts []string
+
+	if uxOutHashes != "" {
+		allowedUxOuts = strings.Split(uxOutHashes, ",")
+	}
+
+	if wltAddr.Address == nil {
+		return AdvancedCreateRawTxFromWallet(rpcClient, wltAddr.Wallet, chgAddr, toAddrs, allowedUxOuts)
+	}
+
+	return AdvancedCreateRawTxFromAddress(rpcClient, wltAddr.Wallet, chgAddr, wltAddr.Address, toAddrs, allowedUxOuts)
+}
+
+func advancedGetToAddresses(c *gcli.Context) ([]AdvancedSendAmount, error) {
+	m := c.String("m")
+	if m != "" {
+		var sas []advancedSendAmountJSON
+		if err := json.NewDecoder(strings.NewReader(m)).Decode(&sas); err != nil {
+			return nil, fmt.Errorf("invalid -m flag string, err:%v", err)
+		}
+		sendAmts := make([]AdvancedSendAmount, 0, len(sas))
+		for _, sa := range sas {
+			amt, err := droplet.FromString(sa.Coins)
+			if err != nil {
+				return nil, fmt.Errorf("invalid coins value in -m flag string: %v", err)
+			}
+
+			var hours uint64
+			if sa.Hours != "" {
+				hours, err = strconv.ParseUint(sa.Hours, 10, 0)
+				if err != nil {
+					return nil, fmt.Errorf("invalid coinhours in -m flag string: %v", err)
+				}
+			}
+			sendAmts = append(sendAmts, AdvancedSendAmount{
+				Addr:  sa.Addr,
+				Coins: amt,
+				Hours: hours,
+			})
+		}
+		return sendAmts, nil
+	}
+
+	if c.NArg() < 2 {
+		return nil, errors.New("invalid argument")
+	}
+
+	toAddr := c.Args().First()
+	// validate address
+	if _, err := cipher.DecodeBase58Address(toAddr); err != nil {
+		return nil, err
+	}
+
+	amt, err := getAmount(c)
+	if err != nil {
+		return nil, err
+	}
+
+	hours, err := getHours(c)
+	if err != nil {
+		return nil, err
+	}
+
+	// no hours given
+	return []AdvancedSendAmount{{toAddr, amt, hours}}, nil
+}
+
+func AdvancedCreateRawTxFromWallet(c *webrpc.Client, walletFile, chgAddr string, toAddrs []AdvancedSendAmount, allowedUxOuts []string) (*coin.Transaction, error) {
+	// check change address
+	cAddr, err := cipher.DecodeBase58Address(chgAddr)
+	if err != nil {
+		return nil, ErrAddress
+	}
+
+	// check if the change address is in wallet.
+	wlt, err := wallet.Load(walletFile)
+	if err != nil {
+		return nil, err
+	}
+
+	_, ok := wlt.GetEntry(cAddr)
+	if !ok {
+		return nil, fmt.Errorf("change address %v is not in wallet", chgAddr)
+	}
+
+	// get all address in the wallet
+	totalAddrs := wlt.GetAddresses()
+	addrStrArray := make([]string, len(totalAddrs))
+	for i, a := range totalAddrs {
+		addrStrArray[i] = a.String()
+	}
+
+	return AdvancedCreateRawTx(c, wlt, addrStrArray, chgAddr, toAddrs, allowedUxOuts)
+}
+
+func AdvancedCreateRawTxFromAddress(c *webrpc.Client, walletFile, chgAddr string, fromAddrs []string, toAddrs []AdvancedSendAmount, allowedUxOuts []string) (*coin.Transaction, error) {
+	// check if the address is in the default wallet.
+	wlt, err := wallet.Load(walletFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check that from addresses are in the wallet
+	for _, addr := range fromAddrs {
+		srcAddr, err := cipher.DecodeBase58Address(addr)
+		if err != nil {
+			return nil, ErrAddress
+		}
+
+		_, ok := wlt.GetEntry(srcAddr)
+		if !ok {
+			return nil, fmt.Errorf("%v address is not in wallet", addr)
+		}
+
+	}
+
+	// validate change address
+	cAddr, err := cipher.DecodeBase58Address(chgAddr)
+	if err != nil {
+		return nil, ErrAddress
+	}
+
+	_, ok := wlt.GetEntry(cAddr)
+	if !ok {
+		return nil, fmt.Errorf("change address %v is not in wallet", chgAddr)
+	}
+
+	return AdvancedCreateRawTx(c, wlt, fromAddrs, chgAddr, toAddrs, allowedUxOuts)
+}
+
+func AdvancedCreateRawTx(c *webrpc.Client, wlt *wallet.Wallet, inAddrs []string, chgAddr string, toAddrs []AdvancedSendAmount, allowedUxOuts []string) (*coin.Transaction, error) {
+	if err := validateSendAmounts(toAddrs); err != nil {
+		return nil, err
+	}
+
+	// Get unspent outputs of those addresses
+	// Filter using address and hashes
+	var filters = map[string][]string{}
+	if len(inAddrs) > 0 {
+		filters["addrs"] = inAddrs
+	}
+	if len(allowedUxOuts) > 0 {
+		filters["hashes"] = allowedUxOuts
+	}
+
+	unspents, err := c.GetUnspentOutputsWithFilters(filters)
+	if err != nil {
+		return nil, err
+	}
+
+	return advancedCreateRawTx(unspents.Outputs, wlt, chgAddr, toAddrs)
+}
+
+func advancedCreateRawTx(uxouts visor.ReadableOutputSet, wlt *wallet.Wallet, chgAddr string, toAddrs []AdvancedSendAmount) (*coin.Transaction, error) {
+	// Calculate total required coins
+	var totalCoins uint64
+	for _, arg := range toAddrs {
+		totalCoins += arg.Coins
+	}
+
+	outs, err := chooseSpends(uxouts, totalCoins)
+	if err != nil {
+		return nil, err
+	}
+
+	keys, err := getKeys(wlt, outs)
+	if err != nil {
+		return nil, err
+	}
+
+	txOuts, err := advancedMakeChangeOut(outs, chgAddr, toAddrs)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := NewTransaction(outs, keys, txOuts)
+	if err != nil {
+		return nil, err
+	}
+
+	return tx, nil
+}
+
+// Total coins are calculated using unspents only
+// Hence haveChange depends on unspent balances and not the total balance of the address
+func advancedMakeChangeOut(outs []wallet.UxBalance, chgAddr string, toAddrs []AdvancedSendAmount) ([]coin.TransactionOutput, error) {
+	var totalInCoins, totalInHours, totalOutCoins uint64
+
+	for _, o := range outs {
+		totalInCoins += o.Coins
+		totalInHours += o.Hours
+	}
+
+	if totalInHours == 0 {
+		return nil, fee.ErrTxnNoFee
+	}
+
+	for _, to := range toAddrs {
+		totalOutCoins += to.Coins
+	}
+
+	if totalInCoins < totalOutCoins {
+		return nil, wallet.ErrInsufficientBalance
+	}
+
+	var outAddrs []coin.TransactionOutput
+	changeAmount := totalInCoins - totalOutCoins
+
+	haveChange := changeAmount > 0
+	nAddrs := uint64(len(toAddrs))
+
+	// give addresses the defined hours
+	addrHours := make([]uint64, nAddrs)
+	for i, toAddr := range toAddrs {
+		addrHours[i] = toAddr.Hours
+	}
+
+	changeHours, addrHours, totalOutHours := wallet.AdvancedDistributeSpendHours(totalInHours, nAddrs, addrHours, haveChange)
+	if err := fee.VerifyTransactionFeeForHours(totalOutHours, totalInHours-totalOutHours); err != nil {
+		return nil, err
+	}
+
+	if haveChange {
+		outAddrs = append(outAddrs, mustMakeUtxoOutput(chgAddr, changeAmount, changeHours))
+	}
+
+	for i, to := range toAddrs {
+		outAddrs = append(outAddrs, mustMakeUtxoOutput(to.Addr, to.Coins, addrHours[i]))
+	}
+
+	return outAddrs, nil
+}

--- a/src/api/cli/create_rawtx.go
+++ b/src/api/cli/create_rawtx.go
@@ -602,7 +602,7 @@ func advancedCreateRawTx(uxouts visor.ReadableOutputSet, wlt *wallet.Wallet, chg
 		totalCoins += arg.Coins
 	}
 
-	outs, err := advancedChooseSpends(uxouts, totalCoins)
+	outs, err := chooseSpends(uxouts, totalCoins)
 	if err != nil {
 		return nil, err
 	}
@@ -626,43 +626,6 @@ func advancedCreateRawTx(uxouts visor.ReadableOutputSet, wlt *wallet.Wallet, chg
 }
 
 func chooseSpends(uxouts visor.ReadableOutputSet, coins uint64) ([]wallet.UxBalance, error) {
-	// Convert spendable unspent outputs to []wallet.UxBalance
-	spendableOutputs, err := visor.ReadableOutputsToUxBalances(uxouts.SpendableOutputs())
-	if err != nil {
-		return nil, err
-	}
-
-	// Choose which unspent outputs to spend
-	// Use the MinimizeUxOuts strategy, since this is most likely used by
-	// application that may need to send frequently.
-	// Using fewer UxOuts will leave more available for other transactions,
-	// instead of waiting for confirmation.
-	outs, err := wallet.ChooseSpendsMinimizeUxOuts(spendableOutputs, coins)
-	if err != nil {
-		// If there is not enough balance in the spendable outputs,
-		// see if there is enough balance when including incoming outputs
-		if err == wallet.ErrInsufficientBalance {
-			expectedOutputs, otherErr := visor.ReadableOutputsToUxBalances(uxouts.ExpectedOutputs())
-			if otherErr != nil {
-				return nil, otherErr
-			}
-
-			if _, otherErr := wallet.ChooseSpendsMinimizeUxOuts(expectedOutputs, coins); otherErr != nil {
-				return nil, err
-			}
-
-			return nil, ErrTemporaryInsufficientBalance
-		}
-
-		return nil, err
-	}
-
-	return outs, nil
-}
-
-// TODO: Implement this
-// Ideas: allow different predefined strategies to choose UxOuts
-func advancedChooseSpends(uxouts visor.ReadableOutputSet, coins uint64) ([]wallet.UxBalance, error) {
 	// Convert spendable unspent outputs to []wallet.UxBalance
 	spendableOutputs, err := visor.ReadableOutputsToUxBalances(uxouts.SpendableOutputs())
 	if err != nil {

--- a/src/api/cli/send.go
+++ b/src/api/cli/send.go
@@ -89,7 +89,7 @@ func advancedSendCmd() gcli.Command {
 	return gcli.Command{
 		Name:      name,
 		Usage:     "Create a custom send transaction from a wallet or address to a recipient address",
-		ArgsUsage: "[to address] [amount]",
+		ArgsUsage: "[to address] [amount] [hours]",
 		Description: `
 		Note: the [amount] argument is the coins you will spend, 1 coins = 1e6 droplets.`,
 		Flags: []gcli.Flag{
@@ -99,16 +99,11 @@ func advancedSendCmd() gcli.Command {
 			},
 			gcli.StringFlag{
 				Name:  "a",
-				Usage: "[address] From address",
+				Usage: "[addresses] From address(es)",
 			},
 			gcli.StringFlag{
 				Name:  "c",
 				Usage: `[changeAddress] Specify change address, by default the from address with most coins is used`,
-			},
-			gcli.StringFlag{
-				Name: "s",
-				Usage: `[spendhours] Specify how many coin hours to send to the destination address
-				can be in percentage or a whole number like 1,2 etc.`,
 			},
 			gcli.StringFlag{
 				Name: "u",
@@ -118,7 +113,7 @@ func advancedSendCmd() gcli.Command {
 			gcli.StringFlag{
 				Name: "m",
 				Usage: `[send to many] use JSON string to set multiple recive addresses and coins,
-				example: -m '[{"addr":"$addr1", "coins": "10.2"}, {"addr":"$addr2", "coins": "20"}]'`,
+				example: -m '[{"addr":"$addr1", "coins": "10.2", "hours": "1"}, {"addr":"$addr2", "coins": "20"}]'`,
 			},
 			gcli.BoolFlag{
 				Name:  "json,j",
@@ -156,6 +151,7 @@ func advancedSendCmd() gcli.Command {
 	// Commands = append(Commands, cmd)
 }
 
+// @TODO: following functions are not used anywhere, remove them if not required
 // SendFromWallet sends from any address or combination of addresses from a wallet. Returns txid.
 func SendFromWallet(c *webrpc.Client, walletFile, chgAddr string, toAddrs []SendAmount) (string, error) {
 	rawTx, err := CreateRawTxFromWallet(c, walletFile, chgAddr, toAddrs)

--- a/src/api/cli/send.go
+++ b/src/api/cli/send.go
@@ -84,8 +84,6 @@ func sendCmd() gcli.Command {
 	// Commands = append(Commands, cmd)
 }
 
-// @TODO: Add Tests
-// @TODO: Add predefined strategies to choose unspents
 func advancedSendCmd() gcli.Command {
 	name := "advancedSend"
 	return gcli.Command{

--- a/src/api/cli/send.go
+++ b/src/api/cli/send.go
@@ -84,6 +84,80 @@ func sendCmd() gcli.Command {
 	// Commands = append(Commands, cmd)
 }
 
+// @TODO: Add Tests
+// @TODO: Add predefined strategies to choose unspents
+func advancedSendCmd() gcli.Command {
+	name := "advancedSend"
+	return gcli.Command{
+		Name:      name,
+		Usage:     "Create a custom send transaction from a wallet or address to a recipient address",
+		ArgsUsage: "[to address] [amount]",
+		Description: `
+		Note: the [amount] argument is the coins you will spend, 1 coins = 1e6 droplets.`,
+		Flags: []gcli.Flag{
+			gcli.StringFlag{
+				Name:  "f",
+				Usage: "[wallet file or path] From wallet. If no path is specified your default wallet path will be used.",
+			},
+			gcli.StringFlag{
+				Name:  "a",
+				Usage: "[address] From address",
+			},
+			gcli.StringFlag{
+				Name:  "c",
+				Usage: `[changeAddress] Specify change address, by default the from address with most coins is used`,
+			},
+			gcli.StringFlag{
+				Name: "s",
+				Usage: `[spendhours] Specify how many coin hours to send to the destination address
+				can be in percentage or a whole number like 1,2 etc.`,
+			},
+			gcli.StringFlag{
+				Name: "u",
+				Usage: `[unspent address hashes] hash of unspent address(es) to use in the transaction, for multiple separate using a comma
+				example: -u "7a1555d60ec1d2a8861376d4b028b321dd9c7d6b438fb628d0ec2e675d91afcb, 4e905cffbbfe0f0f4b7c62bb6c1419ad74fc923eb2d60c239d1f4cf92dce3c5e"`,
+			},
+			gcli.StringFlag{
+				Name: "m",
+				Usage: `[send to many] use JSON string to set multiple recive addresses and coins,
+				example: -m '[{"addr":"$addr1", "coins": "10.2"}, {"addr":"$addr2", "coins": "20"}]'`,
+			},
+			gcli.BoolFlag{
+				Name:  "json,j",
+				Usage: "Returns the results in JSON format.",
+			},
+		},
+		OnUsageError: onCommandUsageError(name),
+		Action: func(c *gcli.Context) error {
+			rpcClient := RpcClientFromContext(c)
+
+			rawtx, err := createAdvancedRawTxCmdHandler(c)
+			if err != nil {
+				errorWithHelp(c, err)
+				return nil
+			}
+
+			txid, err := rpcClient.InjectTransaction(rawtx)
+			if err != nil {
+				return err
+			}
+
+			jsonFmt := c.Bool("json")
+			if jsonFmt {
+				return printJson(struct {
+					Txid string `json:"txid"`
+				}{
+					Txid: txid,
+				})
+			}
+
+			fmt.Printf("txid:%s\n", txid)
+			return nil
+		},
+	}
+	// Commands = append(Commands, cmd)
+}
+
 // SendFromWallet sends from any address or combination of addresses from a wallet. Returns txid.
 func SendFromWallet(c *webrpc.Client, walletFile, chgAddr string, toAddrs []SendAmount) (string, error) {
 	rawTx, err := CreateRawTxFromWallet(c, walletFile, chgAddr, toAddrs)

--- a/src/api/cli/send.go
+++ b/src/api/cli/send.go
@@ -91,7 +91,8 @@ func advancedSendCmd() gcli.Command {
 		Usage:     "Create a custom send transaction from a wallet or address to a recipient address",
 		ArgsUsage: "[to address] [amount] [hours]",
 		Description: `
-		Note: the [amount] argument is the coins you will spend, 1 coins = 1e6 droplets.`,
+		Note: [amount] argument is the coins you will spend, 1 coins = 1e6 droplets.
+		      [hours] argument is number of hours to send to the destination address`,
 		Flags: []gcli.Flag{
 			gcli.StringFlag{
 				Name:  "f",

--- a/src/api/webrpc/client.go
+++ b/src/api/webrpc/client.go
@@ -55,6 +55,15 @@ func (c *Client) GetUnspentOutputs(addrs []string) (*OutputsResult, error) {
 	return &outputs, nil
 }
 
+func (c *Client) GetUnspentOutputsWithFilters(filters map[string][]string) (*OutputsResult, error) {
+	outputs := OutputsResult{}
+	if err := c.Do(&outputs, "get_outputs_filters", filters); err != nil {
+		return nil, err
+	}
+
+	return &outputs, nil
+}
+
 // InjectTransactionString injects a hex-encoded transaction string to the network
 func (c *Client) InjectTransactionString(rawtx string) (string, error) {
 	params := []string{rawtx}

--- a/src/api/webrpc/outputs.go
+++ b/src/api/webrpc/outputs.go
@@ -43,3 +43,57 @@ func getOutputsHandler(req Request, gateway Gatewayer) Response {
 
 	return makeSuccessResponse(req.ID, OutputsResult{outs})
 }
+
+func getOutputsWithFiltersHandler(req Request, gateway Gatewayer) Response {
+	var filters map[string][]string
+	if err := req.DecodeParams(&filters); err != nil {
+		return makeErrorResponse(errCodeInvalidParams, errMsgInvalidParams)
+	}
+
+	addrs, okaddr := filters["addrs"]
+	hashes, okhash := filters["hashes"]
+	addrLen := len(addrs)
+	hashLen := len(hashes)
+
+	// Check that either addrs or hashes are provided
+	if (!okaddr && !okhash) || (addrLen == 0 && hashLen == 0) {
+		return makeErrorResponse(errCodeInvalidParams, errMsgInvalidParams)
+	}
+
+	// Trim whitespace from addrs and hashes
+	for i, a := range addrs {
+		addrs[i] = strings.Trim(a, " ")
+	}
+	for i, h := range hashes {
+		hashes[i] = strings.Trim(h, " ")
+	}
+
+	// validate those addresses
+	for _, a := range addrs {
+		if _, err := cipher.DecodeBase58Address(a); err != nil {
+			return makeErrorResponse(errCodeInvalidParams, fmt.Sprintf("invalid address: %v", a))
+		}
+	}
+
+	// Filter unspent outputs
+	outputFilters := []daemon.OutputsFilter{}
+	if addrLen > 0 && hashLen > 0 {
+		// Filter by addr and hash
+		outputFilters = append(outputFilters, daemon.FbyAddresses(addrs))
+		outputFilters = append(outputFilters, daemon.FbyHashes(hashes))
+	} else if addrLen > 0 {
+		// Filter by addr
+		outputFilters = append(outputFilters, daemon.FbyAddresses(addrs))
+	} else {
+		// Filter by hash
+		outputFilters = append(outputFilters, daemon.FbyHashes(hashes))
+	}
+
+	outs, err := gateway.GetUnspentOutputs(outputFilters...)
+	if err != nil {
+		logger.Error("get unspent outputs with filters failed: %v", err)
+		return makeErrorResponse(errCodeInternalError)
+	}
+
+	return makeSuccessResponse(req.ID, OutputsResult{outs})
+}

--- a/src/api/webrpc/outputs.go
+++ b/src/api/webrpc/outputs.go
@@ -92,7 +92,7 @@ func getOutputsWithFiltersHandler(req Request, gateway Gatewayer) Response {
 	outs, err := gateway.GetUnspentOutputs(outputFilters...)
 	if err != nil {
 		logger.Error("get unspent outputs with filters failed: %v", err)
-		return makeErrorResponse(errCodeInternalError)
+		return makeErrorResponse(errCodeInternalError, fmt.Sprintf("gateway.GetUnspentOutputs failed: %v", err))
 	}
 
 	return makeSuccessResponse(req.ID, OutputsResult{outs})

--- a/src/api/webrpc/webrpc.go
+++ b/src/api/webrpc/webrpc.go
@@ -155,6 +155,8 @@ func (rpc *WebRPC) initHandlers() error {
 		"get_blocks": getBlocksHandler,
 		// get unspent outputs of address
 		"get_outputs": getOutputsHandler,
+		// get unspent outputs of address with filters
+		"get_outputs_filters": getOutputsWithFiltersHandler,
 		// get transaction by txid
 		"get_transaction": getTransactionHandler,
 		// broadcast transaction


### PR DESCRIPTION
# Motivation
Allow the user to tweak his `coin hours`  and `unspents` in a transaction

# Info
- By default in a transaction, a user loses `75%` coin hours wherein `50%` is burned and `25%` is sent to destination addrs.
- The default strategy to select unspents priority is `Max skycoins` > `zero coin hours` > `non-zero coin hours` 

# Tasks
- [x] choose coin hours to be sent to destination addrs
- [x]  choose unspents to be used
- [x]  send from multiple addresses
- [x]  create `advancedCreateRawTx` command
- [x] Update changelog
- [x] Document use cases
- [ ] Tests 

# Use Cases
- This will allow users to send the desired number of coinhours to the receiver.
- Select unspent with lower coin hours to decrease transaction fees and hence preserving coinhours