### PR TITLE
implement advanced spend

### DIFF
--- a/src/cipher/encrypt/sha256xor_test.go
+++ b/src/cipher/encrypt/sha256xor_test.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/skycoin/skycoin/src/cipher"
 	secp256k1 "github.com/skycoin/skycoin/src/cipher/secp256k1-go"
 	"github.com/skycoin/skycoin/src/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestEncrypt(t *testing.T) {

--- a/src/gui/gateway.go
+++ b/src/gui/gateway.go
@@ -14,6 +14,7 @@ import (
 // Gatewayer interface for Gateway methods
 type Gatewayer interface {
 	Spend(wltID string, password []byte, coins uint64, dest cipher.Address) (*coin.Transaction, error)
+	AdvancedSpend(advancedSpend wallet.AdvancedSpend) (*coin.Transaction, error)
 	GetWalletBalance(wltID string) (wallet.BalancePair, error)
 	GetWallet(wltID string) (*wallet.Wallet, error)
 	GetWallets() (wallet.Wallets, error)

--- a/src/gui/gatewayer_mock_test.go
+++ b/src/gui/gatewayer_mock_test.go
@@ -7,6 +7,7 @@ package gui
 
 import (
 	"fmt"
+
 	mock "github.com/stretchr/testify/mock"
 
 	cipher "github.com/skycoin/skycoin/src/cipher"

--- a/src/gui/gatewayer_mock_test.go
+++ b/src/gui/gatewayer_mock_test.go
@@ -7,7 +7,6 @@ package gui
 
 import (
 	"fmt"
-
 	mock "github.com/stretchr/testify/mock"
 
 	cipher "github.com/skycoin/skycoin/src/cipher"
@@ -25,6 +24,33 @@ type GatewayerMock struct {
 
 func NewGatewayerMock() *GatewayerMock {
 	return &GatewayerMock{}
+}
+
+// AdvancedSpend mocked method
+func (m *GatewayerMock) AdvancedSpend(p0 wallet.AdvancedSpend) (*coin.Transaction, error) {
+
+	ret := m.Called(p0)
+
+	var r0 *coin.Transaction
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case *coin.Transaction:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
 }
 
 // CreateWallet mocked method

--- a/src/gui/http.go
+++ b/src/gui/http.go
@@ -243,6 +243,10 @@ func newServerMux(c muxConfig, gateway Gatewayer, csrfStore *CSRFStore) *http.Se
 	//  failure status.
 	webHandler("/wallet/spend", walletSpendHandler(gateway))
 
+	// Advanced spend allows customization of a transaction
+	// provides more control over the unspents used and hours sent
+	webHandler("/spend/advanced", advancedSpendHandler(gateway))
+
 	// GET Arguments:
 	//      id: Wallet ID
 	// Returns all pending transanction for all addresses by selected Wallet

--- a/src/gui/spend.go
+++ b/src/gui/spend.go
@@ -1,0 +1,256 @@
+package gui
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/coin"
+	"github.com/skycoin/skycoin/src/util/droplet"
+	wh "github.com/skycoin/skycoin/src/util/http" //http,json helpers
+	"github.com/skycoin/skycoin/src/wallet"
+	"github.com/skycoin/skycoin/src/util/fee"
+	"github.com/skycoin/skycoin/src/visor"
+)
+
+type AdvancedSpendResult struct {
+	Transaction *visor.ReadableTransaction `json:"txn,omitempty"`
+	Error       string                     `json:"error,omitempty"`
+}
+func advancedSpendHandler(gateway Gatewayer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			wh.Error405(w)
+			return
+		}
+
+		var advancedSpend wallet.AdvancedSpendRequest
+		err := json.NewDecoder(r.Body).Decode(&advancedSpend)
+		if err != nil {
+			logger.Errorf("Invalid advanced spend request: %v", err)
+			wh.Error400(w, fmt.Sprintf("Bad Request: %v", err))
+			return
+		}
+		defer func() {
+			if err := r.Body.Close(); err != nil {
+				logger.Errorf("Failed to close response body: %v", err)
+			}
+		}()
+
+		switch advancedSpend.HoursSelection.Type {
+		case "manual", "auto":
+		case "":
+			logger.Error("missing hours selection type")
+			wh.Error400(w, "missing hours selection type")
+			return
+		default:
+			logger.Errorf("invalid hours selection type: %v", advancedSpend.HoursSelection.Type)
+			wh.Error400(w, fmt.Sprintf("invalid hours selection type: %v", advancedSpend.HoursSelection.Type))
+			return
+		}
+
+		if advancedSpend.HoursSelection.Type == "auto" {
+			switch advancedSpend.HoursSelection.Mode {
+			case "split_even":
+				switch advancedSpend.HoursSelection.ShareFactor {
+				case "":
+					logger.Error("missing hours selection share factor when mode is `split_even`")
+					wh.Error400(w, "missing hours selection share factor when mode is split_even")
+					return
+				default:
+					shareFactor, err := strconv.ParseFloat(advancedSpend.HoursSelection.ShareFactor, 64)
+					if err != nil {
+						logger.Error(err)
+						wh.Error400(w, fmt.Sprintf("invalid share factor: %v", shareFactor))
+						return
+					}
+
+					if shareFactor < 0 {
+						logger.Warning("negative share factor")
+						wh.Error400(w, "share factor cannot be negative")
+						return
+					}
+				}
+
+			case "match_coins":
+			case "":
+				logger.Error("missing hours selection mode when type is auto")
+				wh.Error400(w, "missing hours selection mode when type is auto")
+				return
+			default:
+				logger.Errorf("invalid hours selection mode: %v", advancedSpend.HoursSelection.Mode)
+				wh.Error400(w, fmt.Sprintf("invalid hours selection mode: %v", advancedSpend.HoursSelection.Mode))
+				return
+			}
+		}
+
+		if advancedSpend.ChangeAddress == "" {
+			logger.Warning("missing change address")
+			wh.Error400(w, "missing change address")
+			return
+		}
+
+		changeAddr, err := cipher.DecodeBase58Address(advancedSpend.ChangeAddress)
+		if err != nil {
+			logger.Errorf("invalid change address: %v", err)
+			wh.Error400(w, fmt.Sprintf("invalid change address: %v", err))
+			return
+		}
+
+		// check whether destination addresses are correct or not
+		destList := make([]coin.TransactionOutput, len(advancedSpend.To))
+		for idx, to := range advancedSpend.To {
+			// check that the address is valid
+			toAddress, err := cipher.DecodeBase58Address(to.Address)
+			if err != nil {
+				logger.Errorf("invalid destination address %v", to.Address)
+				wh.Error400(w, fmt.Sprintf("invalid destination address %v", to.Address))
+				return
+			}
+
+			// convert coins to droplets
+			coins, err := droplet.FromString(to.Coins)
+			if err != nil {
+				logger.Errorf("unable to convert coins to droplet: %v", err)
+				wh.Error400(w, fmt.Sprintf("invalid coin amount %v", to.Coins))
+				return
+			}
+
+			destList[idx] = coin.TransactionOutput{
+				Address: toAddress,
+				Coins:   coins,
+			}
+
+			// parse coinhours
+			// when mode is auto the Hours field can be empty
+			// when mode is manual Hours field cannot be empty
+			if to.Hours != "" {
+				hours, err := strconv.ParseUint(to.Hours, 10, 64)
+				if err != nil {
+					logger.Errorf("unable to parse coinhours: %v", err)
+					wh.Error400(w, fmt.Sprintf("invalid coinhours %v", to.Hours))
+					return
+				}
+
+				destList[idx].Hours = hours
+			} else if advancedSpend.HoursSelection.Type == "manual" {
+				logger.Errorf("coinhours value missing for %v when mode is manual", to.Address)
+				wh.Error400(w, fmt.Sprintf("coinhours value missing for %v when mode is manual", to.Address))
+				return
+			}
+
+		}
+
+		// create a wltmap
+		wltMap := make(map[string]struct{})
+		for _, wlt := range advancedSpend.Wallets {
+			wltMap[wlt] = struct{}{}
+		}
+
+		// fetch all wallets on the system
+		wallets, err := gateway.GetWallets()
+		if err != nil {
+			logger.Error(err)
+			wh.Error500(w)
+			return
+		}
+
+		// entry map
+		// stores all entries to be used in creating the transaction
+		entryMap := make(map[cipher.Address]wallet.Entry)
+
+		// addr map to check if provided input addresses
+		// are in the wallets on the system
+		addrMap := make(map[string]wallet.Entry)
+
+		// iterate over all the wallets
+		// look for wallets provided in the input
+		// collect all entries of those wallets
+		for _, wlt := range wallets {
+			if _, ok := wltMap[wlt.Label()]; ok {
+				for _, wltEntry := range wlt.Entries {
+					entryMap[wltEntry.Address] = wltEntry
+				}
+			} else {
+				for _, wltEntry := range wlt.Entries {
+					addrMap[wltEntry.Address.String()] = wltEntry
+				}
+			}
+		}
+
+		// check that provided addresses are in the addrMap
+		for _, addr := range advancedSpend.Addresses {
+			// check that address is not an empty string
+			if addr != "" {
+				if _, ok := addrMap[addr]; !ok {
+					logger.Errorf("address %v not found in any wallet", addr)
+					wh.Error400(w, fmt.Sprintf("address %v not found in any wallet", addr))
+					return
+				}
+
+				wltEntry := addrMap[addr]
+				entryMap[wltEntry.Address] = wltEntry
+			} else {
+				logger.Warningf("empty sender address")
+				wh.Error400(w, "empty sender address")
+				return
+			}
+		}
+
+		if len(entryMap) == 0 {
+			logger.Error("no sender addresses found")
+			wh.Error400(w, "no sender addresses found")
+			return
+		}
+
+		tx, err :=gateway.AdvancedSpend(
+			wallet.AdvancedSpend{
+				HoursSelection: advancedSpend.HoursSelection,
+				Entries:        entryMap,
+				ChangeAddress:  changeAddr,
+				To:             destList,
+			},
+		)
+
+		switch err {
+		case nil:
+		case fee.ErrTxnNoFee, wallet.ErrSpendingUnconfirmed, wallet.ErrInsufficientBalance, wallet.ErrZeroSpend:
+			wh.Error400(w, err.Error())
+			return
+		case wallet.ErrWalletNotExist:
+			wh.Error404(w)
+			return
+		case wallet.ErrWalletAPIDisabled:
+			wh.Error403(w)
+			return
+		default:
+			wh.Error500Msg(w, err.Error())
+			return
+		}
+
+		txStr, err := visor.TransactionToJSON(*tx)
+		if err != nil {
+			logger.Error(err)
+			wh.SendJSONOr500(logger, w, SpendResult{
+				Error: err.Error(),
+			})
+			return
+		}
+
+		logger.Infof("Spend: \ntx= \n %s \n", txStr)
+
+		var ret AdvancedSpendResult
+		ret.Transaction, err = visor.NewReadableTransaction(&visor.Transaction{Txn: *tx})
+		if err != nil {
+			err = fmt.Errorf("Creation of new readable transaction failed: %v", err)
+			logger.Error(err)
+			ret.Error = err.Error()
+			wh.SendJSONOr500(logger, w, ret)
+			return
+		}
+
+		wh.SendJSONOr500(logger, w, ret)
+	}
+}

--- a/src/gui/spent_test.go
+++ b/src/gui/spent_test.go
@@ -1,0 +1,178 @@
+package gui
+
+import (
+	"testing"
+	"github.com/skycoin/skycoin/src/coin"
+	"github.com/skycoin/skycoin/src/wallet"
+	"net/http"
+	"bytes"
+	"github.com/stretchr/testify/require"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+)
+
+func TestAdvancedSpend(t *testing.T) {
+	tt := []struct {
+		name                       string
+		method                     string
+		body                       *wallet.AdvancedSpendRequest
+		status                     int
+		err                        string
+		gatewayAdvancedSpendResult *coin.Transaction
+		gatewayAdvnacedSpendErr    error
+		gatewayGetWalletResult     wallet.Wallets
+		gatewayGetWalletErr        error
+		advancedSpendResult        *AdvancedSpendResult
+		csrfDisabled               bool
+	}{
+		{
+			name:   "405",
+			method: http.MethodGet,
+			status: http.StatusMethodNotAllowed,
+			err:    "405 Method Not Allowed",
+		},
+		{
+			name:   "400 - missing hours selection type",
+			method: http.MethodPost,
+			body:   &wallet.AdvancedSpendRequest{},
+			status: http.StatusBadRequest,
+			err:    "400 Bad Request - missing hours selection type",
+		},
+		{
+			name:   "400 - missing hours selection type",
+			method: http.MethodPost,
+			body: &wallet.AdvancedSpendRequest{
+				HoursSelection: wallet.HoursSelection{
+					Type: "",
+				},
+			},
+			status: http.StatusBadRequest,
+			err:    "400 Bad Request - missing hours selection type",
+		},
+		{
+			name:   "400 - missing hours selection mode",
+			method: http.MethodPost,
+			body: &wallet.AdvancedSpendRequest{
+				HoursSelection: wallet.HoursSelection{
+					Type: "auto",
+				},
+			},
+			status: http.StatusBadRequest,
+			err:    "400 Bad Request - missing hours selection mode when type is auto",
+		},
+		{
+			name:   "400 -  missing hours selection share factor",
+			method: http.MethodPost,
+			body: &wallet.AdvancedSpendRequest{
+				HoursSelection: wallet.HoursSelection{
+					Type: "auto",
+					Mode: "split_even",
+				},
+			},
+			status: http.StatusBadRequest,
+			err:    "400 Bad Request - missing hours selection share factor when mode is split_even",
+		},
+		{
+			name:   "400 - no sender address provided",
+			method: http.MethodPost,
+			body: &wallet.AdvancedSpendRequest{
+				HoursSelection: wallet.HoursSelection{
+					Type: "manual",
+				},
+				Addresses:     []string{},
+				ChangeAddress: "2mEgmYt6NZHA1erYqbAeXmGPD5gqLZ9toFv",
+			},
+			status: http.StatusBadRequest,
+			err:    "400 Bad Request - no sender addresses found",
+		},
+		{
+			name:   "400 - empty sender address",
+			method: http.MethodPost,
+			body: &wallet.AdvancedSpendRequest{
+				HoursSelection: wallet.HoursSelection{
+					Type: "manual",
+				},
+				Addresses:     []string{""},
+				ChangeAddress: "2mEgmYt6NZHA1erYqbAeXmGPD5gqLZ9toFv",
+			},
+			status: http.StatusBadRequest,
+			err:    "400 Bad Request - empty sender address",
+		},
+		{
+			name:   "400 - invalid change address",
+			method: http.MethodPost,
+			body: &wallet.AdvancedSpendRequest{
+				HoursSelection: wallet.HoursSelection{
+					Type: "manual",
+				},
+				Addresses:     []string{"tWPDM36ex9zLjJw1aPMfYTVPbYgkL2Xp9V"},
+				ChangeAddress: "xxxx",
+			},
+			status: http.StatusBadRequest,
+			err:    "400 Bad Request - invalid change address: Invalid address length",
+		},
+		{
+			name:   "400 - invalid change address",
+			method: http.MethodPost,
+			body: &wallet.AdvancedSpendRequest{
+				HoursSelection: wallet.HoursSelection{
+					Type: "manual",
+				},
+				Addresses:     []string{"tWPDM36ex9zLjJw1aPMfYTVPbYgkL2Xp9V"},
+				ChangeAddress: "2mEgmYt6NZHA1erYqbAeXmGPD5gqLZ9toFx",
+			},
+			status: http.StatusBadRequest,
+			err:    "400 Bad Request - invalid change address: Invalid checksum",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.gatewayAdvancedSpendResult == nil {
+				tc.gatewayAdvancedSpendResult = &coin.Transaction{}
+			}
+
+			gateway := &GatewayerMock{}
+			gateway.On("AdvancedSpend", tc.body).Return(tc.gatewayAdvancedSpendResult, tc.gatewayAdvnacedSpendErr)
+			gateway.On("GetWallets").Return(tc.gatewayGetWalletResult, tc.gatewayGetWalletErr)
+
+			endpoint := "/spend/advanced"
+
+			requestJSON, err := json.Marshal(tc.body)
+			require.NoError(t, err)
+
+			req, err := http.NewRequest(tc.method, endpoint, bytes.NewBuffer(requestJSON))
+			require.NoError(t, err)
+			req.Header.Add("Content-Type", "application/json")
+
+			csrfStore := &CSRFStore{
+				Enabled: !tc.csrfDisabled,
+			}
+
+			if csrfStore.Enabled {
+				setCSRFParameters(csrfStore, tokenValid, req)
+			} else {
+				setCSRFParameters(csrfStore, tokenInvalid, req)
+			}
+
+			rr := httptest.NewRecorder()
+			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore)
+
+			handler.ServeHTTP(rr, req)
+
+			status := rr.Code
+			require.Equal(t, tc.status, status, "case: %s, handler returned wrong status code: got `%v` want `%v`", tc.name, status, tc.status)
+
+			if status != http.StatusOK {
+				require.Equal(t, tc.err, strings.TrimSpace(rr.Body.String()), "case: %s, handler returned wrong error message: got `%v`| %d, want `%v`",
+					tc.name, strings.TrimSpace(rr.Body.String()), status, tc.err)
+			} else {
+				var msg AdvancedSpendResult
+				err := json.Unmarshal(rr.Body.Bytes(), &msg)
+				require.NoError(t, err)
+				require.Equal(t, *tc.advancedSpendResult, msg)
+			}
+		})
+	}
+}

