### PR TITLE
Cli with encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Add `-version` flag to show node version
+- Add CLI `encryptWallet` command
+- Add CLI `decryptWallet` command
+- Add CLI `showSeed` command
+- Add `password` argument to the CLI commands of `addPrivateKey`, `createRawTransaction`, `generateAddresses`, `generateWallet`, `send`
 
 ### Fixed
 
-- #1390, Add -version flag
+- Fix #1171, update CLI to support wallet encryption
 
 ### Changed
 ### Removed

--- a/src/api/cli/add_private_key.go
+++ b/src/api/cli/add_private_key.go
@@ -63,7 +63,7 @@ func addPrivateKeyCmd(cfg Config) gcli.Command {
 				errorWithHelp(c, err)
 				return nil
 			case WalletSaveError:
-				return errors.New("Save wallet failed")
+				return errors.New("save wallet failed")
 			default:
 				return err
 			}

--- a/src/api/cli/add_private_key.go
+++ b/src/api/cli/add_private_key.go
@@ -51,7 +51,7 @@ func addPrivateKeyCmd(cfg Config) gcli.Command {
 				return err
 			}
 
-			err = AddPrivateKeyToFile(w, skStr, c)
+			err = AddPrivateKeyToFile(w, skStr, []byte(c.String("p")))
 
 			switch err.(type) {
 			case nil:
@@ -97,14 +97,12 @@ func AddPrivateKey(wlt *wallet.Wallet, key string) error {
 }
 
 // AddPrivateKeyToFile adds a private key to a wallet based on filename.  Will save the wallet after modifying.
-func AddPrivateKeyToFile(walletFile, key string, c *gcli.Context) error {
+func AddPrivateKeyToFile(walletFile, key string, password []byte) error {
 	wlt, err := wallet.Load(walletFile)
 	if err != nil {
 		return WalletLoadError(err)
 	}
 
-	// read password from -p flag
-	password := []byte(c.String("p"))
 	if !wlt.IsEncrypted() {
 		if len(password) != 0 {
 			return wallet.ErrWalletNotEncrypted
@@ -116,7 +114,7 @@ func AddPrivateKeyToFile(walletFile, key string, c *gcli.Context) error {
 	} else {
 		if len(password) == 0 {
 			var err error
-			password, err = readPasswordFromTerminal(c)
+			password, err = readPasswordFromTerminal()
 			if err != nil {
 				return err
 			}

--- a/src/api/cli/add_private_key.go
+++ b/src/api/cli/add_private_key.go
@@ -103,7 +103,11 @@ func AddPrivateKeyToFile(walletFile, key string, pr PasswordReader) error {
 			return wallet.ErrMissingPassword
 		}
 	case PasswordFromBytes:
-		p, _ := pr.Password()
+		p, err := pr.Password()
+		if err != nil {
+			return err
+		}
+
 		if !wlt.IsEncrypted() && len(p) != 0 {
 			return wallet.ErrWalletNotEncrypted
 		}

--- a/src/api/cli/add_private_key.go
+++ b/src/api/cli/add_private_key.go
@@ -69,14 +69,6 @@ func addPrivateKeyCmd(cfg Config) gcli.Command {
 	}
 }
 
-// PUBLIC
-
-// WalletLoadError is returned if a wallet could not be loaded
-type WalletLoadError error
-
-// WalletSaveError is returned if a wallet could not be saved
-type WalletSaveError error
-
 // AddPrivateKey adds a private key to a *wallet.Wallet. Caller should save the wallet afterwards
 func AddPrivateKey(wlt *wallet.Wallet, key string) error {
 	sk, err := cipher.SecKeyFromHex(key)
@@ -100,7 +92,7 @@ func AddPrivateKey(wlt *wallet.Wallet, key string) error {
 func AddPrivateKeyToFile(walletFile, key string, password []byte) error {
 	wlt, err := wallet.Load(walletFile)
 	if err != nil {
-		return WalletLoadError(err)
+		return WalletLoadError{err}
 	}
 
 	if !wlt.IsEncrypted() {
@@ -132,7 +124,7 @@ func AddPrivateKeyToFile(walletFile, key string, password []byte) error {
 	}
 
 	if err := wlt.Save(dir); err != nil {
-		return WalletSaveError(err)
+		return WalletSaveError{err}
 	}
 
 	return nil

--- a/src/api/cli/check_balance.go
+++ b/src/api/cli/check_balance.go
@@ -79,7 +79,12 @@ func checkWltBalance(c *gcli.Context) error {
 	}
 
 	balRlt, err := CheckWalletBalance(rpcClient, w)
-	if err != nil {
+	switch err.(type) {
+	case nil:
+	case WalletLoadError:
+		errorWithHelp(c, err)
+		return nil
+	default:
 		return err
 	}
 
@@ -112,7 +117,7 @@ func addrBalance(c *gcli.Context) error {
 func CheckWalletBalance(c *webrpc.Client, walletFile string) (*BalanceResult, error) {
 	wlt, err := wallet.Load(walletFile)
 	if err != nil {
-		return nil, err
+		return nil, WalletLoadError{err}
 	}
 
 	var addrs []string

--- a/src/api/cli/cli.go
+++ b/src/api/cli/cli.go
@@ -341,3 +341,40 @@ type WalletSaveError struct {
 func (w WalletSaveError) Error() string {
 	return w.error.Error()
 }
+
+// PasswordReader is an interface for getting password
+type PasswordReader interface {
+	Password() ([]byte, error)
+}
+
+// PasswordFromBytes represents an implementation of PasswordReader,
+// which reads password from the bytes itself.
+type PasswordFromBytes []byte
+
+// Password implements the PasswordReader's Password method
+func (p PasswordFromBytes) Password() ([]byte, error) {
+	return []byte(p), nil
+}
+
+// PasswordFromTerm reads password from terminal
+type PasswordFromTerm struct{}
+
+// Password implements the PasswordReader's Password method
+func (p PasswordFromTerm) Password() ([]byte, error) {
+	v, err := readPasswordFromTerminal()
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// NewPasswordReader creats a PasswordReader instance,
+// reads password from the input bytes first, if it's empty, then read from terminal.
+func NewPasswordReader(p []byte) PasswordReader {
+	if len(p) != 0 {
+		return PasswordFromBytes(p)
+	}
+
+	return PasswordFromTerm{}
+}

--- a/src/api/cli/cli.go
+++ b/src/api/cli/cli.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/skycoin/skycoin/src/api/webrpc"
 	"github.com/skycoin/skycoin/src/util/file"
+	"github.com/skycoin/skycoin/src/wallet"
 )
 
 const (
@@ -305,6 +306,19 @@ func printJSON(obj interface{}) error {
 	fmt.Println(string(d))
 
 	return nil
+}
+
+func getPassword(c *gcli.Context, isWltEncrypted bool) ([]byte, error) {
+	password := []byte(c.String("p"))
+	if !isWltEncrypted {
+		return nil, wallet.ErrWalletNotEncrypted
+	}
+
+	if len(password) == 0 {
+		return readPasswordFromTerminal(c)
+	}
+
+	return password, nil
 }
 
 // readPasswordFromTerminal promotes user to enter password and read it.

--- a/src/api/cli/cli.go
+++ b/src/api/cli/cli.go
@@ -307,19 +307,14 @@ func printJSON(obj interface{}) error {
 	return nil
 }
 
-// gePassword reads password from -p flag, or promotes user to enter password
-// and read it.
-func getPassword(c *gcli.Context) (string, error) {
-	password := c.String("p")
-	if len(password) == 0 {
-		// Promotes to enter the wallet password
-		fmt.Fprint(os.Stdout, "enter password:")
-		bp, err := terminal.ReadPassword(0)
-		if err != nil {
-			return "", err
-		}
-		password = string(bp)
-		fmt.Fprintln(os.Stdout, "")
+// readPasswordFromTerminal promotes user to enter password and read it.
+func readPasswordFromTerminal(c *gcli.Context) ([]byte, error) {
+	// Promotes to enter the wallet password
+	fmt.Fprint(os.Stdout, "enter password:")
+	bp, err := terminal.ReadPassword(0)
+	if err != nil {
+		return nil, err
 	}
-	return password, nil
+	fmt.Fprintln(os.Stdout, "")
+	return bp, nil
 }

--- a/src/api/cli/cli.go
+++ b/src/api/cli/cli.go
@@ -15,6 +15,7 @@ import (
 	"os"
 
 	gcli "github.com/urfave/cli"
+	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/skycoin/skycoin/src/api/webrpc"
 	"github.com/skycoin/skycoin/src/util/file"
@@ -284,7 +285,7 @@ func onCommandUsageError(command string) gcli.OnUsageErrorFunc {
 }
 
 func errorWithHelp(c *gcli.Context, err error) {
-	fmt.Fprintf(c.App.Writer, "ERROR: %v. See '%s %s --help'\n\n", err, c.App.HelpName, c.Command.Name)
+	fmt.Fprintf(c.App.Writer, "Error: %v. See '%s %s --help'\n\n", err, c.App.HelpName, c.Command.Name)
 }
 
 func formatJSON(obj interface{}) ([]byte, error) {
@@ -304,4 +305,21 @@ func printJSON(obj interface{}) error {
 	fmt.Println(string(d))
 
 	return nil
+}
+
+// gePassword reads password from -p flag, or promotes user to enter password
+// and read it.
+func getPassword(c *gcli.Context) (string, error) {
+	password := c.String("p")
+	if len(password) == 0 {
+		// Promotes to enter the wallet password
+		fmt.Fprint(os.Stdout, "enter password:")
+		bp, err := terminal.ReadPassword(0)
+		if err != nil {
+			return "", err
+		}
+		password = string(bp)
+		fmt.Fprintln(os.Stdout, "")
+	}
+	return password, nil
 }

--- a/src/api/cli/cli.go
+++ b/src/api/cli/cli.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"os"
 
@@ -314,7 +315,7 @@ func printJSON(obj interface{}) error {
 func readPasswordFromTerminal() ([]byte, error) {
 	// Promotes to enter the wallet password
 	fmt.Fprint(os.Stdout, "enter password:")
-	bp, err := terminal.ReadPassword(0)
+	bp, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		return nil, err
 	}

--- a/src/api/cli/cli.go
+++ b/src/api/cli/cli.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/skycoin/skycoin/src/api/webrpc"
 	"github.com/skycoin/skycoin/src/util/file"
-	"github.com/skycoin/skycoin/src/wallet"
 )
 
 const (
@@ -308,21 +307,8 @@ func printJSON(obj interface{}) error {
 	return nil
 }
 
-func getPassword(c *gcli.Context, isWltEncrypted bool) ([]byte, error) {
-	password := []byte(c.String("p"))
-	if !isWltEncrypted {
-		return nil, wallet.ErrWalletNotEncrypted
-	}
-
-	if len(password) == 0 {
-		return readPasswordFromTerminal(c)
-	}
-
-	return password, nil
-}
-
 // readPasswordFromTerminal promotes user to enter password and read it.
-func readPasswordFromTerminal(c *gcli.Context) ([]byte, error) {
+func readPasswordFromTerminal() ([]byte, error) {
 	// Promotes to enter the wallet password
 	fmt.Fprint(os.Stdout, "enter password:")
 	bp, err := terminal.ReadPassword(0)

--- a/src/api/cli/cli.go
+++ b/src/api/cli/cli.go
@@ -235,6 +235,7 @@ func NewApp(cfg Config) *App {
 		walletHisCmd(),
 		walletOutputsCmd(cfg),
 		encryptWalletCmd(cfg),
+		decryptWalletCmd(cfg),
 	}
 
 	app.Name = fmt.Sprintf("%s-cli", cfg.Coin)

--- a/src/api/cli/cli.go
+++ b/src/api/cli/cli.go
@@ -236,6 +236,7 @@ func NewApp(cfg Config) *App {
 		walletOutputsCmd(cfg),
 		encryptWalletCmd(cfg),
 		decryptWalletCmd(cfg),
+		showSeedCmd(cfg),
 	}
 
 	app.Name = fmt.Sprintf("%s-cli", cfg.Coin)

--- a/src/api/cli/cli.go
+++ b/src/api/cli/cli.go
@@ -329,17 +329,9 @@ type WalletLoadError struct {
 	error
 }
 
-func (w WalletLoadError) Error() string {
-	return w.error.Error()
-}
-
 // WalletSaveError is returned if a wallet could not be saved
 type WalletSaveError struct {
 	error
-}
-
-func (w WalletSaveError) Error() string {
-	return w.error.Error()
 }
 
 // PasswordReader is an interface for getting password

--- a/src/api/cli/cli.go
+++ b/src/api/cli/cli.go
@@ -234,6 +234,7 @@ func NewApp(cfg Config) *App {
 		walletDirCmd(),
 		walletHisCmd(),
 		walletOutputsCmd(cfg),
+		encryptWalletCmd(cfg),
 	}
 
 	app.Name = fmt.Sprintf("%s-cli", cfg.Coin)
@@ -317,4 +318,24 @@ func readPasswordFromTerminal() ([]byte, error) {
 	}
 	fmt.Fprintln(os.Stdout, "")
 	return bp, nil
+}
+
+// PUBLIC
+
+// WalletLoadError is returned if a wallet could not be loaded
+type WalletLoadError struct {
+	error
+}
+
+func (w WalletLoadError) Error() string {
+	return w.error.Error()
+}
+
+// WalletSaveError is returned if a wallet could not be saved
+type WalletSaveError struct {
+	error
+}
+
+func (w WalletSaveError) Error() string {
+	return w.error.Error()
 }

--- a/src/api/cli/create_rawtx.go
+++ b/src/api/cli/create_rawtx.go
@@ -304,7 +304,11 @@ func CreateRawTxFromWallet(c *webrpc.Client, walletFile, chgAddr string, toAddrs
 			return nil, wallet.ErrWalletEncrypted
 		}
 	case PasswordFromBytes:
-		p, _ := pr.Password()
+		p, err := pr.Password()
+		if err != nil {
+			return nil, err
+		}
+
 		if !wlt.IsEncrypted() && len(p) != 0 {
 			return nil, wallet.ErrWalletNotEncrypted
 		}
@@ -364,7 +368,11 @@ func CreateRawTxFromAddress(c *webrpc.Client, addr, walletFile, chgAddr string, 
 			return nil, wallet.ErrWalletEncrypted
 		}
 	case PasswordFromBytes:
-		p, _ := pr.Password()
+		p, err := pr.Password()
+		if err != nil {
+			return nil, err
+		}
+
 		if !wlt.IsEncrypted() && len(p) != 0 {
 			return nil, wallet.ErrWalletNotEncrypted
 		}

--- a/src/api/cli/create_rawtx.go
+++ b/src/api/cli/create_rawtx.go
@@ -147,7 +147,7 @@ func getChangeAddress(wltAddr walletAddress, chgAddr string) (string, error) {
 			// get the default wallet's coin base address
 			wlt, err := wallet.Load(wltAddr.Wallet)
 			if err != nil {
-				return "", WalletLoadError(err)
+				return "", WalletLoadError{err}
 			}
 
 			if len(wlt.Entries) > 0 {

--- a/src/api/cli/create_rawtx.go
+++ b/src/api/cli/create_rawtx.go
@@ -89,8 +89,10 @@ func createRawTxCmd(cfg Config) gcli.Command {
 			tx, err := createRawTxCmdHandler(c)
 			switch err.(type) {
 			case nil:
-			case WalletLoadError, WalletSaveError:
+			case WalletLoadError:
 				errorWithHelp(c, err)
+			case WalletSaveError:
+				return errors.New("save wallet failed")
 			default:
 				return err
 			}

--- a/src/api/cli/encrypt_wallet.go
+++ b/src/api/cli/encrypt_wallet.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/skycoin/skycoin/src/wallet"
+	gcli "github.com/urfave/cli"
+)
+
+func encryptWalletCmd(cfg Config) gcli.Command {
+	name := "encryptWallet"
+	return gcli.Command{
+		Name:      name,
+		Usage:     "Encrypt wallet",
+		ArgsUsage: "[wallet id]",
+		Description: fmt.Sprintf(`
+		The default wallet (%s) will be
+		used if no wallet was specified.
+		
+		Use caution when using the "-p" command. If you have command history enabled 
+		your wallet encryption password can be recovered from the history log. If you
+		do not include the "-p" option you will be prompted to enter your password
+		after you enter your command.`, cfg.FullWalletPath()),
+		Flags: []gcli.Flag{
+			gcli.StringFlag{
+				Name:  "p",
+				Usage: "[password] Wallet password",
+			},
+			gcli.StringFlag{
+				Name:  "x,crypto-type",
+				Value: string(wallet.CryptoTypeScryptChacha20poly1305),
+				Usage: "[crypto type] The crypto type for wallet encryption, can be scrypt-chacha20poly1305 or sha256-xor",
+			},
+		},
+		OnUsageError: onCommandUsageError(name),
+		Action: func(c *gcli.Context) error {
+			cfg := ConfigFromContext(c)
+
+			w, err := resolveWalletPath(cfg, "")
+			if err != nil {
+				return err
+			}
+
+			cryptoType, err := wallet.CryptoTypeFromString(c.String("x"))
+			if err != nil {
+				errorWithHelp(c, err)
+				return nil
+			}
+
+			wlt, err := encryptWallet(w, []byte(c.String("p")), cryptoType)
+			switch err.(type) {
+			case nil:
+			case WalletLoadError:
+				errorWithHelp(c, err)
+				return nil
+			case WalletSaveError:
+				return errors.New("save wallet failed")
+			default:
+				return err
+			}
+
+			printJSON(wallet.NewReadableWallet(wlt))
+			return nil
+		},
+	}
+}
+
+func encryptWallet(walletFile string, password []byte, cryptoType wallet.CryptoType) (*wallet.Wallet, error) {
+	wlt, err := wallet.Load(walletFile)
+	if err != nil {
+		return nil, WalletLoadError{err}
+	}
+
+	if wlt.IsEncrypted() {
+		return nil, wallet.ErrWalletEncrypted
+	}
+
+	if len(password) == 0 {
+		var err error
+		password, err = readPasswordFromTerminal()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := wlt.Lock(password, cryptoType); err != nil {
+		return nil, err
+	}
+
+	dir, err := filepath.Abs(filepath.Dir(walletFile))
+	if err != nil {
+		return nil, err
+	}
+
+	// save the wallet
+	if err := wlt.Save(dir); err != nil {
+		return nil, WalletLoadError{err}
+	}
+
+	return wlt, nil
+}

--- a/src/api/cli/encrypt_wallet.go
+++ b/src/api/cli/encrypt_wallet.go
@@ -12,8 +12,9 @@ import (
 func encryptWalletCmd(cfg Config) gcli.Command {
 	name := "encryptWallet"
 	return gcli.Command{
-		Name:  name,
-		Usage: "Encrypt wallet",
+		Name:      name,
+		Usage:     "Encrypt wallet",
+		ArgsUsage: " ",
 		Description: fmt.Sprintf(`
 		The default wallet (%s) will be
 		used if no wallet was specified.

--- a/src/api/cli/generate_addrs.go
+++ b/src/api/cli/generate_addrs.go
@@ -66,7 +66,7 @@ func generateAddrs(c *gcli.Context) error {
 		return err
 	}
 
-	addrs, err := GenerateAddressesInFile(w, num, c)
+	addrs, err := GenerateAddressesInFile(w, num, []byte(c.String("p")))
 
 	switch err.(type) {
 	case nil:
@@ -93,18 +93,17 @@ func generateAddrs(c *gcli.Context) error {
 }
 
 // GenerateAddressesInFile generates addresses in given wallet file
-func GenerateAddressesInFile(walletFile string, num uint64, c *gcli.Context) ([]cipher.Address, error) {
+func GenerateAddressesInFile(walletFile string, num uint64, password []byte) ([]cipher.Address, error) {
 	wlt, err := wallet.Load(walletFile)
 	if err != nil {
 		return nil, WalletLoadError(err)
 	}
 
 	var addrs []cipher.Address
-	password := []byte(c.String("p"))
 	if wlt.IsEncrypted() {
 		if len(password) == 0 {
 			var err error
-			password, err = readPasswordFromTerminal(c)
+			password, err = readPasswordFromTerminal()
 			if err != nil {
 				return nil, err
 			}

--- a/src/api/cli/generate_addrs.go
+++ b/src/api/cli/generate_addrs.go
@@ -96,7 +96,7 @@ func generateAddrs(c *gcli.Context) error {
 func GenerateAddressesInFile(walletFile string, num uint64, password []byte) ([]cipher.Address, error) {
 	wlt, err := wallet.Load(walletFile)
 	if err != nil {
-		return nil, WalletLoadError(err)
+		return nil, WalletLoadError{err}
 	}
 
 	var addrs []cipher.Address
@@ -134,7 +134,7 @@ func GenerateAddressesInFile(walletFile string, num uint64, password []byte) ([]
 	}
 
 	if err := wlt.Save(dir); err != nil {
-		return nil, WalletSaveError(err)
+		return nil, WalletSaveError{err}
 	}
 
 	return addrs, nil

--- a/src/api/cli/generate_addrs.go
+++ b/src/api/cli/generate_addrs.go
@@ -106,7 +106,11 @@ func GenerateAddressesInFile(walletFile string, num uint64, pr PasswordReader) (
 			return nil, wallet.ErrWalletEncrypted
 		}
 	case PasswordFromBytes:
-		p, _ := pr.Password()
+		p, err := pr.Password()
+		if err != nil {
+			return nil, err
+		}
+
 		if !wlt.IsEncrypted() && len(p) != 0 {
 			return nil, wallet.ErrWalletNotEncrypted
 		}

--- a/src/api/cli/generate_wallet.go
+++ b/src/api/cli/generate_wallet.go
@@ -133,10 +133,14 @@ func generateWalletHandler(c *gcli.Context) error {
 	rd := c.Bool("rd")
 
 	encrypt := c.Bool("e")
-	cryptoType := c.String("x")
 	password := c.String("p")
 
 	sd, err := makeSeed(s, r, rd)
+	if err != nil {
+		return err
+	}
+
+	cryptoType, err := wallet.CryptoTypeFromString(c.String("x"))
 	if err != nil {
 		return err
 	}
@@ -145,7 +149,7 @@ func generateWalletHandler(c *gcli.Context) error {
 		Label:      label,
 		Seed:       sd,
 		Encrypt:    encrypt,
-		CryptoType: wallet.CryptoType(cryptoType),
+		CryptoType: cryptoType,
 		Password:   []byte(password),
 	}
 

--- a/src/api/cli/generate_wallet.go
+++ b/src/api/cli/generate_wallet.go
@@ -109,8 +109,7 @@ func generateWalletHandler(c *gcli.Context) error {
 
 	// check if the wallet file does exist
 	if _, err := os.Stat(filepath.Join(cfg.WalletDir, wltName)); err == nil {
-		errorWithHelp(c, fmt.Errorf("%v already exist", wltName))
-		return nil
+		return fmt.Errorf("%v already exist", wltName)
 	}
 
 	// check if the wallet dir does exist.

--- a/src/api/cli/generate_wallet.go
+++ b/src/api/cli/generate_wallet.go
@@ -145,10 +145,6 @@ func generateWalletHandler(c *gcli.Context) error {
 
 	pr := NewPasswordReader([]byte(c.String("p")))
 	switch pr.(type) {
-	case nil:
-		if encrypt {
-			return wallet.ErrMissingPassword
-		}
 	case PasswordFromBytes:
 		p, _ := pr.Password()
 		if !encrypt && len(p) != 0 {

--- a/src/api/cli/generate_wallet.go
+++ b/src/api/cli/generate_wallet.go
@@ -146,7 +146,11 @@ func generateWalletHandler(c *gcli.Context) error {
 	pr := NewPasswordReader([]byte(c.String("p")))
 	switch pr.(type) {
 	case PasswordFromBytes:
-		p, _ := pr.Password()
+		p, err := pr.Password()
+		if err != nil {
+			return err
+		}
+
 		if !encrypt && len(p) != 0 {
 			return errors.New("password should not be set as we're not going to create a wallet with encryption")
 		}

--- a/src/api/cli/integration/integration_test.go
+++ b/src/api/cli/integration/integration_test.go
@@ -350,6 +350,12 @@ func TestStableGenerateAddresses(t *testing.T) {
 			args:         []string{"generateAddresses", "-p", "invalid password", "-j"},
 			expectOutput: []byte("Error: invalid password. See 'skycoin-cli generateAddresses --help'\n\n"),
 		},
+		{
+			name:         "generateAddresses in unencrypted wallet with password",
+			encrypted:    false,
+			args:         []string{"generateAddresses", "-p", "pwd"},
+			expectOutput: []byte("Error: wallet is not encrypted. See 'skycoin-cli generateAddresses --help'\n\n"),
+		},
 	}
 
 	for _, tc := range tt {

--- a/src/api/cli/integration/integration_test.go
+++ b/src/api/cli/integration/integration_test.go
@@ -304,8 +304,8 @@ func rpcAddress() string {
 	return rpcAddr
 }
 
-func TestStableGenerateAddresses(t *testing.T) {
-	if !doStable(t) {
+func TestGenerateAddresses(t *testing.T) {
+	if !doLiveOrStable(t) {
 		return
 	}
 

--- a/src/api/cli/integration/test-fixtures/generate-addresses-encrypted.golden
+++ b/src/api/cli/integration/test-fixtures/generate-addresses-encrypted.golden
@@ -1,0 +1,27 @@
+{
+    "meta": {
+        "coin": "skycoin",
+        "cryptoType": "scrypt-chacha20poly1305",
+        "encrypted": "true",
+        "filename": "integration-test-encrypted.wlt",
+        "label": "integration-test",
+        "lastSeed": "",
+        "secrets": "",
+        "seed": "",
+        "tm": "1518271871",
+        "type": "deterministic",
+        "version": "0.2"
+    },
+    "entries": [
+        {
+            "address": "2Kg3eRXUhY6hrDZvNGB99DKahtrPDQ1W9vN",
+            "public_key": "03aefe8fc5952f67aca014ae4da6e7eba1321542be02d2d6f718c666750bf4c630",
+            "secret_key": ""
+        },
+        {
+            "address": "7g3M372kxwNwwQEAmrronu4anXTW8aD1XC",
+            "public_key": "0319527fa74053b148d7efe973c0ee734e49f52a11417232e582b8c51e389d638a",
+            "secret_key": ""
+        }
+    ]
+}

--- a/src/api/cli/integration/test-fixtures/integration-test-encrypted.wlt
+++ b/src/api/cli/integration/test-fixtures/integration-test-encrypted.wlt
@@ -1,0 +1,22 @@
+{
+    "meta": {
+        "coin": "skycoin",
+        "cryptoType": "scrypt-chacha20poly1305",
+        "encrypted": "true",
+        "filename": "integration-test-encrypted.wlt",
+        "label": "integration-test",
+        "lastSeed": "",
+        "secrets": "dgB7Im4iOjEwNDg1NzYsInIiOjgsInAiOjEsImtleUxlbiI6MzIsInNhbHQiOiJidHVibVZ2eEhWNHVKc0szcHFwUE5xY3VoL1VvRjRYbjQ5N0IzLzhYUFhJPSIsIm5vbmNlIjoiSEZNd1VwYUNnYUk3eFo2SiJ9BceIdIv3aGRAsANPVAm6gvrgJd2jZxJLazBwd2yQhTTWXxYVReGEsL/fzYZyDbJNvJgGZpTJsQ0R2yVgjlRbr5Km6x4yiGk8riXWiQ1Tpcfjmst7vDzjq/lUrcci/lwuGwVNf+TsmhzyD/uvV/4yR8oPtZHgPDBoMIkB/NPawNkXkcP1D6lA5LAddWHkKt/SCRxF3YdKW64LjojqExUukYSLJenxFHkTbEB/QBLb/dfZXZolLYevIKbPH/Rt7qiwOj8bvfwPPlIRf101VCvqLW8q8fcfYzvidQyjz7CfW8wh6mqMmXW4Wp+I14BQIleuBlkd35Fz2etKMMiyyltYn5FaixbP2WHFHBBg+Yfm5OzYt5K7b0cG8kDfAN1PHyYc30o=",
+        "seed": "",
+        "tm": "1518271871",
+        "type": "deterministic",
+        "version": "0.2"
+    },
+    "entries": [
+        {
+            "address": "2Kg3eRXUhY6hrDZvNGB99DKahtrPDQ1W9vN",
+            "public_key": "03aefe8fc5952f67aca014ae4da6e7eba1321542be02d2d6f718c666750bf4c630",
+            "secret_key": ""
+        }
+    ]
+}

--- a/src/api/cli/list_addrs.go
+++ b/src/api/cli/list_addrs.go
@@ -31,7 +31,7 @@ func listAddresses(c *gcli.Context) error {
 
 	wlt, err := wallet.Load(w)
 	if err != nil {
-		return WalletLoadError(err)
+		return WalletLoadError{err}
 	}
 
 	addrs := wlt.GetAddresses()

--- a/src/api/cli/list_wallets.go
+++ b/src/api/cli/list_wallets.go
@@ -51,7 +51,7 @@ func listWallets(c *gcli.Context) error {
 			path := filepath.Join(cfg.WalletDir, name)
 			w, err := wallet.Load(path)
 			if err != nil {
-				return WalletLoadError(err)
+				return WalletLoadError{err}
 			}
 			wlts.Wallets = append(wlts.Wallets, WalletEntry{
 				Name:       name,

--- a/src/api/cli/send.go
+++ b/src/api/cli/send.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 
 	gcli "github.com/urfave/cli"
-
-	"github.com/skycoin/skycoin/src/api/webrpc"
 )
 
 func sendCmd() gcli.Command {
@@ -39,10 +37,10 @@ func sendCmd() gcli.Command {
 				Usage: `[changeAddress] Specify change address, by default the from address or
 				the wallet's coinbase address will be used`,
 			},
-			// gcli.StringFlag{
-			// 	Name:  "p",
-			// 	Usage: "[password] Password for address or wallet.",
-			// },
+			gcli.StringFlag{
+				Name:  "p",
+				Usage: "[password] Wallet password",
+			},
 			gcli.StringFlag{
 				Name: "m",
 				Usage: `[send to many] use JSON string to set multiple recive addresses and coins,
@@ -81,25 +79,4 @@ func sendCmd() gcli.Command {
 			return nil
 		},
 	}
-	// Commands = append(Commands, cmd)
-}
-
-// SendFromWallet sends from any address or combination of addresses from a wallet. Returns txid.
-func SendFromWallet(c *webrpc.Client, walletFile, chgAddr string, toAddrs []SendAmount) (string, error) {
-	rawTx, err := CreateRawTxFromWallet(c, walletFile, chgAddr, toAddrs)
-	if err != nil {
-		return "", err
-	}
-
-	return c.InjectTransaction(rawTx)
-}
-
-// SendFromAddress sends from a specific address in a wallet. Returns txid.
-func SendFromAddress(c *webrpc.Client, addr, walletFile, chgAddr string, toAddrs []SendAmount) (string, error) {
-	rawTx, err := CreateRawTxFromAddress(c, addr, walletFile, chgAddr, toAddrs)
-	if err != nil {
-		return "", err
-	}
-
-	return c.InjectTransaction(rawTx)
 }

--- a/src/api/cli/show_seed.go
+++ b/src/api/cli/show_seed.go
@@ -79,7 +79,11 @@ func getSeed(walletFile string, pr PasswordReader) (string, error) {
 			return "", wallet.ErrWalletEncrypted
 		}
 	case PasswordFromBytes:
-		p, _ := pr.Password()
+		p, err := pr.Password()
+		if err != nil {
+			return "", err
+		}
+
 		if !wlt.IsEncrypted() && len(p) != 0 {
 			return "", wallet.ErrWalletNotEncrypted
 		}

--- a/src/api/cli/show_seed.go
+++ b/src/api/cli/show_seed.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/skycoin/skycoin/src/wallet"
+	gcli "github.com/urfave/cli"
+)
+
+func showSeedCmd(cfg Config) gcli.Command {
+	name := "showSeed"
+	return gcli.Command{
+		Name:  name,
+		Usage: "Show wallet seed",
+		Description: fmt.Sprintf(`
+		The default wallet (%s) will be
+		used if no wallet was specified.
+		
+		Use caution when using the "-p" command. If you have command history enabled 
+		your wallet encryption password can be recovered from the history log. If you
+		do not include the "-p" option you will be prompted to enter your password
+		after you enter your command.`, cfg.FullWalletPath()),
+		Flags: []gcli.Flag{
+			gcli.StringFlag{
+				Name:  "p",
+				Usage: "[password] Wallet password, if encrypted",
+			},
+			gcli.BoolFlag{
+				Name:  "j,json",
+				Usage: "Returns the results in JSON format",
+			},
+		},
+		OnUsageError: onCommandUsageError(name),
+		Action: func(c *gcli.Context) error {
+			cfg := ConfigFromContext(c)
+
+			w, err := resolveWalletPath(cfg, "")
+			if err != nil {
+				return err
+			}
+
+			seed, err := getSeed(w, []byte(c.String("p")))
+			switch err.(type) {
+			case nil:
+			case WalletLoadError:
+				errorWithHelp(c, err)
+				return nil
+			default:
+				return err
+			}
+
+			if c.Bool("j") {
+				v := struct {
+					Seed string `json:"seed"`
+				}{
+					Seed: seed,
+				}
+
+				printJSON(v)
+				return nil
+			}
+
+			fmt.Println(seed)
+			return nil
+		},
+	}
+}
+
+func getSeed(walletFile string, password []byte) (string, error) {
+	wlt, err := wallet.Load(walletFile)
+	if err != nil {
+		return "", WalletLoadError{err}
+	}
+
+	if !wlt.IsEncrypted() {
+		return wlt.Meta["seed"], nil
+	}
+
+	if len(password) == 0 {
+		var err error
+		password, err = readPasswordFromTerminal()
+		if err != nil {
+			return "", err
+		}
+	}
+
+	var seed string
+	if err := wlt.GuardView(password, func(w *wallet.Wallet) error {
+		seed = w.Meta["seed"]
+		return nil
+	}); err != nil {
+		return "", err
+	}
+
+	return seed, nil
+}

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -372,7 +372,7 @@ func (serv *Service) CreateAndSignTransactionAdvanced(params CreateTransactionPa
 	var tx *coin.Transaction
 	var inputs []UxBalance
 	if w.IsEncrypted() {
-		err = w.guardView(params.Wallet.Password, func(wlt *Wallet) error {
+		err = w.GuardView(params.Wallet.Password, func(wlt *Wallet) error {
 			var err error
 			tx, inputs, err = wlt.CreateAndSignTransactionAdvanced(params, vld, unspent, headTime)
 			return err

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -217,7 +217,7 @@ func (serv *Service) NewAddresses(wltID string, password []byte, num uint64) ([]
 	}
 
 	if w.IsEncrypted() {
-		if err := w.guardUpdate(password, f); err != nil {
+		if err := w.GuardUpdate(password, f); err != nil {
 			return nil, err
 		}
 	} else {
@@ -327,7 +327,7 @@ func (serv *Service) CreateAndSignTransaction(wltID string, password []byte, vld
 	}
 
 	if w.IsEncrypted() {
-		if err := w.guardView(password, f); err != nil {
+		if err := w.GuardView(password, f); err != nil {
 			return nil, err
 		}
 	} else {
@@ -483,7 +483,7 @@ func (serv *Service) GetWalletSeed(wltID string, password []byte) (string, error
 	}
 
 	var seed string
-	if err := w.guardView(password, func(wlt *Wallet) error {
+	if err := w.GuardView(password, func(wlt *Wallet) error {
 		seed = wlt.seed()
 		return nil
 	}); err != nil {

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -145,7 +145,7 @@ func (serv *Service) EncryptWallet(wltID string, password []byte) (*Wallet, erro
 		return nil, ErrWalletEncrypted
 	}
 
-	if err := w.lock(password, serv.cryptoType); err != nil {
+	if err := w.Lock(password, serv.cryptoType); err != nil {
 		return nil, err
 	}
 
@@ -178,7 +178,7 @@ func (serv *Service) DecryptWallet(wltID string, password []byte) (*Wallet, erro
 	}
 
 	// Unlocks the wallet
-	unlockWlt, err := w.unlock(password)
+	unlockWlt, err := w.Unlock(password)
 	if err != nil {
 		return nil, err
 	}

--- a/src/wallet/service_test.go
+++ b/src/wallet/service_test.go
@@ -1881,7 +1881,7 @@ func TestServiceEncryptWallet(t *testing.T) {
 				require.Empty(t, encWlt.lastSeed())
 
 				// Check the decrypted seeds
-				decWlt, err := encWlt.unlock(tc.pwd)
+				decWlt, err := encWlt.Unlock(tc.pwd)
 				require.NoError(t, err)
 				require.Equal(t, w.seed(), decWlt.seed())
 				require.Equal(t, w.lastSeed(), decWlt.lastSeed())

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -332,7 +332,7 @@ func newWallet(wltName string, opts Options, bg BalanceGetter) (*Wallet, error) 
 	}
 
 	// Encrypt the wallet
-	if err := w.lock(opts.Password, opts.CryptoType); err != nil {
+	if err := w.Lock(opts.Password, opts.CryptoType); err != nil {
 		return nil, err
 	}
 
@@ -357,8 +357,8 @@ func NewWalletScanAhead(wltName string, opts Options, bg BalanceGetter) (*Wallet
 	return newWallet(wltName, opts, bg)
 }
 
-// lock encrypts the wallet with the given password and specific crypto type
-func (w *Wallet) lock(password []byte, cryptoType CryptoType) error {
+// Lock encrypts the wallet with the given password and specific crypto type
+func (w *Wallet) Lock(password []byte, cryptoType CryptoType) error {
 	if len(password) == 0 {
 		return ErrMissingPassword
 	}
@@ -424,10 +424,10 @@ func (w *Wallet) lock(password []byte, cryptoType CryptoType) error {
 	return nil
 }
 
-// unlock decrypts the wallet into a temporary decrypted copy of the wallet
+// Unlock decrypts the wallet into a temporary decrypted copy of the wallet
 // Returns error if the decryption fails
 // The temporary decrypted wallet should be erased from memory when done.
-func (w *Wallet) unlock(password []byte) (*Wallet, error) {
+func (w *Wallet) Unlock(password []byte) (*Wallet, error) {
 	if !w.IsEncrypted() {
 		return nil, ErrWalletNotEncrypted
 	}
@@ -545,7 +545,7 @@ func (w *Wallet) GuardUpdate(password []byte, fn func(w *Wallet) error) error {
 	}
 
 	cryptoType := w.cryptoType()
-	wlt, err := w.unlock(password)
+	wlt, err := w.Unlock(password)
 	if err != nil {
 		return err
 	}
@@ -556,7 +556,7 @@ func (w *Wallet) GuardUpdate(password []byte, fn func(w *Wallet) error) error {
 		return err
 	}
 
-	if err := wlt.lock(password, cryptoType); err != nil {
+	if err := wlt.Lock(password, cryptoType); err != nil {
 		return err
 	}
 
@@ -577,7 +577,7 @@ func (w *Wallet) GuardView(password []byte, f func(w *Wallet) error) error {
 		return ErrMissingPassword
 	}
 
-	wlt, err := w.unlock(password)
+	wlt, err := w.Unlock(password)
 	if err != nil {
 		return err
 	}

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -458,7 +458,6 @@ func (w *Wallet) unlock(password []byte) (*Wallet, error) {
 	// Decrypts the secrets
 	sb, err := crypto.Decrypt([]byte(sstr), password)
 	if err != nil {
-		logger.Errorf("Decrypt wallet failed: %v", err)
 		return nil, ErrInvalidPassword
 	}
 
@@ -534,9 +533,9 @@ func (w *Wallet) erase() {
 	}
 }
 
-// guardUpdate executes a function within the context of a read-wirte managed decrypted wallet.
+// GuardUpdate executes a function within the context of a read-wirte managed decrypted wallet.
 // Returns ErrWalletNotEncrypted if wallet is not encrypted.
-func (w *Wallet) guardUpdate(password []byte, fn func(w *Wallet) error) error {
+func (w *Wallet) GuardUpdate(password []byte, fn func(w *Wallet) error) error {
 	if !w.IsEncrypted() {
 		return ErrWalletNotEncrypted
 	}
@@ -567,9 +566,9 @@ func (w *Wallet) guardUpdate(password []byte, fn func(w *Wallet) error) error {
 	return nil
 }
 
-// guardView executes a function within the context of a read-only managed decrypted wallet.
+// GuardView executes a function within the context of a read-only managed decrypted wallet.
 // Returns ErrWalletNotEncrypted if wallet is not encrypted.
-func (w *Wallet) guardView(password []byte, f func(w *Wallet) error) error {
+func (w *Wallet) GuardView(password []byte, f func(w *Wallet) error) error {
 	if !w.IsEncrypted() {
 		return ErrWalletNotEncrypted
 	}

--- a/src/wallet/wallet_test.go
+++ b/src/wallet/wallet_test.go
@@ -438,7 +438,7 @@ func TestWalletUnlock(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				w := makeWallet(t, tc.opts, 1)
 				// Tests the unlock method
-				wlt, err := w.unlock(tc.unlockPwd)
+				wlt, err := w.Unlock(tc.unlockPwd)
 				require.Equal(t, tc.err, err)
 				if err != nil {
 					return
@@ -498,7 +498,7 @@ func TestLockAndUnLock(t *testing.T) {
 			require.NoError(t, err)
 
 			// unlock the cloned wallet
-			ucw, err := cw.unlock([]byte("pwd"))
+			ucw, err := cw.Unlock([]byte("pwd"))
 			require.NoError(t, err)
 
 			require.Equal(t, w, ucw)

--- a/src/wallet/wallet_test.go
+++ b/src/wallet/wallet_test.go
@@ -66,7 +66,7 @@ func init() {
 			log.Panic(err)
 		}
 
-		if err := w.lock([]byte("pwd"), CryptoTypeScryptChacha20poly1305); err != nil {
+		if err := w.Lock([]byte("pwd"), CryptoTypeScryptChacha20poly1305); err != nil {
 			log.Panic(err)
 		}
 
@@ -368,7 +368,7 @@ func TestWalletLock(t *testing.T) {
 					require.NoError(t, err)
 				}
 
-				err = w.lock(tc.lockPwd, ct)
+				err = w.Lock(tc.lockPwd, ct)
 				require.Equal(t, tc.err, err)
 				if err != nil {
 					return
@@ -494,7 +494,7 @@ func TestLockAndUnLock(t *testing.T) {
 			require.Equal(t, w, cw)
 
 			// lock the cloned wallet
-			err = cw.lock([]byte("pwd"), ct)
+			err = cw.Lock([]byte("pwd"), ct)
 			require.NoError(t, err)
 
 			// unlock the cloned wallet
@@ -519,7 +519,7 @@ func makeWallet(t *testing.T, opts Options, addrNum uint64) *Wallet {
 		require.NoError(t, err)
 	}
 	if preOpts.Encrypt {
-		err = w.lock(preOpts.Password, preOpts.CryptoType)
+		err = w.Lock(preOpts.Password, preOpts.CryptoType)
 		require.NoError(t, err)
 	}
 	return w

--- a/src/wallet/wallet_test.go
+++ b/src/wallet/wallet_test.go
@@ -868,7 +868,7 @@ func TestWalletGuard(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.NoError(t, w.guardUpdate([]byte("pwd"), func(w *Wallet) error {
+			require.NoError(t, w.GuardUpdate([]byte("pwd"), func(w *Wallet) error {
 				require.Equal(t, "seed", w.seed())
 				w.setLabel("label")
 				return nil
@@ -876,7 +876,7 @@ func TestWalletGuard(t *testing.T) {
 			require.Equal(t, "label", w.Label())
 			validate(w)
 
-			w.guardView([]byte("pwd"), func(w *Wallet) error {
+			w.GuardView([]byte("pwd"), func(w *Wallet) error {
 				require.Equal(t, "label", w.Label())
 				w.setLabel("new label")
 				return nil


### PR DESCRIPTION
Fixes #1171 

Changes:
- Add password argument to `addPrivateKey`, `createRawTransaction`, `generateAddresses`, `generateWallet`, `send`.
- Add `showSeed` command with encryption support
- Add `decryptWallet` command
- Add `decryptWallet` command
- Update partial integration tests

TODO:
- [x] Add CLI integration tests for `showSeed`
- [x] Add CLI integration tests for `decryptWallet`
- [x] Fill CLI integration tests for `encryptWallet`
- [x] Update CHANGELOG.md

Does this change need to mentioned in CHANGELOG.md?
Yes