### PR TITLE
Disable RPC interface by default for run.sh and electron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - #665, update wallet apis to support wallet encryption
 - #1077, disable initial wallet creating
+- #1270, disable RPC interface by default for run.sh and electron
 
 ### Changed
 

--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -73,7 +73,8 @@ function startSkycoin() {
     '-logtofile=true',
     '-download-peerlist=true',
     '-enable-seed-api=true',
-    '-enable-wallet-api=true'
+    '-enable-wallet-api=true',
+    '-rpc-interface=false',
     // will break
     // broken (automatically generated certs do not work):
     // '-web-interface-https=true',

--- a/run.sh
+++ b/run.sh
@@ -11,9 +11,10 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 GOLDFLAGS="-X main.Commit=${COMMIT} -X main.Branch=${BRANCH}"
 
 go run -ldflags "${GOLDFLAGS}" cmd/skycoin/skycoin.go \
-    --gui-dir="${DIR}/src/gui/static/" \
-    --launch-browser=true \
-    --enable-wallet-api=true \
+    -gui-dir="${DIR}/src/gui/static/" \
+    -launch-browser=true \
+    -enable-wallet-api=true \
+    -rpc-interface=false \
     $@
 
 popd >/dev/null


### PR DESCRIPTION
Fixes #1270 

Changes:
- Disable RPC interface by default for run.sh and electron

Does this change need to mentioned in CHANGELOG.md?
Yes.