### PR TITLE
Return 401 for invalid password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - #665, update wallet apis to support wallet encryption
 - #1077, disable initial wallet creating
 - #1270, disable RPC interface by default for run.sh and electron
+- #1267, return 401 Unauthorized for invalid password
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ lint: ## Run linters. Use make install-linters first.
 		-E varcheck \
 		./...
 
-check: lint test integration-test-stable ## Run tests and linters
+check: lint test integration-test-stable integration-test-disable-wallet-api integration-test-disable-seed-api ## Run tests and linters
 
 integration-test-stable: ## Run stable integration tests
 	./ci-scripts/integration-test-stable.sh -w

--- a/src/gui/integration/integration_test.go
+++ b/src/gui/integration/integration_test.go
@@ -2275,7 +2275,7 @@ func TestDecryptWallet(t *testing.T) {
 
 	// Decrypt wallet with different password, must fail
 	_, err := c.DecryptWallet(w.Meta.Filename, "pwd1")
-	require.EqualError(t, err, "401 Unauthorized\n")
+	require.EqualError(t, err, "401 Unauthorized - invalid password\n")
 
 	// Decrypts wallet with correct password
 	dw, err := c.DecryptWallet(w.Meta.Filename, "pwd")
@@ -2351,7 +2351,7 @@ func TestWalletSeed(t *testing.T) {
 
 	// Check with invalid password
 	_, err = c.GetWalletSeed(w.Meta.Filename, "wrong password")
-	require.EqualError(t, err, "401 Unauthorized\n")
+	require.EqualError(t, err, "401 Unauthorized - invalid password\n")
 
 	// Creates none encrypted wallet
 	nw, _, nclean := createWallet(t, c, false, "")

--- a/src/gui/integration/integration_test.go
+++ b/src/gui/integration/integration_test.go
@@ -2275,7 +2275,7 @@ func TestDecryptWallet(t *testing.T) {
 
 	// Decrypt wallet with different password, must fail
 	_, err := c.DecryptWallet(w.Meta.Filename, "pwd1")
-	require.EqualError(t, err, "400 Bad Request - invalid password\n")
+	require.EqualError(t, err, "401 Unauthorized\n")
 
 	// Decrypts wallet with correct password
 	dw, err := c.DecryptWallet(w.Meta.Filename, "pwd")
@@ -2351,7 +2351,7 @@ func TestWalletSeed(t *testing.T) {
 
 	// Check with invalid password
 	_, err = c.GetWalletSeed(w.Meta.Filename, "wrong password")
-	require.EqualError(t, err, "400 Bad Request - invalid password\n")
+	require.EqualError(t, err, "401 Unauthorized\n")
 
 	// Creates none encrypted wallet
 	nw, _, nclean := createWallet(t, c, false, "")

--- a/src/gui/wallet.go
+++ b/src/gui/wallet.go
@@ -17,6 +17,9 @@ import (
 	wh "github.com/skycoin/skycoin/src/util/http" //http,json helpers
 )
 
+// HTTP401AuthHeader WWW-Authenticate value
+const HTTP401AuthHeader = "SkycoinWallet"
+
 // SpendResult represents the result of spending
 type SpendResult struct {
 	Balance     *wallet.BalancePair        `json:"balance,omitempty"`
@@ -192,7 +195,7 @@ func walletSpendHandler(gateway Gatewayer) http.HandlerFunc {
 			wh.Error400(w, err.Error())
 			return
 		case wallet.ErrInvalidPassword:
-			wh.Error401(w)
+			wh.Error401(w, HTTP401AuthHeader, err.Error())
 			return
 		case wallet.ErrWalletAPIDisabled:
 			wh.Error403(w)
@@ -380,7 +383,7 @@ func walletNewAddresses(gateway Gatewayer) http.HandlerFunc {
 		if err != nil {
 			switch err {
 			case wallet.ErrInvalidPassword:
-				wh.Error401(w)
+				wh.Error401(w, HTTP401AuthHeader, err.Error())
 			case wallet.ErrWalletAPIDisabled:
 				wh.Error403(w)
 			default:
@@ -688,7 +691,7 @@ func walletSeedHandler(gateway Gatewayer) http.HandlerFunc {
 		if err != nil {
 			switch err {
 			case wallet.ErrInvalidPassword:
-				wh.Error401(w)
+				wh.Error401(w, HTTP401AuthHeader, err.Error())
 			case wallet.ErrWalletAPIDisabled,
 				wallet.ErrWalletNotEncrypted,
 				wallet.ErrSeedAPIDisabled:
@@ -763,7 +766,7 @@ func walletEncryptHandler(gateway Gatewayer) http.HandlerFunc {
 			case wallet.ErrWalletEncrypted:
 				wh.Error400(w, "wallet is already encrypted")
 			case wallet.ErrInvalidPassword:
-				wh.Error401(w)
+				wh.Error401(w, HTTP401AuthHeader, err.Error())
 			case wallet.ErrWalletAPIDisabled:
 				wh.Error403(w)
 			case wallet.ErrWalletNotExist:
@@ -813,7 +816,7 @@ func walletDecryptHandler(gateway Gatewayer) http.HandlerFunc {
 			case wallet.ErrWalletNotEncrypted:
 				wh.Error400(w, err.Error())
 			case wallet.ErrInvalidPassword:
-				wh.Error401(w)
+				wh.Error401(w, HTTP401AuthHeader, err.Error())
 			case wallet.ErrWalletAPIDisabled:
 				wh.Error403(w)
 			case wallet.ErrWalletNotExist:

--- a/src/gui/wallet_test.go
+++ b/src/gui/wallet_test.go
@@ -340,7 +340,7 @@ func TestWalletSpendHandler(t *testing.T) {
 			},
 		},
 		{
-			name:   "400 - invalid password",
+			name:   "401 Unauthorized - invalid password",
 			method: http.MethodPost,
 			body: &httpBody{
 				WalletID: "wallet.wlt",
@@ -349,9 +349,9 @@ func TestWalletSpendHandler(t *testing.T) {
 				Password: "pwd",
 			},
 			password:        "pwd",
-			status:          http.StatusBadRequest,
+			status:          http.StatusUnauthorized,
 			gatewaySpendErr: wallet.ErrInvalidPassword,
-			err:             "400 Bad Request - invalid password",
+			err:             "401 Unauthorized",
 			walletID:        "wallet.wlt",
 			coins:           1,
 			dst:             "2konv5no3DZvSMxf2GPVtAfZinfwqCGhfVQ",
@@ -1471,7 +1471,7 @@ func TestGetWalletSeed(t *testing.T) {
 			expectErr:         "400 Bad Request - missing password",
 		},
 		{
-			name:     "400 - invalid password",
+			name:     "401 Unauthorized - Invalid password",
 			method:   http.MethodGet,
 			wltID:    "wallet.wlt",
 			password: "pwd",
@@ -1479,8 +1479,8 @@ func TestGetWalletSeed(t *testing.T) {
 				nil,
 				wallet.ErrInvalidPassword,
 			},
-			expectStatus: http.StatusBadRequest,
-			expectErr:    "400 Bad Request - invalid password",
+			expectStatus: http.StatusUnauthorized,
+			expectErr:    "401 Unauthorized",
 		},
 		{
 			name:     "403 - wallet not encrypted",
@@ -1654,14 +1654,14 @@ func TestWalletNewAddressesHandler(t *testing.T) {
 			gatewayNewAddressesErr: wallet.ErrMissingPassword,
 		},
 		{
-			name:   "400 Bad Request - wallet invalid password",
+			name:   "401 Unauthorized - Invalid password",
 			method: http.MethodPost,
 			body: &httpBody{
 				ID:  "foo",
 				Num: "1",
 			},
-			status:   http.StatusBadRequest,
-			err:      "400 Bad Request - invalid password",
+			status:   http.StatusUnauthorized,
+			err:      "401 Unauthorized",
 			walletID: "foo",
 			n:        1,
 			gatewayNewAddressesErr: wallet.ErrInvalidPassword,
@@ -2232,15 +2232,15 @@ func TestEncryptWallet(t *testing.T) {
 			expectErr: "400 Bad Request - missing wallet id",
 		},
 		{
-			name:     "400 - Invalid Password",
+			name:     "401 Unauthorized - Invalid Password",
 			method:   http.MethodPost,
 			wltID:    "wallet.wlt",
 			password: "pwd",
 			gatewayReturn: gatewayReturnPair{
 				err: wallet.ErrInvalidPassword,
 			},
-			status:    http.StatusBadRequest,
-			expectErr: "400 Bad Request - invalid password",
+			status:    http.StatusUnauthorized,
+			expectErr: "401 Unauthorized",
 		},
 		{
 			name:     "404 - Wallet Not Found",
@@ -2394,15 +2394,15 @@ func TestDecryptWallet(t *testing.T) {
 			expectErr: "400 Bad Request - wallet is not encrypted",
 		},
 		{
-			name:     "400 - Invalid Password",
+			name:     "401 Unauthorized - Invalid Password",
 			method:   http.MethodPost,
 			wltID:    "wallet.wlt",
 			password: "pwd",
 			gatewayReturn: gatewayReturnPair{
 				err: wallet.ErrInvalidPassword,
 			},
-			status:    http.StatusBadRequest,
-			expectErr: "400 Bad Request - invalid password",
+			status:    http.StatusUnauthorized,
+			expectErr: "401 Unauthorized",
 		},
 		{
 			name:     "404 - Wallet Does Not Exist",

--- a/src/gui/wallet_test.go
+++ b/src/gui/wallet_test.go
@@ -351,7 +351,7 @@ func TestWalletSpendHandler(t *testing.T) {
 			password:        "pwd",
 			status:          http.StatusUnauthorized,
 			gatewaySpendErr: wallet.ErrInvalidPassword,
-			err:             "401 Unauthorized",
+			err:             "401 Unauthorized - invalid password",
 			walletID:        "wallet.wlt",
 			coins:           1,
 			dst:             "2konv5no3DZvSMxf2GPVtAfZinfwqCGhfVQ",
@@ -451,6 +451,9 @@ func TestWalletSpendHandler(t *testing.T) {
 
 			if status != http.StatusOK {
 				require.Equal(t, tc.err, strings.TrimSpace(rr.Body.String()))
+				if status == http.StatusUnauthorized {
+					require.Equal(t, HTTP401AuthHeader, rr.Header().Get("WWW-Authenticate"))
+				}
 			} else {
 				var msg SpendResult
 				err := json.Unmarshal(rr.Body.Bytes(), &msg)
@@ -1480,7 +1483,7 @@ func TestGetWalletSeed(t *testing.T) {
 				wallet.ErrInvalidPassword,
 			},
 			expectStatus: http.StatusUnauthorized,
-			expectErr:    "401 Unauthorized",
+			expectErr:    "401 Unauthorized - invalid password",
 		},
 		{
 			name:     "403 - wallet not encrypted",
@@ -1544,6 +1547,9 @@ func TestGetWalletSeed(t *testing.T) {
 
 			if status != http.StatusOK {
 				require.Equal(t, tc.expectErr, strings.TrimSpace(rr.Body.String()))
+				if status == http.StatusUnauthorized {
+					require.Equal(t, HTTP401AuthHeader, rr.Header().Get("WWW-Authenticate"))
+				}
 			} else {
 				var r struct {
 					Seed string `json:"seed"`
@@ -1661,7 +1667,7 @@ func TestWalletNewAddressesHandler(t *testing.T) {
 				Num: "1",
 			},
 			status:   http.StatusUnauthorized,
-			err:      "401 Unauthorized",
+			err:      "401 Unauthorized - invalid password",
 			walletID: "foo",
 			n:        1,
 			gatewayNewAddressesErr: wallet.ErrInvalidPassword,
@@ -1763,6 +1769,9 @@ func TestWalletNewAddressesHandler(t *testing.T) {
 			if status != http.StatusOK {
 				require.Equal(t, tc.err, strings.TrimSpace(rr.Body.String()), "case: %s, handler returned wrong error message: got `%v`| %d, want `%v`",
 					tc.name, strings.TrimSpace(rr.Body.String()), status, tc.err)
+				if status == http.StatusUnauthorized {
+					require.Equal(t, HTTP401AuthHeader, rr.Header().Get("WWW-Authenticate"))
+				}
 			} else {
 				var msg Addresses
 				err = json.Unmarshal(rr.Body.Bytes(), &msg)
@@ -2240,7 +2249,7 @@ func TestEncryptWallet(t *testing.T) {
 				err: wallet.ErrInvalidPassword,
 			},
 			status:    http.StatusUnauthorized,
-			expectErr: "401 Unauthorized",
+			expectErr: "401 Unauthorized - invalid password",
 		},
 		{
 			name:     "404 - Wallet Not Found",
@@ -2295,6 +2304,9 @@ func TestEncryptWallet(t *testing.T) {
 
 			if status != http.StatusOK {
 				require.Equal(t, tc.expectErr, strings.TrimSpace(rr.Body.String()))
+				if status == http.StatusUnauthorized {
+					require.Equal(t, HTTP401AuthHeader, rr.Header().Get("WWW-Authenticate"))
+				}
 				return
 			}
 
@@ -2402,7 +2414,7 @@ func TestDecryptWallet(t *testing.T) {
 				err: wallet.ErrInvalidPassword,
 			},
 			status:    http.StatusUnauthorized,
-			expectErr: "401 Unauthorized",
+			expectErr: "401 Unauthorized - invalid password",
 		},
 		{
 			name:     "404 - Wallet Does Not Exist",
@@ -2446,6 +2458,9 @@ func TestDecryptWallet(t *testing.T) {
 
 			if status != http.StatusOK {
 				require.Equal(t, tc.expectErr, strings.TrimSpace(rr.Body.String()))
+				if status == http.StatusUnauthorized {
+					require.Equal(t, HTTP401AuthHeader, rr.Header().Get("WWW-Authenticate"))
+				}
 				return
 			}
 

--- a/src/util/http/error.go
+++ b/src/util/http/error.go
@@ -28,6 +28,11 @@ func Error400(w http.ResponseWriter, msg string) {
 	HTTPError(w, http.StatusBadRequest, httpMsg)
 }
 
+// Error401 response with a 401 error
+func Error401(w http.ResponseWriter) {
+	HTTPError(w, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
+}
+
 // Error403 respond with a 403 error
 func Error403(w http.ResponseWriter) {
 	HTTPError(w, http.StatusForbidden, "Forbidden")

--- a/src/util/http/error.go
+++ b/src/util/http/error.go
@@ -29,8 +29,13 @@ func Error400(w http.ResponseWriter, msg string) {
 }
 
 // Error401 response with a 401 error
-func Error401(w http.ResponseWriter) {
-	HTTPError(w, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
+func Error401(w http.ResponseWriter, auth, msg string) {
+	w.Header().Set("WWW-Authenticate", auth)
+	httpMsg := http.StatusText(http.StatusUnauthorized)
+	if msg != "" {
+		httpMsg = fmt.Sprintf("%s - %s", httpMsg, msg)
+	}
+	HTTPError(w, http.StatusUnauthorized, httpMsg)
 }
 
 // Error403 respond with a 403 error


### PR DESCRIPTION
Fixes #1267 

Changes:
- Return 401 Unauthorized for invalid password
- Add integration-test-disable-wallet-api and integration-test-disable-seed-api to make check

Does this change need to mentioned in CHANGELOG.md?
Yes.