### PR TITLE
Always report error msg on 500; remove duplicate log lines

### DIFF
--- a/src/gui/blockchain.go
+++ b/src/gui/blockchain.go
@@ -17,8 +17,8 @@ func blockchainHandler(gateway Gatewayer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		metadata, err := gateway.GetBlockchainMetadata()
 		if err != nil {
-			logger.WithError(err).Error("gateway.GetBlockchainMetadata failed")
-			wh.Error500Msg(w, err.Error())
+			err = fmt.Errorf("gateway.GetBlockchainMetadata failed: %v", err)
+			wh.Error500(w, err.Error())
 			return
 		}
 
@@ -79,8 +79,7 @@ func getBlock(gate Gatewayer) http.HandlerFunc {
 
 		rb, err := visor.NewReadableBlock(&b.Block)
 		if err != nil {
-			logger.Error(err)
-			wh.Error500(w)
+			wh.Error500(w, err.Error())
 			return
 		}
 

--- a/src/gui/blockchain_test.go
+++ b/src/gui/blockchain_test.go
@@ -151,7 +151,7 @@ func TestGetBlock(t *testing.T) {
 			name:   "500 - NewReadableBlock error",
 			method: http.MethodGet,
 			status: http.StatusInternalServerError,
-			err:    "500 Internal Server Error",
+			err:    "500 Internal Server Error - Droplet string conversion failed: Value is too large",
 			seqStr: "1",
 			seq:    1,
 			gatewayGetBlockBySeqResult: coin.SignedBlock{

--- a/src/gui/explorer.go
+++ b/src/gui/explorer.go
@@ -1,6 +1,7 @@
 package gui
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -46,8 +47,8 @@ func coinSupply(gateway Gatewayer, w http.ResponseWriter, r *http.Request) *Coin
 
 	allUnspents, err := gateway.GetUnspentOutputs()
 	if err != nil {
-		logger.Errorf("gateway.GetUnspentOutputs error: %v", err)
-		wh.Error500(w)
+		err = fmt.Errorf("gateway.GetUnspentOutputs failed: %v", err)
+		wh.Error500(w, err.Error())
 		return nil
 	}
 
@@ -63,8 +64,8 @@ func coinSupply(gateway Gatewayer, w http.ResponseWriter, r *http.Request) *Coin
 		if _, ok := unlockedAddrMap[u.Address]; ok {
 			coins, err := droplet.FromString(u.Coins)
 			if err != nil {
-				logger.Errorf("Invalid unlocked output balance string %s: %v", u.Coins, err)
-				wh.Error500(w)
+				err = fmt.Errorf("Invalid unlocked output balance string %s: %v", u.Coins, err)
+				wh.Error500(w, err.Error())
 				return nil
 			}
 			unlockedSupply += coins
@@ -81,22 +82,22 @@ func coinSupply(gateway Gatewayer, w http.ResponseWriter, r *http.Request) *Coin
 
 	currentSupplyStr, err := droplet.ToString(currentSupply)
 	if err != nil {
-		logger.Errorf("Failed to convert coins to string: %v", err)
-		wh.Error500(w)
+		err = fmt.Errorf("Failed to convert coins to string: %v", err)
+		wh.Error500(w, err.Error())
 		return nil
 	}
 
 	totalSupplyStr, err := droplet.ToString(totalSupply)
 	if err != nil {
-		logger.Errorf("Failed to convert coins to string: %v", err)
-		wh.Error500(w)
+		err = fmt.Errorf("Failed to convert coins to string: %v", err)
+		wh.Error500(w, err.Error())
 		return nil
 	}
 
 	maxSupplyStr, err := droplet.ToString(visor.MaxCoinSupply * droplet.Multiplier)
 	if err != nil {
-		logger.Errorf("Failed to convert coins to string: %v", err)
-		wh.Error500(w)
+		err = fmt.Errorf("Failed to convert coins to string: %v", err)
+		wh.Error500(w, err.Error())
 		return nil
 	}
 
@@ -125,8 +126,8 @@ func coinSupply(gateway Gatewayer, w http.ResponseWriter, r *http.Request) *Coin
 	}
 
 	if err != nil {
-		logger.Errorf("Failed to get total coinhours: %v", err)
-		wh.Error500(w)
+		err = fmt.Errorf("Failed to get total coinhours: %v", err)
+		wh.Error500(w, err.Error())
 		return nil
 	}
 
@@ -166,8 +167,8 @@ func getTransactionsForAddress(gateway Gatewayer) http.HandlerFunc {
 
 		txns, err := gateway.GetAddressTxns(cipherAddr)
 		if err != nil {
-			logger.Errorf("Get address transactions failed: %v", err)
-			wh.Error500(w)
+			err = fmt.Errorf("gateway.GetAddressTxns failed: %v", err)
+			wh.Error500(w, err.Error())
 			return
 		}
 
@@ -178,27 +179,25 @@ func getTransactionsForAddress(gateway Gatewayer) http.HandlerFunc {
 			for i := range tx.Transaction.In {
 				id, err := cipher.SHA256FromHex(tx.Transaction.In[i])
 				if err != nil {
-					logger.Error(err)
-					wh.Error500(w)
+					wh.Error500(w, err.Error())
 					return
 				}
 
 				uxout, err := gateway.GetUxOutByID(id)
 				if err != nil {
-					logger.Error(err)
-					wh.Error500(w)
+					wh.Error500(w, err.Error())
 					return
 				}
 
 				if uxout == nil {
-					logger.Errorf("uxout of %v does not exist in history db", id.Hex())
-					wh.Error500(w)
+					err := fmt.Errorf("uxout of %v does not exist in history db", id.Hex())
+					wh.Error500(w, err.Error())
 					return
 				}
 
 				tIn, err := visor.NewReadableTransactionInput(tx.Transaction.In[i], uxout.Out.Body.Address.String(), uxout.Out.Body.Coins, uxout.Out.Body.Hours)
 				if err != nil {
-					wh.Error500(w)
+					wh.Error500(w, err.Error())
 					return
 				}
 
@@ -256,8 +255,7 @@ func getRichlist(gateway Gatewayer) http.HandlerFunc {
 
 		richlist, err := gateway.GetRichlist(includeDistribution)
 		if err != nil {
-			logger.Error(err)
-			wh.Error500(w)
+			wh.Error500(w, err.Error())
 			return
 		}
 
@@ -282,8 +280,7 @@ func getAddressCount(gateway Gatewayer) http.HandlerFunc {
 
 		addrCount, err := gateway.GetAddressCount()
 		if err != nil {
-			logger.Error(err)
-			wh.Error500(w)
+			wh.Error500(w, err.Error())
 			return
 		}
 

--- a/src/gui/explorer_test.go
+++ b/src/gui/explorer_test.go
@@ -136,7 +136,7 @@ func TestGetTransactionsForAddress(t *testing.T) {
 			name:                     "500 - gw GetAddressTxns error",
 			method:                   http.MethodGet,
 			status:                   http.StatusInternalServerError,
-			err:                      "500 Internal Server Error",
+			err:                      "500 Internal Server Error - gateway.GetAddressTxns failed: gatewayGetAddressTxnsErr",
 			addressParam:             address.String(),
 			gatewayGetAddressTxnsErr: errors.New("gatewayGetAddressTxnsErr"),
 		},
@@ -144,7 +144,7 @@ func TestGetTransactionsForAddress(t *testing.T) {
 			name:         "500 - cipher.SHA256FromHex(tx.Transaction.In) error",
 			method:       http.MethodGet,
 			status:       http.StatusInternalServerError,
-			err:          "500 Internal Server Error",
+			err:          "500 Internal Server Error - encoding/hex: odd length hex string",
 			addressParam: address.String(),
 			gatewayGetAddressTxnsResult: &visor.TransactionResults{
 				Txns: []visor.TransactionResult{
@@ -162,7 +162,7 @@ func TestGetTransactionsForAddress(t *testing.T) {
 			name:         "500 - GetUxOutByID error",
 			method:       http.MethodGet,
 			status:       http.StatusInternalServerError,
-			err:          "500 Internal Server Error",
+			err:          "500 Internal Server Error - gatewayGetUxOutByIDErr",
 			addressParam: address.String(),
 			gatewayGetAddressTxnsResult: &visor.TransactionResults{
 				Txns: []visor.TransactionResult{
@@ -182,7 +182,7 @@ func TestGetTransactionsForAddress(t *testing.T) {
 			name:         "500 - GetUxOutByID nil result",
 			method:       http.MethodGet,
 			status:       http.StatusInternalServerError,
-			err:          "500 Internal Server Error",
+			err:          "500 Internal Server Error - uxout of 79216473e8f2c17095c6887cc9edca6c023afedfac2e0c5460e8b6f359684f8b does not exist in history db",
 			addressParam: address.String(),
 			gatewayGetAddressTxnsResult: &visor.TransactionResults{
 				Txns: []visor.TransactionResult{
@@ -311,7 +311,7 @@ func TestCoinSupply(t *testing.T) {
 			name:   "500 - gatewayGetUnspentOutputsErr",
 			method: http.MethodGet,
 			status: http.StatusInternalServerError,
-			err:    "500 Internal Server Error",
+			err:    "500 Internal Server Error - gateway.GetUnspentOutputs failed: gatewayGetUnspentOutputsErr",
 			gatewayGetUnspentOutputsArg: filterInUnlocked,
 			gatewayGetUnspentOutputsErr: errors.New("gatewayGetUnspentOutputsErr"),
 		},
@@ -319,7 +319,7 @@ func TestCoinSupply(t *testing.T) {
 			name:   "500 - gatewayGetUnspentOutputsErr",
 			method: http.MethodGet,
 			status: http.StatusInternalServerError,
-			err:    "500 Internal Server Error",
+			err:    "500 Internal Server Error - gateway.GetUnspentOutputs failed: gatewayGetUnspentOutputsErr",
 			gatewayGetUnspentOutputsArg: filterInUnlocked,
 			gatewayGetUnspentOutputsErr: errors.New("gatewayGetUnspentOutputsErr"),
 		},
@@ -327,7 +327,7 @@ func TestCoinSupply(t *testing.T) {
 			name:   "500 - too large HeadOutputs item",
 			method: http.MethodGet,
 			status: http.StatusInternalServerError,
-			err:    "500 Internal Server Error",
+			err:    "500 Internal Server Error - Invalid unlocked output balance string 9223372036854775807: Droplet string conversion failed: Value is too large",
 			gatewayGetUnspentOutputsArg: filterInUnlocked,
 			gatewayGetUnspentOutputsResult: &visor.ReadableOutputSet{
 				HeadOutputs: visor.ReadableOutputs{
@@ -444,7 +444,7 @@ func TestGetRichlist(t *testing.T) {
 			name:   "500 - gw GetRichlist error",
 			method: http.MethodGet,
 			status: http.StatusInternalServerError,
-			err:    "500 Internal Server Error",
+			err:    "500 Internal Server Error - gatewayGetRichlistErr",
 			httpParams: &httpParams{
 				topn:                "1",
 				includeDistribution: "false",
@@ -647,7 +647,7 @@ func TestGetAddressCount(t *testing.T) {
 			name:   "500 - gw GetAddressCount error",
 			method: http.MethodGet,
 			status: http.StatusInternalServerError,
-			err:    "500 Internal Server Error",
+			err:    "500 Internal Server Error - gatewayGetAddressCountErr",
 			gatewayGetAddressCountErr: errors.New("gatewayGetAddressCountErr"),
 		},
 		{

--- a/src/gui/health.go
+++ b/src/gui/health.go
@@ -1,6 +1,7 @@
 package gui
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -34,8 +35,8 @@ func healthCheck(gateway Gatewayer) http.HandlerFunc {
 
 		health, err := gateway.GetHealth()
 		if err != nil {
-			logger.WithError(err).Error("gateway.GetHealth failed")
-			wh.Error500Msg(w, err.Error())
+			err = fmt.Errorf("gateway.GetHealth failed: %v", err)
+			wh.Error500(w, err.Error())
 			return
 		}
 

--- a/src/gui/http.go
+++ b/src/gui/http.go
@@ -442,8 +442,8 @@ func getOutputsHandler(gateway Gatewayer) http.HandlerFunc {
 
 		outs, err := gateway.GetUnspentOutputs(filters...)
 		if err != nil {
-			logger.Errorf("get unspent outputs failed: %v", err)
-			wh.Error500(w)
+			err = fmt.Errorf("get unspent outputs failed: %v", err)
+			wh.Error500(w, err.Error())
 			return
 		}
 
@@ -473,9 +473,8 @@ func getBalanceHandler(gateway Gatewayer) http.HandlerFunc {
 
 		bals, err := gateway.GetBalanceOfAddrs(addrs)
 		if err != nil {
-			errMsg := fmt.Sprintf("Get balance failed: %v", err)
-			logger.Error(errMsg)
-			wh.Error500Msg(w, errMsg)
+			err = fmt.Errorf("gateway.GetBalanceOfAddrs failed: %v", err)
+			wh.Error500(w, err.Error())
 			return
 		}
 
@@ -484,13 +483,13 @@ func getBalanceHandler(gateway Gatewayer) http.HandlerFunc {
 			var err error
 			balance.Confirmed, err = balance.Confirmed.Add(bal.Confirmed)
 			if err != nil {
-				wh.Error500Msg(w, err.Error())
+				wh.Error500(w, err.Error())
 				return
 			}
 
 			balance.Predicted, err = balance.Predicted.Add(bal.Predicted)
 			if err != nil {
-				wh.Error500Msg(w, err.Error())
+				wh.Error500(w, err.Error())
 				return
 			}
 		}

--- a/src/gui/http_test.go
+++ b/src/gui/http_test.go
@@ -69,7 +69,7 @@ func TestGetOutputsHandler(t *testing.T) {
 			name:   "500 - getUnspentOutputsError",
 			method: http.MethodGet,
 			status: http.StatusInternalServerError,
-			err:    "500 Internal Server Error",
+			err:    "500 Internal Server Error - get unspent outputs failed: getUnspentOutputsError",
 			getUnspentOutputsResponse: nil,
 			getUnspentOutputsError:    errors.New("getUnspentOutputsError"),
 		},
@@ -166,7 +166,7 @@ func TestGetBalanceHandler(t *testing.T) {
 			name:   "500 - GetBalanceOfAddrsError",
 			method: http.MethodGet,
 			status: http.StatusInternalServerError,
-			err:    "500 Internal Server Error - Get balance failed: GetBalanceOfAddrsError",
+			err:    "500 Internal Server Error - gateway.GetBalanceOfAddrs failed: GetBalanceOfAddrsError",
 			httpBody: &httpBody{
 				addrs: validAddr,
 			},

--- a/src/gui/spend.go
+++ b/src/gui/spend.go
@@ -466,7 +466,7 @@ func createTransactionHandler(gateway Gatewayer) http.HandlerFunc {
 				case fee.ErrTxnNoFee, fee.ErrTxnInsufficientCoinHours:
 					wh.Error400(w, err.Error())
 				default:
-					wh.Error500Msg(w, err.Error())
+					wh.Error500(w, err.Error())
 				}
 			}
 			return
@@ -475,8 +475,7 @@ func createTransactionHandler(gateway Gatewayer) http.HandlerFunc {
 		txnResp, err := NewCreateTransactionResponse(txn, inputs)
 		if err != nil {
 			err = fmt.Errorf("NewCreateTransactionResponse failed: %v", err)
-			logger.WithError(err).Error()
-			wh.Error500Msg(w, err.Error())
+			wh.Error500(w, err.Error())
 			return
 		}
 

--- a/src/gui/transaction_test.go
+++ b/src/gui/transaction_test.go
@@ -121,7 +121,7 @@ func TestGetPendingTxs(t *testing.T) {
 			name:   "500 - bad unconfirmedTxn",
 			method: http.MethodGet,
 			status: http.StatusInternalServerError,
-			err:    "500 Internal Server Error",
+			err:    "500 Internal Server Error - Droplet string conversion failed: Value is too large",
 			getAllUnconfirmedTxnsResponse: []visor.UnconfirmedTxn{
 				invalidTxn,
 			},
@@ -706,7 +706,7 @@ func TestGetTransactions(t *testing.T) {
 			name:   "500 - getTransactionsError",
 			method: http.MethodGet,
 			status: http.StatusInternalServerError,
-			err:    "500 Internal Server Error",
+			err:    "500 Internal Server Error - gateway.GetTransactions failed: getTransactionsError",
 			httpBody: &httpBody{
 				addrs:     addrsStr,
 				confirmed: "true",
@@ -721,7 +721,7 @@ func TestGetTransactions(t *testing.T) {
 			name:   "500 - visor.NewTransactionResults error",
 			method: http.MethodGet,
 			status: http.StatusInternalServerError,
-			err:    "500 Internal Server Error",
+			err:    "500 Internal Server Error - visor.NewTransactionResults failed: Droplet string conversion failed: Value is too large",
 			httpBody: &httpBody{
 				addrs:     addrsStr,
 				confirmed: "true",

--- a/src/util/http/error.go
+++ b/src/util/http/error.go
@@ -81,13 +81,8 @@ func Error501(w http.ResponseWriter) {
 	httpError(w, http.StatusNotImplemented)
 }
 
-// Error500 respond with a 500 error
-func Error500(w http.ResponseWriter) {
-	httpError(w, http.StatusInternalServerError)
-}
-
-// Error500Msg respond with a 500 error and include a message
-func Error500Msg(w http.ResponseWriter, msg string) {
+// Error500 respond with a 500 error and include a message
+func Error500(w http.ResponseWriter, msg string) {
 	errorXXXMsg(w, http.StatusInternalServerError, msg)
 }
 

--- a/src/util/http/json.go
+++ b/src/util/http/json.go
@@ -18,8 +18,7 @@ import (
 func SendJSONOr500(log *logging.Logger, w http.ResponseWriter, m interface{}) {
 	out, err := json.MarshalIndent(m, "", "    ")
 	if err != nil {
-		log.WithError(err).Error("json.MarshalIndent failed")
-		Error500Msg(w, "json.MarshalIndent failed")
+		Error500(w, "json.MarshalIndent failed")
 		return
 	}
 


### PR DESCRIPTION
Changes:
- Always include an error message for HTTP 500 errors
- Remove duplicate logging of errors, all messages are logged automatically now

Does this change need to mentioned in CHANGELOG.md?
No