### PR TITLE
Add wallet integration test option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,10 +101,10 @@ lint: ## Run linters. Use make install-linters first.
 check: lint test ## Run tests and linters
 
 integration-test-stable: ## Run stable integration tests
-	./ci-scripts/integration-test-stable.sh -v
+	./ci-scripts/integration-test-stable.sh -v -w
 
 integration-test-live: ## Run live integration tests
-	./ci-scripts/integration-test-live.sh -v
+	./ci-scripts/integration-test-live.sh -v -w
 
 cover: ## Runs tests on ./src/ with HTML code coverage
 	go test -cover -coverprofile=cover.out -coverpkg=github.com/skycoin/skycoin/... ./src/...

--- a/ci-scripts/integration-test-live.sh
+++ b/ci-scripts/integration-test-live.sh
@@ -17,14 +17,17 @@ UPDATE=""
 VERBOSE=""
 # run go test with -run flag
 RUN_TESTS=""
+# run wallet tests
+TEST_WALLET=""
 
 usage () {
   echo "Usage: $SCRIPT"
   echo "Optional command line arguments"
   echo "-t <string>  -- Test to run, gui or cli; empty runs both tests"
-  echo "-r <string>  -- Test to run with -run flag"
+  echo "-r <string>  -- Run test with -run flag"
   echo "-u <boolean> -- Update stable testdata"
   echo "-v <boolean> -- Run test with -v flag"
+  echo "-w <boolean> -- Run wallet tests"
   exit 1
 }
 
@@ -34,9 +37,10 @@ case $args in
         usage;
         exit;;
     t ) TEST=${OPTARG};;
-    r ) RUN_TESTS=${OPTARG};;
+    r ) RUN_TESTS="-run ${OPTARG}";;
     u ) UPDATE="--update";;
     v ) VERBOSE="-v";;
+    w ) TEST_WALLET="--test-wallet"
   esac
 done
 
@@ -53,12 +57,12 @@ fi
 
 if [[ -z $TEST || $TEST = "gui" ]]; then
 
-SKYCOIN_INTEGRATION_TESTS=1 SKYCOIN_INTEGRATION_TEST_MODE=$MODE SKYCOIN_NODE_HOST=$HOST go test ./src/gui/integration/... $UPDATE -timeout=3m $VERBOSE -run=$RUN_TESTS
+SKYCOIN_INTEGRATION_TESTS=1 SKYCOIN_INTEGRATION_TEST_MODE=$MODE SKYCOIN_NODE_HOST=$HOST go test ./src/gui/integration/... $UPDATE -timeout=3m $VERBOSE $RUN_TESTS $TEST_WALLET
 
 fi
 
 if [[ -z $TEST || $TEST = "cli" ]]; then
 
-SKYCOIN_INTEGRATION_TESTS=1 SKYCOIN_INTEGRATION_TEST_MODE=$MODE RPC_ADDR=$RPC_ADDR go test ./src/api/cli/integration/... $UPDATE -timeout=3m $VERBOSE -run=$RUN_TESTS
+SKYCOIN_INTEGRATION_TESTS=1 SKYCOIN_INTEGRATION_TEST_MODE=$MODE RPC_ADDR=$RPC_ADDR go test ./src/api/cli/integration/... $UPDATE -timeout=3m $VERBOSE $RUN_TESTS $TEST_WALLET
 
 fi

--- a/ci-scripts/integration-test-live.sh
+++ b/ci-scripts/integration-test-live.sh
@@ -31,7 +31,7 @@ usage () {
   exit 1
 }
 
-while getopts "h?t:r:uv" args; do
+while getopts "h?t:r:uvw" args; do
 case $args in
     h|\?)
         usage;

--- a/ci-scripts/integration-test-stable.sh
+++ b/ci-scripts/integration-test-stable.sh
@@ -15,27 +15,32 @@ TEST=""
 UPDATE=""
 # run go test with -v flag
 VERBOSE=""
+# run go test with -run flag
 RUN_TESTS=""
+# run wallet tests
+TEST_WALLET=""
 
 usage () {
   echo "Usage: $SCRIPT"
   echo "Optional command line arguments"
   echo "-t <string>  -- Test to run, gui or cli; empty runs both tests"
-  echo "-r <string>  -- Test to run with -run flag"
+  echo "-r <string>  -- Run test with -run flag"
   echo "-u <boolean> -- Update stable testdata"
   echo "-v <boolean> -- Run test with -v flag"
+  echo "-w <boolean> -- Run wallet tests"
   exit 1
 }
 
-while getopts "h?t:r:uv" args; do
+while getopts "h?t:r:uvw" args; do
   case $args in
     h|\?)
         usage;
         exit;;
     t ) TEST=${OPTARG};;
