### PR TITLE
Fix e2e test on OSX travis slave

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,7 @@ install:
 
 before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$TRAVIS_PULL_REQUEST" == false ]]; then ./ci-scripts/add-key.sh && npm install -g yarn ;fi
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+  - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then export DISPLAY=:99.0 && sh -e /etc/init.d/xvfb start; fi
 
 script:
   - make lint


### PR DESCRIPTION
Fixes #1476 

Changes:
- Skip xvfb installing on OSX travis slaves, the e2e test can run on OSX travis slave properly.

Does this change need to mentioned in CHANGELOG.md?
No.