### PR TITLE
use gopath instead of home in TestBuildDataDirDotOk

### DIFF
--- a/src/util/file/file_test.go
+++ b/src/util/file/file_test.go
@@ -65,7 +65,7 @@ func TestBuildDataDirDotOk(t *testing.T) {
 	// by default go uses GOPATH=$HOME/go if it is not set
 	if gopath == "" {
 		home := filepath.Clean(UserHome())
-		gopath = home + "/" + "go"
+		gopath = filepath.Join(home, "go")
 	}
 
 	require.True(t, strings.HasPrefix(builtDir, gopath))

--- a/src/util/file/file_test.go
+++ b/src/util/file/file_test.go
@@ -62,12 +62,14 @@ func TestBuildDataDirDotOk(t *testing.T) {
 	require.True(t, strings.HasSuffix(builtDir, cleanDir))
 
 	gopath := os.Getenv("GOPATH")
+	// by default go uses GOPATH=$HOME/go if it is not set
 	if gopath == "" {
-		require.Equal(t, cleanDir, builtDir)
-	} else {
-		require.True(t, strings.HasPrefix(builtDir, gopath))
-		require.NotEqual(t, builtDir, filepath.Clean(gopath))
+		home := filepath.Clean(UserHome())
+		gopath = home + "/" + "go"
 	}
+
+	require.True(t, strings.HasPrefix(builtDir, gopath))
+	require.NotEqual(t, builtDir, filepath.Clean(gopath))
 }
 
 func TestBuildDataDirEmptyError(t *testing.T) {

--- a/src/util/file/file_test.go
+++ b/src/util/file/file_test.go
@@ -61,12 +61,12 @@ func TestBuildDataDirDotOk(t *testing.T) {
 	cleanDir := filepath.Clean(dir)
 	require.True(t, strings.HasSuffix(builtDir, cleanDir))
 
-	home := filepath.Clean(UserHome())
-	if home == "" {
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
 		require.Equal(t, cleanDir, builtDir)
 	} else {
-		require.True(t, strings.HasPrefix(builtDir, home))
-		require.NotEqual(t, builtDir, filepath.Clean(home))
+		require.True(t, strings.HasPrefix(builtDir, gopath))
+		require.NotEqual(t, builtDir, filepath.Clean(gopath))
 	}
 }
 


### PR DESCRIPTION
Changes:
-
Check for `GOPATH` prefix instead of `~` in `TestBuildDataDirDotOk` as when tests are run `go test` goes to the directory of the file containing the test and creates all files/dirs relative to that. Since go projects are under the `GOPATH` directory its better to check for that.

Does this change need to mentioned in CHANGELOG.md?
No