### PR TITLE
Fixed #485 Assigned prefix `/v1` to API endpoints

### DIFF
--- a/src/gui/client.go
+++ b/src/gui/client.go
@@ -54,7 +54,7 @@ func NewClient(addr string) *Client {
 		Transport: transport,
 		Timeout:   httpClientTimeout,
 	}
-	addr = strings.TrimRight(addr, "/")
+	addr = strings.TrimRight(addr, "/v1")
 	addr += "/"
 
 	return &Client{
@@ -94,6 +94,7 @@ func (c *Client) Get(endpoint string, obj interface{}) error {
 
 // get makes a GET request to an endpoint. Caller must close response body.
 func (c *Client) get(endpoint string) (*http.Response, error) {
+	endpoint = "/v1/" + endpoint
 	endpoint = strings.TrimLeft(endpoint, "/")
 	endpoint = c.Addr + endpoint
 
@@ -126,7 +127,7 @@ func (c *Client) post(endpoint string, contentType string, body io.Reader, obj i
 	if err != nil {
 		return err
 	}
-
+	endpoint = "/v1" + endpoint
 	endpoint = strings.TrimLeft(endpoint, "/")
 	endpoint = c.Addr + endpoint
 

--- a/src/gui/static/src/environments/environment.prod.ts
+++ b/src/gui/static/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
-  nodeUrl: 'http://127.0.0.1:6420/',
+  nodeUrl: 'http://127.0.0.1:6420/v1/',
   production: true,
   tellerUrl: 'https://event.skycoin.net/api/',
 };


### PR DESCRIPTION
Fixes #485

Changes:
-Modify the file `src/gui/client.go`, to assign the prefix
-Create a new function in `src/gui/http.go` called` webHandlerAPI`, which assigns the prefix to the urls declared above, separating them if they are stables, assigns the prefix `/v1`, but `/v2`
-Change the value of `nodeUrl` in `src/gui/static/src/environments /environment.prod.ts` so that the `desktopwallet` sees the API

Does this change need to mentioned in CHANGELOG.md?
No