### PR TITLE
Http timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Add Read, Write and Idle timeouts to the HTTP listener, preventing file descriptor leaks
 - Support absolute and relative paths for `-data-dir` option
 - Prevent creating transactions whose size exceeds the maximum block size
 - Check addition and multiplication uint64 overflow

--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -298,9 +298,9 @@ var devConfig = Config{
 	WalletDirectory: "",
 
 	// Timeout settings for http.Server
-	ReadTimeout:  5,
-	WriteTimeout: 10,
-	IdleTimeout:  60,
+	ReadTimeout:  5 * time.Second,
+	WriteTimeout: 10 * time.Second,
+	IdleTimeout:  60 * time.Second,
 
 	// Centralized network configuration
 	RunMaster:        false,
@@ -444,9 +444,9 @@ func createGUI(c *Config, d *daemon.Daemon, host string, quit chan struct{}) (*g
 	config := gui.ServerConfig{
 		StaticDir:    c.GUIDirectory,
 		DisableCSRF:  c.DisableCSRF,
-		IdleTimeout:  time.Second * c.IdleTimeout,
-		ReadTimeout:  time.Second * c.ReadTimeout,
-		WriteTimeout: time.Second * c.WriteTimeout,
+		IdleTimeout:  c.IdleTimeout,
+		ReadTimeout:  c.ReadTimeout,
+		WriteTimeout: c.WriteTimeout,
 	}
 
 	if c.WebInterfaceHTTPS {

--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -135,6 +135,10 @@ type Config struct {
 	// GUI directory contains assets for the html gui
 	GUIDirectory string
 
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+	IdleTimeout  time.Duration
+
 	// Logging
 	ColorLog bool
 	// This is the value registered with flag, it is converted to LogLevel after parsing
@@ -293,6 +297,10 @@ var devConfig = Config{
 	// Wallets
 	WalletDirectory: "",
 
+	ReadTimeout:  5,
+	WriteTimeout: 10,
+	IdleTimeout:  60,
+
 	// Centralized network configuration
 	RunMaster:        false,
 	BlockchainPubkey: cipher.PubKey{},
@@ -433,8 +441,11 @@ func createGUI(c *Config, d *daemon.Daemon, host string, quit chan struct{}) (*g
 	var err error
 
 	config := gui.ServerConfig{
-		StaticDir:   c.GUIDirectory,
-		DisableCSRF: c.DisableCSRF,
+		StaticDir:    c.GUIDirectory,
+		DisableCSRF:  c.DisableCSRF,
+		IdleTimeout:  time.Second * c.IdleTimeout,
+		ReadTimeout:  time.Second * c.ReadTimeout,
+		WriteTimeout: time.Second * c.WriteTimeout,
 	}
 
 	if c.WebInterfaceHTTPS {

--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -297,6 +297,7 @@ var devConfig = Config{
 	// Wallets
 	WalletDirectory: "",
 
+	// Timeout settings for http.Server
 	ReadTimeout:  5,
 	WriteTimeout: 10,
 	IdleTimeout:  60,

--- a/src/api/webrpc/webrpc.go
+++ b/src/api/webrpc/webrpc.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	wh "github.com/skycoin/skycoin/src/util/http"
 	"github.com/skycoin/skycoin/src/util/logging"
@@ -30,9 +31,17 @@ var (
 	// -32000 to -32099	Server error	Reserved for implementation-defined server-errors.
 
 	jsonRPC = "2.0"
+
+	logger = logging.MustGetLogger("webrpc")
 )
 
-var logger = logging.MustGetLogger("webrpc")
+const (
+	defaultReadTimeout  = time.Second * 10
+	defaultWriteTimeout = time.Second * 60
+	defaultIdleTimeout  = time.Second * 120
+	defaultWorkerNum    = 5
+	defaultChanBuffSize = 1000
+)
 
 // Request rpc request struct
 type Request struct {
@@ -116,24 +125,58 @@ type WebRPC struct {
 
 	ops      chan operation // request channel
 	mux      *http.ServeMux
+	server   *http.Server
 	handlers map[string]HandlerFunc
 	listener net.Listener
 	quit     chan struct{}
 }
 
+// Config configures the WebRPC
+type Config struct {
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+	IdleTimeout  time.Duration
+	WorkerNum    uint
+	ChanBuffSize uint // size of ops channel
+}
+
 // New returns a new WebRPC object
-func New(addr string, gw Gatewayer) (*WebRPC, error) {
+func New(addr string, c Config, gw Gatewayer) (*WebRPC, error) {
+	if c.ReadTimeout == 0 {
+		c.ReadTimeout = defaultReadTimeout
+	}
+	if c.WriteTimeout == 0 {
+		c.WriteTimeout = defaultWriteTimeout
+	}
+	if c.IdleTimeout == 0 {
+		c.IdleTimeout = defaultIdleTimeout
+	}
+	if c.WorkerNum == 0 {
+		c.WorkerNum = defaultWorkerNum
+	}
+	if c.ChanBuffSize == 0 {
+		c.ChanBuffSize = defaultChanBuffSize
+	}
+
+	mux := http.NewServeMux()
+
 	rpc := &WebRPC{
 		Addr:         addr,
 		Gateway:      gw,
-		WorkerNum:    5,
-		ChanBuffSize: 1000,
+		WorkerNum:    c.WorkerNum,
+		ChanBuffSize: c.ChanBuffSize,
 		quit:         make(chan struct{}),
-		mux:          http.NewServeMux(),
-		handlers:     make(map[string]HandlerFunc),
+		mux:          mux,
+		server: &http.Server{
+			Handler:      mux,
+			ReadTimeout:  c.ReadTimeout,
+			WriteTimeout: c.WriteTimeout,
+			IdleTimeout:  c.IdleTimeout,
+		},
+		handlers: make(map[string]HandlerFunc),
 	}
 
-	rpc.mux.Handle("/webrpc", wh.HostCheck(logger, addr, http.HandlerFunc(rpc.Handler)))
+	mux.Handle("/webrpc", wh.HostCheck(logger, addr, http.HandlerFunc(rpc.Handler)))
 
 	if err := rpc.initHandlers(); err != nil {
 		return nil, err
@@ -199,7 +242,7 @@ func (rpc *WebRPC) Run() error {
 
 	errC := make(chan error, 1)
 	go func() {
-		if err := http.Serve(rpc.listener, rpc); err != nil {
+		if err := rpc.server.Serve(rpc.listener); err != nil {
 			select {
 			case <-rpc.quit:
 				errC <- nil
@@ -235,11 +278,6 @@ func (rpc *WebRPC) HandleFunc(method string, h HandlerFunc) error {
 
 	rpc.handlers[method] = h
 	return nil
-}
-
-// ServHTTP implements the interface of http.Handler
-func (rpc *WebRPC) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	rpc.mux.ServeHTTP(w, r)
 }
 
 // Handler processes the http request

--- a/src/api/webrpc/webrpc_test.go
+++ b/src/api/webrpc/webrpc_test.go
@@ -23,7 +23,7 @@ import (
 const testWebRPCAddr = "127.0.0.1:8081"
 
 func setupWebRPC(t *testing.T) *WebRPC {
-	rpc, err := New(testWebRPCAddr, &fakeGateway{})
+	rpc, err := New(testWebRPCAddr, Config{}, &fakeGateway{})
 	require.NoError(t, err)
 	rpc.WorkerNum = 1
 	rpc.ChanBuffSize = 2
@@ -194,7 +194,7 @@ func Test_rpcHandler_Handler(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			rpc.ServeHTTP(rr, r)
+			rpc.mux.ServeHTTP(rr, r)
 
 			require.Equal(t, tt.status, rr.Code)
 

--- a/src/gui/http.go
+++ b/src/gui/http.go
@@ -18,6 +18,7 @@ import (
 	wh "github.com/skycoin/skycoin/src/util/http"
 	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/skycoin/skycoin/src/wallet"
+	"time"
 )
 
 var (
@@ -32,14 +33,18 @@ const (
 
 // Server exposes an HTTP API
 type Server struct {
+	*http.Server
 	mux      *http.ServeMux
 	listener net.Listener
 	done     chan struct{}
 }
 
 type ServerConfig struct {
-	StaticDir   string
-	DisableCSRF bool
+	StaticDir    string
+	DisableCSRF  bool
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+	IdleTimeout  time.Duration
 }
 
 func create(host string, serverConfig ServerConfig, daemon *daemon.Daemon) (*Server, error) {
@@ -56,10 +61,22 @@ func create(host string, serverConfig ServerConfig, daemon *daemon.Daemon) (*Ser
 		logger.Warning("CSRF check disabled")
 	}
 
-	return &Server{
-		mux:  NewServerMux(host, appLoc, daemon.Gateway, csrfStore),
+	srvMux := NewServerMux(host, appLoc, daemon.Gateway, csrfStore)
+	srv := &http.Server{
+		Handler:      srvMux,
+		ReadTimeout:  serverConfig.ReadTimeout,
+		WriteTimeout: serverConfig.WriteTimeout,
+		IdleTimeout:  serverConfig.IdleTimeout,
+	}
+
+	server := &Server{
 		done: make(chan struct{}),
-	}, nil
+	}
+
+	server.mux = srvMux
+	server.Server = srv
+
+	return server, nil
 }
 
 // Create creates a new Server instance that listens on HTTP
@@ -110,7 +127,7 @@ func (s *Server) Serve() error {
 	defer logger.Info("Web interface closed")
 	defer close(s.done)
 
-	if err := http.Serve(s.listener, s.mux); err != nil {
+	if err := s.Serve(s.listener); err != nil {
 		if err != http.ErrServerClosed {
 			return err
 		}

--- a/src/gui/http.go
+++ b/src/gui/http.go
@@ -12,13 +12,14 @@ import (
 	"strings"
 	"unicode"
 
+	"time"
+
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/daemon"
 	"github.com/skycoin/skycoin/src/util/file"
 	wh "github.com/skycoin/skycoin/src/util/http"
 	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/skycoin/skycoin/src/wallet"
-	"time"
 )
 
 var (

--- a/src/gui/http.go
+++ b/src/gui/http.go
@@ -33,7 +33,7 @@ const (
 
 // Server exposes an HTTP API
 type Server struct {
-	*http.Server
+	server   *http.Server
 	mux      *http.ServeMux
 	listener net.Listener
 	done     chan struct{}
@@ -70,11 +70,10 @@ func create(host string, serverConfig ServerConfig, daemon *daemon.Daemon) (*Ser
 	}
 
 	server := &Server{
-		done: make(chan struct{}),
+		server: srv,
+		mux:    srvMux,
+		done:   make(chan struct{}),
 	}
-
-	server.mux = srvMux
-	server.Server = srv
 
 	return server, nil
 }
@@ -127,7 +126,7 @@ func (s *Server) Serve() error {
 	defer logger.Info("Web interface closed")
 	defer close(s.done)
 
-	if err := s.Serve(s.listener); err != nil {
+	if err := s.server.Serve(s.listener); err != nil {
 		if err != http.ErrServerClosed {
 			return err
 		}


### PR DESCRIPTION
Fixes #1017

Changes:
- Add Read, Write and Idle timeouts to gui and webrpc http listeners

May fix the "http: Accept error : accept tcp [::]10020:accept4: too many open files" problem that has been reported in #1062 and seen on the explorer node.  This problem may also be affecting exchanges like Cryptopia which actively use the API interfaces in a long running node.

This change is also necessary to support running a node publicly, in the case of the web and mobile wallet.

More information in: 
https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/
https://blog.gopheracademy.com/advent-2016/exposing-go-on-the-internet/

Does this change need to mentioned in CHANGELOG.md?
Yes, added