### PR TITLE
Remove CSP tag

### DIFF
--- a/src/gui/static/src/index.html
+++ b/src/gui/static/src/index.html
@@ -6,7 +6,6 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <meta http-equiv="Content-Security-Policy" content="script-src 'self'">
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
This is a temporary solution to this problem https://github.com/skycoin/skycoin/issues/1426#issuecomment-387392305

Changes
- remove CSP meta tag because `ng serve` uses `eval()`