### PR TITLE
User's pending transactions

### DIFF
--- a/src/gui/static/src/app/components/pages/settings/pending-transactions/pending-transactions.component.ts
+++ b/src/gui/static/src/app/components/pages/settings/pending-transactions/pending-transactions.component.ts
@@ -18,7 +18,7 @@ export class PendingTransactionsComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.walletService.pendingTransactions().subscribe(transactions => {
+    this.walletService.allPendingTransactions().subscribe(transactions => {
       this.transactions = this.mapTransactions(transactions);
     });
   }

--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -32,12 +32,7 @@ export class WalletService {
   }
 
   addressesAsString(): Observable<string> {
-    return this.all().map(wallets => wallets.map(wallet => {
-      return wallet.addresses.reduce((a, b) => {
-        a.push(b.address);
-        return a;
-      }, []).join(',');
-    }).join(','));
+    return this.allAddresses().map(addrs => addrs.map(addr => addr.address)).map(addrs => addrs.join(','));
   }
 
   addAddress(wallet: Wallet, password?: string) {
@@ -93,8 +88,10 @@ export class WalletService {
   }
 
   refreshPendingTransactions() {
-    this.apiService.get('pendingTxs').subscribe(txs => {
-      this.pendingTxs.next(txs);
+    this.addressesAsString().first().subscribe(addrs => {
+      this.apiService.get('transactions', { confirmed: 0, addrs }).subscribe(txs => {
+        this.pendingTxs.next(txs);
+      });
     });
   }
 

--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -83,6 +83,10 @@ export class WalletService {
       .flatMap(addresses => this.apiService.get('outputs', {addrs: addresses}));
   }
 
+  allPendingTransactions(): Observable<any> {
+    return this.apiService.get('pendingTxs');
+  }
+
   pendingTransactions(): Observable<any> {
     return this.pendingTxs.asObservable();
   }


### PR DESCRIPTION
Fixes #1297

Changes:
- red warning saying "There are some pending transactions.." will now be shown only if your addresses are part of those transactions
- using `/transactions?confirmed=0&addrs=<user's adresses>` instead of `/pendingTxs`

`Settings -> Pending transactions` are still using the default `/pendingTxs` endpoint