### PR TITLE
Do not test-libc by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,9 @@ before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$TRAVIS_PULL_REQUEST" == false ]]; then ./ci-scripts/add-key.sh && npm install -g yarn ;fi
 
 script:
-  - gometalinter --disable-all -E goimports --tests --vendor ./...
-  - vendorcheck ./...
-  - GOARCH=386 go test ./...
-  - GOARCH=amd64 go test ./...
+  - make lint
+  - make test-386
+  - make test-amd64
   # stable integration tests
   - make integration-test-stable
   # libskycoin tests

--- a/Makefile
+++ b/Makefile
@@ -69,12 +69,12 @@ test: ## Run tests for Skycoin
 	go test ./src/... -timeout=1m
 
 test-386: ## Run tests for Skycoin with GOARCH=386
-	GOARCH=386 go test ./cmd/... -timeout=1m
-	GOARCH=386 go test ./src/... -timeout=1m
+	GOARCH=386 go test ./cmd/... -timeout=5m
+	GOARCH=386 go test ./src/... -timeout=5m
 
 test-amd64: ## Run tests for Skycoin with GOARCH=amd64
-	GOARCH=amd64 go test ./cmd/... -timeout=1m
-	GOARCH=amd64 go test ./src/... -timeout=1m
+	GOARCH=amd64 go test ./cmd/... -timeout=5m
+	GOARCH=amd64 go test ./src/... -timeout=5m
 
 configure-build:
 	mkdir -p $(BUILD_DIR)/usr/tmp $(BUILD_DIR)/usr/lib $(BUILD_DIR)/usr/include

--- a/Makefile
+++ b/Makefile
@@ -64,28 +64,34 @@ run:  ## Run the skycoin node. To add arguments, do 'make ARGS="--foo" run'.
 run-help: ## Show skycoin node help
 	@go run cmd/skycoin/skycoin.go --help
 
-test-core: ## Run tests for Skycoin core
+test: ## Run tests for Skycoin
 	go test ./cmd/... -timeout=1m
 	go test ./src/... -timeout=1m
+
+test-386: ## Run tests for Skycoin with GOARCH=386
+	GOARCH=386 go test ./cmd/... -timeout=1m
+	GOARCH=386 go test ./src/... -timeout=1m
+
+test-amd64: ## Run tests for Skycoin with GOARCH=amd64
+	GOARCH=amd64 go test ./cmd/... -timeout=1m
+	GOARCH=amd64 go test ./src/... -timeout=1m
 
 configure-build:
 	mkdir -p $(BUILD_DIR)/usr/tmp $(BUILD_DIR)/usr/lib $(BUILD_DIR)/usr/include
 	mkdir -p $(BUILDLIB_DIR) $(BIN_DIR) $(INCLUDE_DIR)
 
-build-libc: configure-build # Build libskycoin C client library
+build-libc: configure-build ## Build libskycoin C client library
 	rm -Rf $(BUILDLIB_DIR)/*
 	go build -buildmode=c-shared  -o $(BUILDLIB_DIR)/libskycoin.so $(LIB_FILES)
 	go build -buildmode=c-archive -o $(BUILDLIB_DIR)/libskycoin.a  $(LIB_FILES)
 	mv $(BUILDLIB_DIR)/libskycoin.h $(INCLUDE_DIR)/
 
-test-libc: build-libc
+test-libc: build-libc ## Run tests for libskycoin C client library
 	cp $(LIB_DIR)/cgo/tests/*.c $(BUILDLIB_DIR)/
 	$(CC) -o $(BIN_DIR)/test_libskycoin_shared $(BUILDLIB_DIR)/*.c -lskycoin                    $(LDLIBS) $(LDFLAGS)
 	$(CC) -o $(BIN_DIR)/test_libskycoin_static $(BUILDLIB_DIR)/*.c $(BUILDLIB_DIR)/libskycoin.a $(LDLIBS) $(LDFLAGS)
 	$(LDPATHVAR)="$(LDPATH):$(BUILD_DIR)/usr/lib"                 $(BIN_DIR)/test_libskycoin_static
 	$(LDPATHVAR)="$(LDPATH):$(BUILD_DIR)/usr/lib:$(BUILDLIB_DIR)" $(BIN_DIR)/test_libskycoin_shared
-
-test: test-core test-libc ## Run tests
 
 lint: ## Run linters. Use make install-linters first.
 	vendorcheck ./...
@@ -111,14 +117,14 @@ install-linters: ## Install linters
 	go get -u github.com/alecthomas/gometalinter
 	gometalinter --vendored-linters --install
 
-install-deps-libc: configure-build # Install locally dependencies for testing libskycoin
+install-deps-libc: configure-build ## Install locally dependencies for testing libskycoin
 	wget -O $(BUILD_DIR)/usr/tmp/criterion-v2.3.2-$(OSNAME)-x86_64.tar.bz2 https://github.com/Snaipe/Criterion/releases/download/v2.3.2/criterion-v2.3.2-$(OSNAME)-x86_64.tar.bz2
-	tar -x -C $(BUILD_DIR)/usr/tmp/ -j -f $(BUILD_DIR)/usr/tmp/criterion-v2.3.2-$(OSNAME)-x86_64.tar.bz2 
+	tar -x -C $(BUILD_DIR)/usr/tmp/ -j -f $(BUILD_DIR)/usr/tmp/criterion-v2.3.2-$(OSNAME)-x86_64.tar.bz2
 	ls $(BUILD_DIR)/usr/tmp/criterion-v2.3.2/include
 	ls -1 $(BUILD_DIR)/usr/tmp/criterion-v2.3.2/lib     | xargs -I NAME mv $(BUILD_DIR)/usr/tmp/criterion-v2.3.2/lib/NAME     $(BUILD_DIR)/usr/lib/NAME
 	ls -1 $(BUILD_DIR)/usr/tmp/criterion-v2.3.2/include | xargs -I NAME mv $(BUILD_DIR)/usr/tmp/criterion-v2.3.2/include/NAME $(BUILD_DIR)/usr/include/NAME
 
-format:  # Formats the code. Must have goimports installed (use make install-linters).
+format: ## Formats the code. Must have goimports installed (use make install-linters).
 	goimports -w -local github.com/skycoin/skycoin ./cmd
 	goimports -w -local github.com/skycoin/skycoin ./src
 	goimports -w -local github.com/skycoin/skycoin ./lib


### PR DESCRIPTION
Remove `make test-libc` from the list of targets for `make test`. Travis will still run these tests.