### PR TITLE
Build the UI in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,13 @@ env:
     - LIB_DIR: lib
 
 cache:
-  yarn: true
   directories:
   - electron/node_modules
   - electron/src/node_modules
   - $HOME/.cache/electron
   - $HOME/.cache/electron-builder
   - $HOME/.npm/_prebuilds
+  - src/gui/static/node_modules
 
 install:
   # Install gox
@@ -38,6 +38,7 @@ install:
   - go get -t ./...
   - make install-linters
   - make install-deps-libc
+  - make install-deps-ui
 
 before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$TRAVIS_PULL_REQUEST" == false ]]; then ./ci-scripts/add-key.sh && npm install -g yarn ;fi
@@ -53,6 +54,7 @@ script:
   # TODO: test pyskycoin
   # - make test-libpy
   # build wallets
+  - make build-ui
   - if [[ "$TRAVIS_PULL_REQUEST" == false ]]; then ./ci-scripts/build-wallet.sh; fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
     - BUILD_DIR: build
     - BUILDLIB_DIR: $BUILD_DIR/libskycoin
     - LIB_DIR: lib
+    - BUILD_UI_TRAVIS_DIR: HOME/.skycoin-ui-travis
 
 cache:
   directories:
@@ -53,8 +54,14 @@ script:
   - make test-libc
   # TODO: test pyskycoin
   # - make test-libpy
+  # TODO: test ui
+  # - make test-ui
+  # TODO: lint ui
+  # - make lint-ui
+  # Check that the UI can build. Don't use make build-ui since it will rewrite the dist folder which will change the wallet release
+  # If the UI tests can be run to verify compilation, we can remove this
+  - make build-ui-travis
   # build wallets
-  - make build-ui
   - if [[ "$TRAVIS_PULL_REQUEST" == false ]]; then ./ci-scripts/build-wallet.sh; fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ env:
     - BUILD_DIR: build
     - BUILDLIB_DIR: $BUILD_DIR/libskycoin
     - LIB_DIR: lib
-    - BUILD_UI_TRAVIS_DIR: HOME/.skycoin-ui-travis
 
 cache:
+  yarn: true
   directories:
   - electron/node_modules
   - electron/src/node_modules
@@ -34,8 +34,7 @@ install:
   # Install gox
   - go get github.com/gz-c/gox
   # Install dependences for building wallet
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_PULL_REQUEST" == false ]]; then sudo apt-get install --no-install-recommends -y icnsutils graphicsmagick xz-utils  &&nvm install 8; fi
-  # for test
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_PULL_REQUEST" == false ]]; then sudo apt-get install --no-install-recommends -y icnsutils graphicsmagick xz-utils && nvm install 8; fi
   - go get -t ./...
   - make install-linters
   - make install-deps-libc
@@ -48,7 +47,7 @@ script:
   - make lint
   - make test-386
   - make test-amd64
-  # stable integration tests
+  # Stable integration tests
   - make integration-test-stable
   # libskycoin tests
   - make test-libc
@@ -58,15 +57,16 @@ script:
   # - make test-ui
   # TODO: lint ui
   # - make lint-ui
-  # Check that the UI can build. Don't use make build-ui since it will rewrite the dist folder which will change the wallet release
-  # If the UI tests can be run to verify compilation, we can remove this
-  - make build-ui-travis
-  # build wallets
+  # Build wallets
   - if [[ "$TRAVIS_PULL_REQUEST" == false ]]; then ./ci-scripts/build-wallet.sh; fi
-
+  # Check that the UI can build. this is done after the wallet build step, because make build-ui
+  # will change the dist/ folder.
+  # If make test-ui can verify that the wallet compiles, we can remove this step after we enable make test-ui
+  - make build-ui
 
 notifications:
-  email: false
+  email:
+    - travis@skycoin.net
 
 deploy:
   provider: s3

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .DEFAULT_GOAL := help
-.PHONY: run run-help test test-core test-libc test-lint build-libc check cover integration-test-stable integration-test-live integration-test-disable-wallet-api integration-test-enable-seed-api install-linters format release clean help
+.PHONY: run run-help test test-core test-libc test-lint build-libc check cover integration-test-stable integration-test-live integration-test-disable-wallet-api integration-test-enable-seed-api install-linters format release clean-release install-deps-ui build-ui help
 
 # Static files directory
-STATIC_DIR = src/gui/static
+GUI_STATIC_DIR = src/gui/static
 
 # Electron files directory
 ELECTRON_DIR = electron
@@ -142,11 +142,17 @@ format: ## Formats the code. Must have goimports installed (use make install-lin
 	goimports -w -local github.com/skycoin/skycoin ./src
 	goimports -w -local github.com/skycoin/skycoin ./lib
 
+install-deps-ui:  ## Install the UI dependencies
+	cd $(GUI_STATIC_DIR) && npm install
+
+build-ui:  ## Builds the UI
+	cd $(GUI_STATIC_DIR) && npm run build
+
 release: ## Build electron apps, the builds are located in electron/release folder.
 	cd $(ELECTRON_DIR) && ./build.sh
 	@echo release files are in the folder of electron/release
 
-clean: ## Clean dist files and delete all builds in electron/release
+clean-release: ## Clean dist files and delete all builds in electron/release
 	rm $(ELECTRON_DIR)/release/*
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -145,8 +145,18 @@ format: ## Formats the code. Must have goimports installed (use make install-lin
 install-deps-ui:  ## Install the UI dependencies
 	cd $(GUI_STATIC_DIR) && npm install
 
+lint-ui:  ## Lint the UI code
+	cd $(GUI_STATIC_DIR) && npm run lint
+
+test-ui:  ## Run UI tests
+	cd $(GUI_STATIC_DIR) && npm run test
+	cd $(GUI_STATIC_DIR) && npm run e2e
+
 build-ui:  ## Builds the UI
 	cd $(GUI_STATIC_DIR) && npm run build
+
+build-ui-travis:  ## Builds the UI for travis
+	cd $(GUI_STATIC_DIR) && npm run build-travis
 
 release: ## Build electron apps, the builds are located in electron/release folder.
 	cd $(ELECTRON_DIR) && ./build.sh

--- a/Makefile
+++ b/Makefile
@@ -155,9 +155,6 @@ test-ui:  ## Run UI tests
 build-ui:  ## Builds the UI
 	cd $(GUI_STATIC_DIR) && npm run build
 
-build-ui-travis:  ## Builds the UI for travis
-	cd $(GUI_STATIC_DIR) && npm run build-travis
-
 release: ## Build electron apps, the builds are located in electron/release folder.
 	cd $(ELECTRON_DIR) && ./build.sh
 	@echo release files are in the folder of electron/release

--- a/src/gui/static/package.json
+++ b/src/gui/static/package.json
@@ -6,6 +6,7 @@
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.config.js --delete-output-path false",
     "build": "ng build --prod",
+    "build-travis": "ng build --prod --output-path=$BUILD_UI_TRAVIS_DIR --delete-output-path=false",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"

--- a/src/gui/static/package.json
+++ b/src/gui/static/package.json
@@ -6,7 +6,6 @@
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.config.js --delete-output-path false",
     "build": "ng build --prod",
-    "build-travis": "ng build --prod --output-path=$BUILD_UI_TRAVIS_DIR --delete-output-path=false",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"


### PR DESCRIPTION
Changes:
- Add `make install-deps-ui` and `make build-ui`
- Update travis dependency caching, yarn is no longer used
- Run `make build-ui` in travis to make sure the UI compiles

Does this change need to mentioned in CHANGELOG.md?
No