### PR TITLE
Improve wallet metadata API format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 - Remove dependency [op/go-logging](https://github.com/op/go-logging)
+- Remove `seed`, `lastSeed`, `secrets` and `secret_key` in address entries from wallet apis response
 
 ## [0.22.0] - 2018-03-20
 

--- a/src/gui/README.md
+++ b/src/gui/README.md
@@ -479,6 +479,8 @@ URI: /wallet/newAddress
 Method: POST
 Args:
     id: wallet file name
+    num: the number you want to generate
+    password: wallet password
 ```
 
 Example:
@@ -486,7 +488,9 @@ Example:
 ```sh
 curl -X POST http://127.0.0.1:6420/wallet/newAddress \
  -H 'Content-Type: x-www-form-urlencoded' \
- -d 'id=2017_05_09_d554.wlt'
+ -d 'id=2017_05_09_d554.wlt' \
+ -d 'num=2' \
+ -d 'password=$password'
 ```
 
 Result:

--- a/src/gui/README.md
+++ b/src/gui/README.md
@@ -255,25 +255,23 @@ Result:
 ```json
 {
     "meta":{
-        "coin":"skycoin",
-        "filename":"2017_11_25_e5fb.wlt",
-        "label":"test",
-        "lastSeed":"",
-        "seed":"",
-        "tm":"1511640884",
-        "type":"deterministic",
-        "version":"0.1"
+        "coin": "skycoin",
+        "filename": "2017_11_25_e5fb.wlt",
+        "label": "test",
+        "type": "deterministic",
+        "version": "0.2",
+        "cryptoType": "",
+        "timestamp": 1511640884,
+        "encrypted": false,
     },
     "entries":[
         {
             "address": "2HTnQe3ZupkG6k8S81brNC3JycGV2Em71F2",
-            "public_key": "030479afcf24dbc1579769522d4d80c13270a6bb829e9aa121e012f600d5aab992",
-            "secret_key": ""
+            "public_key": "***",
         },
         {
             "address": "SMnCGfpt7zVXm8BkRSFMLeMRA6LUu3Ewne",
-            "public_key": "0258245e0f3a27b70ba8816e9ebd4470624f2924a79240b4b7624aaa129eff399e",
-            "secret_key": ""
+            "public_key": "***",
         },
     ]
 }
@@ -361,22 +359,20 @@ Result:
             "coin": "skycoin",
             "filename": "2017_11_25_e5fb.wlt",
             "label": "test",
-            "lastSeed": "",
-            "seed": "",
-            "tm": "1511640884",
             "type": "deterministic",
-            "version": "0.2"
+            "version": "0.2",
+            "cryptoType": "",
+            "timestamp": 1511640884,
+            "encrypted": false,
         },
         "entries": [
             {
                 "address": "8C5icxR9zdkYTZZTVV3cCX7QoK4EkLuK4p",
                 "public_key": "***",
-                "secret_key": "",
             },
             {
                 "address": "23A1EWMZopUFLCwtXMe2CU9xTCbi5Gth643",
                 "public_key": "***",
-                "secret_key": ""
             }
         ]
     }
@@ -460,18 +456,17 @@ Result:
     "meta": {
         "coin": "skycoin",
         "filename": "2017_05_09_d554.wlt",
-        "label": "label",
-        "lastSeed": "",
-        "seed": "",
-        "tm": "1494315855",
+        "label": "test",
         "type": "deterministic",
-        "version": "0.2"
+        "version": "0.2",
+        "cryptoType": "",
+        "timestamp": 1511640884,
+        "encrypted": false,
     },
     "entries": [
         {
             "address": "y2JeYS4RS8L9GYM7UKdjLRyZanKHXumFoH",
-            "public_key": "0343581927c12d07582168d6092d06d0a8cefdef47541f804eae33faf027932245",
-            "secret_key": ""
+            "public_key": "***",
         }
     ]
 }
@@ -682,22 +677,18 @@ Result:
 {
     "meta": {
         "coin": "skycoin",
-        "cryptoType": "scrypt-chacha20poly1305",
-        "encrypted": "true",
         "filename": "test.wlt",
-        "label": "ec",
-        "lastSeed": "",
-        "secrets": "",
-        "seed": "",
-        "tm": "1521083044",
+        "label": "test",
         "type": "deterministic",
-        "version": "0.2"
+        "version": "0.2",
+        "cryptoType": "scrypt-chacha20poly1305",
+        "timestamp": 1521083044,
+        "encrypted": true,
     },
     "entries": [
         {
             "address": "fznGedkc87a8SsW94dBowEv6J7zLGAjT17",
-            "public_key": "032a1218cbafc8a93233f363c19c667cf02d42fa5a8a07c0d6feca79e82d72753d",
-            "secret_key": ""
+            "public_key": "***",
         }
     ]
 }
