### PR TITLE
Fix unordered addr string split

### DIFF
--- a/src/gui/http.go
+++ b/src/gui/http.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-
 	"unicode"
 
 	"github.com/skycoin/skycoin/src/cipher"
@@ -301,18 +300,18 @@ func splitCommaString(s string) []string {
 	words := strings.FieldsFunc(s, func(r rune) bool {
 		return r == ',' || unicode.IsSpace(r)
 	})
+
 	// Deduplicate
-	seen := make(map[string]struct{}, len(words))
-	for i := 0; i < len(words); i++ {
-		w := words[i]
-		if _, ok := seen[w]; ok {
-			// Delete the already existing string
-			words = append(words[:i], words[i+1:]...)
-		} else {
-			seen[w] = struct{}{}
+	var dedupWords []string
+	wordsMap := make(map[string]struct{})
+	for _, w := range words {
+		if _, ok := wordsMap[w]; !ok {
+			dedupWords = append(dedupWords, w)
 		}
+		wordsMap[w] = struct{}{}
 	}
-	return words
+
+	return dedupWords
 }
 
 // getOutputsHandler returns UxOuts filtered by a set of addresses or a set of hashes

--- a/src/gui/transaction_test.go
+++ b/src/gui/transaction_test.go
@@ -766,7 +766,7 @@ func TestGetTransactions(t *testing.T) {
 			require.Equal(t, tc.status, status, "case: %s, handler returned wrong status code: got `%v` want `%v`", tc.name, status, tc.status)
 
 			if status != http.StatusOK {
-				require.Equal(t, tc.err, strings.TrimSpace(rr.Body.String()), "case: %s, handler returned wrong error message: got `%v`| %s, want `%v`",
+				require.Equal(t, tc.err, strings.TrimSpace(rr.Body.String()), "case: %s, handler returned wrong error message: got `%v`| %d, want `%v`",
 					tc.name, strings.TrimSpace(rr.Body.String()), status, tc.err)
 			} else {
 				var msg []visor.Transaction


### PR DESCRIPTION
The issue arises due to the fact that maps are unordered.
This means that before the output of splitting `"invalid,addrs"` could either be `[invalid addr]` or `[addr invalid]` because the deduplication was done using a map

Hence the test returned two different errors as `invalid` fails with `invalid base58 character` while `addrs` fails with `invalid address length`  
Fixes: https://github.com/skycoin/skycoin/issues/978

Note: We should keep this behavior in mind for future tests as this can be seen at other places as well like output of cli command `addressOutputs`