### PR TITLE
[daemon] fixes #1388 - Add PeerHeight field in RPC Connection struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add CLI `showSeed` command
 - Add `password` argument to the CLI commands of `addPrivateKey`, `createRawTransaction`, `generateAddresses`, `generateWallet`, `send`
 - Support for decoding map values in cipher binary encoder
+- Expose known block height of peer in brand new `height` field added in responses of `/network/connections` API endpoints
 
 
 ### Fixed


### PR DESCRIPTION
Visor is used to put together a table to lookup blockchain height by peer address.
This is done once per request

Fixes #1388

Changes:
- Add `PeerHeight` field in `./src/daemon/rpc.go:Connection` struct
- Compute (peer) address to block height lookup table
- Build aforementioned index once, per API request

Does this change need to mentioned in CHANGELOG.md?
yes