@@ -728,16 +719,13 @@ Result:
 {
     "meta": {
         "coin": "skycoin",
-        "cryptoType": "",
-        "encrypted": "false",
         "filename": "test.wlt",
-        "label": "ec",
-        "lastSeed": "",
-        "secrets": "",
-        "seed": "",
-        "tm": "1521083044",
+        "label": "test",
         "type": "deterministic",
-        "version": "0.2"
+        "version": "0.2",
+        "cryptoType": "",
+        "timestamp": 1521083044,
+        "encrypted": false,
     },
     "entries": [
         {

--- a/src/gui/client.go
+++ b/src/gui/client.go
@@ -364,7 +364,7 @@ func (c *Client) AddressUxOuts(addr string) ([]*historydb.UxOutJSON, error) {
 }
 
 // Wallet makes a request to /wallet
-func (c *Client) Wallet(id string) (*wallet.Wallet, error) {
+func (c *Client) Wallet(id string) (*WalletResponse, error) {
 	v := url.Values{}
 	v.Add("id", id)
 	endpoint := "/wallet?" + v.Encode()
@@ -374,31 +374,23 @@ func (c *Client) Wallet(id string) (*wallet.Wallet, error) {
 		return nil, err
 	}
 
-	return wr.ToWallet()
+	return &wr, nil
 }
 
 // Wallets makes a request to /wallets
-func (c *Client) Wallets() ([]*wallet.Wallet, error) {
+func (c *Client) Wallets() ([]*WalletResponse, error) {
 	var wrs []*WalletResponse
 	if err := c.Get("/wallets", &wrs); err != nil {
 		return nil, err
 	}
 
-	var ws []*wallet.Wallet
-	for _, rw := range wrs {
-		w, err := rw.ToWallet()
-		if err != nil {
-			return nil, err
-		}
-		ws = append(ws, w)
-	}
-	return ws, nil
+	return wrs, nil
 }
 
 // CreateUnencryptedWallet makes a request to /wallet/create and create
 // a wallet without no encryption
 // If scanN is <= 0, the scan number defaults to 1
-func (c *Client) CreateUnencryptedWallet(seed, label string, scanN int) (*wallet.Wallet, error) {
+func (c *Client) CreateUnencryptedWallet(seed, label string, scanN int) (*WalletResponse, error) {
 	v := url.Values{}
 	v.Add("seed", seed)
 	v.Add("label", label)
@@ -412,13 +404,13 @@ func (c *Client) CreateUnencryptedWallet(seed, label string, scanN int) (*wallet
 	if err := c.PostForm("/wallet/create", strings.NewReader(v.Encode()), &w); err != nil {
 		return nil, err
 	}
-	return w.ToWallet()
+	return &w, nil
 }
 
 // CreateEncryptedWallet makes a request to /wallet/create and try to create
 // a wallet with encryption.
 // If scanN is <= 0, the scan number defaults to 1
-func (c *Client) CreateEncryptedWallet(seed, label, password string, scanN int) (*wallet.Wallet, error) {
+func (c *Client) CreateEncryptedWallet(seed, label, password string, scanN int) (*WalletResponse, error) {
 	v := url.Values{}
 	v.Add("seed", seed)
 	v.Add("label", label)
@@ -433,7 +425,7 @@ func (c *Client) CreateEncryptedWallet(seed, label, password string, scanN int) 
 	if err := c.PostForm("/wallet/create", strings.NewReader(v.Encode()), &w); err != nil {
 		return nil, err
 	}
-	return w.ToWallet()
+	return &w, nil
 }
 
 // NewWalletAddress makes a request to /wallet/newAddress
@@ -773,7 +765,7 @@ func (c *Client) Health() (*HealthResponse, error) {
 }
 
 // EncryptWallet encrypts specific wallet with given password
-func (c *Client) EncryptWallet(id string, password string) (*wallet.Wallet, error) {
+func (c *Client) EncryptWallet(id string, password string) (*WalletResponse, error) {
 	v := url.Values{}
 	v.Add("id", id)
 	v.Add("password", password)
@@ -782,11 +774,11 @@ func (c *Client) EncryptWallet(id string, password string) (*wallet.Wallet, erro
 		return nil, err
 	}
 
-	return wlt.ToWallet()
+	return &wlt, nil
 }
 
 // DecryptWallet decrypts wallet by making a request to /wallet/decrypt
-func (c *Client) DecryptWallet(id string, password string) (*wallet.Wallet, error) {
+func (c *Client) DecryptWallet(id string, password string) (*WalletResponse, error) {
 	v := url.Values{}
 	v.Add("id", id)
 	v.Add("password", password)
@@ -795,5 +787,5 @@ func (c *Client) DecryptWallet(id string, password string) (*wallet.Wallet, erro
 		return nil, err
 	}
 
-	return wlt.ToWallet()
+	return &wlt, nil
 }

--- a/src/gui/client.go
+++ b/src/gui/client.go
@@ -369,23 +369,23 @@ func (c *Client) Wallet(id string) (*wallet.Wallet, error) {
 	v.Add("id", id)
 	endpoint := "/wallet?" + v.Encode()
 
-	var rw wallet.ReadableWallet
-	if err := c.Get(endpoint, &rw); err != nil {
+	var wr WalletResponse
+	if err := c.Get(endpoint, &wr); err != nil {
 		return nil, err
 	}
 
-	return rw.ToWallet()
+	return wr.ToWallet()
 }
 
 // Wallets makes a request to /wallets
 func (c *Client) Wallets() ([]*wallet.Wallet, error) {
-	var rws []*wallet.ReadableWallet
-	if err := c.Get("/wallets", &rws); err != nil {
+	var wrs []*WalletResponse
+	if err := c.Get("/wallets", &wrs); err != nil {
 		return nil, err
 	}
 
 	var ws []*wallet.Wallet
-	for _, rw := range rws {
+	for _, rw := range wrs {
 		w, err := rw.ToWallet()
 		if err != nil {
 			return nil, err
@@ -408,7 +408,7 @@ func (c *Client) CreateUnencryptedWallet(seed, label string, scanN int) (*wallet
 		v.Add("scan", fmt.Sprint(scanN))
 	}
 
-	var w wallet.ReadableWallet
+	var w WalletResponse
 	if err := c.PostForm("/wallet/create", strings.NewReader(v.Encode()), &w); err != nil {
 		return nil, err
 	}
@@ -429,7 +429,7 @@ func (c *Client) CreateEncryptedWallet(seed, label, password string, scanN int) 
 		v.Add("scan", fmt.Sprint(scanN))
 	}
 
-	var w wallet.ReadableWallet
+	var w WalletResponse
 	if err := c.PostForm("/wallet/create", strings.NewReader(v.Encode()), &w); err != nil {
 		return nil, err
 	}
@@ -777,7 +777,7 @@ func (c *Client) EncryptWallet(id string, password string) (*wallet.Wallet, erro
 	v := url.Values{}
 	v.Add("id", id)
 	v.Add("password", password)
-	var wlt wallet.ReadableWallet
+	var wlt WalletResponse
 	if err := c.PostForm("/wallet/encrypt", strings.NewReader(v.Encode()), &wlt); err != nil {
 		return nil, err
 	}
@@ -790,7 +790,7 @@ func (c *Client) DecryptWallet(id string, password string) (*wallet.Wallet, erro
 	v := url.Values{}
 	v.Add("id", id)
 	v.Add("password", password)
-	var wlt wallet.ReadableWallet
+	var wlt WalletResponse
 	if err := c.PostForm("/wallet/decrypt", strings.NewReader(v.Encode()), &wlt); err != nil {
 		return nil, err
 	}

--- a/src/gui/integration/integration_test.go
+++ b/src/gui/integration/integration_test.go
@@ -2514,9 +2514,6 @@ func createWallet(t *testing.T, c *gui.Client, encrypt bool, password string) (*
 	require.NoError(t, err)
 	checkNoSensitiveData(t, w)
 
-	err = w.Validate()
-	require.NoError(t, err)
-
 	walletDir := getWalletDir(t, c)
 
 	return w, seed, func() {

--- a/src/gui/integration/integration_test.go
+++ b/src/gui/integration/integration_test.go
@@ -1978,12 +1978,12 @@ func TestCreateWallet(t *testing.T) {
 
 	w, seed, clean := createWallet(t, c, false, "")
 	defer clean()
-	require.False(t, w.IsEncrypted())
+	require.False(t, w.Meta.Encrypted)
 
 	walletDir := getWalletDir(t, c)
 
 	// Confirms the wallet does exist
-	walletPath := filepath.Join(walletDir, w.Filename())
+	walletPath := filepath.Join(walletDir, w.Meta.Filename)
 	_, err := os.Stat(walletPath)
 	require.NoError(t, err)
 
@@ -1995,16 +1995,16 @@ func TestCreateWallet(t *testing.T) {
 	require.Equal(t, len(w.Entries), len(lw.Entries))
 
 	for i := range w.Entries {
-		require.Equal(t, w.Entries[i].Address, lw.Entries[i].Address)
-		require.Equal(t, w.Entries[i].Public, lw.Entries[i].Public)
+		require.Equal(t, w.Entries[i].Address, lw.Entries[i].Address.String())
+		require.Equal(t, w.Entries[i].Public, lw.Entries[i].Public.Hex())
 	}
 
 	// Creates wallet with encryption
 	encW, _, encWClean := createWallet(t, c, true, "pwd")
 	defer encWClean()
-	require.True(t, encW.IsEncrypted())
+	require.True(t, encW.Meta.Encrypted)
 
-	walletPath = filepath.Join(walletDir, encW.Filename())
+	walletPath = filepath.Join(walletDir, encW.Meta.Filename)
 	encLW, err := wallet.Load(walletPath)
 	require.NoError(t, err)
 
@@ -2013,15 +2013,8 @@ func TestCreateWallet(t *testing.T) {
 	require.Equal(t, len(encW.Entries), len(encLW.Entries))
 
 	for i := range encW.Entries {
-		require.Equal(t, encW.Entries[i].Address, encLW.Entries[i].Address)
-		require.Equal(t, encW.Entries[i].Public, encLW.Entries[i].Public)
-	}
-
-	// Confirms that no sensitive data are exist in encrypted wallet file
-	require.Empty(t, w.Meta["seed"])
-	require.Empty(t, w.Meta["lastSeed"])
-	for _, e := range w.Entries {
-		require.Equal(t, cipher.SecKey{}, e.Secret)
+		require.Equal(t, encW.Entries[i].Address, encLW.Entries[i].Address.String())
+		require.Equal(t, encW.Entries[i].Public, encLW.Entries[i].Public.Hex())
 	}
 }
 
@@ -2037,10 +2030,9 @@ func TestGetWallet(t *testing.T) {
 	defer clean()
 
 	// Confirms the wallet can be acquired
-	w1, err := c.Wallet(w.Filename())
+	w1, err := c.Wallet(w.Meta.Filename)
 	require.NoError(t, err)
 	require.Equal(t, *w, *w1)
-	checkNoSensitiveData(t, w1)
 }
 
 func TestGetWallets(t *testing.T) {
@@ -2051,7 +2043,7 @@ func TestGetWallets(t *testing.T) {
 	c := gui.NewClient(nodeAddress())
 
 	// Creates 2 new wallets
-	var ws []wallet.Wallet
+	var ws []gui.WalletResponse
 	for i := 0; i < 2; i++ {
 		w, _, clean := createWallet(t, c, false, "")
 		defer clean()
@@ -2064,14 +2056,14 @@ func TestGetWallets(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the wallet map
-	walletMap := make(map[string]wallet.Wallet)
+	walletMap := make(map[string]gui.WalletResponse)
 	for _, w := range wlts {
-		walletMap[w.Filename()] = *w
+		walletMap[w.Meta.Filename] = *w
 	}
 
 	// Confirms the returned wallets contains the wallet we created.
 	for _, w := range ws {
-		retW, ok := walletMap[w.Filename()]
+		retW, ok := walletMap[w.Meta.Filename]
 		require.True(t, ok)
 		require.Equal(t, w, retW)
 	}
@@ -2102,7 +2094,7 @@ func TestWalletNewAddress(t *testing.T) {
 			w, seed, clean := createWallet(t, c, encrypt, password)
 			defer clean()
 
-			addrs, err := c.NewWalletAddress(w.Filename(), i, password)
+			addrs, err := c.NewWalletAddress(w.Meta.Filename, i, password)
 			if err != nil {
 				t.Fatalf("%v", err)
 				return
@@ -2133,7 +2125,7 @@ func TestStableWalletBalance(t *testing.T) {
 	w, _, clean := createWallet(t, c, false, "")
 	defer clean()
 
-	bp, err := c.WalletBalance(w.Filename())
+	bp, err := c.WalletBalance(w.Meta.Filename)
 	require.NoError(t, err)
 
 	var expect wallet.BalancePair
@@ -2164,13 +2156,13 @@ func TestWalletUpdate(t *testing.T) {
 	w, _, clean := createWallet(t, c, false, "")
 	defer clean()
 
-	err := c.UpdateWallet(w.Filename(), "new wallet")
+	err := c.UpdateWallet(w.Meta.Filename, "new wallet")
 	require.NoError(t, err)
 
 	// Confirms the wallet has label of "new wallet"
-	w1, err := c.Wallet(w.Filename())
+	w1, err := c.Wallet(w.Meta.Filename)
 	require.NoError(t, err)
-	require.Equal(t, w1.Label(), "new wallet")
+	require.Equal(t, w1.Meta.Label, "new wallet")
 }
 
 func TestStableWalletTransactions(t *testing.T) {
@@ -2182,7 +2174,7 @@ func TestStableWalletTransactions(t *testing.T) {
 	w, _, clean := createWallet(t, c, false, "")
 	defer clean()
 
-	txns, err := c.WalletTransactions(w.Filename())
+	txns, err := c.WalletTransactions(w.Meta.Filename)
 	require.NoError(t, err)
 
 	var expect gui.UnconfirmedTxnsResponse
@@ -2241,23 +2233,20 @@ func TestEncryptWallet(t *testing.T) {
 	w, _, clean := createWallet(t, c, false, "")
 	defer clean()
 
-	checkNoSensitiveData(t, w)
-
 	// Encrypts the wallet
-	rlt, err := c.EncryptWallet(w.Filename(), "pwd")
+	rlt, err := c.EncryptWallet(w.Meta.Filename, "pwd")
 	require.NoError(t, err)
-	checkNoSensitiveData(t, rlt)
-	require.NotEmpty(t, rlt.Meta["cryptoType"])
-	require.Equal(t, rlt.Meta["encrypted"], "true")
+	require.NotEmpty(t, rlt.Meta.CryptoType)
+	require.True(t, rlt.Meta.Encrypted)
 
 	//  Encrypt the wallet again, should returns error
-	_, err = c.EncryptWallet(w.Filename(), "pwd")
+	_, err = c.EncryptWallet(w.Meta.Filename, "pwd")
 	require.EqualError(t, err, "400 Bad Request - wallet is already encrypted\n")
 
 	// Confirms that no sensitive data do exist in wallet file
 	wf, err := c.WalletFolderName()
 	require.NoError(t, err)
-	wltPath := filepath.Join(wf.Address, w.Filename())
+	wltPath := filepath.Join(wf.Address, w.Meta.Filename)
 	lw, err := wallet.Load(wltPath)
 	require.NoError(t, err)
 	require.Empty(t, lw.Meta["seed"])
@@ -2266,7 +2255,7 @@ func TestEncryptWallet(t *testing.T) {
 
 	// Decrypts the wallet, and confirms that the
 	// seed and address entries are the same as it was before being encrypted.
-	dw, err := c.DecryptWallet(w.Filename(), "pwd")
+	dw, err := c.DecryptWallet(w.Meta.Filename, "pwd")
 	require.NoError(t, err)
 	require.Equal(t, w, dw)
 }
@@ -2284,25 +2273,22 @@ func TestDecryptWallet(t *testing.T) {
 	w, seed, clean := createWallet(t, c, true, "pwd")
 	defer clean()
 
-	checkNoSensitiveData(t, w)
-
 	// Decrypt wallet with different password, must fail
-	_, err := c.DecryptWallet(w.Filename(), "pwd1")
+	_, err := c.DecryptWallet(w.Meta.Filename, "pwd1")
 	require.EqualError(t, err, "400 Bad Request - invalid password\n")
 
 	// Decrypts wallet with correct password
-	dw, err := c.DecryptWallet(w.Filename(), "pwd")
+	dw, err := c.DecryptWallet(w.Meta.Filename, "pwd")
 	require.NoError(t, err)
 
 	// Confirms that no sensitive data are returned
-	checkNoSensitiveData(t, dw)
-	require.Empty(t, dw.Meta["cryptoType"])
-	require.Equal(t, dw.Meta["encrypted"], "false")
+	require.Empty(t, dw.Meta.CryptoType)
+	require.False(t, dw.Meta.Encrypted)
 
 	// Loads wallet from file
 	wf, err := c.WalletFolderName()
 	require.NoError(t, err)
-	wltPath := filepath.Join(wf.Address, w.Filename())
+	wltPath := filepath.Join(wf.Address, w.Meta.Filename)
 	lw, err := wallet.Load(wltPath)
 	require.NoError(t, err)
 
@@ -2315,8 +2301,8 @@ func TestDecryptWallet(t *testing.T) {
 
 	// Confirms that the first address is derivied from the private key
 	pubkey := cipher.PubKeyFromSecKey(seckeys[0])
-	require.Equal(t, w.Entries[0].Address, cipher.AddressFromPubKey(pubkey))
-	require.Equal(t, lw.Entries[0].Address, w.Entries[0].Address)
+	require.Equal(t, w.Entries[0].Address, cipher.AddressFromPubKey(pubkey).String())
+	require.Equal(t, lw.Entries[0].Address.String(), w.Entries[0].Address)
 }
 
 func TestGetWalletSeed(t *testing.T) {
@@ -2334,7 +2320,7 @@ func TestGetWalletSeed(t *testing.T) {
 	w, _, clean := createWallet(t, c, true, "pwd")
 	defer clean()
 
-	_, err := c.GetWalletSeed(w.Filename(), "pwd")
+	_, err := c.GetWalletSeed(w.Meta.Filename, "pwd")
 	require.EqualError(t, err, "403 Forbidden\n")
 }
 
@@ -2353,7 +2339,7 @@ func TestEnableSeedAPIAndGetWalletSeed(t *testing.T) {
 	w, seed, clean := createWallet(t, c, true, "pwd")
 	defer clean()
 
-	sd, err := c.GetWalletSeed(w.Filename(), "pwd")
+	sd, err := c.GetWalletSeed(w.Meta.Filename, "pwd")
 	require.NoError(t, err)
 
 	// Confirms the seed are matched
@@ -2364,13 +2350,13 @@ func TestEnableSeedAPIAndGetWalletSeed(t *testing.T) {
 	require.EqualError(t, err, "404 Not Found\n")
 
 	// Check with invalid password
-	_, err = c.GetWalletSeed(w.Filename(), "wrong password")
+	_, err = c.GetWalletSeed(w.Meta.Filename, "wrong password")
 	require.EqualError(t, err, "400 Bad Request - invalid password\n")
 
 	// Creates none encrypted wallet
 	nw, _, nclean := createWallet(t, c, false, "")
 	defer nclean()
-	_, err = c.GetWalletSeed(nw.Filename(), "pwd")
+	_, err = c.GetWalletSeed(nw.Meta.Filename, "pwd")
 	require.EqualError(t, err, "403 Forbidden\n")
 }
 
@@ -2497,13 +2483,13 @@ func checkWalletEntriesAndLastSeed(t *testing.T, w *wallet.Wallet) {
 
 // createWallet creates a wallet with rand seed.
 // Returns the generated wallet, seed and clean up function.
-func createWallet(t *testing.T, c *gui.Client, encrypt bool, password string) (*wallet.Wallet, string, func()) {
+func createWallet(t *testing.T, c *gui.Client, encrypt bool, password string) (*gui.WalletResponse, string, func()) {
 	if !doWallet(t) {
 		return nil, "", func() {}
 	}
 	seed := hex.EncodeToString(cipher.RandByte(32))
 	// Use the first 6 letter of the seed as label.
-	var w *wallet.Wallet
+	var w *gui.WalletResponse
 	var err error
 	if encrypt {
 		w, err = c.CreateEncryptedWallet(seed, seed[:6], password, 0)
@@ -2512,13 +2498,12 @@ func createWallet(t *testing.T, c *gui.Client, encrypt bool, password string) (*
 	}
 
 	require.NoError(t, err)
-	checkNoSensitiveData(t, w)
 
 	walletDir := getWalletDir(t, c)
 
 	return w, seed, func() {
 		// Cleaner function to delete the wallet and bak wallet
-		walletPath := filepath.Join(walletDir, w.Filename())
+		walletPath := filepath.Join(walletDir, w.Meta.Filename)
 		err = os.Remove(walletPath)
 		require.NoError(t, err)
 
@@ -2531,7 +2516,7 @@ func createWallet(t *testing.T, c *gui.Client, encrypt bool, password string) (*
 		require.NoError(t, err)
 
 		// Removes the wallet from memory
-		c.UnloadWallet(w.Filename())
+		c.UnloadWallet(w.Meta.Filename)
 	}
 }
 

--- a/src/gui/wallet.go
+++ b/src/gui/wallet.go
@@ -28,26 +28,28 @@ type UnconfirmedTxnsResponse struct {
 	Transactions []visor.ReadableUnconfirmedTxn `json:"transactions"`
 }
 
-type walletEntry struct {
+// WalletEntry the wallet entry struct
+type WalletEntry struct {
 	Address string `json:"address"`
 	Public  string `json:"public_key"`
 }
 
-type walletMeta struct {
+// WalletMeta the wallet meta struct
+type WalletMeta struct {
 	Coin       string `json:"coin"`
 	Filename   string `json:"filename"`
 	Label      string `json:"label"`
 	Type       string `json:"type"`
 	Version    string `json:"version"`
-	CryptoType string `json:"cryptoType"`
+	CryptoType string `json:"crypto_type"`
 	Timestamp  int64  `json:"timestamp"`
 	Encrypted  bool   `json:"encrypted"`
 }
 
 // WalletResponse wallet response struct for http apis
 type WalletResponse struct {
-	Meta    walletMeta    `json:"meta"`
-	Entries []walletEntry `json:"entries"`
+	Meta    WalletMeta    `json:"meta"`
+	Entries []WalletEntry `json:"entries"`
 }
 
 // NewWalletResponse creates WalletResponse struct from *wallet.Wallet
@@ -80,44 +82,13 @@ func NewWalletResponse(w *wallet.Wallet) (*WalletResponse, error) {
 	}
 
 	for _, e := range w.Entries {
-		wr.Entries = append(wr.Entries, walletEntry{
+		wr.Entries = append(wr.Entries, WalletEntry{
 			Address: e.Address.String(),
 			Public:  e.Public.Hex(),
 		})
 	}
 
 	return &wr, nil
-}
-
-// ToWallet converts WalletResponse to wallet.Wallet
-func (wr *WalletResponse) ToWallet() (*wallet.Wallet, error) {
-	w := wallet.Wallet{Meta: make(map[string]string)}
-	w.Meta["coin"] = wr.Meta.Coin
-	w.Meta["filename"] = wr.Meta.Filename
-	w.Meta["label"] = wr.Meta.Label
-	w.Meta["type"] = wr.Meta.Type
-	w.Meta["version"] = wr.Meta.Version
-	w.Meta["cryptoType"] = wr.Meta.CryptoType
-	w.Meta["tm"] = strconv.FormatInt(wr.Meta.Timestamp, 10)
-	w.Meta["encrypted"] = strconv.FormatBool(wr.Meta.Encrypted)
-
-	for _, e := range wr.Entries {
-		addr, err := cipher.DecodeBase58Address(e.Address)
-		if err != nil {
-			return nil, err
-		}
-
-		pubkey, err := cipher.PubKeyFromHex(e.Public)
-		if err != nil {
-			return nil, err
-		}
-		w.Entries = append(w.Entries, wallet.Entry{
-			Address: addr,
-			Public:  pubkey,
-		})
-	}
-
-	return &w, nil
 }
 
 // Returns the wallet's balance, both confirmed and predicted.  The predicted

--- a/src/gui/wallet.go
+++ b/src/gui/wallet.go
@@ -28,6 +28,98 @@ type UnconfirmedTxnsResponse struct {
 	Transactions []visor.ReadableUnconfirmedTxn `json:"transactions"`
 }
 
+type walletEntry struct {
+	Address string `json:"address"`
+	Public  string `json:"public_key"`
+}
+
+type walletMeta struct {
+	Coin       string `json:"coin"`
+	Filename   string `json:"filename"`
+	Label      string `json:"label"`
+	Type       string `json:"type"`
+	Version    string `json:"version"`
+	CryptoType string `json:"cryptoType"`
+	Timestamp  int64  `json:"timestamp"`
+	Encrypted  bool   `json:"encrypted"`
+}
+
+// WalletResponse wallet response struct for http apis
+type WalletResponse struct {
+	Meta    walletMeta    `json:"meta"`
+	Entries []walletEntry `json:"entries"`
+}
+
+// NewWalletResponse creates WalletResponse struct from *wallet.Wallet
+func NewWalletResponse(w *wallet.Wallet) (*WalletResponse, error) {
+	var wr WalletResponse
+
+	wr.Meta.Coin = w.Meta["coin"]
+	wr.Meta.Filename = w.Meta["filename"]
+	wr.Meta.Label = w.Meta["label"]
+	wr.Meta.Type = w.Meta["type"]
+	wr.Meta.Version = w.Meta["version"]
+	wr.Meta.CryptoType = w.Meta["cryptoType"]
+
+	// Converts "encrypted" string to boolean if any
+	if encryptedStr, ok := w.Meta["encrypted"]; ok {
+		encrypted, err := strconv.ParseBool(encryptedStr)
+		if err != nil {
+			return nil, err
+		}
+		wr.Meta.Encrypted = encrypted
+	}
+
+	if tmStr, ok := w.Meta["tm"]; ok {
+		// Converts "tm" string to integer timestamp.
+		tm, err := strconv.ParseInt(tmStr, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		wr.Meta.Timestamp = tm
+	}
+
+	for _, e := range w.Entries {
+		wr.Entries = append(wr.Entries, walletEntry{
+			Address: e.Address.String(),
+			Public:  e.Public.Hex(),
+		})
+	}
+
+	return &wr, nil
+}
+
+// ToWallet converts WalletResponse to wallet.Wallet
+func (wr *WalletResponse) ToWallet() (*wallet.Wallet, error) {
+	w := wallet.Wallet{Meta: make(map[string]string)}
+	w.Meta["coin"] = wr.Meta.Coin
+	w.Meta["filename"] = wr.Meta.Filename
+	w.Meta["label"] = wr.Meta.Label
+	w.Meta["type"] = wr.Meta.Type
+	w.Meta["version"] = wr.Meta.Version
+	w.Meta["cryptoType"] = wr.Meta.CryptoType
+	w.Meta["tm"] = strconv.FormatInt(wr.Meta.Timestamp, 10)
+	w.Meta["encrypted"] = strconv.FormatBool(wr.Meta.Encrypted)
+
+	for _, e := range wr.Entries {
+		addr, err := cipher.DecodeBase58Address(e.Address)
+		if err != nil {
+			return nil, err
+		}
+
+		pubkey, err := cipher.PubKeyFromHex(e.Public)
+		if err != nil {
+			return nil, err
+		}
+		w.Entries = append(w.Entries, wallet.Entry{
+			Address: addr,
+			Public:  pubkey,
+		})
+	}
+
+	return &w, nil
+}
+
 // Returns the wallet's balance, both confirmed and predicted.  The predicted
 // balance is the confirmed balance minus the pending spends.
 // URI: /wallet/balance
@@ -270,8 +362,11 @@ func walletCreate(gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 		// Wipes all sensitive data
-		rlt := wallet.NewReadableWallet(wlt)
-		rlt.Erase()
+		rlt, err := NewWalletResponse(wlt)
+		if err != nil {
+			wh.Error500Msg(w, err.Error())
+			return
+		}
 		wh.SendJSONOr500(logger, w, rlt)
 	}
 }
@@ -410,9 +505,11 @@ func walletGet(gateway Gatewayer) http.HandlerFunc {
 			}
 			return
 		}
-		// Wipes all sensitive data
-		rlt := wallet.NewReadableWallet(wlt)
-		rlt.Erase()
+		rlt, err := NewWalletResponse(wlt)
+		if err != nil {
+			wh.Error500Msg(w, err.Error())
+			return
+		}
 		wh.SendJSONOr500(logger, w, rlt)
 	}
 }
@@ -478,13 +575,17 @@ func walletsHandler(gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 
-		rlts := wlts.ToReadable()
-		// Erase sensitive data
-		for i := range rlts {
-			rlts[i].Erase()
-		}
+		var wrs []*WalletResponse
+		for _, wlt := range wlts {
+			wr, err := NewWalletResponse(wlt)
+			if err != nil {
+				wh.Error500Msg(w, err.Error())
+				return
+			}
 
-		wh.SendJSONOr500(logger, w, rlts)
+			wrs = append(wrs, wr)
+		}
+		wh.SendJSONOr500(logger, w, wrs)
 	}
 }
 
@@ -695,8 +796,11 @@ func walletEncryptHandler(gateway Gatewayer) http.HandlerFunc {
 		}
 
 		// Make sure the sensitive data are wiped
-		rlt := wallet.NewReadableWallet(wlt)
-		rlt.Erase()
+		rlt, err := NewWalletResponse(wlt)
+		if err != nil {
+			wh.Error500Msg(w, err.Error())
+			return
+		}
 		wh.SendJSONOr500(logger, w, rlt)
 	}
 }
@@ -740,9 +844,11 @@ func walletDecryptHandler(gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 
-		rlt := wallet.NewReadableWallet(wlt)
-		// Wipes sensitive data in wallet
-		rlt.Erase()
+		rlt, err := NewWalletResponse(wlt)
+		if err != nil {
+			wh.Error500Msg(w, err.Error())
+			return
+		}
 		wh.SendJSONOr500(logger, w, rlt)
 	}
 }

--- a/src/gui/wallet_test.go
+++ b/src/gui/wallet_test.go
@@ -1159,7 +1159,7 @@ func TestWalletCreateHandler(t *testing.T) {
 				Entries: cloneEntries(entries),
 			},
 			responseBody: WalletResponse{
-				Meta: walletMeta{
+				Meta: WalletMeta{
 					Filename: "filename",
 				},
 				Entries: responseEntries[:],
@@ -1194,7 +1194,7 @@ func TestWalletCreateHandler(t *testing.T) {
 				},
 			},
 			responseBody: WalletResponse{
-				Meta: walletMeta{
+				Meta: WalletMeta{
 					Filename: "filename",
 				},
 			},
@@ -1237,7 +1237,7 @@ func TestWalletCreateHandler(t *testing.T) {
 				},
 			},
 			responseBody: WalletResponse{
-				Meta: walletMeta{
+				Meta: WalletMeta{
 					Filename:  "filename",
 					Label:     "bar",
 					Encrypted: true,
@@ -1983,7 +1983,7 @@ func TestEncryptWallet(t *testing.T) {
 			},
 			status: http.StatusOK,
 			expectWallet: WalletResponse{
-				Meta: walletMeta{
+				Meta: WalletMeta{
 					Filename:  "wallet.wlt",
 					Encrypted: true,
 				},
@@ -2135,7 +2135,7 @@ func TestDecryptWallet(t *testing.T) {
 			},
 			status: http.StatusOK,
 			expectWallet: WalletResponse{
-				Meta: walletMeta{
+				Meta: WalletMeta{
 					Filename:  "wallet",
 					Encrypted: false,
 				},
@@ -2253,10 +2253,10 @@ func TestDecryptWallet(t *testing.T) {
 // makeEntries derives N wallet address entries from given seed
 // Returns set of wallet.Entry and wallet.ReadableEntry, the readable
 // entries' secrets are removed.
-func makeEntries(seed []byte, n int) ([]wallet.Entry, []walletEntry) {
+func makeEntries(seed []byte, n int) ([]wallet.Entry, []WalletEntry) {
 	seckeys := cipher.GenerateDeterministicKeyPairs(seed, n)
 	var entries []wallet.Entry
-	var responseEntries []walletEntry
+	var responseEntries []WalletEntry
 	for i, seckey := range seckeys {
 		pubkey := cipher.PubKeyFromSecKey(seckey)
 		entries = append(entries, wallet.Entry{
@@ -2264,7 +2264,7 @@ func makeEntries(seed []byte, n int) ([]wallet.Entry, []walletEntry) {
 			Public:  pubkey,
 			Secret:  seckey,
 		})
-		responseEntries = append(responseEntries, walletEntry{
+		responseEntries = append(responseEntries, WalletEntry{
 			Address: entries[i].Address.String(),
 			Public:  entries[i].Public.Hex(),
 		})

--- a/src/gui/wallet_test.go
+++ b/src/gui/wallet_test.go
@@ -462,7 +462,7 @@ func TestWalletSpendHandler(t *testing.T) {
 }
 
 func TestWalletGet(t *testing.T) {
-	entries, noSecReadableEntries := makeEntries([]byte("seed"), 5)
+	entries, resEntries := makeEntries([]byte("seed"), 5)
 	type httpBody struct {
 		WalletID string
 		Dst      string
@@ -478,7 +478,7 @@ func TestWalletGet(t *testing.T) {
 		err                    string
 		walletID               string
 		gatewayGetWalletResult wallet.Wallet
-		responseBody           wallet.ReadableWallet
+		responseBody           WalletResponse
 		gatewayGetWalletErr    error
 	}{
 		{
@@ -533,10 +533,7 @@ func TestWalletGet(t *testing.T) {
 				Meta:    map[string]string{"seed": "seed", "lastSeed": "seed"},
 				Entries: cloneEntries(entries),
 			},
-			responseBody: wallet.ReadableWallet{
-				Meta:    map[string]string{"seed": "", "lastSeed": "", "secrets": ""},
-				Entries: noSecReadableEntries[:],
-			},
+			responseBody: WalletResponse{Entries: resEntries[:]},
 		},
 	}
 
@@ -580,7 +577,7 @@ func TestWalletGet(t *testing.T) {
 					"case: %s, handler returned wrong error message: got `%v`| %s, want `%v`",
 					tc.name, strings.TrimSpace(rr.Body.String()), status, tc.err)
 			} else {
-				var rlt wallet.ReadableWallet
+				var rlt WalletResponse
 				err = json.Unmarshal(rr.Body.Bytes(), &rlt)
 				require.NoError(t, err)
 				require.Equal(t, tc.responseBody, rlt)
@@ -999,7 +996,7 @@ func TestWalletTransactionsHandler(t *testing.T) {
 }
 
 func TestWalletCreateHandler(t *testing.T) {
-	entries, noSecReadableEntries := makeEntries([]byte("seed"), 5)
+	entries, responseEntries := makeEntries([]byte("seed"), 5)
 	type httpBody struct {
 		Seed     string
 		Label    string
@@ -1020,7 +1017,7 @@ func TestWalletCreateHandler(t *testing.T) {
 		gatewayCreateWalletErr    error
 		scanWalletAddressesResult wallet.Wallet
 		scanWalletAddressesError  error
-		responseBody              wallet.ReadableWallet
+		responseBody              WalletResponse
 		csrfDisabled              bool
 	}{
 		{
@@ -1161,14 +1158,11 @@ func TestWalletCreateHandler(t *testing.T) {
 				},
 				Entries: cloneEntries(entries),
 			},
-			responseBody: wallet.ReadableWallet{
-				Meta: map[string]string{
-					"filename": "filename",
-					"seed":     "",
-					"lastSeed": "",
-					"secrets":  "",
+			responseBody: WalletResponse{
+				Meta: walletMeta{
+					Filename: "filename",
 				},
-				Entries: noSecReadableEntries[:],
+				Entries: responseEntries[:],
 			},
 		},
 		// CSRF Tests
@@ -1199,14 +1193,10 @@ func TestWalletCreateHandler(t *testing.T) {
 					"filename": "filename",
 				},
 			},
-			responseBody: wallet.ReadableWallet{
-				Meta: map[string]string{
-					"filename": "filename",
-					"seed":     "",
-					"lastSeed": "",
-					"secrets":  "",
+			responseBody: WalletResponse{
+				Meta: walletMeta{
+					Filename: "filename",
 				},
-				Entries: wallet.ReadableEntries{},
 			},
 			csrfDisabled: true,
 		},
@@ -1235,7 +1225,6 @@ func TestWalletCreateHandler(t *testing.T) {
 					"filename":  "filename",
 					"label":     "bar",
 					"encrypted": "true",
-					"password":  "pwd",
 					"secrets":   "secrets",
 				},
 			},
@@ -1244,21 +1233,15 @@ func TestWalletCreateHandler(t *testing.T) {
 					"filename":  "filename",
 					"label":     "bar",
 					"encrypted": "true",
-					"password":  "pwd",
 					"secrets":   "secrets",
 				},
 			},
-			responseBody: wallet.ReadableWallet{
-				Meta: map[string]string{
-					"filename":  "filename",
-					"label":     "bar",
-					"seed":      "",
-					"lastSeed":  "",
-					"encrypted": "true",
-					"password":  "pwd",
-					"secrets":   "",
+			responseBody: WalletResponse{
+				Meta: walletMeta{
+					Filename:  "filename",
+					Label:     "bar",
+					Encrypted: true,
 				},
-				Entries: wallet.ReadableEntries{},
 			},
 		},
 		{
@@ -1330,7 +1313,7 @@ func TestWalletCreateHandler(t *testing.T) {
 					"case: %s, handler returned wrong error message: got `%v`| %s, want `%v`",
 					tc.name, strings.TrimSpace(rr.Body.String()), status, tc.err)
 			} else {
-				var msg wallet.ReadableWallet
+				var msg WalletResponse
 				err = json.Unmarshal(rr.Body.Bytes(), &msg)
 				require.NoError(t, err)
 				require.Equal(t, tc.responseBody, msg, tc.name)
@@ -1966,7 +1949,7 @@ func TestWalletUnloadHandler(t *testing.T) {
 }
 
 func TestEncryptWallet(t *testing.T) {
-	entries, noSensitiveReadableEntries := makeEntries([]byte("seed"), 5)
+	entries, responseEntries := makeEntries([]byte("seed"), 5)
 	type gatewayReturnPair struct {
 		w   *wallet.Wallet
 		err error
@@ -1978,7 +1961,7 @@ func TestEncryptWallet(t *testing.T) {
 		password      string
 		gatewayReturn gatewayReturnPair
 		status        int
-		expectWallet  wallet.ReadableWallet
+		expectWallet  WalletResponse
 		expectErr     string
 	}{
 		{
@@ -1999,15 +1982,12 @@ func TestEncryptWallet(t *testing.T) {
 				},
 			},
 			status: http.StatusOK,
-			expectWallet: wallet.ReadableWallet{
-				Meta: map[string]string{
-					"filename":  "wallet.wlt",
-					"seed":      "",
-					"lastSeed":  "",
-					"encrypted": "true",
-					"secrets":   "",
+			expectWallet: WalletResponse{
+				Meta: walletMeta{
+					Filename:  "wallet.wlt",
+					Encrypted: true,
 				},
-				Entries: noSensitiveReadableEntries,
+				Entries: responseEntries,
 			},
 		},
 		{
@@ -2104,14 +2084,14 @@ func TestEncryptWallet(t *testing.T) {
 			handler.ServeHTTP(rr, req)
 
 			status := rr.Code
-			require.Equal(t, tc.status, status, "wrong status code: got `%v` want `%v`", status, tc.status)
+			require.Equal(t, tc.status, status, "wrong status code: got `%v` want `%v`, body: %v", status, tc.status, rr.Body.String())
 
 			if status != http.StatusOK {
 				require.Equal(t, tc.expectErr, strings.TrimSpace(rr.Body.String()))
 				return
 			}
 
-			var rlt wallet.ReadableWallet
+			var rlt WalletResponse
 			err = json.NewDecoder(rr.Body).Decode(&rlt)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectWallet, rlt)
@@ -2120,7 +2100,7 @@ func TestEncryptWallet(t *testing.T) {
 }
 
 func TestDecryptWallet(t *testing.T) {
-	entries, noSensitiveReadableEntries := makeEntries([]byte("seed"), 5)
+	entries, responseEntries := makeEntries([]byte("seed"), 5)
 	type gatewayReturnPair struct {
 		w   *wallet.Wallet
 		err error
@@ -2133,7 +2113,7 @@ func TestDecryptWallet(t *testing.T) {
 		password      string
 		gatewayReturn gatewayReturnPair
 		status        int
-		expectWallet  wallet.ReadableWallet
+		expectWallet  WalletResponse
 		expectErr     string
 	}{
 		{
@@ -2154,15 +2134,12 @@ func TestDecryptWallet(t *testing.T) {
 				},
 			},
 			status: http.StatusOK,
-			expectWallet: wallet.ReadableWallet{
-				Meta: map[string]string{
-					"filename":  "wallet",
-					"seed":      "",
-					"lastSeed":  "",
-					"secrets":   "",
-					"encrypted": "false",
+			expectWallet: WalletResponse{
+				Meta: walletMeta{
+					Filename:  "wallet",
+					Encrypted: false,
 				},
-				Entries: noSensitiveReadableEntries,
+				Entries: responseEntries,
 			},
 		},
 		{
@@ -2265,10 +2242,10 @@ func TestDecryptWallet(t *testing.T) {
 				return
 			}
 
-			var rlt wallet.ReadableWallet
-			err = json.NewDecoder(rr.Body).Decode(&rlt)
+			var r WalletResponse
+			err = json.NewDecoder(rr.Body).Decode(&r)
 			require.NoError(t, err)
-			require.Equal(t, tc.expectWallet, rlt)
+			require.Equal(t, tc.expectWallet, r)
 		})
 	}
 }
@@ -2276,10 +2253,10 @@ func TestDecryptWallet(t *testing.T) {
 // makeEntries derives N wallet address entries from given seed
 // Returns set of wallet.Entry and wallet.ReadableEntry, the readable
 // entries' secrets are removed.
-func makeEntries(seed []byte, n int) ([]wallet.Entry, []wallet.ReadableEntry) {
+func makeEntries(seed []byte, n int) ([]wallet.Entry, []walletEntry) {
 	seckeys := cipher.GenerateDeterministicKeyPairs(seed, n)
 	var entries []wallet.Entry
-	var noSecReadableEntries []wallet.ReadableEntry
+	var responseEntries []walletEntry
 	for i, seckey := range seckeys {
 		pubkey := cipher.PubKeyFromSecKey(seckey)
 		entries = append(entries, wallet.Entry{
@@ -2287,12 +2264,12 @@ func makeEntries(seed []byte, n int) ([]wallet.Entry, []wallet.ReadableEntry) {
 			Public:  pubkey,
 			Secret:  seckey,
 		})
-		noSecReadableEntries = append(noSecReadableEntries, wallet.ReadableEntry{
+		responseEntries = append(responseEntries, walletEntry{
 			Address: entries[i].Address.String(),
 			Public:  entries[i].Public.Hex(),
 		})
 	}
-	return entries, noSecReadableEntries
+	return entries, responseEntries
 }
 
 func cloneEntries(es []wallet.Entry) []wallet.Entry {

--- a/src/wallet/readable.go
+++ b/src/wallet/readable.go
@@ -189,9 +189,9 @@ func (rw *ReadableWallet) time() string {
 
 // Erase remove sensitive data
 func (rw *ReadableWallet) Erase() {
-	rw.Meta["seed"] = ""
-	rw.Meta["lastSeed"] = ""
-	rw.Meta["secrets"] = ""
+	delete(rw.Meta, metaSeed)
+	delete(rw.Meta, metaLastSeed)
+	delete(rw.Meta, metaSecrets)
 	for i := range rw.Entries {
 		rw.Entries[i].Secret = ""
 	}


### PR DESCRIPTION
Fixes #1220 

Changes:
- Remove seed, lastSeed, secrets meta fileds and secret in address entries of wallet apis response
- Change the "encrypted" type to boolean
- Rename the "tm" to "timestamp", and change the type from string to integer

Does this change need to mentioned in CHANGELOG.md?
Yes.
