### PR TITLE
Treat overflowing input hours as 0 in blocks, reject in txns

### DIFF
--- a/src/coin/block.go
+++ b/src/coin/block.go
@@ -48,6 +48,11 @@ type SignedBlock struct {
 	Sig cipher.Sig
 }
 
+// VerifySignature verifies that the block is signed by pubkey
+func (b SignedBlock) VerifySignature(pubkey cipher.PubKey) error {
+	return cipher.VerifySignature(pubkey, b.Sig, b.Block.HashHeader())
+}
+
 // NewBlock creates new block.
 func NewBlock(prev Block, currentTime uint64, uxHash cipher.SHA256, txns Transactions, calc FeeCalculator) (*Block, error) {
 	if len(txns) == 0 {

--- a/src/coin/outputs.go
+++ b/src/coin/outputs.go
@@ -95,16 +95,18 @@ func (uo *UxOut) CoinHours(t uint64) (uint64, error) {
 	wholeCoins := uo.Body.Coins / 1e6
 	wholeCoinSeconds, err := multUint64(seconds, wholeCoins)
 	if err != nil {
-		logger.Critical("UxOut.CoinHours: Calculating whole coin seconds overflows uint64 seconds=%d coins=%d uxid=%s", seconds, wholeCoins, uo.Hash().Hex())
-		return 0, fmt.Errorf("UxOut.CoinHours: Calculating whole coin seconds overflows uint64 seconds=%d coins=%d uxid=%s", seconds, wholeCoins, uo.Hash().Hex())
+		err := fmt.Errorf("UxOut.CoinHours: Calculating whole coin seconds overflows uint64 seconds=%d coins=%d uxid=%s", seconds, wholeCoins, uo.Hash().Hex())
+		logger.Critical(err.Error())
+		return 0, err
 	}
 
 	// Calculate remainder droplet seconds
 	remainderDroplets := uo.Body.Coins % 1e6
 	dropletSeconds, err := multUint64(seconds, remainderDroplets)
 	if err != nil {
-		logger.Critical("UxOut.CoinHours: Calculating droplet seconds overflows uint64 seconds=%d droplets=%d uxid=%s", seconds, remainderDroplets, uo.Hash().Hex())
-		return 0, fmt.Errorf("UxOut.CoinHours: Calculating droplet seconds overflows uint64 seconds=%d droplets=%d uxid=%s", seconds, remainderDroplets, uo.Hash().Hex())
+		err := fmt.Errorf("UxOut.CoinHours: Calculating droplet seconds overflows uint64 seconds=%d droplets=%d uxid=%s", seconds, remainderDroplets, uo.Hash().Hex())
+		logger.Critical(err.Error())
+		return 0, error
 	}
 
 	// Add coinSeconds and seconds earned by droplets, rounded off
@@ -113,7 +115,7 @@ func (uo *UxOut) CoinHours(t uint64) (uint64, error) {
 	coinHours := coinSeconds / 3600                        // coin hours
 	totalHours, err := AddUint64(uo.Body.Hours, coinHours) // starting+earned
 	if err != nil {
-		logger.Critical("UxOut.CoinHours: addition of earned coin hours overflows uxid=%s", uo.Hash().Hex())
+		logger.Critical("%v uxid=%s", errAddEarnedCoinHoursAdditionOverflow, uo.Hash().Hex())
 		return 0, errAddEarnedCoinHoursAdditionOverflow
 	}
 	return totalHours, nil

--- a/src/coin/outputs.go
+++ b/src/coin/outputs.go
@@ -83,9 +83,6 @@ func (ub *UxBody) Hash() cipher.SHA256 {
 var errAddEarnedCoinHoursAdditionOverflow = errors.New("UxOut.CoinHours addition of earned coin hours overflow")
 
 // CoinHours Calculate coinhour balance of output. t is the current unix utc time.
-// If the calculated CoinHours would overflow, return zero.
-// It can't return an error due to block 13277 which spends a UxOut that overflows this calculation.
-// If the blockchain is reset/repaired in the future, this method should return an error instead.
 func (uo *UxOut) CoinHours(t uint64) (uint64, error) {
 	if t < uo.Head.Time {
 		logger.Warning("Calculating coin hours with t < head time")

--- a/src/coin/outputs.go
+++ b/src/coin/outputs.go
@@ -106,7 +106,7 @@ func (uo *UxOut) CoinHours(t uint64) (uint64, error) {
 	if err != nil {
 		err := fmt.Errorf("UxOut.CoinHours: Calculating droplet seconds overflows uint64 seconds=%d droplets=%d uxid=%s", seconds, remainderDroplets, uo.Hash().Hex())
 		logger.Critical(err.Error())
-		return 0, error
+		return 0, err
 	}
 
 	// Add coinSeconds and seconds earned by droplets, rounded off

--- a/src/coin/transactions.go
+++ b/src/coin/transactions.go
@@ -485,7 +485,15 @@ func VerifyTransactionHoursSpending(headTime uint64, uxIn UxArray, uxOut UxArray
 	for i := range uxIn {
 		uxHours, err := uxIn[i].CoinHours(headTime)
 		if err != nil {
-			return err
+			// If the error was specifically an overflow when adding the
+			// earned coin hours to the base coin hours, treat the uxHours as 0.
+			// Block 13277 spends an input which overflows in this way,
+			// so the block will not sync if an error is returned.
+			if err == errAddEarnedCoinHoursAdditionOverflow {
+				uxHours = 0
+			} else {
+				return err
+			}
 		}
 
 		hoursIn, err = AddUint64(hoursIn, uxHours)

--- a/src/visor/blockchain.go
+++ b/src/visor/blockchain.go
@@ -645,7 +645,7 @@ func (bc *Blockchain) verifyBlockSig(seq uint64) error {
 		return err
 	}
 
-	return cipher.VerifySignature(bc.pubkey, sb.Sig, sb.Block.HashHeader())
+	return sb.VerifySignature(bc.pubkey)
 }
 
 // VerifyBlockHeader Returns error if the BlockHeader is not valid

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -431,7 +431,7 @@ func (vs *Visor) CreateAndExecuteBlock() (coin.SignedBlock, error) {
 // ExecuteSignedBlock adds a block to the blockchain, or returns error.
 // Blocks must be executed in sequence, and be signed by the master server
 func (vs *Visor) ExecuteSignedBlock(b coin.SignedBlock) error {
-	if err := vs.verifySignedBlock(&b); err != nil {
+	if err := b.VerifySignature(vs.Config.BlockchainPubkey); err != nil {
 		return err
 	}
 
@@ -456,22 +456,18 @@ func (vs *Visor) ExecuteSignedBlock(b coin.SignedBlock) error {
 	return nil
 }
 
-// Returns an error if the cipher.Sig is not valid for the coin.Block
-func (vs *Visor) verifySignedBlock(b *coin.SignedBlock) error {
-	return cipher.VerifySignature(vs.Config.BlockchainPubkey, b.Sig, b.Block.HashHeader())
-}
-
 // SignBlock signs a block for master.  Will panic if anything is invalid
 func (vs *Visor) SignBlock(b coin.Block) coin.SignedBlock {
 	if !vs.Config.IsMaster {
 		logger.Panic("Only master chain can sign blocks")
 	}
+
 	sig := cipher.SignHash(b.HashHeader(), vs.Config.BlockchainSeckey)
-	sb := coin.SignedBlock{
+
+	return coin.SignedBlock{
 		Block: b,
 		Sig:   sig,
 	}
-	return sb
 }
 
 /*


### PR DESCRIPTION
Fixes #930 