### PR TITLE
Require password confirmation when encrypting wallet

### DIFF
--- a/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.html
@@ -5,9 +5,13 @@
       <input formControlName="password" id="password" type="password"
              placeholder="Wallet Password" appDontSavePassword>
     </div>
+    <div class="form-field" *ngIf="data.confirm">
+      <label for="password">Confirm password</label>
+      <input formControlName="confirm_password" id="confirm_password" type="password" appDontSavePassword>
+    </div>
   </div>
   <div class="-buttons">
-    <app-button #button (action)="proceed()" class="primary">
+    <app-button #button (action)="proceed()" class="primary" [disabled]="!form.valid">
       Proceed
     </app-button>
   </div>

--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
@@ -42,7 +42,10 @@ export class WalletDetailComponent {
   }
 
   toggleEncryption() {
-    this.dialog.open(PasswordDialogComponent).componentInstance.passwordSubmit
+    const config = new MatDialogConfig();
+    config.data = { confirm: !this.wallet.encrypted };
+
+    this.dialog.open(PasswordDialogComponent, config).componentInstance.passwordSubmit
       .subscribe(passwordDialog => {
         this.walletService.toggleEncryption(this.wallet, passwordDialog.password).subscribe(() => {
           passwordDialog.close();


### PR DESCRIPTION
Fixes #1299

Changes:
- when encrypting wallet, you are required to enter two passwords (for confirmation)

![screen shot 2018-04-20 at 13 27 28](https://user-images.githubusercontent.com/1536298/39048670-9b31250a-449e-11e8-98d9-623bf6f3ad21.png)
