### PR TITLE
Individual addresses balance in /wallet/balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - JSON 2.0 RPC interface (used by the CLI tool) is now served on the same host interface as the REST API, port `6420`. The additional listener has been removed.
 - CLI's `RPC_ADDR` environment variable must now start with a scheme e.g. `http://127.0.0.1:6420`, previously it did not use a scheme.
 - API response will be gzip compressed if client sends request with 'Accept-Encoding' contains 'gzip' in the header.
+- `/wallet/balance/` and `/balance/` now return an address balance list as well.
 
 ### Removed
 

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -179,12 +179,34 @@ Result:
 ```json
 {
     "confirmed": {
-        "coins": 70000000,
-        "hours": 28052
+        "coins": 21000000,
+        "hours": 142744
     },
     "predicted": {
-        "coins": 9000000,
-        "hours": 8385
+        "coins": 21000000,
+        "hours": 142744
+    },
+    "addresses": {
+        "7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD": {
+            "confirmed": {
+                "coins": 9000000,
+                "hours": 88075
+            },
+            "predicted": {
+                "coins": 9000000,
+                "hours": 88075
+            }
+        },
+        "nu7eSpT6hr5P21uzw7bnbxm83B6ywSjHdq": {
+            "confirmed": {
+                "coins": 12000000,
+                "hours": 54669
+            },
+            "predicted": {
+                "coins": 12000000,
+                "hours": 54669
+            }
+        }
     }
 }
 ```
