### PR TITLE
Avoid writing http header twice on error

### DIFF
--- a/src/util/http/json.go
+++ b/src/util/http/json.go
@@ -10,27 +10,19 @@ import (
 	"github.com/skycoin/skycoin/src/util/logging"
 )
 
-// SendJSON emits JSON to an http response
-func SendJSON(w http.ResponseWriter, m interface{}) error {
+// SendJSONOr500 writes an object as JSON, writing a 500 error if it fails
+func SendJSONOr500(log *logging.Logger, w http.ResponseWriter, m interface{}) {
 	out, err := json.MarshalIndent(m, "", "    ")
 	if err != nil {
-		return err
+		log.WithError(err).Error("json.MarshalIndent failed")
+		Error500Msg(w, "json.MarshalIndent failed")
+		return
 	}
 
 	w.Header().Add("Content-Type", "application/json")
 
 	if _, err := w.Write(out); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// SendJSONOr500 writes an object as JSON, writing a 500 error if it fails
-func SendJSONOr500(log *logging.Logger, w http.ResponseWriter, m interface{}) {
-	if err := SendJSON(w, m); err != nil {
-		log.Errorf("%v", err)
-		Error500(w)
+		log.WithError(err).Error("http Write failed")
 	}
 }
 


### PR DESCRIPTION
Changes:
- If http.ResponseWriter.Write fails, don't try to write an error header

Does this change need to mentioned in CHANGELOG.md?
No