### PR TITLE
Don't delete dist folder with npm start

### DIFF
--- a/src/gui/static/package.json
+++ b/src/gui/static/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --proxy-config proxy.config.js",
+    "start": "ng serve --proxy-config proxy.config.js --delete-output-path false",
     "build": "ng build --prod",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
Fixes #1208 

Changes:
- `npm start` no longer deletes dist folder
