### PR TITLE
Run disable wallet and seed apis in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,10 @@ script:
   - make test-amd64
   # Stable integration tests
   - make integration-test-stable
+  # Disable wallet api test
+  - make integration-test-disable-wallet-api
+  # Disable seed api test
+  - make integration-test-disable-seed-api
   # libskycoin tests
   - make test-libc
   # TODO: test pyskycoin

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: run run-help test test-core test-libc test-lint build-libc check cover integration-test-stable integration-test-live integration-test-disable-wallet-api integration-test-enable-seed-api install-linters format release clean-release install-deps-ui build-ui help
+.PHONY: run run-help test test-core test-libc test-lint build-libc check cover integration-test-stable integration-test-live integration-test-disable-wallet-api integration-test-disable-seed-api install-linters format release clean-release install-deps-ui build-ui help
 
 # Static files directory
 GUI_STATIC_DIR = src/gui/static

--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,8 @@ integration-test-live: ## Run live integration tests
 integration-test-disable-wallet-api: ## Run disable wallet api integration tests
 	./ci-scripts/integration-test-disable-wallet-api.sh
 
-integration-test-enable-seed-api: ## Run enable seed api integration test
-	./ci-scripts/integration-test-enable-seed-api.sh -w
+integration-test-disable-seed-api: ## Run enable seed api integration test
+	./ci-scripts/integration-test-disable-seed-api.sh -w
 
 cover: ## Runs tests on ./src/ with HTML code coverage
 	go test -cover -coverprofile=cover.out -coverpkg=github.com/skycoin/skycoin/... ./src/...

--- a/ci-scripts/integration-test-disable-seed-api.sh
+++ b/ci-scripts/integration-test-disable-seed-api.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-# Runs "enable-seed-api"-mode tests against a skycoin node configured with -enable-seed-api option
-# "enable-seed-api"-mode confirms that wallet seed api is enabled, and only the wallet with encryption
-# that is allowed to return seed.
+# Runs "disable-seed-api"-mode tests against a skycoin node configured with -enable-seed-api=false
+# and /wallet/seed api endpoint should return 403 forbidden error.
 
 #Set Script Name variable
 SCRIPT=`basename ${BASH_SOURCE[0]}`
@@ -9,7 +8,7 @@ PORT="46422"
 RPC_PORT="46432"
 HOST="http://127.0.0.1:$PORT"
 RPC_ADDR="127.0.0.1:$RPC_PORT"
-MODE="enable-seed-api"
+MODE="disable-seed-api"
 BINARY="skycoin-integration"
 TEST=""
 RUN_TESTS=""
@@ -67,7 +66,8 @@ echo "starting skycoin node in background with http listener on $HOST"
                       -launch-browser=false \
                       -data-dir="$DATA_DIR" \
                       -wallet-dir="$WALLET_DIR" \
-                      -enable-seed-api=true &
+                      -enable-wallet-api=true \
+                      -enable-seed-api=false &
 SKYCOIN_PID=$!
 
 echo "skycoin node pid=$SKYCOIN_PID"

--- a/ci-scripts/integration-test-stable.sh
+++ b/ci-scripts/integration-test-stable.sh
@@ -76,7 +76,8 @@ echo "starting skycoin node in background with http listener on $HOST"
                       -launch-browser=false \
                       -data-dir="$DATA_DIR" \
                       -enable-wallet-api=true \
-                      -wallet-dir="$WALLET_DIR" &
+                      -wallet-dir="$WALLET_DIR" \
+                      -enable-seed-api=true &
 SKYCOIN_PID=$!
 
 echo "skycoin node pid=$SKYCOIN_PID"

--- a/src/gui/integration/integration_test.go
+++ b/src/gui/integration/integration_test.go
@@ -53,7 +53,7 @@ const (
 	testModeStable           = "stable"
 	testModeLive             = "live"
 	testModeDisableWalletApi = "disable-wallet-api"
-	testModeEnableSeedApi    = "enable-seed-api"
+	testModeDisableSeedApi   = "disable-seed-api"
 
 	testFixturesDir = "test-fixtures"
 )
@@ -82,7 +82,7 @@ func mode(t *testing.T) string {
 	case testModeLive,
 		testModeStable,
 		testModeDisableWalletApi,
-		testModeEnableSeedApi:
+		testModeDisableSeedApi:
 	default:
 		t.Fatal("Invalid test mode, must be stable, live or disable-wallet-api")
 	}
@@ -120,8 +120,8 @@ func doDisableWalletApi(t *testing.T) bool {
 	return false
 }
 
-func doEnableSeedApi(t *testing.T) bool {
-	if enabled() && mode(t) == testModeEnableSeedApi {
+func doDisableSeedApi(t *testing.T) bool {
+	if enabled() && mode(t) == testModeDisableSeedApi {
 		return true
 	}
 
@@ -2305,8 +2305,8 @@ func TestDecryptWallet(t *testing.T) {
 	require.Equal(t, lw.Entries[0].Address.String(), w.Entries[0].Address)
 }
 
-func TestGetWalletSeed(t *testing.T) {
-	if !doLiveOrStable(t) {
+func TestStableDisableGetWalletSeed(t *testing.T) {
+	if !doDisableSeedApi(t) {
 		return
 	}
 
@@ -2324,8 +2324,8 @@ func TestGetWalletSeed(t *testing.T) {
 	require.EqualError(t, err, "403 Forbidden\n")
 }
 
-func TestEnableSeedAPIAndGetWalletSeed(t *testing.T) {
-	if !doEnableSeedApi(t) {
+func TestWalletSeed(t *testing.T) {
+	if !doLiveOrStable(t) {
 		return
 	}
 


### PR DESCRIPTION
Fixes #1268 

Changes:
- Run all normal stable tests with `-enable-seed-api=true`, and rename the integration-test-enable-seed-api.sh to integration-test-disable-seed-api, which run node with `-enable-seed-api=false`.
- Run stable integration tests for disable wallet api and disable seed api in travis.

Does this change need to mentioned in CHANGELOG.md?
No.