### PR TITLE
Improve duplicate wallet create error

### DIFF
--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -97,8 +97,8 @@ func (serv *Service) loadWallet(wltName string, options Options, bg BalanceGette
 	}
 
 	// Check for duplicate wallets by initial seed
-	if id, ok := serv.firstAddrIDMap[w.Entries[0].Address.String()]; ok {
-		return nil, fmt.Errorf("wallet %s would be duplicate with %v, same seed", w.Filename(), id)
+	if _, ok := serv.firstAddrIDMap[w.Entries[0].Address.String()]; ok {
+		return nil, ErrSeedUsed
 	}
 
 	if err := serv.wallets.add(w); err != nil {

--- a/src/wallet/service_test.go
+++ b/src/wallet/service_test.go
@@ -160,7 +160,7 @@ func TestServiceCreateWallet(t *testing.T) {
 				_, err = s.CreateWallet(dupWlt, Options{
 					Seed: seed,
 				}, nil)
-				require.EqualError(t, err, fmt.Sprintf("wallet %s would be duplicate with %v, same seed", dupWlt, wltName))
+				require.Equal(t, err, ErrSeedUsed)
 
 				// check if the dup wallet is created
 				_, ok := s.wallets[dupWlt]

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -72,6 +72,8 @@ var (
 	ErrWrongCryptoType = NewError(errors.New("wrong crypto type"))
 	// ErrWalletNotExist is returned if a wallet does not exist
 	ErrWalletNotExist = NewError(errors.New("wallet doesn't exist"))
+	// ErrSeedUsed is returned if a wallet already exists with the same seed
+	ErrSeedUsed = NewError(errors.New("a wallet already exists with this seed"))
 	// ErrWalletAPIDisabled is returned when trying to do wallet actions while the EnableWalletAPI option is false
 	ErrWalletAPIDisabled = NewError(errors.New("wallet api is disabled"))
 	// ErrSeedAPIDisabled is returned when trying to get seed of wallet while the EnableWalletAPI or EnableSeedAPI is false


### PR DESCRIPTION
Changes:
- Make the duplicate wallet clearer to the user

Does this change need to mentioned in CHANGELOG.md?
No