### PR TITLE
[lib] refs #1028 - libskycoin.h is generated in include folder

### DIFF
--- a/lib/cgo/README.md
+++ b/lib/cgo/README.md
@@ -28,7 +28,7 @@ In order to test the C client libraries follow these steps
 
 The following files will be generated
 
-- `build/libskycoin.h` - Header file for including libskycoin symbols in your app code
+- `include/libskycoin.h` - Platform-specific header file for including libskycoin symbols in your app code
 - `build/libskycoin.a` - Static library.
 - `build/libskycoin.so` - Shared library object.
 


### PR DESCRIPTION
Refers to #1028

Changes:
- libskycoin README

Does this change need to mentioned in CHANGELOG.md?
No