@@ -541,7 +563,7 @@ Args:
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/wallet/balance?id=2017_05_09_d554.wlt
+curl http://127.0.0.1:6420/wallet/balance?id=2018_03_07_3088.wlt
 ```
 
 Result:
@@ -549,12 +571,64 @@ Result:
 ```json
 {
     "confirmed": {
-        "coins": 0,
-        "hours": 0
+        "coins": 210400000,
+        "hours": 1873147
     },
     "predicted": {
-        "coins": 0,
-        "hours": 0
+        "coins": 210400000,
+        "hours": 1873147
+    },
+    "addresses": {
+        "AXrFisGovRhRHipsbGahs4u2hXX7pDRT5p": {
+            "confirmed": {
+                "coins": 1250000,
+                "hours": 941185
+            },
+            "predicted": {
+                "coins": 1250000,
+                "hours": 941185
+            }
+        },
+        "AtNorKBpCgkSRL7zES7aAQyNjqjqPp2QJU": {
+            "confirmed": {
+                "coins": 1150000,
+                "hours": 61534
+            },
+            "predicted": {
+                "coins": 1150000,
+                "hours": 61534
+            }
+        },
+        "VUv9ehMZWmDvwWV36BQ3eL1ujb4MQ5TGyK": {
+            "confirmed": {
+                "coins": 208000000,
+                "hours": 870428
+            },
+            "predicted": {
+                "coins": 208000000,
+                "hours": 870428
+            }
+        },
+        "j4mbF1fTe8jgXbrRARZSBjDpD1hMGSe1E4": {
+            "confirmed": {
+                "coins": 0,
+                "hours": 0
+            },
+            "predicted": {
+                "coins": 0,
+                "hours": 0
+            }
+        },
+        "uyqBPcRCWucHXs18e9VZyNEeuNsD5tFDhy": {
+            "confirmed": {
+                "coins": 0,
+                "hours": 0
+            },
+            "predicted": {
+                "coins": 0,
+                "hours": 0
+            }
+        }
     }
 }
 ```

--- a/src/api/client.go
+++ b/src/api/client.go
@@ -457,12 +457,12 @@ func (c *Client) NewWalletAddress(id string, n int, password string) ([]string, 
 }
 
 // WalletBalance makes a request to /wallet/balance
-func (c *Client) WalletBalance(id string) (*wallet.BalancePair, error) {
+func (c *Client) WalletBalance(id string) (*BalanceResponse, error) {
 	v := url.Values{}
 	v.Add("id", id)
 	endpoint := "/wallet/balance?" + v.Encode()
 
-	var b wallet.BalancePair
+	var b BalanceResponse
 	if err := c.Get(endpoint, &b); err != nil {
 		return nil, err
 	}

--- a/src/api/gateway.go
+++ b/src/api/gateway.go
@@ -16,7 +16,7 @@ import (
 type Gatewayer interface {
 	Spend(wltID string, password []byte, coins uint64, dest cipher.Address) (*coin.Transaction, error)
 	CreateTransaction(w wallet.CreateTransactionParams) (*coin.Transaction, []wallet.UxBalance, error)
-	GetWalletBalance(wltID string) (wallet.BalancePair, error)
+	GetWalletBalance(wltID string) (wallet.BalancePair, wallet.AddressBalance, error)
 	GetWallet(wltID string) (*wallet.Wallet, error)
 	GetWallets() (wallet.Wallets, error)
 	UpdateWalletLabel(wltID, label string) error

--- a/src/api/gatewayer_mock_test.go
+++ b/src/api/gatewayer_mock_test.go
@@ -730,7 +730,7 @@ func (m *GatewayerMock) GetWallet(p0 string) (*wallet.Wallet, error) {
 }
 
 // GetWalletBalance mocked method
-func (m *GatewayerMock) GetWalletBalance(p0 string) (wallet.BalancePair, error) {
+func (m *GatewayerMock) GetWalletBalance(p0 string) (wallet.BalancePair, wallet.AddressBalance, error) {
 
 	ret := m.Called(p0)
 
@@ -743,16 +743,25 @@ func (m *GatewayerMock) GetWalletBalance(p0 string) (wallet.BalancePair, error) 
 		panic(fmt.Sprintf("unexpected type: %v", res))
 	}
 
-	var r1 error
+	var r1 wallet.AddressBalance
 	switch res := ret.Get(1).(type) {
 	case nil:
-	case error:
+	case wallet.AddressBalance:
 		r1 = res
 	default:
 		panic(fmt.Sprintf("unexpected type: %v", res))
 	}
 
-	return r0, r1
+	var r2 error
+	switch res := ret.Get(2).(type) {
+	case nil:
+	case error:
+		r2 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1, r2
 
 }
 

--- a/src/api/integration/integration_test.go
+++ b/src/api/integration/integration_test.go
@@ -2873,6 +2873,7 @@ func TestLiveWalletBalance(t *testing.T) {
 	bp, err := c.WalletBalance(walletName)
 	require.NoError(t, err)
 	require.NotNil(t, bp)
+	require.NotNil(t, bp.Addresses)
 }
 
 func TestWalletUpdate(t *testing.T) {

--- a/src/api/integration/integration_test.go
+++ b/src/api/integration/integration_test.go
@@ -2704,7 +2704,7 @@ func TestCreateWallet(t *testing.T) {
 
 	c := api.NewClient(nodeAddress())
 
-	w, seed, clean := createWallet(t, c, false, "")
+	w, seed, clean := createWallet(t, c, false, "", "")
 	defer clean()
 	require.False(t, w.Meta.Encrypted)
 
@@ -2728,7 +2728,7 @@ func TestCreateWallet(t *testing.T) {
 	}
 
 	// Creates wallet with encryption
-	encW, _, encWClean := createWallet(t, c, true, "pwd")
+	encW, _, encWClean := createWallet(t, c, true, "pwd", "")
 	defer encWClean()
 	require.True(t, encW.Meta.Encrypted)
 
@@ -2754,7 +2754,7 @@ func TestGetWallet(t *testing.T) {
 	c := api.NewClient(nodeAddress())
 
 	// Create a wallet
-	w, _, clean := createWallet(t, c, false, "")
+	w, _, clean := createWallet(t, c, false, "", "")
 	defer clean()
 
 	// Confirms the wallet can be acquired
@@ -2773,7 +2773,7 @@ func TestGetWallets(t *testing.T) {
 	// Creates 2 new wallets
 	var ws []api.WalletResponse
 	for i := 0; i < 2; i++ {
-		w, _, clean := createWallet(t, c, false, "")
+		w, _, clean := createWallet(t, c, false, "", "")
 		defer clean()
 		// cleaners = append(cleaners, clean)
 		ws = append(ws, *w)
@@ -2819,7 +2819,7 @@ func TestWalletNewAddress(t *testing.T) {
 				password = "pwd"
 			}
 
-			w, seed, clean := createWallet(t, c, encrypt, password)
+			w, seed, clean := createWallet(t, c, encrypt, password, "")
 			defer clean()
 
 			addrs, err := c.NewWalletAddress(w.Meta.Filename, i, password)
@@ -2850,13 +2850,13 @@ func TestStableWalletBalance(t *testing.T) {
 	}
 
 	c := api.NewClient(nodeAddress())
-	w, _, clean := createWallet(t, c, false, "")
+	w, _, clean := createWallet(t, c, false, "", "casino away claim road artist where blossom warrior demise royal still palm")
 	defer clean()
 
 	bp, err := c.WalletBalance(w.Meta.Filename)
 	require.NoError(t, err)
 
-	var expect wallet.BalancePair
+	var expect api.BalanceResponse
 	loadGoldenFile(t, "wallet-balance.golden", TestData{bp, &expect})
 	require.Equal(t, expect, *bp)
 }
@@ -2881,7 +2881,7 @@ func TestWalletUpdate(t *testing.T) {
 	}
 
 	c := api.NewClient(nodeAddress())
-	w, _, clean := createWallet(t, c, false, "")
+	w, _, clean := createWallet(t, c, false, "", "")
 	defer clean()
 
 	err := c.UpdateWallet(w.Meta.Filename, "new wallet")
@@ -2899,7 +2899,7 @@ func TestStableWalletTransactions(t *testing.T) {
 	}
 
 	c := api.NewClient(nodeAddress())
-	w, _, clean := createWallet(t, c, false, "")
+	w, _, clean := createWallet(t, c, false, "", "")
 	defer clean()
 
 	txns, err := c.WalletTransactions(w.Meta.Filename)
@@ -2954,7 +2954,7 @@ func TestEncryptWallet(t *testing.T) {
 	c := api.NewClient(nodeAddress())
 
 	// Create a unencrypted wallet
-	w, _, clean := createWallet(t, c, false, "")
+	w, _, clean := createWallet(t, c, false, "", "")
 	defer clean()
 
 	// Encrypts the wallet
@@ -2990,7 +2990,7 @@ func TestDecryptWallet(t *testing.T) {
 	}
 
 	c := api.NewClient(nodeAddress())
-	w, seed, clean := createWallet(t, c, true, "pwd")
+	w, seed, clean := createWallet(t, c, true, "pwd", "")
 	defer clean()
 
 	// Decrypt wallet with different password, must fail
@@ -3037,7 +3037,7 @@ func TestGetWalletSeedDisabledAPI(t *testing.T) {
 	c := api.NewClient(nodeAddress())
 
 	// Create an encrypted wallet
-	w, _, clean := createWallet(t, c, true, "pwd")
+	w, _, clean := createWallet(t, c, true, "pwd", "")
 	defer clean()
 
 	_, err := c.GetWalletSeed(w.Meta.Filename, "pwd")
@@ -3052,7 +3052,7 @@ func TestGetWalletSeedEnabledAPI(t *testing.T) {
 	c := api.NewClient(nodeAddress())
 
 	// Create an encrypted wallet
-	w, seed, clean := createWallet(t, c, true, "pwd")
+	w, seed, clean := createWallet(t, c, true, "pwd", "")
 	defer clean()
 
 	require.NotEmpty(t, seed)
@@ -3076,7 +3076,7 @@ func TestGetWalletSeedEnabledAPI(t *testing.T) {
 	assertResponseError(t, err, http.StatusBadRequest, "400 Bad Request - missing password\n")
 
 	// Create unencrypted wallet to check against
-	nw, _, nclean := createWallet(t, c, false, "")
+	nw, _, nclean := createWallet(t, c, false, "", "")
 	defer nclean()
 	_, err = c.GetWalletSeed(nw.Meta.Filename, "pwd")
 	assertResponseError(t, err, http.StatusBadRequest, "400 Bad Request - wallet is not encrypted\n")
@@ -3216,8 +3216,10 @@ func checkWalletEntriesAndLastSeed(t *testing.T, w *wallet.Wallet) {
 
 // createWallet creates a wallet with rand seed.
 // Returns the generated wallet, seed and clean up function.
-func createWallet(t *testing.T, c *api.Client, encrypt bool, password string) (*api.WalletResponse, string, func()) {
-	seed := hex.EncodeToString(cipher.RandByte(32))
+func createWallet(t *testing.T, c *api.Client, encrypt bool, password string, seed string) (*api.WalletResponse, string, func()) {
+	if seed == "" {
+		seed = hex.EncodeToString(cipher.RandByte(32))
+	}
 	// Use the first 6 letter of the seed as label.
 	var w *api.WalletResponse
 	var err error

--- a/src/api/integration/testdata/wallet-balance.golden
+++ b/src/api/integration/testdata/wallet-balance.golden
@@ -6,5 +6,17 @@
 	"predicted": {
 		"coins": 0,
 		"hours": 0
+	},
+	"addresses": {
+		"27nAhbBjHLcvD3UdbrH1YouKWYwmG94K9cw": {
+			"confirmed": {
+				"coins": 0,
+				"hours": 0
+			},
+			"predicted": {
+				"coins": 0,
+				"hours": 0
+			}
+		}
 	}
 }

--- a/src/api/wallet.go
+++ b/src/api/wallet.go
@@ -180,6 +180,12 @@ func getBalanceHandler(gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 
+		// create map of address to balance
+		addressBalances := make(wallet.AddressBalance, len(addrs))
+		for idx, addr := range addrs {
+			addressBalances[addr.String()] = bals[idx]
+		}
+
 		var balance wallet.BalancePair
 		for _, bal := range bals {
 			var err error
@@ -196,7 +202,10 @@ func getBalanceHandler(gateway Gatewayer) http.HandlerFunc {
 			}
 		}
 
-		wh.SendJSONOr500(logger, w, balance)
+		wh.SendJSONOr500(logger, w, BalanceResponse{
+			BalancePair: balance,
+			Addresses:   addressBalances,
+		})
 	}
 }
 

--- a/src/api/wallet.go
+++ b/src/api/wallet.go
@@ -56,6 +56,11 @@ type WalletResponse struct {
 	Entries []WalletEntry `json:"entries"`
 }
 
+type BalanceResponse struct {
+	wallet.BalancePair
+	Addresses wallet.AddressBalance `json:"addresses"`
+}
+
 // NewWalletResponse creates WalletResponse struct from *wallet.Wallet
 func NewWalletResponse(w *wallet.Wallet) (*WalletResponse, error) {
 	var wr WalletResponse
@@ -113,7 +118,7 @@ func walletBalanceHandler(gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 
-		b, err := gateway.GetWalletBalance(wltID)
+		walletBalance, addressBalances, err := gateway.GetWalletBalance(wltID)
 		if err != nil {
 			logger.Errorf("Get wallet balance failed: %v", err)
 			switch err {
@@ -129,7 +134,10 @@ func walletBalanceHandler(gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 
-		wh.SendJSONOr500(logger, w, b)
+		wh.SendJSONOr500(logger, w, BalanceResponse{
+			BalancePair: walletBalance,
+			Addresses:   addressBalances,
+		})
 	}
 }
 
@@ -289,7 +297,7 @@ func walletSpendHandler(gateway Gatewayer) http.HandlerFunc {
 		}
 
 		// Get the new wallet balance
-		b, err := gateway.GetWalletBalance(wltID)
+		walletBalance, _, err := gateway.GetWalletBalance(wltID)
 		if err != nil {
 			err = fmt.Errorf("Get wallet balance failed: %v", err)
 			logger.Error(err)
@@ -297,7 +305,7 @@ func walletSpendHandler(gateway Gatewayer) http.HandlerFunc {
 			wh.SendJSONOr500(logger, w, ret)
 			return
 		}
-		ret.Balance = &b
+		ret.Balance = &walletBalance
 
 		wh.SendJSONOr500(logger, w, ret)
 	}

--- a/src/api/wallet.go
+++ b/src/api/wallet.go
@@ -56,6 +56,7 @@ type WalletResponse struct {
 	Entries []WalletEntry `json:"entries"`
 }
 
+// BalanceResponse address balance summary struct
 type BalanceResponse struct {
 	wallet.BalancePair
 	Addresses wallet.AddressBalance `json:"addresses"`

--- a/src/api/wallet_test.go
+++ b/src/api/wallet_test.go
@@ -45,7 +45,7 @@ func TestWalletSpendHandler(t *testing.T) {
 		password                      string
 		gatewaySpendResult            *coin.Transaction
 		gatewaySpendErr               error
-		gatewayGetWalletBalanceResult wallet.BalancePair
+		gatewayGetWalletBalanceResult BalanceResponse
 		gatewayBalanceErr             error
 		spendResult                   *SpendResult
 		csrfDisabled                  bool
@@ -408,7 +408,8 @@ func TestWalletSpendHandler(t *testing.T) {
 			gateway := &GatewayerMock{}
 			addr, _ := cipher.DecodeBase58Address(tc.dst)
 			gateway.On("Spend", tc.walletID, []byte(tc.password), tc.coins, addr).Return(tc.gatewaySpendResult, tc.gatewaySpendErr)
-			gateway.On("GetWalletBalance", tc.walletID).Return(tc.gatewayGetWalletBalanceResult, tc.gatewayBalanceErr)
+			gateway.On("GetWalletBalance", tc.walletID).Return(tc.gatewayGetWalletBalanceResult.BalancePair,
+				tc.gatewayGetWalletBalanceResult.Addresses, tc.gatewayBalanceErr)
 
 			endpoint := "/wallet/spend"
 
@@ -603,7 +604,7 @@ func TestWalletBalanceHandler(t *testing.T) {
 		status                        int
 		err                           string
 		walletID                      string
-		gatewayGetWalletBalanceResult wallet.BalancePair
+		gatewayGetWalletBalanceResult BalanceResponse
 		gatewayBalanceErr             error
 		result                        *wallet.BalancePair
 	}{
@@ -630,10 +631,7 @@ func TestWalletBalanceHandler(t *testing.T) {
 			status:   http.StatusNotFound,
 			err:      "404 Not Found",
 			walletID: "notFoundId",
-			gatewayGetWalletBalanceResult: wallet.BalancePair{
-				Confirmed: wallet.Balance{Coins: 0, Hours: 0},
-				Predicted: wallet.Balance{Coins: 0, Hours: 0},
-			},
+			gatewayGetWalletBalanceResult: BalanceResponse{},
 			gatewayBalanceErr: wallet.ErrWalletNotExist,
 			result: &wallet.BalancePair{
 				Confirmed: wallet.Balance{Coins: 0, Hours: 0},
@@ -649,10 +647,7 @@ func TestWalletBalanceHandler(t *testing.T) {
 			status:   http.StatusInternalServerError,
 			err:      "500 Internal Server Error - gatewayBalanceError",
 			walletID: "someId",
-			gatewayGetWalletBalanceResult: wallet.BalancePair{
-				Confirmed: wallet.Balance{Coins: 0, Hours: 0},
-				Predicted: wallet.Balance{Coins: 0, Hours: 0},
-			},
+			gatewayGetWalletBalanceResult: BalanceResponse{},
 			gatewayBalanceErr: errors.New("gatewayBalanceError"),
 			result: &wallet.BalancePair{
 				Confirmed: wallet.Balance{Coins: 0, Hours: 0},
@@ -668,7 +663,7 @@ func TestWalletBalanceHandler(t *testing.T) {
 			status:                        http.StatusForbidden,
 			err:                           "403 Forbidden",
 			walletID:                      "foo",
-			gatewayGetWalletBalanceResult: wallet.BalancePair{},
+			gatewayGetWalletBalanceResult: BalanceResponse{},
 			gatewayBalanceErr:             wallet.ErrWalletAPIDisabled,
 		},
 		{
@@ -687,7 +682,8 @@ func TestWalletBalanceHandler(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &GatewayerMock{}
-			gateway.On("GetWalletBalance", tc.walletID).Return(tc.gatewayGetWalletBalanceResult, tc.gatewayBalanceErr)
+			gateway.On("GetWalletBalance", tc.walletID).Return(tc.gatewayGetWalletBalanceResult.BalancePair,
+			tc.gatewayGetWalletBalanceResult.Addresses, tc.gatewayBalanceErr)
 
 			endpoint := "/wallet/balance"
 

--- a/src/api/wallet_test.go
+++ b/src/api/wallet_test.go
@@ -628,11 +628,11 @@ func TestWalletBalanceHandler(t *testing.T) {
 			body: &httpBody{
 				WalletID: "notFoundId",
 			},
-			status:   http.StatusNotFound,
-			err:      "404 Not Found",
-			walletID: "notFoundId",
+			status:                        http.StatusNotFound,
+			err:                           "404 Not Found",
+			walletID:                      "notFoundId",
 			gatewayGetWalletBalanceResult: BalanceResponse{},
-			gatewayBalanceErr: wallet.ErrWalletNotExist,
+			gatewayBalanceErr:             wallet.ErrWalletNotExist,
 			result: &wallet.BalancePair{
 				Confirmed: wallet.Balance{Coins: 0, Hours: 0},
 				Predicted: wallet.Balance{Coins: 0, Hours: 0},
@@ -644,11 +644,11 @@ func TestWalletBalanceHandler(t *testing.T) {
 			body: &httpBody{
 				WalletID: "someId",
 			},
-			status:   http.StatusInternalServerError,
-			err:      "500 Internal Server Error - gatewayBalanceError",
-			walletID: "someId",
+			status:                        http.StatusInternalServerError,
+			err:                           "500 Internal Server Error - gatewayBalanceError",
+			walletID:                      "someId",
 			gatewayGetWalletBalanceResult: BalanceResponse{},
-			gatewayBalanceErr: errors.New("gatewayBalanceError"),
+			gatewayBalanceErr:             errors.New("gatewayBalanceError"),
 			result: &wallet.BalancePair{
 				Confirmed: wallet.Balance{Coins: 0, Hours: 0},
 				Predicted: wallet.Balance{Coins: 0, Hours: 0},
@@ -683,7 +683,7 @@ func TestWalletBalanceHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("GetWalletBalance", tc.walletID).Return(tc.gatewayGetWalletBalanceResult.BalancePair,
-			tc.gatewayGetWalletBalanceResult.Addresses, tc.gatewayBalanceErr)
+				tc.gatewayGetWalletBalanceResult.Addresses, tc.gatewayBalanceErr)
 
 			endpoint := "/wallet/balance"
 

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -699,7 +699,6 @@ func (gw *Gateway) DecryptWallet(wltID string, password []byte) (*wallet.Wallet,
 	return w, err
 }
 
-
 // GetWalletBalance returns balance pairs of specific wallet
 func (gw *Gateway) GetWalletBalance(wltID string) (wallet.BalancePair, wallet.AddressBalance, error) {
 	var addressBalances wallet.AddressBalance

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -699,13 +699,15 @@ func (gw *Gateway) DecryptWallet(wltID string, password []byte) (*wallet.Wallet,
 	return w, err
 }
 
-// GetWalletBalance returns balance pair of specific wallet
-func (gw *Gateway) GetWalletBalance(wltID string) (wallet.BalancePair, error) {
+
+// GetWalletBalance returns balance pairs of specific wallet
+func (gw *Gateway) GetWalletBalance(wltID string) (wallet.BalancePair, wallet.AddressBalance, error) {
+	var addressBalances wallet.AddressBalance
+	var walletBalance wallet.BalancePair
 	if !gw.Config.EnableWalletAPI {
-		return wallet.BalancePair{}, wallet.ErrWalletAPIDisabled
+		return walletBalance, addressBalances, wallet.ErrWalletAPIDisabled
 	}
 
-	var balances []wallet.BalancePair
 	var err error
 	gw.strand("GetWalletBalance", func() {
 		var addrs []cipher.Address
@@ -714,26 +716,43 @@ func (gw *Gateway) GetWalletBalance(wltID string) (wallet.BalancePair, error) {
 			return
 		}
 
-		balances, err = gw.v.GetBalanceOfAddrs(addrs)
+		// get list of address balances
+		addrsBalanceList, err := gw.v.GetBalanceOfAddrs(addrs)
+		if err != nil {
+			return
+		}
+
+		// create map of address to balance
+		addressBalances = make(wallet.AddressBalance, len(addrs))
+		for idx, addr := range addrs {
+			addressBalances[addr.String()] = addrsBalanceList[idx]
+		}
+
+		// compute the sum of all addresses
+		for _, addrBalance := range addressBalances {
+			// compute confirmed balance
+			walletBalance.Confirmed.Coins, err = coin.AddUint64(walletBalance.Confirmed.Coins, addrBalance.Confirmed.Coins)
+			if err != nil {
+				return
+			}
+			walletBalance.Confirmed.Hours, err = coin.AddUint64(walletBalance.Confirmed.Hours, addrBalance.Confirmed.Hours)
+			if err != nil {
+				return
+			}
+
+			// compute predicted balance
+			walletBalance.Predicted.Coins, err = coin.AddUint64(walletBalance.Predicted.Coins, addrBalance.Predicted.Coins)
+			if err != nil {
+				return
+			}
+			walletBalance.Predicted.Hours, err = coin.AddUint64(walletBalance.Predicted.Hours, addrBalance.Predicted.Hours)
+			if err != nil {
+				return
+			}
+		}
 	})
 
-	if err != nil {
-		return wallet.BalancePair{}, err
-	}
-
-	var balance wallet.BalancePair
-	for _, bp := range balances {
-		balance.Confirmed, err = balance.Confirmed.Add(bp.Confirmed)
-		if err != nil {
-			return wallet.BalancePair{}, err
-		}
-		balance.Predicted, err = balance.Predicted.Add(bp.Predicted)
-		if err != nil {
-			return wallet.BalancePair{}, err
-		}
-	}
-
-	return balance, nil
+	return walletBalance, addressBalances, err
 }
 
 // GetBalanceOfAddrs gets balance of given addresses

--- a/src/daemon/gateway_test.go
+++ b/src/daemon/gateway_test.go
@@ -404,7 +404,7 @@ func TestGateway_GetWalletBalance(t *testing.T) {
 					EnableWalletAPI: tc.enableWalletAPI,
 				},
 			}
-			res, err := gw.GetWalletBalance(tc.walletID)
+			res, _, err := gw.GetWalletBalance(tc.walletID)
 			if tc.err != nil {
 				require.Equal(t, tc.err, err)
 				return

--- a/src/wallet/balance.go
+++ b/src/wallet/balance.go
@@ -15,6 +15,9 @@ type BalancePair struct {
 	Predicted Balance `json:"predicted"` //do "pending"
 }
 
+//  AddressBalance represents a map of address balances
+type AddressBalance map[string]BalancePair
+
 // Balance is consisted of Coins and Hours
 type Balance struct {
 	Coins uint64 `json:"coins"`

--- a/src/wallet/balance.go
+++ b/src/wallet/balance.go
@@ -15,7 +15,7 @@ type BalancePair struct {
 	Predicted Balance `json:"predicted"` //do "pending"
 }
 
-//  AddressBalance represents a map of address balances
+// AddressBalance represents a map of address balances
 type AddressBalance map[string]BalancePair
 
 // Balance is consisted of Coins and Hours


### PR DESCRIPTION
Fixes #1462 

Changes:
- `/wallet/balance/` and `/balance` now return individual address balances under `addresses` field.
- updated tests

Does this change need to mentioned in CHANGELOG.md?
Yes