### PR TITLE
Show dollar price in header when balance is not available

### DIFF
--- a/src/gui/static/src/app/components/layout/header/header.component.html
+++ b/src/gui/static/src/app/components/layout/header/header.component.html
@@ -5,7 +5,8 @@
       <div class="balance">
         <p *ngIf="highest && loading" class="coins"><span>{{ percentage | percent:'1.2-2' }}</span></p>
         <p *ngIf="!loading" class="coins"><span>{{ coins | number:'1.0-6' }}</span> sky</p>
-        <p *ngIf="!loading" class="dollars">{{ balance }}</p>
+        <p *ngIf="!highest && loading" class="coins"><span>&nbsp;</span></p>
+        <p class="dollars">{{ balance }}</p>
       </div>
     </div>
     <div class="hour-balance">

--- a/src/gui/static/src/app/components/layout/header/header.component.ts
+++ b/src/gui/static/src/app/components/layout/header/header.component.ts
@@ -34,8 +34,11 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   get balance() {
     if (this.price === null) { return 'loading..'; }
+
+    const dollarPrice = Math.round(this.price * 100) / 100;
     const balance = Math.round(this.coins * this.price * 100) / 100;
-    return '$' + balance.toFixed(2) + ' ($' + (Math.round(this.price * 100) / 100) + ')';
+
+    return `${this.loading ? '-' : '$' + balance.toFixed(2)} ($${dollarPrice})`;
   }
 
   get loading() {


### PR DESCRIPTION
Fixes #1124 

Changes:
- dollar price of 1 SKY is always visible in header

![screen shot 2018-04-09 at 11 31 34](https://user-images.githubusercontent.com/1536298/38490518-981d1756-3be9-11e8-9410-bf977f310e37.png)
