### PR TITLE
Propagate error for GetBlocks, GetLastBlocks

### DIFF
--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -194,9 +194,14 @@ func (gw *Gateway) GetBlockBySeq(seq uint64) (block coin.SignedBlock, ok bool) {
 // GetBlocks returns a *visor.ReadableBlocks
 func (gw *Gateway) GetBlocks(start, end uint64) (*visor.ReadableBlocks, error) {
 	var blocks []coin.SignedBlock
+	var err error
+
 	gw.strand("GetBlocks", func() {
-		blocks = gw.v.GetBlocks(start, end)
+		blocks, err = gw.v.GetBlocks(start, end)
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	return visor.NewReadableBlocks(blocks)
 }
@@ -233,9 +238,13 @@ func (gw *Gateway) GetBlocksInDepth(vs []uint64) (*visor.ReadableBlocks, error) 
 // GetLastBlocks get last N blocks
 func (gw *Gateway) GetLastBlocks(num uint64) (*visor.ReadableBlocks, error) {
 	var blocks []coin.SignedBlock
+	var err error
 	gw.strand("GetLastBlocks", func() {
-		blocks = gw.v.GetLastBlocks(num)
+		blocks, err = gw.v.GetLastBlocks(num)
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	return visor.NewReadableBlocks(blocks)
 }

--- a/src/visor/blockchain.go
+++ b/src/visor/blockchain.go
@@ -384,17 +384,16 @@ func (bc Blockchain) verifySingleTxnHardConstraints(tx coin.Transaction, head *c
 }
 
 // GetBlocks return blocks whose seq are in the range of start and end.
-func (bc Blockchain) GetBlocks(start, end uint64) []coin.SignedBlock {
+func (bc Blockchain) GetBlocks(start, end uint64) ([]coin.SignedBlock, error) {
 	if start > end {
-		return []coin.SignedBlock{}
+		return nil, nil
 	}
 
-	blocks := []coin.SignedBlock{}
+	var blocks []coin.SignedBlock
 	for i := start; i <= end; i++ {
 		b, err := bc.store.GetBlockBySeq(i)
 		if err != nil {
-			logger.Error(err)
-			return []coin.SignedBlock{}
+			return nil, err
 		}
 
 		if b == nil {
@@ -403,14 +402,14 @@ func (bc Blockchain) GetBlocks(start, end uint64) []coin.SignedBlock {
 
 		blocks = append(blocks, *b)
 	}
-	return blocks
+
+	return blocks, nil
 }
 
 // GetLastBlocks return the latest N blocks.
-func (bc Blockchain) GetLastBlocks(num uint64) []coin.SignedBlock {
-	var blocks []coin.SignedBlock
+func (bc Blockchain) GetLastBlocks(num uint64) ([]coin.SignedBlock, error) {
 	if num == 0 {
-		return blocks
+		return nil, nil
 	}
 
 	end := bc.HeadSeq()

--- a/src/visor/blockchain_test.go
+++ b/src/visor/blockchain_test.go
@@ -348,7 +348,7 @@ func TestGetBlocks(t *testing.T) {
 				1,
 				0,
 			},
-			blocks[0:0],
+			nil,
 		},
 		{
 			"start overflow",
@@ -362,7 +362,7 @@ func TestGetBlocks(t *testing.T) {
 				6,
 				7,
 			},
-			blocks[0:0],
+			nil,
 		},
 		{
 			"start == end",
@@ -400,7 +400,8 @@ func TestGetBlocks(t *testing.T) {
 				store: tc.store,
 			}
 
-			bs := bc.GetBlocks(tc.req.st, tc.req.ed)
+			bs, err := bc.GetBlocks(tc.req.st, tc.req.ed)
+			require.NoError(t, err)
 			require.Equal(t, len(tc.expect), len(bs))
 			require.Equal(t, tc.expect, bs)
 		})
@@ -413,7 +414,7 @@ func TestGetLastBlocks(t *testing.T) {
 		name   string
 		store  chainStore
 		n      uint64
-		expcet []coin.SignedBlock
+		expect []coin.SignedBlock
 	}{
 		{
 			"get last block",
@@ -443,7 +444,7 @@ func TestGetLastBlocks(t *testing.T) {
 			"get block from empty chain",
 			&fakeChainStore{},
 			1,
-			blocks[0:0],
+			nil,
 		},
 	}
 
@@ -453,8 +454,9 @@ func TestGetLastBlocks(t *testing.T) {
 				store: tc.store,
 			}
 
-			bs := bc.GetLastBlocks(tc.n)
-			require.Equal(t, tc.expcet, bs)
+			bs, err := bc.GetLastBlocks(tc.n)
+			require.NoError(t, err)
+			require.Equal(t, tc.expect, bs)
 		})
 	}
 }

--- a/src/visor/blockchainer_mock_test.go
+++ b/src/visor/blockchainer_mock_test.go
@@ -106,7 +106,7 @@ func (m *BlockchainerMock) GetBlockBySeq(p0 uint64) (*coin.SignedBlock, error) {
 }
 
 // GetBlocks mocked method
-func (m *BlockchainerMock) GetBlocks(p0 uint64, p1 uint64) []coin.SignedBlock {
+func (m *BlockchainerMock) GetBlocks(p0 uint64, p1 uint64) ([]coin.SignedBlock, error) {
 
 	ret := m.Called(p0, p1)
 
@@ -119,7 +119,16 @@ func (m *BlockchainerMock) GetBlocks(p0 uint64, p1 uint64) []coin.SignedBlock {
 		panic(fmt.Sprintf("unexpected type: %v", res))
 	}
 
-	return r0
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
 
 }
 
@@ -142,7 +151,7 @@ func (m *BlockchainerMock) GetGenesisBlock() *coin.SignedBlock {
 }
 
 // GetLastBlocks mocked method
-func (m *BlockchainerMock) GetLastBlocks(p0 uint64) []coin.SignedBlock {
+func (m *BlockchainerMock) GetLastBlocks(p0 uint64) ([]coin.SignedBlock, error) {
 
 	ret := m.Called(p0)
 
@@ -155,7 +164,16 @@ func (m *BlockchainerMock) GetLastBlocks(p0 uint64) []coin.SignedBlock {
 		panic(fmt.Sprintf("unexpected type: %v", res))
 	}
 
-	return r0
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
 
 }
 

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -190,8 +190,8 @@ type historyer interface {
 // Blockchainer is the interface that provides methods for accessing the blockchain data
 type Blockchainer interface {
 	GetGenesisBlock() *coin.SignedBlock
-	GetBlocks(start, end uint64) []coin.SignedBlock
-	GetLastBlocks(n uint64) []coin.SignedBlock
+	GetBlocks(start, end uint64) ([]coin.SignedBlock, error)
+	GetLastBlocks(n uint64) ([]coin.SignedBlock, error)
 	GetBlockByHash(hash cipher.SHA256) (*coin.SignedBlock, error)
 	GetBlockBySeq(seq uint64) (*coin.SignedBlock, error)
 	Unspent() blockdb.UnspentPool
@@ -568,10 +568,8 @@ func (vs *Visor) GetBlock(seq uint64) (*coin.SignedBlock, error) {
 	return vs.Blockchain.GetBlockBySeq(seq)
 }
 
-// GetBlocks returns multiple blocks between start and end (not including end). Returns
-// empty slice if unable to fulfill request, it does not return nil.
-// move to blockdb
-func (vs *Visor) GetBlocks(start, end uint64) []coin.SignedBlock {
+// GetBlocks returns multiple blocks between start and end (not including end).
+func (vs *Visor) GetBlocks(start, end uint64) ([]coin.SignedBlock, error) {
 	return vs.Blockchain.GetBlocks(start, end)
 }
 
@@ -1017,7 +1015,7 @@ func (vs *Visor) GetBlockBySeq(seq uint64) (*coin.SignedBlock, error) {
 }
 
 // GetLastBlocks returns last N blocks
-func (vs *Visor) GetLastBlocks(num uint64) []coin.SignedBlock {
+func (vs *Visor) GetLastBlocks(num uint64) ([]coin.SignedBlock, error) {
 	return vs.Blockchain.GetLastBlocks(num)
 }
 


### PR DESCRIPTION
Changes:
- Return the error from Blockchain.GetBlocks and Blockchain.GetLastBlocks instead of returning empty array
- Return nil instead of empty array

Does this change need to mentioned in CHANGELOG.md?
No