### PR TITLE
GUI integration test: /pendingTxs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- #951, cap cli createRawTransaction and send command coinhour distribution, coinhours are capped to a maximum of receiving coins for the address with a minimum of 1 coinhour   
+- Remove `/lastTxs` API endpoint
+- CLI and GUI integration tests against a stable and live blockchain
+- HTTP API client
+- `/richlist` API method, returns top n address balances
+- `/addresscoint` API method, returns the number of addresses that have any amount of coins
+- #951, cap cli createRawTransaction and send command coinhour distribution, coinhours are capped to a maximum of receiving coins for the address with a minimum of 1 coinhour
 - #896, Add CSRF check to wallet api
 - #800, Add entropy parameter to `/wallet/newSeed` endpoint
 - #877, Add -disable-wallet-api CLI option

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -466,16 +466,6 @@ func (gw *Gateway) GetUnconfirmedTxns(addrs []cipher.Address) []visor.Unconfirme
 	return txns
 }
 
-// GetLastTxs returns last confirmed transactions, return nil if empty
-func (gw *Gateway) GetLastTxs() ([]*visor.Transaction, error) {
-	var txns []*visor.Transaction
-	var err error
-	gw.strand("GetLastTxs", func() {
-		txns, err = gw.v.GetLastTxs()
-	})
-	return txns, err
-}
-
 // GetUnspent returns the unspent pool
 func (gw *Gateway) GetUnspent() blockdb.UnspentPool {
 	var unspent blockdb.UnspentPool

--- a/src/gui/client.go
+++ b/src/gui/client.go
@@ -525,15 +525,6 @@ func (c *Client) PendingTransactions() ([]*visor.ReadableUnconfirmedTxn, error) 
 	return v, nil
 }
 
