### PR TITLE
Prevent browser to store passwords from inputs

### DIFF
--- a/src/gui/static/src/app/app.module.ts
+++ b/src/gui/static/src/app/app.module.ts
@@ -59,6 +59,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientModule } from '@angular/common/http';
 import { AppService } from './services/app.service';
 import { SeedModalComponent } from './components/pages/settings/backup/seed-modal/seed-modal.component';
+import { DontsavepasswordDirective } from './directives/dontsavepassword.directive';
 
 
 const ROUTES = [
@@ -141,6 +142,7 @@ const ROUTES = [
     ModalComponent,
     PasswordDialogComponent,
     SeedModalComponent,
+    DontsavepasswordDirective,
   ],
   entryComponents: [
     AddDepositAddressComponent,

--- a/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.html
@@ -2,7 +2,8 @@
   <div [formGroup]="form">
     <div class="form-field">
       <label for="password">Password</label>
-      <input formControlName="password" id="password" type="password" placeholder="Wallet Password">
+      <input formControlName="password" id="password" type="password"
+             placeholder="Wallet Password" autocomplete="new-password">
     </div>
   </div>
   <div class="-buttons">

--- a/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.html
@@ -3,7 +3,7 @@
     <div class="form-field">
       <label for="password">Password</label>
       <input formControlName="password" id="password" type="password"
-             placeholder="Wallet Password" autocomplete="new-password">
+             placeholder="Wallet Password" appDontSavePassword>
     </div>
   </div>
   <div class="-buttons">

--- a/src/gui/static/src/app/components/pages/wallets/create-wallet/create-wallet.component.html
+++ b/src/gui/static/src/app/components/pages/wallets/create-wallet/create-wallet.component.html
@@ -27,13 +27,13 @@
       <div class="col-md-6" [ngClass]="{ '-hidden': !encrypt }">
         <div class="form-field">
           <label for="password">Password</label>
-          <input formControlName="password" id="password" type="password" autocomplete="new-password">
+          <input formControlName="password" id="password" type="password" appDontSavePassword>
         </div>
       </div>
       <div class="col-md-6" [ngClass]="{ '-hidden': !encrypt }">
         <div class="form-field">
           <label for="confirm_password">Confirm password</label>
-          <input formControlName="confirm_password" id="confirm_password" type="password" autocomplete="new-password">
+          <input formControlName="confirm_password" id="confirm_password" type="password" appDontSavePassword>
         </div>
       </div>
     </div>

--- a/src/gui/static/src/app/components/pages/wallets/create-wallet/create-wallet.component.html
+++ b/src/gui/static/src/app/components/pages/wallets/create-wallet/create-wallet.component.html
@@ -27,13 +27,13 @@
       <div class="col-md-6" [ngClass]="{ '-hidden': !encrypt }">
         <div class="form-field">
           <label for="password">Password</label>
-          <input formControlName="password" id="password" type="password">
+          <input formControlName="password" id="password" type="password" autocomplete="new-password">
         </div>
       </div>
       <div class="col-md-6" [ngClass]="{ '-hidden': !encrypt }">
         <div class="form-field">
           <label for="confirm_password">Confirm password</label>
-          <input formControlName="confirm_password" id="confirm_password" type="password">
+          <input formControlName="confirm_password" id="confirm_password" type="password" autocomplete="new-password">
         </div>
       </div>
     </div>

--- a/src/gui/static/src/app/directives/dontsavepassword.directive.spec.ts
+++ b/src/gui/static/src/app/directives/dontsavepassword.directive.spec.ts
@@ -1,0 +1,8 @@
+import { DontsavepasswordDirective } from './dontsavepassword.directive';
+
+describe('DontsavepasswordDirective', () => {
+  it('should create an instance', () => {
+    const directive = new DontsavepasswordDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/src/gui/static/src/app/directives/dontsavepassword.directive.ts
+++ b/src/gui/static/src/app/directives/dontsavepassword.directive.ts
@@ -1,0 +1,17 @@
+import { Directive, ElementRef, HostListener } from '@angular/core';
+
+@Directive({
+  selector: '[appDontSavePassword]'
+})
+export class DontsavepasswordDirective {
+
+  constructor(private el: ElementRef) {
+    el.nativeElement.autocomplete = 'new-password';
+    el.nativeElement.readOnly = true;
+  }
+
+  @HostListener('focus') onFocus() {
+    this.el.nativeElement.readOnly = false;
+  }
+
+}


### PR DESCRIPTION
Fixes #1249

Changes:
- added `autocomplete="new-password"` to password inputs so browser won't ask to store it

#1238 has additional password inputs that will need to be added here after it's merged 