### PR TITLE
[util] fixes #1219 - Remove imports of go lang 'log' built-in package

### DIFF
--- a/src/api/webrpc/client_test.go
+++ b/src/api/webrpc/client_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	log = logging.MustGetLogger("webrpc")
+	log = logging.MustGetLogger("webrpc_test")
 )
 
 // Tests are setup as subtests, to retain a single *WebRPC instance for scaffolding

--- a/src/api/webrpc/client_test.go
+++ b/src/api/webrpc/client_test.go
@@ -1,7 +1,6 @@
 package webrpc
 
 import (
-	"log"
 	"sort"
 	"strings"
 	"testing"
@@ -12,7 +11,12 @@ import (
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/coin"
 	"github.com/skycoin/skycoin/src/testutil"
+	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/skycoin/skycoin/src/visor"
+)
+
+var (
+	log = logging.MustGetLogger("webrpc")
 )
 
 // Tests are setup as subtests, to retain a single *WebRPC instance for scaffolding

--- a/src/util/http/handler.go
+++ b/src/util/http/handler.go
@@ -2,7 +2,6 @@ package httphelper
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 
@@ -26,14 +25,14 @@ func HostCheck(logger *logging.Logger, host string, handler http.Handler) http.H
 		var err error
 		addr, port, err = iputil.SplitAddr(host)
 		if err != nil {
-			log.Panic(err)
+			logger.Panic(err)
 		}
 	}
 
 	isLocalhost := iputil.IsLocalhost(addr)
 
 	if isLocalhost && port == 0 {
-		log.Panic("localhost with no port specified is unsupported")
+		logger.Panic("localhost with no port specified is unsupported")
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/src/visor/historydb/historydb_test.go
+++ b/src/visor/historydb/historydb_test.go
@@ -24,7 +24,7 @@ var (
 	transactionBkt       = []byte("transactions")
 	outputBkt            = []byte("uxouts")
 	addressInBkt         = []byte("address_in")
-	log                  = logging.MustGetLogger("historydb")
+	log                  = logging.MustGetLogger("historydb_test")
 )
 
 var _genTime uint64 = 1000

--- a/src/visor/historydb/historydb_test.go
+++ b/src/visor/historydb/historydb_test.go
@@ -3,7 +3,6 @@ package historydb
 import (
 	"errors"
 	"fmt"
-	"log"
 	"math/rand"
 	"testing"
 	"time"
@@ -16,6 +15,7 @@ import (
 	"github.com/skycoin/skycoin/src/cipher/encoder"
 	"github.com/skycoin/skycoin/src/coin"
 	"github.com/skycoin/skycoin/src/testutil"
+	"github.com/skycoin/skycoin/src/util/logging"
 )
 
 var (
@@ -24,6 +24,7 @@ var (
 	transactionBkt       = []byte("transactions")
 	outputBkt            = []byte("uxouts")
 	addressInBkt         = []byte("address_in")
+	log                  = logging.MustGetLogger("historydb")
 )
 
 var _genTime uint64 = 1000

--- a/src/wallet/wallet_test.go
+++ b/src/wallet/wallet_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	log = logging.MustGetLogger("wallet")
+	log = logging.MustGetLogger("wallet_test")
 )
 
 // set rand seed.

--- a/src/wallet/wallet_test.go
+++ b/src/wallet/wallet_test.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"math/rand"
 	"testing"
 	"time"
@@ -18,6 +17,11 @@ import (
 	"github.com/skycoin/skycoin/src/cipher/encrypt"
 	"github.com/skycoin/skycoin/src/testutil"
 	"github.com/skycoin/skycoin/src/util/fee"
+	"github.com/skycoin/skycoin/src/util/logging"
+)
+
+var (
+	log = logging.MustGetLogger("wallet")
 )
 
 // set rand seed.


### PR DESCRIPTION

Fixes #1219 

Changes:
- Remove call to `log` function and use `util.logging` package instead. Changes here

```
src//api/webrpc/client_test.go:4: "log"
src//util/http/handler.go:5: "log"
src//visor/historydb/historydb_test.go:6: "log"
src//wallet/wallet_test.go:10: "log"
```

Does this change need to mentioned in CHANGELOG.md?
no