-    r ) RUN_TESTS=${OPTARG};;
+    r ) RUN_TESTS="-run ${OPTARG}";;
     u ) UPDATE="--update";;
     v ) VERBOSE="-v";;
+    w ) TEST_WALLET="--test-wallet"
   esac
 done
 
@@ -79,7 +84,7 @@ set +e
 
 if [[ -z $TEST || $TEST = "gui" ]]; then
 
-SKYCOIN_INTEGRATION_TESTS=1 SKYCOIN_INTEGRATION_TEST_MODE=$MODE SKYCOIN_NODE_HOST=$HOST WALLET_DIR=$WALLET_DIR go test ./src/gui/integration/... $UPDATE -timeout=30s $VERBOSE -run=$RUN_TESTS
+SKYCOIN_INTEGRATION_TESTS=1 SKYCOIN_INTEGRATION_TEST_MODE=$MODE SKYCOIN_NODE_HOST=$HOST go test ./src/gui/integration/... $UPDATE -timeout=30s $VERBOSE $RUN_TESTS $TEST_WALLET
 
 GUI_FAIL=$?
 
@@ -87,7 +92,7 @@ fi
 
 if [[ -z $TEST  || $TEST = "cli" ]]; then
 
-SKYCOIN_INTEGRATION_TESTS=1 SKYCOIN_INTEGRATION_TEST_MODE=$MODE RPC_ADDR=$RPC_ADDR go test ./src/api/cli/integration/... $UPDATE -timeout=30s $VERBOSE -run=$RUN_TESTS
+SKYCOIN_INTEGRATION_TESTS=1 SKYCOIN_INTEGRATION_TEST_MODE=$MODE RPC_ADDR=$RPC_ADDR go test ./src/api/cli/integration/... $UPDATE -timeout=30s $VERBOSE $RUN_TESTS $TEST_WALLET
 
 CLI_FAIL=$?
 