-// LastTransactions makes a request to /lastTxs
-func (c *Client) LastTransactions() ([]visor.TransactionResult, error) {
-	var r []visor.TransactionResult
-	if err := c.Get("/lastTxs", &r); err != nil {
-		return nil, err
-	}
-	return r, nil
-}
-
 // Transaction makes a request to /transaction
 func (c *Client) Transaction(txid string) (*visor.ReadableTransaction, error) {
 	v := url.Values{}

--- a/src/gui/csrf_test.go
+++ b/src/gui/csrf_test.go
@@ -73,7 +73,6 @@ var endpoints = []string{
 	"/network/connections/trust",
 	"/network/connections/exchange",
 	"/pendingTxs",
-	"/lastTxs",
 	"/transaction",
 	"/transactions",
 	"/injectTransaction",

--- a/src/gui/gateway.go
+++ b/src/gui/gateway.go
@@ -38,7 +38,6 @@ type Gatewayer interface {
 	GetTrustConnections() []string
 	GetExchgConnection() []string
 	GetAllUnconfirmedTxns() []visor.UnconfirmedTxn
-	GetLastTxs() ([]*visor.Transaction, error)
 	GetTransaction(txid cipher.SHA256) (*visor.Transaction, error)
 	GetTransactions(flts ...visor.TxFilter) ([]visor.Transaction, error)
 	InjectBroadcastTransaction(txn coin.Transaction) error

--- a/src/gui/gatewayer_mock_test.go
+++ b/src/gui/gatewayer_mock_test.go
@@ -414,33 +414,6 @@ func (m *GatewayerMock) GetLastBlocks(p0 uint64) (*visor.ReadableBlocks, error) 
 
 }
 
-// GetLastTxs mocked method
-func (m *GatewayerMock) GetLastTxs() ([]*visor.Transaction, error) {
-
-	ret := m.Called()
-
-	var r0 []*visor.Transaction
-	switch res := ret.Get(0).(type) {
-	case nil:
-	case []*visor.Transaction:
-		r0 = res
-	default:
-		panic(fmt.Sprintf("unexpected type: %v", res))
-	}
-
-	var r1 error
-	switch res := ret.Get(1).(type) {
-	case nil:
-	case error:
-		r1 = res
-	default:
-		panic(fmt.Sprintf("unexpected type: %v", res))
-	}
-
-	return r0, r1
-
-}
-
 // GetRichlist mocked method
 func (m *GatewayerMock) GetRichlist(p0 bool) (visor.Richlist, error) {
 

--- a/src/gui/http.go
+++ b/src/gui/http.go
@@ -244,8 +244,6 @@ func NewServerMux(host, appLoc string, gateway Gatewayer, csrfStore *CSRFStore) 
 
 	// get set of pending transactions
 	webHandler("/pendingTxs", getPendingTxs(gateway))
-	// get latest confirmed transactions
-	webHandler("/lastTxs", getLastTxs(gateway))
 	// get txn by txid
 	webHandler("/transaction", getTransactionByID(gateway))
 

--- a/src/gui/integration/integration_test.go
+++ b/src/gui/integration/integration_test.go
@@ -1752,3 +1752,26 @@ func TestLiveAddressCount(t *testing.T) {
 	// 5296 addresses as of 2018-03-06, the count could decrease but is unlikely to
 	require.True(t, count > 5000)
 }
+
+func TestStablePendingTransactions(t *testing.T) {
+	if !doStable(t) {
+		return
+	}
+
+	c := gui.NewClient(nodeAddress())
+
+	txns, err := c.PendingTransactions()
+	require.NoError(t, err)
+	require.Empty(t, txns)
+}
+
+func TestLivePendingTransactions(t *testing.T) {
+	if !doLive(t) {
+		return
+	}
+
+	c := gui.NewClient(nodeAddress())
+
+	_, err := c.PendingTransactions()
+	require.NoError(t, err)
+}

--- a/src/gui/transaction.go
+++ b/src/gui/transaction.go
@@ -38,40 +38,6 @@ func getPendingTxs(gateway Gatewayer) http.HandlerFunc {
 	}
 }
 
-// DEPRECATED: last txs can't recover from db when restart
-// , and it's not used actually
-func getLastTxs(gateway Gatewayer) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			wh.Error405(w)
-			return
-		}
-		txs, err := gateway.GetLastTxs()
-		if err != nil {
-			logger.Error("gateway.GetLastTxs failed: %v", err)
-			wh.Error500(w)
-			return
-		}
-
-		resTxs := make([]visor.TransactionResult, len(txs))
-		for i, tx := range txs {
-			rbTx, err := visor.NewReadableTransaction(tx)
-			if err != nil {
-				logger.Error("%v", err)
-				wh.Error500(w)
-				return
-			}
-
-			resTxs[i] = visor.TransactionResult{
-				Transaction: *rbTx,
-				Status:      tx.Status,
-			}
-		}
-
-		wh.SendOr404(w, &resTxs)
-	}
-}
-
 func getTransactionByID(gate Gatewayer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {

--- a/src/visor/historydb/historydb.go
+++ b/src/visor/historydb/historydb.go
@@ -188,20 +188,6 @@ func (hd HistoryDB) GetTransaction(hash cipher.SHA256) (*Transaction, error) {
 	return hd.txns.Get(hash)
 }
 
-// GetLastTxs gets the latest N transactions.
-func (hd HistoryDB) GetLastTxs() ([]*Transaction, error) {
-	txHashes := hd.txns.GetLastTxs()
-	txs := make([]*Transaction, len(txHashes))
-	for i, h := range txHashes {
-		tx, err := hd.txns.Get(h)
-		if err != nil {
-			return []*Transaction{}, err
-		}
-		txs[i] = tx
-	}
-	return txs, nil
-}
-
 // GetAddrUxOuts get all uxout that the address affected.
 func (hd HistoryDB) GetAddrUxOuts(address cipher.Address) ([]*UxOut, error) {
 	hashes, err := hd.addrUx.Get(address)

--- a/src/visor/historydb/transaction.go
+++ b/src/visor/historydb/transaction.go
@@ -14,13 +14,9 @@ import (
 	"github.com/skycoin/skycoin/src/visor/bucket"
 )
 
-// lastTxNum reprsents the number of transactions that the GetLastTxs function will return.
-const lastTxNum = 20
-
 // Transactions transaction bucket instance.
 type transactions struct {
-	bkt     *bucket.Bucket
-	lastTxs []cipher.SHA256 // records the latest transactions
+	bkt *bucket.Bucket
 }
 
 // Transaction contains transaction info and the seq of block which executed this block.
@@ -51,11 +47,6 @@ func addTransaction(b *bolt.Bucket, tx *Transaction) error {
 
 // Add transaction to the db.
 func (txs *transactions) Add(t *Transaction) error {
-	txs.lastTxs = append(txs.lastTxs, t.Hash())
-	if len(txs.lastTxs) > lastTxNum {
-		txs.lastTxs = txs.lastTxs[1:]
-	}
-
 	key := t.Hash()
 	v := encoder.Serialize(t)
 	return txs.bkt.Put(key[:], v)
@@ -105,16 +96,4 @@ func (txs *transactions) IsEmpty() bool {
 // Reset resets the bucket
 func (txs *transactions) Reset() error {
 	return txs.bkt.Reset()
-}
-
-// GetLastTxs get latest tx hash set.
-func (txs *transactions) GetLastTxs() []cipher.SHA256 {
-	return txs.lastTxs
-}
-
-func (txs *transactions) updateLastTxs(hash cipher.SHA256) {
-	txs.lastTxs = append(txs.lastTxs, hash)
-	if len(txs.lastTxs) > lastTxNum {
-		txs.lastTxs = txs.lastTxs[1:]
-	}
 }

--- a/src/visor/historydb/transaction_test.go
+++ b/src/visor/historydb/transaction_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/skycoin/skycoin/src/cipher"
@@ -19,34 +18,6 @@ var _ = func() int64 {
 	rand.Seed(t)
 	return t
 }()
-
-func TestGetLastTxs(t *testing.T) {
-	testData := []uint64{0, 3, lastTxNum, lastTxNum + 10}
-	for i := range testData {
-		func(i uint64) {
-			db, teardown := testutil.PrepareDB(t)
-			defer teardown()
-			txIns, err := newTransactionsBkt(db)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			var txs []cipher.SHA256
-			for j := uint64(0); j < testData[i]; j++ {
-				tx := makeTransaction()
-				txs = append(txs, tx.Hash())
-				if err := txIns.Add(&tx); err != nil {
-					t.Fatal(err)
-				}
-			}
-			if testData[i] > lastTxNum {
-				txs = txs[len(txs)-lastTxNum:]
-			}
-			lastTxHash := txIns.GetLastTxs()
-			assert.Equal(t, txs, lastTxHash)
-		}(uint64(i))
-	}
-}
 
 func TestTransactionGet(t *testing.T) {
 	txs := make([]Transaction, 0, 3)

--- a/src/visor/historyer_mock_test.go
+++ b/src/visor/historyer_mock_test.go
@@ -96,33 +96,6 @@ func (m *historyerMock) GetAddrUxOuts(p0 cipher.Address) ([]*historydb.UxOut, er
 
 }
 
-// GetLastTxs mocked method
-func (m *historyerMock) GetLastTxs() ([]*historydb.Transaction, error) {
-
-	ret := m.Called()
-
-	var r0 []*historydb.Transaction
-	switch res := ret.Get(0).(type) {
-	case nil:
-	case []*historydb.Transaction:
-		r0 = res
-	default:
-		panic(fmt.Sprintf("unexpected type: %v", res))
-	}
-
-	var r1 error
-	switch res := ret.Get(1).(type) {
-	case nil:
-	case error:
-		r1 = res
-	default:
-		panic(fmt.Sprintf("unexpected type: %v", res))
-	}
-
-	return r0, r1
-
-}
-
 // GetTransaction mocked method
 func (m *historyerMock) GetTransaction(p0 cipher.SHA256) (*historydb.Transaction, error) {
 

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -173,7 +173,6 @@ type historyer interface {
 	GetUxout(uxid cipher.SHA256) (*historydb.UxOut, error)
 	ParseBlock(b *coin.Block) error
 	GetTransaction(hash cipher.SHA256) (*historydb.Transaction, error)
-	GetLastTxs() ([]*historydb.Transaction, error)
 	GetAddrUxOuts(address cipher.Address) ([]*historydb.UxOut, error)
 	GetAddrTxns(address cipher.Address) ([]historydb.Transaction, error)
 	ForEach(f func(tx *historydb.Transaction) error) error
@@ -1003,37 +1002,6 @@ func (vs *Visor) GetBlockBySeq(seq uint64) (*coin.SignedBlock, error) {
 // GetLastBlocks returns last N blocks
 func (vs *Visor) GetLastBlocks(num uint64) []coin.SignedBlock {
 	return vs.Blockchain.GetLastBlocks(num)
-}
-
-// GetLastTxs returns last confirmed transactions, return nil if empty
-func (vs *Visor) GetLastTxs() ([]*Transaction, error) {
-	ltxs, err := vs.history.GetLastTxs()
-	if err != nil {
-		return nil, err
-	}
-
-	txs := make([]*Transaction, len(ltxs))
-	var confirms uint64
-	bh := vs.HeadBkSeq()
-	var b *coin.SignedBlock
-	for i, tx := range ltxs {
-		confirms = uint64(bh) - tx.BlockSeq + 1
-		b, err = vs.GetBlockBySeq(tx.BlockSeq)
-		if err != nil {
-			return nil, err
-		}
-
-		if b == nil {
-			return nil, fmt.Errorf("found no block in seq %v", tx.BlockSeq)
-		}
-
-		txs[i] = &Transaction{
-			Txn:    tx.Tx,
-			Status: NewConfirmedTransactionStatus(confirms, tx.BlockSeq),
-			Time:   b.Time(),
-		}
-	}
-	return txs, nil
 }
 
 // GetHeadBlock gets head block.


### PR DESCRIPTION
Also remove `/lastTxs` endpoint, it is unused and the history data is reset between restarts (fix #632 by removing the endpoint and the temporary transaction history)