--- a/src/testutil/require/require.go
+++ b/src/testutil/require/require.go
@@ -1,9 +1,10 @@
 package require
 
 import (
-	_assert "github.com/skycoin/skycoin/src/testutil/assert"
 	assert "github.com/stretchr/testify/assert"
 	require "github.com/stretchr/testify/require"
+
+	_assert "github.com/skycoin/skycoin/src/testutil/assert"
 )
 
 // PanicsWithCondition asserts that the code inside the specified PanicTestFunc panics, and that

--- a/src/util/droplet/droplet.go
+++ b/src/util/droplet/droplet.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/shopspring/decimal"
+
 	logging "github.com/skycoin/skycoin/src/util/logging"
 )
 

--- a/src/visor/rpc.go
+++ b/src/visor/rpc.go
@@ -158,6 +158,12 @@ func (rpc *RPC) CreateAndSignTransaction(wltID string, password []byte, vld wall
 	return rpc.v.Wallets.CreateAndSignTransaction(wltID, password, vld, unspent, headTime, coins, dest)
 }
 
+//CreateAndSignTransaction creates and sign transaction from wallet
+func (rpc *RPC) CreateAndSignAdvancedTransaction(advancedSpend wallet.AdvancedSpend, sv wallet.Validator,
+	unspent blockdb.UnspentGetter, headTime uint64) (*coin.Transaction, error) {
+	return rpc.v.Wallets.CreateAndSignAdvancedTransaction(advancedSpend, sv, unspent, headTime)
+}
+
 // UpdateWalletLabel updates wallet label
 func (rpc *RPC) UpdateWalletLabel(wltID, label string) error {
 	return rpc.v.Wallets.UpdateWalletLabel(wltID, label)

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -6,14 +6,14 @@ import (
 	"sync"
 
 	"errors"
-	"math"
+
+	"github.com/shopspring/decimal"
 
 	"github.com/skycoin/skycoin/src/cipher"
-	"github.com/skycoin/skycoin/src/coin"
-	"github.com/skycoin/skycoin/src/visor/blockdb"
 	"github.com/skycoin/skycoin/src/cipher/go-bip39"
+	"github.com/skycoin/skycoin/src/coin"
 	"github.com/skycoin/skycoin/src/util/fee"
-	"strconv"
+	"github.com/skycoin/skycoin/src/visor/blockdb"
 )
 
 // BalanceGetter interface for getting the balance of given addresses
@@ -479,12 +479,10 @@ func (serv *Service) CreateAndSignAdvancedTransaction(advancedSpend AdvancedSpen
 	case "auto":
 		switch advancedSpend.HoursSelection.Mode {
 		case "split_even":
-			shareFactor, err := strconv.ParseFloat(advancedSpend.HoursSelection.ShareFactor, 64)
-			if err != nil {
-				return nil, err
-			}
+
 			addrHours := make([]uint64, nAddrs)
-			totalAddrHours = uint64(math.Floor(float64(remainingHours) * shareFactor))
+			// multiply remaining hours after fee burn with share factor
+			totalAddrHours = uint64(advancedSpend.HoursSelection.ShareFactor.Mul(decimal.New(int64(remainingHours), 64)).IntPart())
 			// split addrhours evenly among all hours
 			perAddrHour := totalAddrHours / nAddrs
 			for i := range addrHours {

--- a/src/wallet/service_test.go
+++ b/src/wallet/service_test.go
@@ -14,11 +14,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/coin"
 	"github.com/skycoin/skycoin/src/testutil"
 	"github.com/skycoin/skycoin/src/util/fee"
-	"github.com/stretchr/testify/require"
 )
 
 func prepareWltDir() string {
@@ -763,7 +764,7 @@ func TestServiceCreateAndSignTx(t *testing.T) {
 			},
 			0,
 			addrs[0],
-			errors.New("zero spend amount"),
+			ErrZeroSpend,
 		},
 		{
 			"encrypted=false spend fractional coins",

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -18,6 +18,8 @@ import (
 	"github.com/skycoin/skycoin/src/coin"
 	"github.com/skycoin/skycoin/src/visor/blockdb"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/skycoin/skycoin/src/util/fee"
 	"github.com/skycoin/skycoin/src/util/logging"
 )
@@ -101,25 +103,10 @@ type Options struct {
 	CryptoType CryptoType // wallet encryption type, scrypt-chacha20poly1305 or sha256-xor.
 }
 
-type Receiver struct {
-	Address string `json:"address"`
-	Coins   string `json:"coins"`
-	Hours   string `json:"hours"`
-}
-
 type HoursSelection struct {
-	Type        string  `json:"type"`
-	Mode        string  `json:"mode"`
-	ShareFactor string `json:"share_factor"`
-}
-
-type AdvancedSpendRequest struct {
-	HoursSelection HoursSelection `json:"hours_selection"`
-	//Outputs        []string       `json:"outputs"`
-	Addresses     []string   `json:"addresses"`
-	Wallets       []string   `json:"wallets"`
-	ChangeAddress string     `json:"change_address"`
-	To            []Receiver `json:"to"`
+	Type        string           `json:"type"`
+	Mode        string           `json:"mode"`
+	ShareFactor *decimal.Decimal `json:"share_factor"`
 }
 
 type AdvancedSpend struct {


### PR DESCRIPTION
*Note*: usual spends done by all other functions usually have `change` as the first output, advanced spend puts it as the last output.

- [x] Implement advanced spend
- [ ] Tests

Fixes #1177 

Changes:
- Implement advanced spend for REST API

Does this change need to mentioned in CHANGELOG.md?
Yes