### PR TITLE
fixes #828 skycoin docker testnet

### DIFF
--- a/docker/images/testnet/templates/Dockerfile
+++ b/docker/images/testnet/templates/Dockerfile
@@ -44,4 +44,4 @@ VOLUME $DATA_DIR
 
 EXPOSE 6000 6420 6430
 
-CMD ["/usr/bin/skycoin", "{{ .SkyCoinParameters }}"]
+CMD ["/usr/bin/skycoin"{{ range .SkyCoinParameters }}, "{{ . }}"{{ end }}]

--- a/docker/images/testnet/templates/Dockerfile
+++ b/docker/images/testnet/templates/Dockerfile
@@ -1,0 +1,47 @@
+# skycoin build
+# reference https://github.com/skycoin/skycoin
+FROM golang:1.9 AS build
+
+# dirs
+RUN mkdir -p $GOPATH/src/github.com/skycoin/skycoin
+
+# copy code to build
+ADD src $GOPATH/src/github.com/skycoin/skycoin/src
+ADD cmd $GOPATH/src/github.com/skycoin/skycoin/cmd
+ADD vendor $GOPATH/src/github.com/skycoin/skycoin/vendor
+
+# install cli
+RUN cd $GOPATH/src/github.com/skycoin/skycoin/cmd/cli && \
+  CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /go/bin/skycoin-cli .
+
+# install skycoin
+RUN cd $GOPATH/src/github.com/skycoin/skycoin/cmd/skycoin && \
+  CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /go/bin/skycoin .
+
+# install address_gen
+RUN cd $GOPATH/src/github.com/skycoin/skycoin/cmd/address_gen && \
+  CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /go/bin/address_gen .
+
+
+# skycoin image
+FROM alpine:3.7
+
+ENV COIN="skycoin" \
+    RPC_ADDR="0.0.0.0:6430" \
+    DATA_DIR="/root/.$COIN" \
+    WALLET_DIR="/wallet" \
+    WALLET_NAME="$COIN_cli.wlt"
+
+# copy all the binaries
+COPY --from=build /go/bin/* /usr/bin/
+
+# copy assets
+COPY --from=build /go/src/github.com/skycoin/skycoin/src/gui/static /usr/local/skycoin/static
+
+# volumes
+VOLUME $WALLET_DIR
+VOLUME $DATA_DIR
+
+EXPOSE 6000 6420 6430
+
+CMD ["/usr/bin/skycoin", "--gui-dir=/usr/local/skycoin/static", "--web-interface-addr=0.0.0.0"]

--- a/docker/images/testnet/templates/Dockerfile
+++ b/docker/images/testnet/templates/Dockerfile
@@ -44,4 +44,4 @@ VOLUME $DATA_DIR
 
 EXPOSE 6000 6420 6430
 
-CMD ["/usr/bin/skycoin", "--gui-dir=/usr/local/skycoin/static", "--web-interface-addr=0.0.0.0"]
+CMD ["/usr/bin/skycoin", "{{ .SkyCoinParameters }}"]

--- a/docker/images/testnet/testnet.go
+++ b/docker/images/testnet/testnet.go
@@ -1,0 +1,60 @@
+// Package testnet provides a Docker test net for SkyCoin
+package main
+
+import (
+	"html/template"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+)
+
+// DockerParameters Dockerfile parameters
+type DockerParameters struct {
+	Execution    string
+	BuildContext string
+	GitCommit    string
+}
+
+// GetCurrentGitCommit returns the current git commit SHA
+func GetCurrentGitCommit() string {
+	var (
+		cmdOut []byte
+		err    error
+	)
+	cmdName := "git"
+	cmdArgs := []string{"rev-parse", "--verify", "HEAD"}
+	if cmdOut, err = exec.Command(cmdName, cmdArgs...).Output(); err != nil {
+		log.Print("There was an error running git rev-parse command: ", err)
+		os.Exit(1)
+	}
+	sha := string(cmdOut)
+	firstSix := sha[:6]
+	return firstSix
+}
+
+// CreateDockerfiles makes the Dockerfiles needed to build the images
+// for the testnet
+func CreateDockerfiles() {
+	gitCommit := GetCurrentGitCommit()
+	parameters := DockerParameters{
+		Execution:    "run",
+		BuildContext: "run",
+		GitCommit:    gitCommit,
+	}
+	dockerfileTemplate := path.Join("templates", "Dockerfile")
+	_, err := os.Stat(dockerfileTemplate)
+	if err != nil {
+		log.Print(err)
+		return
+	}
+	buildTemplate, err := template.ParseFiles(dockerfileTemplate)
+	err = buildTemplate.Execute(os.Stdout, parameters)
+	if err != nil {
+		log.Print(err)
+		return
+	}
+}
+func main() {
+	CreateDockerfiles()
+}

--- a/docker/images/testnet/testnet.go
+++ b/docker/images/testnet/testnet.go
@@ -101,12 +101,15 @@ func (d *DockerFile) BuildImage() {
 
 // ConfigureNodes generates a Dockerfile with the passed parameters
 func ConfigureNodes() {
+	commonParameters := []string{
+		"--launch-browser=false",
+		"--gui-dir=/usr/local/skycoin/static",
+	}
 	currentCommit := GetCurrentGitCommit()
 	nodes := [2]DockerFile{
 		DockerFile{
 			NodeType: "gui",
 			SkyCoinParameters: []string{
-				"--gui-dir=/usr/local/skycoin/static",
 				"--web-interface-addr=0.0.0.0",
 			},
 			GitCommit: currentCommit,
@@ -120,6 +123,7 @@ func ConfigureNodes() {
 		},
 	}
 	for _, d := range nodes {
+		d.SkyCoinParameters = append(d.SkyCoinParameters, commonParameters...)
 		d.CreateDockerFile()
 		d.BuildImage()
 	}

--- a/docker/images/testnet/testnet.go
+++ b/docker/images/testnet/testnet.go
@@ -2,18 +2,19 @@
 package main
 
 import (
-	"html/template"
 	"log"
 	"os"
 	"os/exec"
 	"path"
+	"strings"
+	"text/template"
 )
 
 // DockerParameters Dockerfile parameters
 type DockerParameters struct {
-	Execution    string
-	BuildContext string
-	GitCommit    string
+	SkyCoinParameters string
+	BuildContext      string
+	GitCommit         string
 }
 
 // GetCurrentGitCommit returns the current git commit SHA
@@ -33,28 +34,54 @@ func GetCurrentGitCommit() string {
 	return firstSix
 }
 
-// CreateDockerfiles makes the Dockerfiles needed to build the images
+// CreateDockerFile makes the Dockerfiles needed to build the images
 // for the testnet
-func CreateDockerfiles() {
-	gitCommit := GetCurrentGitCommit()
-	parameters := DockerParameters{
-		Execution:    "run",
-		BuildContext: "run",
-		GitCommit:    gitCommit,
-	}
+func CreateDockerFile(parameters DockerParameters) {
 	dockerfileTemplate := path.Join("templates", "Dockerfile")
 	_, err := os.Stat(dockerfileTemplate)
 	if err != nil {
 		log.Print(err)
 		return
 	}
+	f, err := os.Create("Dockerfile")
+	if err != nil {
+		log.Print(err)
+		return
+	}
 	buildTemplate, err := template.ParseFiles(dockerfileTemplate)
-	err = buildTemplate.Execute(os.Stdout, parameters)
+	err = buildTemplate.Execute(f, parameters)
 	if err != nil {
 		log.Print(err)
 		return
 	}
 }
+
+// GenerateDockerFile generates a Dockerfile with the passed parameters
+func GenerateDockerFiles() {
+	commonParameters := []string{
+		"-launch-browser false",
+	}
+	guiParameters := []string{
+		"--gui-dir=/usr/local/skycoin/static",
+		"--web-interface-addr=0.0.0.0",
+	}
+	noGuiParameters := []string{
+		"-web-interface false",
+		"-web-interface false",
+	}
+	parameters := DockerParameters{
+		SkyCoinParameters: strings.Join(append(commonParameters, noGuiParameters...), "\", \""),
+		BuildContext:      "run",
+		GitCommit:         GetCurrentGitCommit(),
+	}
+	noparameters := DockerParameters{
+		SkyCoinParameters: strings.Join(append(commonParameters, guiParameters...), "\", \""),
+		BuildContext:      "run",
+		GitCommit:         GetCurrentGitCommit(),
+	}
+	CreateDockerFile(parameters)
+	CreateDockerFile(noparameters)
+}
 func main() {
-	CreateDockerfiles()
+	GenerateDockerFiles()
 }

--- a/docker/images/testnet/testnet.go
+++ b/docker/images/testnet/testnet.go
@@ -47,14 +47,14 @@ type networkIpamConfig struct {
 }
 type networkIpam struct {
 	Driver string
-	Config networkIpamConfig
+	Config []networkIpamConfig
 }
 type network struct {
 	Driver string
 	Ipam   networkIpam
 }
 type dockerCompose struct {
-	Version  int
+	Version  string
 	Services map[string]service
 	Networks map[string]network
 }
@@ -173,15 +173,15 @@ func NewSkyCoinTestNetwork(nodesNum int, buildContext string, tempDir string) Sk
 		},
 	}
 	t.Compose = dockerCompose{
-		Version:  3,
+		Version:  "3",
 		Services: make(map[string]service),
 		Networks: map[string]network{
 			string(networkName): network{
 				Driver: "bridge",
 				Ipam: networkIpam{
 					Driver: "default",
-					Config: networkIpamConfig{
-						Subnet: networkAddr + "0/24",
+					Config: []networkIpamConfig{
+						networkIpamConfig{Subnet: networkAddr + "0/24"},
 					},
 				},
 			},

--- a/docker/images/testnet/testnet.go
+++ b/docker/images/testnet/testnet.go
@@ -101,23 +101,24 @@ func (d *DockerFile) BuildImage() {
 
 // ConfigureNodes generates a Dockerfile with the passed parameters
 func ConfigureNodes() {
-	var nodes []DockerFile
 	currentCommit := GetCurrentGitCommit()
-	nodes = append(nodes, DockerFile{
-		NodeType: "gui",
-		SkyCoinParameters: []string{
-			"--gui-dir=/usr/local/skycoin/static",
-			"--web-interface-addr=0.0.0.0",
+	nodes := [2]DockerFile{
+		DockerFile{
+			NodeType: "gui",
+			SkyCoinParameters: []string{
+				"--gui-dir=/usr/local/skycoin/static",
+				"--web-interface-addr=0.0.0.0",
+			},
+			GitCommit: currentCommit,
 		},
-		GitCommit: currentCommit,
-	})
-	nodes = append(nodes, DockerFile{
-		NodeType: "nogui",
-		SkyCoinParameters: []string{
-			"-web-interface false",
+		DockerFile{
+			NodeType: "nogui",
+			SkyCoinParameters: []string{
+				"--web-interface=false",
+			},
+			GitCommit: currentCommit,
 		},
-		GitCommit: currentCommit,
-	})
+	}
 	for _, d := range nodes {
 		d.CreateDockerFile()
 		d.BuildImage()

--- a/docker/images/testnet/testnet.go
+++ b/docker/images/testnet/testnet.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
 	"github.com/skycoin/skycoin/src/cipher"
 	"gopkg.in/yaml.v2"
@@ -264,7 +265,10 @@ func (t *SkyCoinTestNetwork) prepareTestEnv(tempDir string) {
 }
 
 func main() {
-	buildContext, err := filepath.Abs("../../../")
+	nodesPtr := flag.Int("-nodes", 5, "Number of nodes to launch.")
+	buildContextPtr := flag.String("-buildcontext", "../../../", "Docker build context (source code root).")
+	flag.Parse()
+	buildContext, err := filepath.Abs(*buildContextPtr)
 	tempDir, err := ioutil.TempDir("", "skycointest")
 	if err != nil {
 		log.Fatal(err)
@@ -272,9 +276,8 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	testNet := NewSkyCoinTestNetwork(10, buildContext, tempDir)
+	testNet := NewSkyCoinTestNetwork(*nodesPtr, buildContext, tempDir)
 	testNet.prepareTestEnv(tempDir)
 	testNet.createComposeFile(tempDir)
 	runTest(tempDir)
-	fmt.Println(tempDir)
 }

--- a/docker/images/testnet/testnet.go
+++ b/docker/images/testnet/testnet.go
@@ -192,7 +192,7 @@ func NewSkyCoinTestNetwork(nodesNum int) SkyCoinTestNetwork {
 						IPv4Address: ipAddress,
 					}},
 			}
-			t.Peers = append(t.Peers, ipAddress+"6000")
+			t.Peers = append(t.Peers, ipAddress+":6000")
 			ipHostNum++
 		}
 		s.SkyCoinParameters = append(s.SkyCoinParameters, commonParameters...)
@@ -227,17 +227,23 @@ func (t *SkyCoinTestNetwork) prepareTestEnv() string {
 		s.CreateDockerFile(tempDir)
 	}
 	peersText := []byte(strings.Join(t.Peers, "\n"))
-	f, err := os.Create(path.Join(tempDir, "peers.txt"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	_, err = f.Write(peersText)
-	if err != nil {
-		log.Fatal(err)
-	}
-	f.Close()
-	if err != nil {
-		log.Fatal(err)
+	for k, _ := range t.Compose.Services {
+		err := os.Mkdir(path.Join(tempDir, k), os.ModePerm)
+		if err != nil {
+			log.Fatal(err)
+		}
+		f, err := os.Create(path.Join(tempDir, k, "peers.txt"))
+		if err != nil {
+			log.Fatal(err)
+		}
+		_, err = f.Write(peersText)
+		if err != nil {
+			log.Fatal(err)
+		}
+		f.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 	return tempDir
 }

--- a/docker/images/testnet/testnet.go
+++ b/docker/images/testnet/testnet.go
@@ -160,6 +160,8 @@ func NewSkyCoinTestNetwork(nodesNum int, buildContext string, tempDir string) Sk
 			SkyCoinParameters: []string{
 				"--web-interface-addr=0.0.0.0",
 				"--master",
+				"--master-secret-key=47f7616ea6f9b923076625b4488115de1ef1187f760e65f89eb6f4f7ff04b012",
+				"--master-public-key=03fe43d0c2c3daab30f9472beb5b767be020b81c7cc940ed7a7e910f0c1d9feef1",
 			},
 			ImageTag: currentCommit,
 			NodesNum: 1,

--- a/docker/images/testnet/testnet.go
+++ b/docker/images/testnet/testnet.go
@@ -145,7 +145,7 @@ func (d *DockerService) BuildImage() {
 // NewSkyCoinTestNetwork is the SkyCoinTestNetwork factory function
 func NewSkyCoinTestNetwork(nodesNum int, buildContext string, tempDir string) SkyCoinTestNetwork {
 	t := SkyCoinTestNetwork{}
-	ipHostNum := 1
+	ipHostNum := 2
 	networkAddr := "172.16.200."
 	commonParameters := []string{
 		"--launch-browser=false",
@@ -159,6 +159,7 @@ func NewSkyCoinTestNetwork(nodesNum int, buildContext string, tempDir string) Sk
 			ImageName: "skycoin-gui",
 			SkyCoinParameters: []string{
 				"--web-interface-addr=0.0.0.0",
+				"--master",
 			},
 			ImageTag: currentCommit,
 			NodesNum: 1,
@@ -187,7 +188,7 @@ func NewSkyCoinTestNetwork(nodesNum int, buildContext string, tempDir string) Sk
 			},
 		},
 	}
-	for _, s := range t.Services {
+	for idx, s := range t.Services {
 		for i := 1; i <= s.NodesNum; i++ {
 			num := strconv.Itoa(ipHostNum)
 			ipAddress := networkAddr + num
@@ -210,7 +211,7 @@ func NewSkyCoinTestNetwork(nodesNum int, buildContext string, tempDir string) Sk
 			t.Peers = append(t.Peers, ipAddress+":6000")
 			ipHostNum++
 		}
-		s.SkyCoinParameters = append(s.SkyCoinParameters, commonParameters...)
+		t.Services[idx].SkyCoinParameters = append(t.Services[idx].SkyCoinParameters, commonParameters...)
 	}
 	return t
 }


### PR DESCRIPTION
- Generates the Dockerfiles and the docker-compose file
- Creates a test network, the volumes for the containers and runs the testnet.
There are some things missing
- A webserver to serve the peers list peers.txt
- A log server to save the logs
- Some polishment.
Right now the testnet should be run offline, with a webserver running on the host serving the peers.txt. This is because the daemon downloads the peers list, but it adds those peers to the hardcoded list it has in the source code.