### PR TITLE
Fix /coinSupply

### DIFF
--- a/src/coin/outputs.go
+++ b/src/coin/outputs.go
@@ -80,7 +80,11 @@ func (ub *UxBody) Hash() cipher.SHA256 {
 	Creation time of transaction cant be hashed
 */
 
-var errAddEarnedCoinHoursAdditionOverflow = errors.New("UxOut.CoinHours addition of earned coin hours overflow")
+// ErrAddEarnedCoinHoursAdditionOverflow is returned by UxOut.CoinHours() if during the addition of base coin
+// hours to additional earned coin hours, the value would overflow a uint64.
+// Callers may choose to ignore this errors and use 0 as the coinhours value instead.
+// This affects one existing spent output, spent in block 13277.
+var ErrAddEarnedCoinHoursAdditionOverflow = errors.New("UxOut.CoinHours addition of earned coin hours overflow")
 
 // CoinHours Calculate coinhour balance of output. t is the current unix utc time.
 func (uo *UxOut) CoinHours(t uint64) (uint64, error) {
@@ -115,8 +119,8 @@ func (uo *UxOut) CoinHours(t uint64) (uint64, error) {
 	coinHours := coinSeconds / 3600                        // coin hours
 	totalHours, err := AddUint64(uo.Body.Hours, coinHours) // starting+earned
 	if err != nil {
-		logger.Critical("%v uxid=%s", errAddEarnedCoinHoursAdditionOverflow, uo.Hash().Hex())
-		return 0, errAddEarnedCoinHoursAdditionOverflow
+		logger.Critical("%v uxid=%s", ErrAddEarnedCoinHoursAdditionOverflow, uo.Hash().Hex())
+		return 0, ErrAddEarnedCoinHoursAdditionOverflow
 	}
 	return totalHours, nil
 }

--- a/src/coin/outputs_test.go
+++ b/src/coin/outputs_test.go
@@ -190,7 +190,7 @@ func TestUxOutCoinHours(t *testing.T) {
 	uxo.Body.Coins = 3600e6
 	uxo.Body.Hours = math.MaxUint64 - 1
 	_, err = uxo.CoinHours(uxo.Head.Time + 1000)
-	testutil.RequireError(t, err, errAddEarnedCoinHoursAdditionOverflow.Error())
+	testutil.RequireError(t, err, ErrAddEarnedCoinHoursAdditionOverflow.Error())
 }
 
 func makeUxArray(t *testing.T, n int) UxArray {
@@ -240,7 +240,7 @@ func TestUxArrayCoinHours(t *testing.T) {
 	require.Equal(t, errors.New("UxArray.CoinHours addition overflow"), err)
 
 	_, err = uxa.CoinHours(uxa[0].Head.Time * 1000000000000)
-	require.Equal(t, errAddEarnedCoinHoursAdditionOverflow, err)
+	require.Equal(t, ErrAddEarnedCoinHoursAdditionOverflow, err)
 }
 
 func TestUxArrayHashArray(t *testing.T) {

--- a/src/coin/transactions.go
+++ b/src/coin/transactions.go
@@ -489,7 +489,7 @@ func VerifyTransactionHoursSpending(headTime uint64, uxIn UxArray, uxOut UxArray
 			// earned coin hours to the base coin hours, treat the uxHours as 0.
 			// Block 13277 spends an input which overflows in this way,
 			// so the block will not sync if an error is returned.
-			if err == errAddEarnedCoinHoursAdditionOverflow {
+			if err == ErrAddEarnedCoinHoursAdditionOverflow {
 				uxHours = 0
 			} else {
 				return err

--- a/src/gui/explorer.go
+++ b/src/gui/explorer.go
@@ -46,6 +46,7 @@ func coinSupply(gateway Gatewayer, w http.ResponseWriter, r *http.Request) *Coin
 
 	allUnspents, err := gateway.GetUnspentOutputs()
 	if err != nil {
+		logger.Error("gateway.GetUnspentOutputs error: %v", err)
 		wh.Error500(w)
 		return nil
 	}

--- a/src/visor/readable.go
+++ b/src/visor/readable.go
@@ -293,7 +293,15 @@ func NewReadableOutput(headTime uint64, t coin.UxOut) (ReadableOutput, error) {
 	}
 
 	calculatedHours, err := t.CoinHours(headTime)
-	if err != nil {
+
+	// Treat overflowing coin hours calculations as a non-error and force hours to 0
+	// This affects one bad spent output which had overflowed hours, spent in block 13277.
+	switch err {
+	case nil:
+	case coin.ErrAddEarnedCoinHoursAdditionOverflow:
+		calculatedHours = 0
+		err = nil
+	default:
 		return ReadableOutput{}, err
 	}
 


### PR DESCRIPTION
Treat an error from UxOut.CoinHours as a non-error
when constructing ReadableOutput.