### PR TITLE
Improve syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - #1309, Float imprecision error in frontend malformed some spend amounts, preventing the spend
+- Fix one aspect of sync stalling caused by a 5-second blocking channel write, switching it to a non-blocking write
 
 ### Changed
 

--- a/src/daemon/visor.go
+++ b/src/daemon/visor.go
@@ -301,7 +301,7 @@ func (vs *Visor) SetTxnsAnnounced(txns []cipher.SHA256) {
 		now := utc.Now()
 		for _, h := range txns {
 			if err := vs.v.Unconfirmed.SetAnnounced(h, now); err != nil {
-				logger.Error("Failed to set unconfirmed txn announce time")
+				logger.Error("Failed to set unconfirmed txn announce time: ", err)
 			}
 		}
 


### PR DESCRIPTION
Improves some of sync stall behavior described in #1362 

Changes:
- Remove the 5-second blocking write call in BroadcastMessages, use a non-blocking write
- Reduce connection timeouts to 30 seconds
- Increase channel sizes for BroadcastResults, ConnectionWriteQueue

Does this change need to mentioned in CHANGELOG.md?
Yes