### PR TITLE
Fixed #1139 Corrupted peers.txt file prevents startup without clear reason

### DIFF
--- a/src/daemon/pex/peerlist.go
+++ b/src/daemon/pex/peerlist.go
@@ -41,18 +41,21 @@ type Filter func(peer Peer) bool
 // return nil if the file doesn't exist
 func loadPeersFromFile(path string) (map[string]*Peer, error) {
 	// check if the file does exist
+
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return nil, nil
 	}
 
 	peersJSON := make(map[string]PeerJSON)
+
 	if err := file.LoadJSON(path, &peersJSON); err != nil {
+		logger.Error("the file %s is empty or corrupt %v", path, err)
 		return nil, err
 	}
-
 	peers := make(map[string]*Peer, len(peersJSON))
 	for addr, peerJSON := range peersJSON {
 		a, err := validateAddress(addr, true)
+
 		if err != nil {
 			logger.Error("Invalid address in peers JSON file %s: %v", addr, err)
 			continue
@@ -71,6 +74,8 @@ func loadPeersFromFile(path string) (map[string]*Peer, error) {
 
 		peers[a] = peer
 	}
+
+	logger.Info("Return PeersList")
 
 	return peers, nil
 }

--- a/src/daemon/pex/peerlist.go
+++ b/src/daemon/pex/peerlist.go
@@ -3,6 +3,7 @@ package pex
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/rand"
 	"os"
 	"time"
@@ -47,9 +48,13 @@ func loadPeersFromFile(path string) (map[string]*Peer, error) {
 	}
 
 	peersJSON := make(map[string]PeerJSON)
+	err := file.LoadJSON(path, &peersJSON)
 
-	if err := file.LoadJSON(path, &peersJSON); err != nil {
-		logger.Error("the file %s is empty or corrupt %v", path, err)
+	if err == io.EOF {
+		logger.Error(" %s corrupt or empty file, rewriting file", path)
+		return nil, nil
+
+	} else if err != nil {
 		return nil, err
 	}
 	peers := make(map[string]*Peer, len(peersJSON))


### PR DESCRIPTION
Fixes #1139 

Changes:
-Changes in the loadPeersFromFile function of peerlist.go, validating the EOF error