### PR TITLE
Add wallet unload endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `/richlist` API method, returns top n address balances
 - `/addresscount` API method, returns the number of addresses that have any amount of coins
 - `/transactions` API method, returns transactions of addresses
+- `/wallet/unload` API method, removes the wallet of given id from wallet services
 
 ### Fixed
 

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -769,7 +769,7 @@ func (gw *Gateway) UnloadWallet(id string) error {
 		return wallet.ErrWalletApiDisabled
 	}
 
-	gw.strand("CreateWallet", func() {
+	gw.strand("UnloadWallet", func() {
 		gw.vrpc.UnloadWallet(id)
 	})
 

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -762,3 +762,16 @@ func (gw *Gateway) GetAddressCount() (uint64, error) {
 
 	return uint64(len(allAccounts)), nil
 }
+
+// UnloadWallet removes wallet of given id from memory.
+func (gw *Gateway) UnloadWallet(id string) error {
+	if gw.Config.DisableWalletAPI {
+		return wallet.ErrWalletApiDisabled
+	}
+
+	gw.strand("CreateWallet", func() {
+		gw.vrpc.UnloadWallet(id)
+	})
+
+	return nil
+}

--- a/src/gui/README.md
+++ b/src/gui/README.md
@@ -572,6 +572,22 @@ result:
 }
 ```
 
+### Unload wallet
+
+```
+URI: /wallet/unload
+Method: POST
+Args:
+    id: wallet file name
+```
+
+example:
+
+```bash
+curl -X POST \
+    'http://127.0.0.1:6420/wallet/unload?id=2017_05_09_d554.wlt'
+```
+
 ## Transaction apis
 
 ### Get unconfirmed transactions

--- a/src/gui/client.go
+++ b/src/gui/client.go
@@ -683,5 +683,5 @@ func (c *Client) AddressCount() (uint64, error) {
 func (c *Client) UnloadWallet(id string) error {
 	v := url.Values{}
 	v.Add("id", id)
-	return c.Post("/wallet/unload", strings.NewReader(v.Encode()), nil)
+	return c.PostForm("/wallet/unload", strings.NewReader(v.Encode()), nil)
 }

--- a/src/gui/client.go
+++ b/src/gui/client.go
@@ -448,10 +448,7 @@ func (c *Client) UpdateWallet(id, label string) error {
 	v.Add("id", id)
 	v.Add("label", label)
 
-	if err := c.PostForm("/wallet/update", strings.NewReader(v.Encode()), nil); err != nil {
-		return err
-	}
-	return nil
+	return c.PostForm("/wallet/update", strings.NewReader(v.Encode()), nil)
 }
 
 // WalletFolderName makes a request to /wallets/folderName
@@ -680,4 +677,11 @@ func (c *Client) AddressCount() (uint64, error) {
 	}
 	return r.Count, nil
 
+}
+
+// UnloadWallet make a request to /wallet/unload
+func (c *Client) UnloadWallet(id string) error {
+	v := url.Values{}
+	v.Add("id", id)
+	return c.Post("/wallet/unload", strings.NewReader(v.Encode()), nil)
 }

--- a/src/gui/csrf_test.go
+++ b/src/gui/csrf_test.go
@@ -62,6 +62,7 @@ var endpoints = []string{
 	"/wallets",
 	"/wallets/folderName",
 	"/wallet/newSeed",
+	"/wallet/unload",
 	"/blockchain/metadata",
 	"/blockchain/progress",
 	"/block",

--- a/src/gui/gateway.go
+++ b/src/gui/gateway.go
@@ -47,4 +47,5 @@ type Gatewayer interface {
 	GetAddressTxns(a cipher.Address) (*visor.TransactionResults, error)
 	GetRichlist(includeDistribution bool) (visor.Richlist, error)
 	GetAddressCount() (uint64, error)
+	UnloadWallet(id string) error
 }

--- a/src/gui/gatewayer_mock_test.go
+++ b/src/gui/gatewayer_mock_test.go
@@ -819,6 +819,24 @@ func (m *GatewayerMock) Spend(p0 string, p1 uint64, p2 cipher.Address) (*coin.Tr
 
 }
 
+// UnloadWallet mocked method
+func (m *GatewayerMock) UnloadWallet(p0 string) error {
+
+	ret := m.Called(p0)
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
 // UpdateWalletLabel mocked method
 func (m *GatewayerMock) UpdateWalletLabel(p0 string, p1 string) error {
 

--- a/src/gui/http.go
+++ b/src/gui/http.go
@@ -262,6 +262,11 @@ func newServerMux(c muxConfig, gateway Gatewayer, csrfStore *CSRFStore) *http.Se
 	// generate wallet seed
 	webHandler("/wallet/newSeed", newWalletSeed(gateway))
 
+	// unload wallet
+	// POST Argument:
+	//         id: wallet id
+	webHandler("/wallet/unload", walletUnloadHandler(gateway))
+
 	// Blockchain interface
 
 	webHandler("/blockchain/metadata", blockchainHandler(gateway))

--- a/src/gui/integration/integration_test.go
+++ b/src/gui/integration/integration_test.go
@@ -2281,7 +2281,7 @@ func createWallet(t *testing.T, c *gui.Client) (*wallet.Wallet, func()) {
 		require.NoError(t, err)
 
 		// Removes the wallet from memory
-		c.UnloadWallet(walletName)
+		c.UnloadWallet(w.GetFilename())
 	}
 }
 

--- a/src/gui/integration/integration_test.go
+++ b/src/gui/integration/integration_test.go
@@ -2009,9 +2009,6 @@ func TestGetWallets(t *testing.T) {
 
 // TestWalletNewAddress will generate 30 wallets for testing, and they will
 // be removed automatically after testing.
-//
-// Note: Though the new generated wallet files are all deleted, they are still
-// in the memory, you need to resrat the node to free them.
 func TestWalletNewAddress(t *testing.T) {
 	if !doLiveOrStable(t) {
 		return
@@ -2282,6 +2279,9 @@ func createWallet(t *testing.T, c *gui.Client) (*wallet.Wallet, func()) {
 		bakWalletPath := walletPath + ".bak"
 		err = os.Remove(bakWalletPath)
 		require.NoError(t, err)
+
+		// Removes the wallet from memory
+		c.UnloadWallet(walletName)
 	}
 }
 

--- a/src/gui/wallet.go
+++ b/src/gui/wallet.go
@@ -506,8 +506,12 @@ func walletUnloadHandler(gateway Gatewayer) http.HandlerFunc {
 		}
 
 		if err := gateway.UnloadWallet(id); err != nil {
-			wh.Error400(w, err.Error())
-			return
+			switch err {
+			case wallet.ErrWalletApiDisabled:
+				wh.Error403(w)
+			default:
+				wh.Error500(w)
+			}
 		}
 	}
 }

--- a/src/gui/wallet.go
+++ b/src/gui/wallet.go
@@ -491,3 +491,23 @@ func newWalletSeed(gateway Gatewayer) http.HandlerFunc {
 		wh.SendJSONOr500(logger, w, rlt)
 	}
 }
+
+func walletUnloadHandler(gateway Gatewayer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			wh.Error405(w)
+			return
+		}
+
+		id := r.FormValue("id")
+		if id == "" {
+			wh.Error400(w, "missing wallet id")
+			return
+		}
+
+		if err := gateway.UnloadWallet(id); err != nil {
+			wh.Error400(w, err.Error())
+			return
+		}
+	}
+}

--- a/src/gui/wallet_test.go
+++ b/src/gui/wallet_test.go
@@ -1581,7 +1581,7 @@ func TestWalletUnloadHandler(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			handler := NewServerMux(configuredHost, ".", gateway, csrfStore)
+			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore)
 
 			handler.ServeHTTP(rr, req)
 

--- a/src/visor/rpc.go
+++ b/src/visor/rpc.go
@@ -182,3 +182,8 @@ func (rpc *RPC) ReloadWallets() error {
 func (rpc *RPC) GetBuildInfo() BuildInfo {
 	return rpc.v.Config.BuildInfo
 }
+
+// UnloadWallet removes the wallet of given id from wallet service.
+func (rpc *RPC) UnloadWallet(id string) {
+	rpc.v.wallets.Remove(id)
+}

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -275,6 +275,13 @@ func (serv *Service) UpdateWalletLabel(wltID, label string) error {
 	return wlt.Save(serv.WalletDirectory)
 }
 
+// Remove removes wallet of given wallet id from the service
+func (serv *Service) Remove(wltID string) {
+	serv.Lock()
+	defer serv.Unlock()
+	serv.wallets.Remove(wltID)
+}
+
 func (serv *Service) removeDup(wlts Wallets) Wallets {
 	var rmWltIDS []string
 	// remove dup wallets


### PR DESCRIPTION
Fixes #1086 

Changes:
- Add `/wallet/unload` endpoint
- Remove temporary created wallets from memory in clean up function for integration tests

Does this change need to mentioned in CHANGELOG.md?
Yes, added.