### PR TITLE
Sort wallets response by timestamp

### DIFF
--- a/src/gui/wallet.go
+++ b/src/gui/wallet.go
@@ -4,6 +4,7 @@ package gui
 import (
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 
 	"github.com/skycoin/skycoin/src/cipher"
@@ -555,6 +556,11 @@ func walletsHandler(gateway Gatewayer) http.HandlerFunc {
 
 			wrs = append(wrs, wr)
 		}
+
+		sort.Slice(wrs, func(i, j int) bool {
+			return wrs[i].Meta.Timestamp < wrs[j].Meta.Timestamp
+		})
+
 		wh.SendJSONOr500(logger, w, wrs)
 	}
 }

--- a/src/gui/wallet_test.go
+++ b/src/gui/wallet_test.go
@@ -1843,8 +1843,17 @@ func TestGetWalletFolderHandler(t *testing.T) {
 }
 
 func TestGetWallets(t *testing.T) {
-	pubkey, seckey := cipher.GenerateKeyPair()
-	addr := cipher.AddressFromPubKey(pubkey)
+	var pubkeys []cipher.PubKey
+	var seckeys []cipher.SecKey
+	var addrs []cipher.Address
+
+	for i := 0; i < 4; i++ {
+		pubkey, seckey := cipher.GenerateKeyPair()
+		addr := cipher.AddressFromPubKey(pubkey)
+		pubkeys = append(pubkeys, pubkey)
+		seckeys = append(seckeys, seckey)
+		addrs = append(addrs, addr)
+	}
 
 	cases := []struct {
 		name               string
@@ -1902,14 +1911,63 @@ func TestGetWallets(t *testing.T) {
 						"type":       "footype",
 						"version":    "fooversion",
 						"cryptoType": "foocryptotype",
-						"tm":         "123456",
+						"tm":         "345678",
 						"encrypted":  "true",
 					},
 					Entries: []wallet.Entry{
 						{
-							Address: addr,
-							Public:  pubkey,
-							Secret:  seckey,
+							Address: addrs[0],
+							Public:  pubkeys[0],
+							Secret:  seckeys[0],
+						},
+					},
+				},
+				"foofilename2": {
+					Meta: map[string]string{
+						"foo":        "bar2",
+						"seed":       "fooseed2",
+						"lastSeed":   "foolastseed2",
+						"coin":       "foocoin",
+						"filename":   "foofilename2",
+						"label":      "foolabel2",
+						"type":       "footype",
+						"version":    "fooversion",
+						"cryptoType": "foocryptotype",
+						"tm":         "123456",
+						"encrypted":  "false",
+					},
+					Entries: []wallet.Entry{
+						{
+							Address: addrs[1],
+							Public:  pubkeys[1],
+							Secret:  seckeys[1],
+						},
+					},
+				},
+				"foofilename3": {
+					Meta: map[string]string{
+						"foo":        "bar3",
+						"seed":       "fooseed3",
+						"lastSeed":   "foolastseed3",
+						"coin":       "foocoin",
+						"filename":   "foofilename3",
+						"label":      "foolabel3",
+						"type":       "footype",
+						"version":    "fooversion",
+						"cryptoType": "foocryptotype",
+						"tm":         "234567",
+						"encrypted":  "true",
+					},
+					Entries: []wallet.Entry{
+						{
+							Address: addrs[2],
+							Public:  pubkeys[2],
+							Secret:  seckeys[2],
+						},
+						{
+							Address: addrs[3],
+							Public:  pubkeys[3],
+							Secret:  seckeys[3],
 						},
 					},
 				},
@@ -1918,18 +1976,58 @@ func TestGetWallets(t *testing.T) {
 				{
 					Meta: WalletMeta{
 						Coin:       "foocoin",
+						Filename:   "foofilename2",
+						Label:      "foolabel2",
+						Type:       "footype",
+						Version:    "fooversion",
+						CryptoType: "foocryptotype",
+						Timestamp:  123456,
+						Encrypted:  false,
+					},
+					Entries: []WalletEntry{
+						{
+							Address: addrs[1].String(),
+							Public:  pubkeys[1].Hex(),
+						},
+					},
+				},
+				{
+					Meta: WalletMeta{
+						Coin:       "foocoin",
+						Filename:   "foofilename3",
+						Label:      "foolabel3",
+						Type:       "footype",
+						Version:    "fooversion",
+						CryptoType: "foocryptotype",
+						Timestamp:  234567,
+						Encrypted:  true,
+					},
+					Entries: []WalletEntry{
+						{
+							Address: addrs[2].String(),
+							Public:  pubkeys[2].Hex(),
+						},
+						{
+							Address: addrs[3].String(),
+							Public:  pubkeys[3].Hex(),
+						},
+					},
+				},
+				{
+					Meta: WalletMeta{
+						Coin:       "foocoin",
 						Filename:   "foofilename",
 						Label:      "foolabel",
 						Type:       "footype",
 						Version:    "fooversion",
 						CryptoType: "foocryptotype",
-						Timestamp:  123456,
+						Timestamp:  345678,
 						Encrypted:  true,
 					},
 					Entries: []WalletEntry{
 						{
-							Address: addr.String(),
-							Public:  pubkey.Hex(),
+							Address: addrs[0].String(),
+							Public:  pubkeys[0].Hex(),
 						},
 					},
 				},


### PR DESCRIPTION
Fixes #1255

Changes:
- `GET /wallets` response array is sorted by wallet timestamp

Does this change need to mentioned in CHANGELOG.md?
No