### PR TITLE
Handle newline characters in seed input

### DIFF
--- a/src/gui/static/src/app/components/pages/wallets/create-wallet/create-wallet.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/create-wallet/create-wallet.component.ts
@@ -28,12 +28,12 @@ export class CreateWalletComponent implements OnInit {
   }
 
   createWallet() {
-    this.walletService.create(this.form.value.label, this.form.value.seed.trim(), this.scan)
+    this.walletService.create(this.form.value.label, this.form.value.seed, this.scan)
       .subscribe(() => this.dialogRef.close());
   }
 
   generateSeed() {
-    this.walletService.generateSeed().subscribe(seed => this.form.controls.seed.setValue(seed, { emitEvent: false }));
+    this.walletService.generateSeed().subscribe(seed => this.form.controls.seed.setValue(seed));
   }
 
   private initForm() {
@@ -43,12 +43,6 @@ export class CreateWalletComponent implements OnInit {
     this.form.addControl('confirm_seed', new FormControl('', [
       Validators.compose([Validators.required, this.validateAreEqual.bind(this)])
     ]));
-
-    ['seed', 'confirm_seed'].forEach(control =>
-      this.form.get(control).valueChanges.subscribe(v =>
-        this.form.get(control).setValue(v.replace(/\r?\n|\r/g, ' ').replace(/ +/g, ' '), { emitEvent: false })
-      )
-    );
 
     this.generateSeed();
 

--- a/src/gui/static/src/app/components/pages/wallets/create-wallet/create-wallet.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/create-wallet/create-wallet.component.ts
@@ -46,7 +46,7 @@ export class CreateWalletComponent implements OnInit {
 
     ['seed', 'confirm_seed'].forEach(control =>
       this.form.get(control).valueChanges.subscribe(v =>
-        this.form.get(control).setValue(this.reformatInput(v), { emitEvent: false })
+        this.form.get(control).setValue(v.replace(/\r?\n|\r/g, ' ').replace(/ +/g, ' '), { emitEvent: false })
       )
     );
 
@@ -57,9 +57,5 @@ export class CreateWalletComponent implements OnInit {
 
   private validateAreEqual(fieldControl: FormControl) {
     return fieldControl.value.trim() === this.form.get('seed').value.trim() ? null : { NotEqual: true };
-  }
-
-  private reformatInput(value) {
-    return value.replace(/\r?\n|\r/g, ' ').replace(/ +/g, ' ');
   }
 }

--- a/src/gui/static/src/app/components/pages/wallets/create-wallet/create-wallet.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/create-wallet/create-wallet.component.ts
@@ -33,7 +33,7 @@ export class CreateWalletComponent implements OnInit {
   }
 
   generateSeed() {
-    this.walletService.generateSeed().subscribe(seed => this.form.controls.seed.setValue(seed));
+    this.walletService.generateSeed().subscribe(seed => this.form.controls.seed.setValue(seed, { emitEvent: false }));
   }
 
   private initForm() {

--- a/src/gui/static/src/app/components/pages/wallets/create-wallet/create-wallet.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/create-wallet/create-wallet.component.ts
@@ -28,7 +28,7 @@ export class CreateWalletComponent implements OnInit {
   }
 
   createWallet() {
-    this.walletService.create(this.form.value.label, this.form.value.seed, this.scan)
+    this.walletService.create(this.form.value.label, this.form.value.seed.trim(), this.scan)
       .subscribe(() => this.dialogRef.close());
   }
 
@@ -44,12 +44,22 @@ export class CreateWalletComponent implements OnInit {
       Validators.compose([Validators.required, this.validateAreEqual.bind(this)])
     ]));
 
+    ['seed', 'confirm_seed'].forEach(control =>
+      this.form.get(control).valueChanges.subscribe(v =>
+        this.form.get(control).setValue(this.reformatInput(v), { emitEvent: false })
+      )
+    );
+
     this.generateSeed();
 
     this.scan = 100;
   }
 
-  private validateAreEqual(fieldControl: FormControl){
-    return fieldControl.value === this.form.get('seed').value ? null : { NotEqual: true };
+  private validateAreEqual(fieldControl: FormControl) {
+    return fieldControl.value.trim() === this.form.get('seed').value.trim() ? null : { NotEqual: true };
+  }
+
+  private reformatInput(value) {
+    return value.replace(/\r?\n|\r/g, ' ').replace(/ +/g, ' ');
   }
 }

--- a/src/gui/static/src/app/components/pages/wallets/load-wallet/load-wallet.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/load-wallet/load-wallet.component.ts
@@ -30,7 +30,7 @@ export class LoadWalletComponent implements OnInit {
   }
 
   loadWallet() {
-    this.walletService.create(this.form.value.label, this.form.value.seed.trim(), this.scan)
+    this.walletService.create(this.form.value.label, this.form.value.seed, this.scan)
       .subscribe(
         () => this.dialogRef.close(),
         error => this.snackbar.open(error['_body'], null, { duration: 5000 })
@@ -42,9 +42,5 @@ export class LoadWalletComponent implements OnInit {
     this.form.addControl('label', new FormControl('', [Validators.required]));
     this.form.addControl('seed', new FormControl('', [Validators.required]));
     this.scan = 100;
-
-    this.form.get('seed').valueChanges.subscribe(v =>
-      this.form.get('seed').setValue(v.replace(/\r?\n|\r/g, ' ').replace(/ +/g, ' '), { emitEvent: false })
-    );
   }
 }

--- a/src/gui/static/src/app/components/pages/wallets/load-wallet/load-wallet.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/load-wallet/load-wallet.component.ts
@@ -30,7 +30,7 @@ export class LoadWalletComponent implements OnInit {
   }
 
   loadWallet() {
-    this.walletService.create(this.form.value.label, this.form.value.seed, this.scan)
+    this.walletService.create(this.form.value.label, this.form.value.seed.trim(), this.scan)
       .subscribe(
         () => this.dialogRef.close(),
         error => this.snackbar.open(error['_body'], null, { duration: 5000 })
@@ -42,5 +42,9 @@ export class LoadWalletComponent implements OnInit {
     this.form.addControl('label', new FormControl('', [Validators.required]));
     this.form.addControl('seed', new FormControl('', [Validators.required]));
     this.scan = 100;
+
+    this.form.get('seed').valueChanges.subscribe(v =>
+      this.form.get('seed').setValue(v.replace(/\r?\n|\r/g, ' ').replace(/ +/g, ' '), { emitEvent: false })
+    );
   }
 }

--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -52,6 +52,8 @@ export class WalletService {
   }
 
   create(label, seed, scan) {
+    seed = seed.replace(/\r?\n|\r/g, ' ').replace(/ +/g, ' ').trim();
+
     return this.apiService.postWalletCreate(label ? label : 'undefined', seed, scan ? scan : 100)
       .do(wallet => {
         console.log(wallet);


### PR DESCRIPTION
Fixes #725 

Changes:
- newline characters are removed from seed input (also works for seeds copied as multiline text)
- starting/trailing whitespaces are ignored for convenience (when validating), but trimmed on submit