### PR TITLE
Fix 1244, /wallets api returns [], instead of null when there're no wallets

### DIFF
--- a/src/gui/wallet.go
+++ b/src/gui/wallet.go
@@ -540,7 +540,7 @@ func walletsHandler(gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 
-		var wrs []*WalletResponse
+		wrs := make([]*WalletResponse, 0, len(wlts))
 		for _, wlt := range wlts {
 			wr, err := NewWalletResponse(wlt)
 			if err != nil {


### PR DESCRIPTION
Fixes #1244 

Changes:
- /wallets returns [], instead of null when there're no wallets

Does this change need to mentioned in CHANGELOG.md?
No.