--- a/src/api/cli/integration/integration_test.go
+++ b/src/api/cli/integration/integration_test.go
@@ -48,6 +48,7 @@ var (
 
 	update     = flag.Bool("update", false, "update golden files")
 	liveTxFull = flag.Bool("live-tx-full", false, "run live transaction test against full blockchain")
+	testWallet = flag.Bool("test-wallet", false, "run wallet tests")
 )
 
 type TestData struct {
@@ -212,6 +213,15 @@ func doLive(t *testing.T) bool {
 	return false
 }
 
+func doWallet(t *testing.T) bool {
+	if *testWallet {
+		return true
+	}
+
+	t.Skip("Wallet tests disabled")
+	return false
+}
+
 // doLiveEnvCheck checks if the WALLET_DIR and WALLET_NAME environment value do exist
 func doLiveEnvCheck(t *testing.T) {
 	t.Helper()
@@ -264,6 +274,10 @@ func rpcAddress() string {
 
 func TestStableGenerateAddresses(t *testing.T) {
 	if !doStable(t) {
+		return
+	}
+
+	if !doWallet(t) {
 		return
 	}
 
@@ -669,6 +683,10 @@ func TestStableListWallets(t *testing.T) {
 		return
 	}
 
+	if !doWallet(t) {
+		return
+	}
+
 	_, clean := createTempWalletFile(t)
 	defer clean()
 
@@ -693,6 +711,10 @@ func TestLiveListWallets(t *testing.T) {
 		return
 	}
 
+	if !doWallet(t) {
+		return
+	}
+
 	doLiveEnvCheck(t)
 
 	output, err := exec.Command(binaryPath, "listWallets").CombinedOutput()
@@ -707,6 +729,10 @@ func TestLiveListWallets(t *testing.T) {
 
 func TestStableListAddress(t *testing.T) {
 	if !doStable(t) {
+		return
+	}
+
+	if !doWallet(t) {
 		return
 	}
 
@@ -731,6 +757,10 @@ func TestStableListAddress(t *testing.T) {
 
 func TestLiveListAddresses(t *testing.T) {
 	if !doLive(t) {
+		return
+	}
+
+	if !doWallet(t) {
 		return
 	}
 
@@ -782,6 +812,10 @@ func TestStableWalletBalance(t *testing.T) {
 		return
 	}
 
+	if !doWallet(t) {
+		return
+	}
+
 	_, clean := createTempWalletFile(t)
 	defer clean()
 
@@ -802,6 +836,10 @@ func TestLiveWalletBalance(t *testing.T) {
 		return
 	}
 
+	if !doWallet(t) {
+		return
+	}
+
 	doLiveEnvCheck(t)
 
 	output, err := exec.Command(binaryPath, "walletBalance").CombinedOutput()
@@ -814,6 +852,10 @@ func TestLiveWalletBalance(t *testing.T) {
 
 func TestStableWalletOutputs(t *testing.T) {
 	if !doStable(t) {
+		return
+	}
+
+	if !doWallet(t) {
 		return
 	}
 
@@ -834,6 +876,10 @@ func TestStableWalletOutputs(t *testing.T) {
 
 func TestLiveWalletOutputs(t *testing.T) {
 	if !doLive(t) {
+		return
+	}
+
+	if !doWallet(t) {
 		return
 	}
 
@@ -1332,6 +1378,10 @@ func TestStableWalletDir(t *testing.T) {
 		return
 	}
 
+	if !doWallet(t) {
+		return
+	}
+
 	walletPath, clean := createTempWalletFile(t)
 	defer clean()
 
@@ -1343,6 +1393,10 @@ func TestStableWalletDir(t *testing.T) {
 
 func TestLiveWalletDir(t *testing.T) {
 	if !doLive(t) {
+		return
+	}
+
+	if !doWallet(t) {
 		return
 	}
 
@@ -1366,6 +1420,10 @@ func TestLiveWalletDir(t *testing.T) {
 // 2. The wallet must must have at least 2 coins and 16 coinhours.
 func TestLiveSend(t *testing.T) {
 	if !doLive(t) {
+		return
+	}
+
+	if !doWallet(t) {
 		return
 	}
 
@@ -1540,6 +1598,10 @@ func TestLiveSend(t *testing.T) {
 // function like in TestLiveSend.
 func TestLiveCreateAndBroadcastRawTransaction(t *testing.T) {
 	if !doLive(t) {
+		return
+	}
+
+	if !doWallet(t) {
 		return
 	}
 
@@ -1843,6 +1905,10 @@ func TestStableWalletHistory(t *testing.T) {
 		return
 	}
 
+	if !doWallet(t) {
+		return
+	}
+
 	_, clean := createTempWalletFile(t)
 	defer clean()
 
@@ -1860,6 +1926,10 @@ func TestStableWalletHistory(t *testing.T) {
 
 func TestLiveWalletHistory(t *testing.T) {
 	if !doLive(t) {
+		return
+	}
+
+	if !doWallet(t) {
 		return
 	}
 
@@ -1948,6 +2018,10 @@ func TestVersion(t *testing.T) {
 
 func TestStableGenerateWallet(t *testing.T) {
 	if !doStable(t) {
+		return
+	}
+
+	if !doWallet(t) {
 		return
 	}
 
@@ -2072,7 +2146,6 @@ func TestStableGenerateWallet(t *testing.T) {
 				require.Equal(t, tc.errMsg, output)
 				return
 			}
-			fmt.Println("output:", string(output))
 
 			var rw wallet.ReadableWallet
 			err = json.NewDecoder(bytes.NewReader(output)).Decode(&rw)

--- a/src/gui/integration/integration_test.go
+++ b/src/gui/integration/integration_test.go
@@ -59,6 +59,7 @@ type TestData struct {
 }
 
 var update = flag.Bool("update", false, "update golden files")
+var testWallet = flag.Bool("test-wallet", false, "run wallet tests")
 
 func nodeAddress() string {
 	addr := os.Getenv("SKYCOIN_NODE_HOST")
@@ -111,6 +112,15 @@ func doLiveOrStable(t *testing.T) bool {
 	}
 
 	t.Skip("Live and stable tests disabled")
+	return false
+}
+
+func doWallet(t *testing.T) bool {
+	if *testWallet {
+		return true
+	}
+
+	t.Skip("Wallet tests disabled")
 	return false
 }
 
@@ -1518,6 +1528,10 @@ func TestWalletNewSeed(t *testing.T) {
 		return
 	}
 
+	if !doWallet(t) {
+		return
+	}
+
 	cases := []struct {
 		name     string
 		entropy  int
@@ -1806,6 +1820,10 @@ func TestLiveWalletSpend(t *testing.T) {
 	}
 
 	doLiveEnvCheck(t)
+
+	if !doWallet(t) {
+		return
+	}
 
 	c := gui.NewClient(nodeAddress())
 	w, totalCoins, _ := prepareAndCheckWallet(t, c, 2e6, 2)


### PR DESCRIPTION
Add `-w` option in `/ci-scripts/integration-test-live.sh` and `/ci-scripts/integration-test.stable.sh`.

To run the wallet integration tests, please specify the `-w` option explicitly. 

The `Makefile` in project root is using the `-w` option, so wallet integration tests will be tested if we run `make integration-test-live` or `make integration-test-stable`.

Fix #1067