### PR TITLE
Change logger out from os.Stderr to os.Stdout

### DIFF
--- a/src/util/logging/logger.go
+++ b/src/util/logging/logger.go
@@ -46,7 +46,7 @@ var (
 func NewLogger(priorityKey, criticalPriority string) (logger *Logger) {
 	logger = &Logger{
 		Logger: &logrus.Logger{
-			Out: os.Stderr,
+			Out: os.Stdout,
 			Formatter: &TextFormatter{
 				FullTimestamp:          true,
 				AlwaysQuoteStrings:     true,


### PR DESCRIPTION
Fixes #1345 

Changes:
- Change the logger out from os.Stderr to os.Stdout, as the electron is listening on the stdout to catch the 'Starting web interface on' string to emit windows creating event.

Does this change need to mentioned in CHANGELOG.md?
No.