### PR TITLE
Add -disable-wallet-api option to skycoin cmd

### DIFF
--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -95,6 +95,9 @@ type Config struct {
 	DisableIncomingConnections bool
 	// Disables networking altogether
 	DisableNetworking bool
+	// Disables wallet API
+	DisableWalletApi bool
+
 	// Only run on localhost and only connect to others on localhost
 	LocalhostOnly bool
 	// Which address to serve on. Leave blank to automatically assign to a
@@ -181,6 +184,7 @@ func (c *Config) register() {
 	flag.BoolVar(&c.DisableOutgoingConnections, "disable-outgoing", c.DisableOutgoingConnections, "Don't make outgoing connections")
 	flag.BoolVar(&c.DisableIncomingConnections, "disable-incoming", c.DisableIncomingConnections, "Don't make incoming connections")
 	flag.BoolVar(&c.DisableNetworking, "disable-networking", c.DisableNetworking, "Disable all network activity")
+	flag.BoolVar(&c.DisableWalletApi, "disable-wallet-api", c.DisableWalletApi, "Disable the wallet API")
 	flag.StringVar(&c.Address, "address", c.Address, "IP Address to run application on. Leave empty to default to a public interface")
 	flag.IntVar(&c.Port, "port", c.Port, "Port to run application on")
 
@@ -238,6 +242,8 @@ var devConfig = Config{
 	DisableIncomingConnections: false,
 	// Disables networking altogether
 	DisableNetworking: false,
+	// Disable wallet API
+	DisableWalletApi: false,
 	// Only run on localhost and only connect to others on localhost
 	LocalhostOnly: false,
 	// Which address to serve on. Leave blank to automatically assign to a
@@ -507,7 +513,6 @@ func configureDaemon(c *Config) daemon.Config {
 		c.OutgoingConnectionsRate = time.Millisecond
 	}
 	dc.Daemon.OutgoingRate = c.OutgoingConnectionsRate
-
 	dc.Visor.Config.IsMaster = c.RunMaster
 
 	dc.Visor.Config.BlockchainPubkey = c.BlockchainPubkey
@@ -524,6 +529,9 @@ func configureDaemon(c *Config) daemon.Config {
 		Version: Version,
 		Commit:  Commit,
 	}
+
+	dc.Gateway.DisableWalletAPI = c.DisableWalletApi
+
 	return dc
 }
 

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -18,13 +18,15 @@ import (
 
 // GatewayConfig configuration set of gateway.
 type GatewayConfig struct {
-	BufferSize int
+	BufferSize       int
+	DisableWalletAPI bool
 }
 
 // NewGatewayConfig create and init an GatewayConfig
 func NewGatewayConfig() GatewayConfig {
 	return GatewayConfig{
-		BufferSize: 32,
+		BufferSize:       32,
+		DisableWalletAPI: false,
 	}
 }
 
@@ -492,6 +494,9 @@ func (sv spendValidator) HasUnconfirmedSpendTx(addr []cipher.Address) (bool, err
 func (gw *Gateway) Spend(wltID string, coins uint64, dest cipher.Address) (*coin.Transaction, error) {
 	var tx *coin.Transaction
 	var err error
+	if gw.Config.DisableWalletAPI {
+		return tx, wallet.ErrWalletApiDisabled
+	}
 	gw.strand("Spend", func() {
 		// create spend validator
 		unspent := gw.v.Blockchain.Unspent()
@@ -517,6 +522,9 @@ func (gw *Gateway) Spend(wltID string, coins uint64, dest cipher.Address) (*coin
 func (gw *Gateway) CreateWallet(wltName string, options wallet.Options) (wallet.Wallet, error) {
 	var wlt wallet.Wallet
 	var err error
+	if gw.Config.DisableWalletAPI {
+		return wlt, wallet.ErrWalletApiDisabled
+	}
 	gw.strand("CreateWallet", func() {
 		wlt, err = gw.vrpc.CreateWallet(wltName, options)
 	})
@@ -527,6 +535,9 @@ func (gw *Gateway) CreateWallet(wltName string, options wallet.Options) (wallet.
 func (gw *Gateway) ScanAheadWalletAddresses(wltName string, scanN uint64) (wallet.Wallet, error) {
 	var wlt wallet.Wallet
 	var err error
+	if gw.Config.DisableWalletAPI {
+		return wlt, wallet.ErrWalletApiDisabled
+	}
 	gw.strand("ScanAheadWalletAddresses", func() {
 		wlt, err = gw.v.ScanAheadWalletAddresses(wltName, scanN)
 	})
@@ -537,6 +548,9 @@ func (gw *Gateway) ScanAheadWalletAddresses(wltName string, scanN uint64) (walle
 func (gw *Gateway) GetWalletBalance(wltID string) (wallet.BalancePair, error) {
 	var balance wallet.BalancePair
 	var err error
+	if gw.Config.DisableWalletAPI {
+		return balance, wallet.ErrWalletApiDisabled
+	}
 	gw.strand("GetWalletBalance", func() {
 		var addrs []cipher.Address
 		addrs, err = gw.vrpc.GetWalletAddresses(wltID)
@@ -582,14 +596,20 @@ func (gw *Gateway) GetBalanceOfAddrs(addrs []cipher.Address) ([]wallet.BalancePa
 }
 
 // GetWalletDir returns path for storing wallet files
-func (gw *Gateway) GetWalletDir() string {
-	return gw.v.Config.WalletDirectory
+func (gw *Gateway) GetWalletDir() (string, error) {
+	if gw.Config.DisableWalletAPI {
+		return "", wallet.ErrWalletApiDisabled
+	}
+	return gw.v.Config.WalletDirectory, nil
 }
 
 // NewAddresses generate addresses in given wallet
 func (gw *Gateway) NewAddresses(wltID string, n uint64) ([]cipher.Address, error) {
 	var addrs []cipher.Address
 	var err error
+	if gw.Config.DisableWalletAPI {
+		return addrs, wallet.ErrWalletApiDisabled
+	}
 	gw.strand("NewAddresses", func() {
 		addrs, err = gw.vrpc.NewAddresses(wltID, n)
 	})
@@ -599,6 +619,9 @@ func (gw *Gateway) NewAddresses(wltID string, n uint64) ([]cipher.Address, error
 // UpdateWalletLabel updates the label of wallet
 func (gw *Gateway) UpdateWalletLabel(wltID, label string) error {
 	var err error
+	if gw.Config.DisableWalletAPI {
+		return wallet.ErrWalletApiDisabled
+	}
 	gw.strand("UpdateWalletLabel", func() {
 		err = gw.vrpc.UpdateWalletLabel(wltID, label)
 	})
@@ -609,6 +632,9 @@ func (gw *Gateway) UpdateWalletLabel(wltID, label string) error {
 func (gw *Gateway) GetWallet(wltID string) (wallet.Wallet, error) {
 	var w wallet.Wallet
 	var err error
+	if gw.Config.DisableWalletAPI {
+		return w, wallet.ErrWalletApiDisabled
+	}
 	gw.strand("GetWallet", func() {
 		w, err = gw.vrpc.GetWallet(wltID)
 	})
@@ -616,18 +642,24 @@ func (gw *Gateway) GetWallet(wltID string) (wallet.Wallet, error) {
 }
 
 // GetWallets returns wallets
-func (gw *Gateway) GetWallets() wallet.Wallets {
+func (gw *Gateway) GetWallets() (wallet.Wallets, error) {
 	var w wallet.Wallets
+	if gw.Config.DisableWalletAPI {
+		return w, wallet.ErrWalletApiDisabled
+	}
 	gw.strand("GetWallets", func() {
 		w = gw.vrpc.GetWallets()
 	})
-	return w
+	return w, nil
 }
 
 // GetWalletUnconfirmedTxns returns all unconfirmed transactions in given wallet
 func (gw *Gateway) GetWalletUnconfirmedTxns(wltID string) ([]visor.UnconfirmedTxn, error) {
 	var txns []visor.UnconfirmedTxn
 	var err error
+	if gw.Config.DisableWalletAPI {
+		return txns, wallet.ErrWalletApiDisabled
+	}
 	gw.strand("GetWalletUnconfirmedTxns", func() {
 		var addrs []cipher.Address
 		addrs, err = gw.vrpc.GetWalletAddresses(wltID)
@@ -644,6 +676,9 @@ func (gw *Gateway) GetWalletUnconfirmedTxns(wltID string) ([]visor.UnconfirmedTx
 // ReloadWallets reloads all wallets
 func (gw *Gateway) ReloadWallets() error {
 	var err error
+	if gw.Config.DisableWalletAPI {
+		return wallet.ErrWalletApiDisabled
+	}
 	gw.strand("ReloadWallets", func() {
 		err = gw.vrpc.ReloadWallets()
 	})

--- a/src/gui/wallet.go
+++ b/src/gui/wallet.go
@@ -404,7 +404,12 @@ func walletsHandler(gateway *daemon.Gateway) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		wlts, err := gateway.GetWallets()
 		if err != nil {
-			wh.Error403(w)
+			switch err {
+			case wallet.ErrWalletApiDisabled:
+				wh.Error403(w)
+			default:
+				wh.Error500(w)
+			}
 			return
 		}
 		wh.SendOr404(w, wlts.ToReadable())
@@ -424,11 +429,10 @@ func getWalletFolder(gateway Gatewayer) http.HandlerFunc {
 			switch err {
 			case wallet.ErrWalletApiDisabled:
 				wh.Error403(w)
-				return
 			default:
 				wh.Error500(w)
-				return
 			}
+			return
 		}
 		ret := WalletFolder{
 			Address: addr,

--- a/src/gui/wallet.go
+++ b/src/gui/wallet.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	"github.com/skycoin/skycoin/src/cipher"
-	bip39 "github.com/skycoin/skycoin/src/cipher/go-bip39"
+	"github.com/skycoin/skycoin/src/cipher/go-bip39"
 	"github.com/skycoin/skycoin/src/coin"
 	"github.com/skycoin/skycoin/src/daemon"
 	"github.com/skycoin/skycoin/src/visor"
@@ -27,7 +27,7 @@ type Gatewayer interface {
 	CreateWallet(wltName string, options wallet.Options) (wallet.Wallet, error)
 	ScanAheadWalletAddresses(wltName string, scanN uint64) (wallet.Wallet, error)
 	NewAddresses(wltID string, n uint64) ([]cipher.Address, error)
-	GetWalletDir() string
+	GetWalletDir() (string, error)
 	GetBlockByHash(hash cipher.SHA256) (block coin.SignedBlock, ok bool)
 	GetBlockBySeq(seq uint64) (block coin.SignedBlock, ok bool)
 }
@@ -47,7 +47,6 @@ func walletBalanceHandler(gateway Gatewayer) http.HandlerFunc {
 			wh.Error405(w)
 			return
 		}
-
 		wltID := r.FormValue("id")
 		if wltID == "" {
 			wh.Error400(w, "missing wallet id")
@@ -60,6 +59,10 @@ func walletBalanceHandler(gateway Gatewayer) http.HandlerFunc {
 			switch err {
 			case wallet.ErrWalletNotExist:
 				wh.Error404(w)
+				break
+			case wallet.ErrWalletApiDisabled:
+				wh.Error403(w)
+				break
 			default:
 				wh.Error500Msg(w, err.Error())
 			}
@@ -126,6 +129,9 @@ func walletSpendHandler(gateway Gatewayer) http.HandlerFunc {
 			return
 		case wallet.ErrWalletNotExist:
 			wh.Error404(w)
+			return
+		case wallet.ErrWalletApiDisabled:
+			wh.Error403(w)
 			return
 		default:
 			wh.Error500Msg(w, err.Error())
@@ -217,8 +223,14 @@ func walletCreate(gateway Gatewayer) http.HandlerFunc {
 			Label: label,
 		})
 		if err != nil {
-			wh.Error400(w, err.Error())
-			return
+			switch err {
+			case wallet.ErrWalletApiDisabled:
+				wh.Error403(w)
+				return
+			default:
+				wh.Error400(w, err.Error())
+				return
+			}
 		}
 
 		wlt, err = gateway.ScanAheadWalletAddresses(wlt.GetFilename(), scanN-1)
@@ -265,8 +277,14 @@ func walletNewAddresses(gateway Gatewayer) http.HandlerFunc {
 
 		addrs, err := gateway.NewAddresses(wltID, n)
 		if err != nil {
-			wh.Error400(w, err.Error())
-			return
+			switch err {
+			case wallet.ErrWalletApiDisabled:
+				wh.Error403(w)
+				return
+			default:
+				wh.Error400(w, err.Error())
+				return
+			}
 		}
 
 		var rlt = struct {
@@ -308,6 +326,8 @@ func walletUpdateHandler(gateway Gatewayer) http.HandlerFunc {
 			switch err {
 			case wallet.ErrWalletNotExist:
 				wh.Error404(w)
+			case wallet.ErrWalletApiDisabled:
+				wh.Error403(w)
 			default:
 				wh.Error500Msg(w, err.Error())
 			}
@@ -334,7 +354,12 @@ func walletGet(gateway Gatewayer) http.HandlerFunc {
 
 		wlt, err := gateway.GetWallet(wltID)
 		if err != nil {
-			wh.Error400(w, err.Error())
+			switch err {
+			case wallet.ErrWalletApiDisabled:
+				wh.Error403(w)
+			default:
+				wh.Error400(w, err.Error())
+			}
 			return
 		}
 
@@ -362,6 +387,8 @@ func walletTransactionsHandler(gateway Gatewayer) http.HandlerFunc {
 			switch err {
 			case wallet.ErrWalletNotExist:
 				wh.Error404(w)
+			case wallet.ErrWalletApiDisabled:
+				wh.Error403(w)
 			default:
 				wh.Error500Msg(w, err.Error())
 			}
@@ -375,8 +402,12 @@ func walletTransactionsHandler(gateway Gatewayer) http.HandlerFunc {
 // Returns all loaded wallets
 func walletsHandler(gateway *daemon.Gateway) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		wlts := gateway.GetWallets().ToReadable()
-		wh.SendOr404(w, wlts)
+		wlts, err := gateway.GetWallets()
+		if err != nil {
+			wh.Error403(w)
+			return
+		}
+		wh.SendOr404(w, wlts.ToReadable())
 	}
 }
 
@@ -388,8 +419,19 @@ type WalletFolder struct {
 // Loads/unloads wallets from the wallet directory
 func getWalletFolder(gateway Gatewayer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		addr, err := gateway.GetWalletDir()
+		if err != nil {
+			switch err {
+			case wallet.ErrWalletApiDisabled:
+				wh.Error403(w)
+				return
+			default:
+				wh.Error500(w)
+				return
+			}
+		}
 		ret := WalletFolder{
-			Address: gateway.GetWalletDir(),
+			Address: addr,
 		}
 		wh.SendOr404(w, ret)
 	}

--- a/src/gui/wallet_test.go
+++ b/src/gui/wallet_test.go
@@ -1665,7 +1665,7 @@ func TestGetWalletFolderHandler(t *testing.T) {
 		status               int
 		err                  string
 		getWalletDirResponse string
-		getWalletDirErr error
+		getWalletDirErr      error
 		httpResponse         WalletFolder
 	}{
 		{

--- a/src/util/http/error.go
+++ b/src/util/http/error.go
@@ -21,6 +21,11 @@ func Error400(w http.ResponseWriter, msg string) {
 	HTTPError(w, http.StatusBadRequest, httpMsg)
 }
 
+// Error403 response 404 error
+func Error403(w http.ResponseWriter) {
+	HTTPError(w, http.StatusForbidden, "Forbidden")
+}
+
 // Error404 response 404 error
 func Error404(w http.ResponseWriter) {
 	HTTPError(w, http.StatusNotFound, "Not Found")

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -14,6 +14,7 @@ import (
 
 // ErrWalletNotExist is returned if a wallet does not exist
 var ErrWalletNotExist = errors.New("wallet doesn't exist")
+var ErrWalletApiDisabled = errors.New("wallet api disabled")
 
 // BalanceGetter interface for getting the balance of given addresses
 type BalanceGetter interface {


### PR DESCRIPTION
Related to #648 

Add "disable-wallet-api" option to the skycoin cmd, which will disable all wallet API from the gateway. 
Return 403 when a call to any API requiring the wallet is done from the GUI.

----
_Donation is not required, but highly appreciated (in case you find PR useful of course)._

_Skycoin Wallet: VfF9T7dWkE5TRHjwi84cnbg189vVRtbYQL_