### PR TITLE
Restore log functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,10 +45,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Whitespace will be trimmed from the seed string by the frontend client before creating or loading a wallet
 - Notify the user when their wallets have unconfirmed transactions
 - Return an error when providing a transaction that spends to the null address in `POST /injectTransaction`
+- Change accepted `-log-level` values to `debug`, `info`, `warn`, `error`, `fatal` and `panic` (previously were `debug`, `info`, `notice`, `warning`, `error` and `critical`)
 
 ### Removed
 
 - Remove `"seed"`, `"lastSeed"` and `"secret_key"` in address entries from wallet API responses. A wallet's seed can be accessed through `POST /wallet/seed` only if the wallet is encrypted and the node is run with `-enable-seed-api`
+- Remove unused `-logtogui` and `-logbufsize` options
 
 ## [0.22.0] - 2018-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Notify the user when their wallets have unconfirmed transactions
 - Return an error when providing a transaction that spends to the null address in `POST /injectTransaction`
 - Change accepted `-log-level` values to `debug`, `info`, `warn`, `error`, `fatal` and `panic` (previously were `debug`, `info`, `notice`, `warning`, `error` and `critical`)
+- Default log level is `info`
 
 ### Removed
 

--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -208,7 +208,7 @@ func (c *Config) register() {
 	flag.BoolVar(&c.HTTPProf, "http-prof", c.HTTPProf, "Run the http profiling interface")
 	flag.StringVar(&c.LogLevel, "log-level", c.LogLevel, "Choices are: debug, info, warn, error, fatal, panic")
 	flag.BoolVar(&c.ColorLog, "color-log", c.ColorLog, "Add terminal colors to log output")
-	flag.BoolVar(&c.DisablePingPong, "no-ping-log", c.DisablePingPong, `disable "reply to ping" and "received pong" log messages`)
+	flag.BoolVar(&c.DisablePingPong, "no-ping-log", c.DisablePingPong, `disable "reply to ping" and "received pong" debug log messages`)
 	flag.BoolVar(&c.LogToFile, "logtofile", c.LogToFile, "log to file")
 	flag.StringVar(&c.GUIDirectory, "gui-dir", c.GUIDirectory, "static content directory for the html gui")
 
@@ -285,7 +285,7 @@ var devConfig = Config{
 	GUIDirectory: "./src/gui/static/",
 	// Logging
 	ColorLog:        true,
-	LogLevel:        "DEBUG",
+	LogLevel:        "INFO",
 	LogToFile:       false,
 	DisablePingPong: false,
 
@@ -601,7 +601,7 @@ func Run(c *Config) {
 	}
 	host := fmt.Sprintf("%s:%d", c.WebInterfaceAddr, c.WebInterfacePort)
 	fullAddress := fmt.Sprintf("%s://%s", scheme, host)
-	logger.Noticef("Full address: %s", fullAddress)
+	logger.Critical().Infof("Full address: %s", fullAddress)
 	if c.PrintWebInterfaceAddress {
 		fmt.Println(fullAddress)
 	}

--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -590,7 +590,7 @@ func Run(c *Config) {
 		var err error
 		logFile, err = initLogFile(c.DataDirectory)
 		if err != nil {
-			fmt.Println(err)
+			logger.Error(err)
 			return
 		}
 	}
@@ -603,6 +603,7 @@ func Run(c *Config) {
 	fullAddress := fmt.Sprintf("%s://%s", scheme, host)
 	logger.Critical().Infof("Full address: %s", fullAddress)
 	if c.PrintWebInterfaceAddress {
+		// This must be printed without the decorated logger so that electron can parse it properly
 		fmt.Println(fullAddress)
 	}
 

--- a/run.sh
+++ b/run.sh
@@ -15,6 +15,7 @@ go run -ldflags "${GOLDFLAGS}" cmd/skycoin/skycoin.go \
     -launch-browser=true \
     -enable-wallet-api=true \
     -rpc-interface=false \
+    -log-level=debug \
     $@
 
 popd >/dev/null

--- a/src/api/webrpc/transaction.go
+++ b/src/api/webrpc/transaction.go
@@ -22,7 +22,7 @@ type TxIDJson struct {
 func getTransactionHandler(req Request, gateway Gatewayer) Response {
 	var txid []string
 	if err := req.DecodeParams(&txid); err != nil {
-		logger.Criticalf("decode params failed: %v", err)
+		logger.Critical().Errorf("decode params failed: %v", err)
 		return makeErrorResponse(errCodeInvalidParams, errMsgInvalidParams)
 	}
 
@@ -32,7 +32,7 @@ func getTransactionHandler(req Request, gateway Gatewayer) Response {
 
 	t, err := cipher.SHA256FromHex(txid[0])
 	if err != nil {
-		logger.Criticalf("decode txid err: %v", err)
+		logger.Critical().Errorf("decode txid err: %v", err)
 		return makeErrorResponse(errCodeInvalidParams, "invalid transaction hash")
 	}
 	txn, err := gateway.GetTransaction(t)
@@ -57,7 +57,7 @@ func getTransactionHandler(req Request, gateway Gatewayer) Response {
 func injectTransactionHandler(req Request, gateway Gatewayer) Response {
 	var rawtx []string
 	if err := req.DecodeParams(&rawtx); err != nil {
-		logger.Criticalf("decode params failed: %v", err)
+		logger.Critical().Errorf("decode params failed: %v", err)
 		return makeErrorResponse(errCodeInvalidParams, errMsgInvalidParams)
 	}
 

--- a/src/api/webrpc/uxout.go
+++ b/src/api/webrpc/uxout.go
@@ -16,7 +16,7 @@ type AddrUxoutResult struct {
 func getAddrUxOutsHandler(req Request, gateway Gatewayer) Response {
 	var addrs []string
 	if err := req.DecodeParams(&addrs); err != nil {
-		logger.Criticalf("decode params failed:%v", err)
+		logger.Critical().Errorf("decode params failed:%v", err)
 		return makeErrorResponse(errCodeInvalidParams, errMsgInvalidParams)
 	}
 

--- a/src/api/webrpc/webrpc.go
+++ b/src/api/webrpc/webrpc.go
@@ -307,7 +307,7 @@ func (rpc *WebRPC) Handler(w http.ResponseWriter, r *http.Request) {
 	rpc.ops <- func(rpc *WebRPC) {
 		defer func() {
 			if r := recover(); r != nil {
-				logger.Criticalf(fmt.Sprintf("%v", r))
+				logger.Critical().Errorf(fmt.Sprintf("%v", r))
 				resC <- makeErrorResponse(errCodeInternalError, errMsgInternalError)
 			}
 		}()

--- a/src/cipher/crypto.go
+++ b/src/cipher/crypto.go
@@ -291,7 +291,7 @@ func VerifySignedHash(sig Sig, hash SHA256) error {
 	}
 	if secp256k1.VerifySignature(hash[:], sig[:], rawPubKey) != 1 {
 		// If this occurs, secp256k1 is bugged
-		logger.Critical("Recovered public key is not valid for signed hash")
+		logger.Critical().Error("Recovered public key is not valid for signed hash")
 		return errors.New("Signature invalid for hash")
 	}
 	return nil

--- a/src/coin/outputs.go
+++ b/src/coin/outputs.go
@@ -100,7 +100,7 @@ func (uo *UxOut) CoinHours(t uint64) (uint64, error) {
 	wholeCoinSeconds, err := multUint64(seconds, wholeCoins)
 	if err != nil {
 		err := fmt.Errorf("UxOut.CoinHours: Calculating whole coin seconds overflows uint64 seconds=%d coins=%d uxid=%s", seconds, wholeCoins, uo.Hash().Hex())
-		logger.Critical(err)
+		logger.Critical().Error(err)
 		return 0, err
 	}
 
@@ -109,7 +109,7 @@ func (uo *UxOut) CoinHours(t uint64) (uint64, error) {
 	dropletSeconds, err := multUint64(seconds, remainderDroplets)
 	if err != nil {
 		err := fmt.Errorf("UxOut.CoinHours: Calculating droplet seconds overflows uint64 seconds=%d droplets=%d uxid=%s", seconds, remainderDroplets, uo.Hash().Hex())
-		logger.Critical(err)
+		logger.Critical().Error(err)
 		return 0, err
 	}
 
@@ -119,7 +119,7 @@ func (uo *UxOut) CoinHours(t uint64) (uint64, error) {
 	coinHours := coinSeconds / 3600                        // coin hours
 	totalHours, err := AddUint64(uo.Body.Hours, coinHours) // starting+earned
 	if err != nil {
-		logger.Criticalf("%v uxid=%s", ErrAddEarnedCoinHoursAdditionOverflow, uo.Hash().Hex())
+		logger.Critical().Errorf("%v uxid=%s", ErrAddEarnedCoinHoursAdditionOverflow, uo.Hash().Hex())
 		return 0, ErrAddEarnedCoinHoursAdditionOverflow
 	}
 	return totalHours, nil

--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -509,7 +509,7 @@ loop:
 
 				// Not a critical error, but we want it visible in logs
 				head := sb.Block.Head
-				logger.Noticef("Created and published a new block, version=%d seq=%d time=%d", head.Version, head.BkSeq, head.Time)
+				logger.Critical().Infof("Created and published a new block, version=%d seq=%d time=%d", head.Version, head.BkSeq, head.Time)
 			}
 
 		case <-unconfirmedRefreshTicker:

--- a/src/daemon/pex/pex.go
+++ b/src/daemon/pex/pex.go
@@ -225,11 +225,11 @@ func New(cfg Config, defaultConns []string) (*Pex, error) {
 	for _, addr := range defaultConns {
 		// Default peers will mark as trusted peers.
 		if err := pex.AddPeer(addr); err != nil {
-			logger.Criticalf("add peer failed:%v", err)
+			logger.Critical().Errorf("add peer failed:%v", err)
 			continue
 		}
 		if err := pex.SetTrusted(addr); err != nil {
-			logger.Criticalf("pex.SetTrust failed: %v", err)
+			logger.Critical().Errorf("pex.SetTrust failed: %v", err)
 		}
 	}
 

--- a/src/daemon/visor.go
+++ b/src/daemon/visor.go
@@ -219,7 +219,7 @@ func (vs *Visor) AnnounceAllTxns(pool *Pool) error {
 	})
 
 	if err != nil {
-		logger.Debugf("Broadcast AnnounceTxnsMessage failed, err:%v", err)
+		logger.Debugf("Broadcast AnnounceTxnsMessage failed, err: %v", err)
 	}
 
 	return err

--- a/src/daemon/visor.go
+++ b/src/daemon/visor.go
@@ -631,7 +631,7 @@ func (gbm *GiveBlocksMessage) Handle(mc *gnet.MessageContext,
 // Process process message
 func (gbm *GiveBlocksMessage) Process(d *Daemon) {
 	if d.Visor.Config.DisableNetworking {
-		logger.Notice("Visor disabled, ignoring GiveBlocksMessage")
+		logger.Critical().Info("Visor disabled, ignoring GiveBlocksMessage")
 		return
 	}
 
@@ -650,10 +650,10 @@ func (gbm *GiveBlocksMessage) Process(d *Daemon) {
 
 		err := d.Visor.ExecuteSignedBlock(b)
 		if err == nil {
-			logger.Noticef("Added new block %d", b.Block.Head.BkSeq)
+			logger.Critical().Infof("Added new block %d", b.Block.Head.BkSeq)
 			processed++
 		} else {
-			logger.Criticalf("Failed to execute received block %d: %v", b.Block.Head.BkSeq, err)
+			logger.Critical().Errorf("Failed to execute received block %d: %v", b.Block.Head.BkSeq, err)
 			// Blocks must be received in order, so if one fails its assumed
 			// the rest are failing
 			break

--- a/src/gui/csrf.go
+++ b/src/gui/csrf.go
@@ -161,13 +161,13 @@ func OriginRefererCheck(host string, handler http.Handler) http.Handler {
 		if toCheck != "" {
 			u, err := url.Parse(toCheck)
 			if err != nil {
-				logger.Criticalf("Invalid URL in Origin or Referer header: %s %v", toCheck, err)
+				logger.Critical().Errorf("Invalid URL in Origin or Referer header: %s %v", toCheck, err)
 				wh.Error403(w)
 				return
 			}
 
 			if u.Host != host {
-				logger.Criticalf("Origin or Referer header value %s does not match host", toCheck)
+				logger.Critical().Errorf("Origin or Referer header value %s does not match host", toCheck)
 				wh.Error403(w)
 				return
 			}

--- a/src/gui/http.go
+++ b/src/gui/http.go
@@ -1,14 +1,12 @@
 package gui
 
 import (
-	"bytes"
 	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -509,69 +507,5 @@ func versionHandler(gateway Gatewayer) http.HandlerFunc {
 		}
 
 		wh.SendJSONOr500(logger, w, gateway.GetBuildInfo())
-	}
-}
-
-/*
-attrActualLog remove color char in log
-origin: "\u001b[36m[skycoin.daemon:DEBUG] Trying to connect to 47.88.33.156:6000\u001b[0m",
-*/
-func attrActualLog(logInfo string) string {
-	//return logInfo
-	var actualLog string
-	actualLog = logInfo
-	if strings.HasPrefix(logInfo, "[skycoin") {
-		if strings.Contains(logInfo, "\u001b") {
-			actualLog = logInfo[0 : len(logInfo)-4]
-		}
-	} else {
-		if len(logInfo) > 5 {
-			if strings.Contains(logInfo, "\u001b") {
-				actualLog = logInfo[5 : len(logInfo)-4]
-			}
-		}
-	}
-	return actualLog
-}
-func getLogsHandler(logbuf *bytes.Buffer) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			wh.Error405(w)
-			return
-		}
-
-		var err error
-		defaultLineNum := 1000 // default line numbers
-		linenum := defaultLineNum
-		if lines := r.FormValue("lines"); lines != "" {
-			linenum, err = strconv.Atoi(lines)
-			if err != nil {
-				linenum = defaultLineNum
-			}
-		}
-		keyword := r.FormValue("include")
-		excludeKeyword := r.FormValue("exclude")
-		logs := []string{}
-		logList := strings.Split(logbuf.String(), "\n")
-		for _, logInfo := range logList {
-			if excludeKeyword != "" && strings.Contains(logInfo, excludeKeyword) {
-				continue
-			}
-			if keyword != "" && !strings.Contains(logInfo, keyword) {
-				continue
-			}
-
-			if len(logs) >= linenum {
-				logger.Debugf("logs size %d,total size:%d", len(logs), len(logList))
-				break
-			}
-			log := attrActualLog(logInfo)
-			if "" != log {
-				logs = append(logs, log)
-			}
-
-		}
-
-		wh.SendJSONOr500(logger, w, logs)
 	}
 }

--- a/src/util/droplet/droplet.go
+++ b/src/util/droplet/droplet.go
@@ -62,7 +62,7 @@ func FromString(b string) (uint64, error) {
 	// Check that there are no decimal places remaining. This error should not
 	// occur, because of the earlier check of Exponent()
 	if e.Exponent() < 0 {
-		logger.Criticalf("Balance still has decimals after converting to droplets: %s", b)
+		logger.Critical().Errorf("Balance still has decimals after converting to droplets: %s", b)
 		return 0, ErrTooManyDecimals
 	}
 

--- a/src/util/http/handler.go
+++ b/src/util/http/handler.go
@@ -38,7 +38,7 @@ func HostCheck(logger *logging.Logger, host string, handler http.Handler) http.H
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// NOTE: The "Host" header is not in http.Request.Header, it's put in the http.Request.Host field
 		if r.Host != "" && isLocalhost && r.Host != fmt.Sprintf("127.0.0.1:%d", port) && r.Host != fmt.Sprintf("localhost:%d", port) {
-			logger.Criticalf("Detected DNS rebind attempt - configured-host=%s header-host=%s", host, r.Host)
+			logger.Critical().Errorf("Detected DNS rebind attempt - configured-host=%s header-host=%s", host, r.Host)
 			Error403(w)
 			return
 		}

--- a/src/util/logging/formatter.go
+++ b/src/util/logging/formatter.go
@@ -79,12 +79,6 @@ type compiledColorScheme struct {
 
 // TextFormatter formats log output
 type TextFormatter struct {
-	// Name of the logging field containing priority level
-	PriorityKey string
-
-	// Highlight messages with this priority
-	HighlightPriorityValue string
-
 	// Set to true to bypass checking for a TTY before outputting colors.
 	ForceColors bool
 
@@ -259,8 +253,8 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 		levelColor = colorScheme.DebugLevelColor
 	}
 
-	priority, ok := entry.Data[f.PriorityKey]
-	hasPriority := ok && priority == f.HighlightPriorityValue
+	priority, ok := entry.Data[logPriorityKey]
+	hasPriority := ok && priority == logPriorityCritical
 
 	if entry.Level != logrus.WarnLevel {
 		levelText = entry.Level.String()
@@ -345,7 +339,7 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 	}
 
 	for _, k := range keys {
-		if k != "prefix" && k != "file" && k != "func" && k != "line" && k != f.PriorityKey && k != LogModuleKey {
+		if k != "prefix" && k != "file" && k != "func" && k != "line" && k != logPriorityKey && k != logModuleKey {
 			v := entry.Data[k]
 			fmt.Fprintf(b, " %s", f.formatKeyValue(levelColor(k), v))
 		}
@@ -375,12 +369,12 @@ func (f *TextFormatter) needsQuoting(text string) bool {
 
 func extractPrefix(e *logrus.Entry) string {
 	var module string
-	if iModule, ok := e.Data[LogModuleKey]; ok {
+	if iModule, ok := e.Data[logModuleKey]; ok {
 		module, _ = iModule.(string)
 	}
 
 	var priority string
-	if iPriority, ok := e.Data[LogPriorityKey]; ok {
+	if iPriority, ok := e.Data[logPriorityKey]; ok {
 		priority, _ = iPriority.(string)
 	}
 

--- a/src/util/logging/hooks.go
+++ b/src/util/logging/hooks.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"io"
 	"reflect"
 
 	"github.com/sirupsen/logrus"
@@ -85,4 +86,41 @@ func (h ModuleLogHook) Fire(entry *logrus.Entry) error {
 	}
 
 	return nil
+}
+
+// WriteHook is a logrus.Hook that logs to an io.Writer
+type WriteHook struct {
+	w         io.Writer
+	formatter logrus.Formatter
+}
+
+// NewWriteHook returns a new WriteHook
+func NewWriteHook(w io.Writer) *WriteHook {
+	return &WriteHook{
+		w: w,
+		formatter: &TextFormatter{
+			DisableColors:      true,
+			FullTimestamp:      true,
+			AlwaysQuoteStrings: true,
+			QuoteEmptyFields:   true,
+			ForceFormatting:    true,
+		},
+	}
+}
+
+// Levels returns Levels accepted by the WriteHook.
+// All logrus.Levels are returned.
+func (f *WriteHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// Fire writes a logrus.Entry to the file
+func (f *WriteHook) Fire(e *logrus.Entry) error {
+	b, err := f.formatter.Format(e)
+	if err != nil {
+		return err
+	}
+
+	_, err = f.w.Write(b)
+	return err
 }

--- a/src/util/logging/hooks.go
+++ b/src/util/logging/hooks.go
@@ -2,91 +2,9 @@ package logging
 
 import (
 	"io"
-	"reflect"
 
 	"github.com/sirupsen/logrus"
 )
-
-// NewReplayHook creates a ReplayHook
-func NewReplayHook(logger *Logger) ReplayHook {
-	return newExclusiveReplayHook(logger, []reflect.Type{
-		reflect.TypeOf(ReplayHook{}),
-		reflect.TypeOf(ModuleLogHook{}),
-	})
-}
-
-// newExclusiveReplayHook creates a ReplayHook that does not replay hooks of given excluded types
-func newExclusiveReplayHook(logger *Logger, exclude []reflect.Type) (h ReplayHook) {
-	h = ReplayHook{
-		Logger:       logger,
-		excludeTypes: make(map[reflect.Type]struct{}, len(exclude)),
-	}
-	for _, _type := range exclude {
-		h.excludeTypes[_type] = struct{}{}
-	}
-	return
-}
-
-// ReplayHook is a hook for replaying hooks bound to another logger
-type ReplayHook struct {
-	Logger       *Logger
-	excludeTypes map[reflect.Type]struct{}
-}
-
-// Levels returns all levels
-func (h ReplayHook) Levels() []logrus.Level {
-	return logrus.AllLevels
-}
-
-// Fire fires other hooks that are not excluded from replay
-func (h ReplayHook) Fire(entry *logrus.Entry) error {
-	hooks := h.Logger.Hooks
-	level := entry.Level
-	for _, hook := range hooks[level] {
-		if _, ok := h.excludeTypes[reflect.TypeOf(hook)]; ok {
-			continue
-		}
-		if err := hook.Fire(entry); err != nil {
-			return err
-		}
-	}
-	return hooks.Fire(entry.Level, entry)
-}
-
-// ModuleLogHook tags log entries with module information
-type ModuleLogHook struct {
-	FieldKey    string
-	PriorityKey string
-	ModuleName  string
-}
-
-// NewModuleLogHook creates a ModuleLogHook
-func NewModuleLogHook(moduleName string) ModuleLogHook {
-	return ModuleLogHook{
-		FieldKey:    LogModuleKey,
-		PriorityKey: LogPriorityKey,
-		ModuleName:  moduleName,
-	}
-}
-
-// Levels returns all levels
-func (h ModuleLogHook) Levels() []logrus.Level {
-	return logrus.AllLevels
-}
-
-// Fire adds module prefix to the logrus.Entry data
-func (h ModuleLogHook) Fire(entry *logrus.Entry) error {
-	entry.Data[h.FieldKey] = h.ModuleName
-	prefix := h.ModuleName
-	if value, hasField := entry.Data[h.PriorityKey]; hasField && value.(string) != "" {
-		prefix += ":" + value.(string)
-	}
-	if prefix != "" {
-		entry.Data["prefix"] = "[" + prefix + "]"
-	}
-
-	return nil
-}
 
 // WriteHook is a logrus.Hook that logs to an io.Writer
 type WriteHook struct {

--- a/src/util/logging/logger.go
+++ b/src/util/logging/logger.go
@@ -1,170 +1,73 @@
 package logging
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/sirupsen/logrus"
 )
 
-// ExtendedFieldLogger is an enhanced logger supporting critical and important levels
-type ExtendedFieldLogger interface {
-	logrus.FieldLogger
-
-	// Critical level
-	Criticalf(format string, args ...interface{})
-	Critical(args ...interface{})
-	Criticalln(args ...interface{})
-
-	// Notice level
-	Noticef(format string, args ...interface{})
-	Notice(args ...interface{})
-	Noticeln(args ...interface{})
-}
-
-// Logger wraps sirupsen/logrus.Logger to implement ExtendendFieldLogger
-type Logger struct {
+// MasterLogger wraps logrus.Logger and is able to create new package-aware loggers
+type MasterLogger struct {
 	*logrus.Logger
-	formatter         *TextFormatter
-	module            string
-	allModulesEnabled bool
-	moduleLoggers     map[string]*Logger
-	PriorityKey       string
-	CriticalPriority  string
 }
 
-var (
-	// QuietLogger disables all log output
-	QuietLogger = logrus.Logger{
-		Out:       ioutil.Discard,
-		Formatter: new(logrus.TextFormatter), // FIXME: Performance?
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.FatalLevel,
-	}
-)
+// NewMasterLogger creates a new package-aware logger with formatting string
+func NewMasterLogger() *MasterLogger {
+	hooks := make(logrus.LevelHooks)
 
-// NewLogger creates a new modules-aware logger with formatting string
-func NewLogger(priorityKey, criticalPriority string) (logger *Logger) {
-	formatter := &TextFormatter{
-		FullTimestamp:          true,
-		AlwaysQuoteStrings:     true,
-		QuoteEmptyFields:       true,
-		ForceFormatting:        true,
-		PriorityKey:            priorityKey,
-		HighlightPriorityValue: criticalPriority,
-	}
-
-	logger = &Logger{
+	return &MasterLogger{
 		Logger: &logrus.Logger{
-			Out:       os.Stdout,
-			Formatter: formatter,
-			Hooks:     make(logrus.LevelHooks),
-			Level:     logrus.InfoLevel,
+			Out: os.Stdout,
+			Formatter: &TextFormatter{
+				FullTimestamp:          true,
+				AlwaysQuoteStrings:     true,
+				QuoteEmptyFields:       true,
+				ForceFormatting:        true,
+				DisableColors:          false,
+				ForceColors:            false,
+				PriorityKey:            LogPriorityKey,
+				HighlightPriorityValue: LogPriorityCritical,
+			},
+			Hooks: hooks,
+			Level: logrus.DebugLevel,
 		},
-		formatter:         formatter,
-		allModulesEnabled: true,
-		moduleLoggers:     make(map[string]*Logger),
-		PriorityKey:       priorityKey,
-		CriticalPriority:  criticalPriority,
 	}
-	logger.Hooks.Add(NewModuleLogHook(""))
-	logger.moduleLoggers[""] = logger
-	return
 }
 
-func (logger *Logger) cloneForModule(moduleName string) *Logger {
-	newLogger := &Logger{
-		Logger: &logrus.Logger{
-			Out:       logger.Out,
-			Formatter: logger.Formatter,
-			Hooks:     make(logrus.LevelHooks),
-			Level:     logger.Level,
-		},
-		allModulesEnabled: logger.allModulesEnabled,
-		moduleLoggers:     logger.moduleLoggers,
-		PriorityKey:       logger.PriorityKey,
-		CriticalPriority:  logger.CriticalPriority,
-	}
-	newLogger.Hooks.Add(NewReplayHook(logger.moduleLoggers[""]))
-	newLogger.Hooks.Add(NewModuleLogHook(moduleName))
-	return newLogger
+// Logger wraps logrus.FieldLogger
+type Logger struct {
+	logrus.FieldLogger
 }
 
-// MustGetLogger returns an existing logger for a given module or creates a new one
-func (logger *Logger) MustGetLogger(moduleName string) *Logger {
-	newLogger, isInCache := logger.moduleLoggers[moduleName]
-	if !(isInCache && newLogger != nil) {
-		if isInCache || logger.allModulesEnabled {
-			newLogger = logger.cloneForModule(moduleName)
-			logger.moduleLoggers[moduleName] = newLogger
-		} else {
-			newLogger = &Logger{
-				Logger:            &QuietLogger,
-				allModulesEnabled: logger.allModulesEnabled,
-				moduleLoggers:     logger.moduleLoggers,
-			}
-		}
+// Critical adds special critical-level fields for specially highlighted logging,
+// since logrus lacks a distinct critical field and does not have configurable log levels
+func (logger *Logger) Critical() logrus.FieldLogger {
+	return logger.WithField(LogPriorityKey, LogPriorityCritical)
+}
+
+// PackageLogger instantiates a package-aware logger
+func (logger *MasterLogger) PackageLogger(moduleName string) *Logger {
+	return &Logger{
+		FieldLogger: logger.WithField(LogModuleKey, moduleName),
 	}
-	return newLogger
 }
 
 // AddHook adds a logrus.Hook to the logger and its module loggers
-func (logger *Logger) AddHook(hook logrus.Hook) {
-	logger.Logger.Hooks.Add(hook)
-	for _, module := range logger.moduleLoggers {
-		module.Logger.Hooks.Add(hook)
-	}
+func (logger *MasterLogger) AddHook(hook logrus.Hook) {
+	logger.Hooks.Add(hook)
 }
 
 // SetLevel sets the log level for the logger and its module loggers
-func (logger *Logger) SetLevel(level logrus.Level) {
-	logger.Logger.Level = level
-	for _, module := range logger.moduleLoggers {
-		module.Logger.Level = level
-	}
+func (logger *MasterLogger) SetLevel(level logrus.Level) {
+	logger.Level = level
 }
 
 // EnableColors enables colored logging
-func (logger *Logger) EnableColors() {
-	logger.formatter.DisableColors = false
+func (logger *MasterLogger) EnableColors() {
+	logger.Formatter.(*TextFormatter).DisableColors = false
 }
 
 // DisableColors disables colored logging
-func (logger *Logger) DisableColors() {
-	logger.formatter.DisableColors = true
-}
-
-// Criticalf formatted log with Critical priority
-func (logger *Logger) Criticalf(format string, args ...interface{}) {
-	logger.WithField(logger.PriorityKey, logger.CriticalPriority).Error(args...)
-}
-
-// Critical log with Critical priority
-func (logger *Logger) Critical(args ...interface{}) {
-	logger.WithField(logger.PriorityKey, logger.CriticalPriority).Error(args...)
-}
-
-// Criticalln log line with Critical priority
-func (logger *Logger) Criticalln(args ...interface{}) {
-	logger.WithField(logger.PriorityKey, logger.CriticalPriority).Error(args...)
-}
-
-// Noticef formatted log with Critical priority
-func (logger *Logger) Noticef(format string, args ...interface{}) {
-	logger.WithField(logger.PriorityKey, logger.CriticalPriority).Info(args...)
-}
-
-// Notice log with Critical priority
-func (logger *Logger) Notice(args ...interface{}) {
-	logger.WithField(logger.PriorityKey, logger.CriticalPriority).Info(args...)
-}
-
-// Noticeln log line with Critical priority
-func (logger *Logger) Noticeln(args ...interface{}) {
-	logger.WithField(logger.PriorityKey, logger.CriticalPriority).Info(args...)
-}
-
-// Disable discards all log output
-func (logger *Logger) Disable() {
-	logger.Out = ioutil.Discard
+func (logger *MasterLogger) DisableColors() {
+	logger.Formatter.(*TextFormatter).DisableColors = true
 }

--- a/src/util/logging/logger.go
+++ b/src/util/logging/logger.go
@@ -6,6 +6,17 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Logger wraps logrus.FieldLogger
+type Logger struct {
+	logrus.FieldLogger
+}
+
+// Critical adds special critical-level fields for specially highlighted logging,
+// since logrus lacks a distinct critical field and does not have configurable log levels
+func (logger *Logger) Critical() logrus.FieldLogger {
+	return logger.WithField(logPriorityKey, logPriorityCritical)
+}
+
 // MasterLogger wraps logrus.Logger and is able to create new package-aware loggers
 type MasterLogger struct {
 	*logrus.Logger
@@ -30,17 +41,6 @@ func NewMasterLogger() *MasterLogger {
 			Level: logrus.DebugLevel,
 		},
 	}
-}
-
-// Logger wraps logrus.FieldLogger
-type Logger struct {
-	logrus.FieldLogger
-}
-
-// Critical adds special critical-level fields for specially highlighted logging,
-// since logrus lacks a distinct critical field and does not have configurable log levels
-func (logger *Logger) Critical() logrus.FieldLogger {
-	return logger.WithField(logPriorityKey, logPriorityCritical)
 }
 
 // PackageLogger instantiates a package-aware logger

--- a/src/util/logging/logger.go
+++ b/src/util/logging/logger.go
@@ -19,14 +19,12 @@ func NewMasterLogger() *MasterLogger {
 		Logger: &logrus.Logger{
 			Out: os.Stdout,
 			Formatter: &TextFormatter{
-				FullTimestamp:          true,
-				AlwaysQuoteStrings:     true,
-				QuoteEmptyFields:       true,
-				ForceFormatting:        true,
-				DisableColors:          false,
-				ForceColors:            false,
-				PriorityKey:            LogPriorityKey,
-				HighlightPriorityValue: LogPriorityCritical,
+				FullTimestamp:      true,
+				AlwaysQuoteStrings: true,
+				QuoteEmptyFields:   true,
+				ForceFormatting:    true,
+				DisableColors:      false,
+				ForceColors:        false,
 			},
 			Hooks: hooks,
 			Level: logrus.DebugLevel,
@@ -42,13 +40,13 @@ type Logger struct {
 // Critical adds special critical-level fields for specially highlighted logging,
 // since logrus lacks a distinct critical field and does not have configurable log levels
 func (logger *Logger) Critical() logrus.FieldLogger {
-	return logger.WithField(LogPriorityKey, LogPriorityCritical)
+	return logger.WithField(logPriorityKey, logPriorityCritical)
 }
 
 // PackageLogger instantiates a package-aware logger
 func (logger *MasterLogger) PackageLogger(moduleName string) *Logger {
 	return &Logger{
-		FieldLogger: logger.WithField(LogModuleKey, moduleName),
+		FieldLogger: logger.WithField(logModuleKey, moduleName),
 	}
 }
 

--- a/src/util/logging/logging.go
+++ b/src/util/logging/logging.go
@@ -12,12 +12,12 @@ import (
 var log = NewMasterLogger()
 
 const (
-	// LogModuleKey is the key used for the module name data entry
-	LogModuleKey = "_module"
-	// LogPriorityKey is the log entry key for priority log statements
-	LogPriorityKey = "_priority"
-	// LogPriorityCritical is the log entry value for priority log statements
-	LogPriorityCritical = "CRITICAL"
+	// logModuleKey is the key used for the module name data entry
+	logModuleKey = "_module"
+	// logPriorityKey is the log entry key for priority log statements
+	logPriorityKey = "_priority"
+	// logPriorityCritical is the log entry value for priority log statements
+	logPriorityCritical = "CRITICAL"
 )
 
 // LevelFromString returns a logrus.Level from a string identifier

--- a/src/util/logging/logging.go
+++ b/src/util/logging/logging.go
@@ -1,7 +1,11 @@
 package logging
 
 import (
+	"errors"
 	"io"
+	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 var log = NewLogger(LogPriorityKey, LogPriorityCritical)
@@ -27,8 +31,48 @@ func Disable() {
 	}
 }
 
-// RedirectTo redirects log to the given io.Wirter
-func RedirectTo(w io.Writer) {
+// AddHook adds a hook to the global logger
+func AddHook(hook logrus.Hook) {
+	log.AddHook(hook)
+}
+
+// EnableColors enables colored logging
+func EnableColors() {
+	log.EnableColors()
+}
+
+// DisableColors disables colored logging
+func DisableColors() {
+	log.DisableColors()
+}
+
+// SetLevel sets the logger's minimum log level
+func SetLevel(level logrus.Level) {
+	log.SetLevel(level)
+}
+
+// LevelFromString returns a logrus.Level from a string identifier
+func LevelFromString(s string) (logrus.Level, error) {
+	switch strings.ToLower(s) {
+	case "debug":
+		return logrus.DebugLevel, nil
+	case "info", "notice":
+		return logrus.InfoLevel, nil
+	case "warn", "warning":
+		return logrus.WarnLevel, nil
+	case "error":
+		return logrus.ErrorLevel, nil
+	case "fatal", "critical":
+		return logrus.FatalLevel, nil
+	case "panic":
+		return logrus.PanicLevel, nil
+	default:
+		return logrus.DebugLevel, errors.New("could not convert string to log level")
+	}
+}
+
+// SetOutputTo sets the logger's output to an io.Writer
+func SetOutputTo(w io.Writer) {
 	for k := range log.moduleLoggers {
 		log.moduleLoggers[k].Out = w
 	}

--- a/src/visor/db.go
+++ b/src/visor/db.go
@@ -35,7 +35,7 @@ func loadBlockchain(db *bolt.DB, pubkey cipher.PubKey, arbitrating bool) (*bolt.
 	dbPath := db.Path()
 	dbReadOnly := db.IsReadOnly()
 
-	logger.Criticalf("Block database signature missing, recreating db: %v", err)
+	logger.Critical().Errorf("Block database signature missing, recreating db: %v", err)
 	if err := db.Close(); err != nil {
 		return nil, nil, fmt.Errorf("failed to close db: %v", err)
 	}
@@ -45,7 +45,7 @@ func loadBlockchain(db *bolt.DB, pubkey cipher.PubKey, arbitrating bool) (*bolt.
 		return nil, nil, fmt.Errorf("Failed to copy corrupted db: %v", err)
 	}
 
-	logger.Criticalf("Moved corrupted db to %s", corruptDBPath)
+	logger.Critical().Errorf("Moved corrupted db to %s", corruptDBPath)
 
 	db, err = OpenDB(dbPath, dbReadOnly)
 	if err != nil {

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -632,7 +632,7 @@ func (vs *Visor) GetAddressTxns(a cipher.Address) ([]Transaction, error) {
 	for _, ux := range uxs {
 		tx, ok := vs.Unconfirmed.Get(ux.Body.SrcTransaction)
 		if !ok {
-			logger.Critical("Unconfirmed unspent missing unconfirmed txn")
+			logger.Critical().Error("Unconfirmed unspent missing unconfirmed txn")
 			continue
 		}
 		txns = append(txns, Transaction{
@@ -849,7 +849,7 @@ func (vs *Visor) getTransactionsOfAddrs(addrs []cipher.Address) (map[cipher.Addr
 		for _, ux := range uxs {
 			tx, ok := vs.Unconfirmed.Get(ux.Body.SrcTransaction)
 			if !ok {
-				logger.Critical("Unconfirmed unspent missing unconfirmed txn")
+				logger.Critical().Error("Unconfirmed unspent missing unconfirmed txn")
 				continue
 			}
 			txns = append(txns, Transaction{

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -1270,7 +1270,7 @@ func (w *Wallet) CreateAndSignTransactionAdvanced(params CreateTransactionParams
 	}
 
 	if err := verifyCreatedTransactionInvariants(params, txn, inputs); err != nil {
-		logger.Criticalf("CreateAndSignTransactionAdvanced created transaction that violates invariants, aborting: %v", err)
+		logger.Critical().Errorf("CreateAndSignTransactionAdvanced created transaction that violates invariants, aborting: %v", err)
 		return nil, nil, fmt.Errorf("Created transaction that violates invariants, this is a bug: %v", err)
 	}
 


### PR DESCRIPTION
Fixes #1372 
Fixes #1319 

Changes:
- Refactor logging module into a single master logger that provides a `Critical()` method to tag lines as critical and works with subsequent chained `WithField` and `WithFields` calls
- Add support for multi-destination writing with `WriteHook`; restore `-logtofile` functionality
- Restore `-color-log` option
- Restore `-log-level` option
- Remove unused `-logtofile`, `-logbufsize` options and related code

Does this change need to mentioned in CHANGELOG.md?
Yes