### PR TITLE
Fix wrong output uxid in readable genesis transaction

### DIFF
--- a/src/api/cli/integration/test-fixtures/genesis-transaction-cli.golden
+++ b/src/api/cli/integration/test-fixtures/genesis-transaction-cli.golden
@@ -18,7 +18,7 @@
 			"inputs": [],
 			"outputs": [
 				{
-					"uxid": "54c5dd9aebbe4656eb1adc658fdd4ff63a073aae473cc99b20c0ef5f0a21f08e",
+					"uxid": "043836eb6f29aaeb8b9bfce847e07c159c72b25ae17d291f32125e7f1912e2a0",
 					"dst": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "100000000.000000",
 					"hours": 100000000000000

--- a/src/api/cli/integration/test-fixtures/genesis-transaction.golden
+++ b/src/api/cli/integration/test-fixtures/genesis-transaction.golden
@@ -18,7 +18,7 @@
 			"inputs": [],
 			"outputs": [
 				{
-					"uxid": "54c5dd9aebbe4656eb1adc658fdd4ff63a073aae473cc99b20c0ef5f0a21f08e",
+					"uxid": "043836eb6f29aaeb8b9bfce847e07c159c72b25ae17d291f32125e7f1912e2a0",
 					"dst": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "100000000.000000",
 					"hours": 100000000000000

--- a/src/gui/integration/test-fixtures/empty-addrs.golden
+++ b/src/gui/integration/test-fixtures/empty-addrs.golden
@@ -18,7 +18,7 @@
 			"inputs": [],
 			"outputs": [
 				{
-					"uxid": "54c5dd9aebbe4656eb1adc658fdd4ff63a073aae473cc99b20c0ef5f0a21f08e",
+					"uxid": "043836eb6f29aaeb8b9bfce847e07c159c72b25ae17d291f32125e7f1912e2a0",
 					"dst": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "100000000.000000",
 					"hours": 100000000000000

--- a/src/gui/integration/test-fixtures/genesis-transaction.golden
+++ b/src/gui/integration/test-fixtures/genesis-transaction.golden
@@ -8,7 +8,7 @@
 	"inputs": [],
 	"outputs": [
 		{
-			"uxid": "54c5dd9aebbe4656eb1adc658fdd4ff63a073aae473cc99b20c0ef5f0a21f08e",
+			"uxid": "043836eb6f29aaeb8b9bfce847e07c159c72b25ae17d291f32125e7f1912e2a0",
 			"dst": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 			"coins": "100000000.000000",
 			"hours": 100000000000000


### PR DESCRIPTION
Fixes #1469 

Changes:
- Fix wrong output uxid in genesis transaction

Does this change need to mentioned in CHANGELOG.md?
No.