### PR TITLE
make balance container center aligned

### DIFF
--- a/src/gui/static/src/app/components/layout/header/header.component.scss
+++ b/src/gui/static/src/app/components/layout/header/header.component.scss
@@ -25,6 +25,7 @@
   flex: 1 1 auto;
   font-size: 12px;
   justify-content: center;
+  text-align: center;
 
   .balance {
     .coins {


### PR DESCRIPTION
Fixes #1133 

Changes:
- Make balance container center aligned

Before:
<img width="365" alt="screen shot 2018-03-21 at 6 00 25 pm" src="https://user-images.githubusercontent.com/8619106/37711004-6992d4a6-2d35-11e8-8c66-8f2420c08ed0.png">

After:
<img width="333" alt="screen shot 2018-03-21 at 6 26 57 pm" src="https://user-images.githubusercontent.com/8619106/37711030-7b3cbbe0-2d35-11e8-98ee-aa4085015311.png">

Does this change need to mentioned in CHANGELOG.md?
No