### PR TITLE
Add more droplet.FromString test cases

### DIFF
--- a/src/util/droplet/droplet.go
+++ b/src/util/droplet/droplet.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/shopspring/decimal"
+
 	logging "github.com/skycoin/skycoin/src/util/logging"
 )
 

--- a/src/util/droplet/droplet_test.go
+++ b/src/util/droplet/droplet_test.go
@@ -107,6 +107,34 @@ func TestFromString(t *testing.T) {
 			s: "9223372036854775806.000001",
 			e: ErrTooLarge,
 		},
+		{
+			s: "1.1",
+			n: 1e6 + 1e5,
+		},
+		{
+			s: "1.01",
+			n: 1e6 + 1e4,
+		},
+		{
+			s: "1.001",
+			n: 1e6 + 1e3,
+		},
+		{
+			s: "1.0001",
+			n: 1e6 + 1e2,
+		},
+		{
+			s: "1.00001",
+			n: 1e6 + 1e1,
+		},
+		{
+			s: "1.000001",
+			n: 1e6 + 1e0,
+		},
+		{
+			s: "1.0000001",
+			e: ErrTooManyDecimals,
+		},
 	}
 
 	for _, tcc := range cases {


### PR DESCRIPTION
Changes:
- Add some more test cases for droplet.FromString, with strings having less than all 6 decimal places

Does this change need to mentioned in CHANGELOG.md?
No