### PR TITLE
[util] fixes #1161 - logging compatibility

### DIFF
--- a/src/util/logging/formatter.go
+++ b/src/util/logging/formatter.go
@@ -81,6 +81,9 @@ type TextFormatter struct {
 	// Name of the logging field containing priority level
 	PriorityKey string
 
+	// Highlight messages with this priority
+	HighlightPriorityValue string
+
 	// Set to true to bypass checking for a TTY before outputting colors.
 	ForceColors bool
 
@@ -254,7 +257,7 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 	}
 
 	priority, ok := entry.Data[f.PriorityKey]
-	hasPriority := ok && priority == "CRITICAL"
+	hasPriority := ok && priority == f.HighlightPriorityValue
 
 	if entry.Level != logrus.WarnLevel {
 		levelText = entry.Level.String()

--- a/src/util/logging/formatter.go
+++ b/src/util/logging/formatter.go
@@ -348,7 +348,7 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 	}
 
 	for _, k := range keys {
-		if k != "prefix" && k != "file" && k != "func" && k != "line" {
+		if k != "prefix" && k != "file" && k != "func" && k != "line" && k != f.PriorityKey && k != LogModuleKey {
 			v := entry.Data[k]
 			fmt.Fprintf(b, " %s", f.formatKeyValue(levelColor(k), v))
 		}

--- a/src/util/logging/hooks.go
+++ b/src/util/logging/hooks.go
@@ -56,10 +56,10 @@ type ModuleLogHook struct {
 	ModuleName  string
 }
 
-func NewModuleLogHook(moduleName string) logrus.Hook {
+func NewModuleLogHook(moduleName string) ModuleLogHook {
 	return ModuleLogHook{
-		FieldKey:    "module",
-		PriorityKey: "priority",
+		FieldKey:    LogModuleKey,
+		PriorityKey: LogPriorityKey,
 		ModuleName:  moduleName,
 	}
 }

--- a/src/util/logging/logging.go
+++ b/src/util/logging/logging.go
@@ -4,7 +4,12 @@ import (
 	"io"
 )
 
-var log = NewLogger()
+var log = NewLogger(LogPriorityKey, LogPriorityCritical)
+
+const (
+	LogPriorityKey      = "priority"
+	LogPriorityCritical = "CRITICAL"
+)
 
 // MustGetLogger safe initialize global logger
 func MustGetLogger(module string) *Logger {

--- a/src/util/logging/logging.go
+++ b/src/util/logging/logging.go
@@ -8,6 +8,7 @@ var log = NewLogger(LogPriorityKey, LogPriorityCritical)
 
 const (
 	LogPriorityKey      = "priority"
+	LogModuleKey        = "module"
 	LogPriorityCritical = "CRITICAL"
 )
 


### PR DESCRIPTION
Fixes #1161 

Changes:
- Hide module, and priority fields out of text messages (suggested by @iketheadore in #1149 )
- Include log level in prefix
- Add constant for CRITICAL priority .

Does this change need to mentioned in CHANGELOG.md?
No