### PR TITLE
Add unparam linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,14 +110,14 @@ test-libc: build-libc ## Run tests for libskycoin C client library
 
 lint: ## Run linters. Use make install-linters first.
 	vendorcheck ./...
-	gometalinter --deadline=3m --concurrency=2 --disable-all --tests --vendor --skip=lib/cgo \
+	gometalinter --deadline=3m --concurrency=2 --disable-all --tests --vendor --skip=lib/cgo --warn-unmatched-nolint \
 		-E goimports \
 		-E golint \
 		-E varcheck \
 		-E unparam \
 		./...
 	# lib cgo can't use golint because it needs export directives in function docstrings that do not obey golint rules
-	gometalinter --deadline=3m --concurrency=2 --disable-all --tests --vendor \
+	gometalinter --deadline=3m --concurrency=2 --disable-all --tests --vendor --warn-unmatched-nolint \
 		-E goimports \
 		-E varcheck \
 		-E unparam \

--- a/Makefile
+++ b/Makefile
@@ -92,15 +92,15 @@ $(BUILDLIB_DIR)/libskycoin.so $(BUILDLIB_DIR)/libskycoin.a: $(LIB_FILES) $(SRC_F
 	rm -Rf $(BUILDLIB_DIR)/*
 	go build -buildmode=c-shared  -o $(BUILDLIB_DIR)/libskycoin.so $(LIB_FILES)
 	go build -buildmode=c-archive -o $(BUILDLIB_DIR)/libskycoin.a  $(LIB_FILES)
-	mv $(BUILDLIB_DIR)/libskycoin.h $(INCLUDE_DIR)/	
-	
+	mv $(BUILDLIB_DIR)/libskycoin.h $(INCLUDE_DIR)/
+
 ## Build libskycoin C client library and executable C test suites
 ## with debug symbols. Use this target to debug the source code
 ## with the help of an IDE
 build-libc-dbg: configure-build $(BUILDLIB_DIR)/libskycoin.so $(BUILDLIB_DIR)/libskycoin.a
 	$(CC) -g -o $(BIN_DIR)/test_libskycoin_shared $(LIB_DIR)/cgo/tests/*.c -lskycoin                    $(LDLIBS) $(LDFLAGS)
 	$(CC) -g -o $(BIN_DIR)/test_libskycoin_static $(LIB_DIR)/cgo/tests/*.c $(BUILDLIB_DIR)/libskycoin.a $(LDLIBS) $(LDFLAGS)
-	
+
 test-libc: build-libc ## Run tests for libskycoin C client library
 	cp $(LIB_DIR)/cgo/tests/*.c $(BUILDLIB_DIR)/
 	$(CC) -o $(BIN_DIR)/test_libskycoin_shared $(BUILDLIB_DIR)/*.c -lskycoin                    $(LDLIBS) $(LDFLAGS)
@@ -114,11 +114,13 @@ lint: ## Run linters. Use make install-linters first.
 		-E goimports \
 		-E golint \
 		-E varcheck \
+		-E unparam \
 		./...
 	# lib cgo can't use golint because it needs export directives in function docstrings that do not obey golint rules
 	gometalinter --deadline=3m --concurrency=2 --disable-all --tests --vendor \
 		-E goimports \
 		-E varcheck \
+		-E unparam \
 		./lib/cgo/...
 
 check: lint test integration-test-stable integration-test-stable-disable-csrf integration-test-disable-wallet-api integration-test-disable-seed-api ## Run tests and linters

--- a/src/api/cli/integration/integration_test.go
+++ b/src/api/cli/integration/integration_test.go
@@ -95,11 +95,11 @@ func TestMain(m *testing.M) {
 	os.Exit(ret)
 }
 
-func createUnEncryptedWallet(t *testing.T) (string, func()) {
+func createUnencryptedWallet(t *testing.T) (string, func()) {
 	return createTempWallet(t, false)
 }
 
-func createEncryptedWallet(t *testing.T) (string, func()) {
+func createEncryptedWallet(t *testing.T) (string, func()) { // nolint: unparam
 	return createTempWallet(t, true)
 }
 
@@ -765,7 +765,7 @@ func TestStableListWallets(t *testing.T) {
 		return
 	}
 
-	_, clean := createUnEncryptedWallet(t)
+	_, clean := createUnencryptedWallet(t)
 	defer clean()
 
 	output, err := exec.Command(binaryPath, "listWallets").CombinedOutput()
@@ -807,7 +807,7 @@ func TestStableListAddress(t *testing.T) {
 		return
 	}
 
-	_, clean := createUnEncryptedWallet(t)
+	_, clean := createUnencryptedWallet(t)
 	defer clean()
 
 	output, err := exec.Command(binaryPath, "listAddresses").CombinedOutput()
@@ -881,7 +881,7 @@ func TestStableWalletBalance(t *testing.T) {
 		return
 	}
 
-	_, clean := createUnEncryptedWallet(t)
+	_, clean := createUnencryptedWallet(t)
 	defer clean()
 
 	output, err := exec.Command(binaryPath, "walletBalance").CombinedOutput()
@@ -919,7 +919,7 @@ func TestStableWalletOutputs(t *testing.T) {
 		return
 	}
 
-	_, clean := createUnEncryptedWallet(t)
+	_, clean := createUnencryptedWallet(t)
 	defer clean()
 
 	output, err := exec.Command(binaryPath, "walletOutputs").CombinedOutput()
@@ -1415,8 +1415,8 @@ func testKnownBlocks(t *testing.T) {
 	scanBlocks(t, "0", "180")
 }
 
-func scanBlocks(t *testing.T, s, e string) {
-	outputs, err := exec.Command(binaryPath, "blocks", s, e).CombinedOutput()
+func scanBlocks(t *testing.T, start, end string) { // nolint: unparam
+	outputs, err := exec.Command(binaryPath, "blocks", start, end).CombinedOutput()
 	require.NoError(t, err)
 
 	var blocks visor.ReadableBlocks
@@ -1522,7 +1522,7 @@ func TestStableWalletDir(t *testing.T) {
 		return
 	}
 
-	walletPath, clean := createUnEncryptedWallet(t)
+	walletPath, clean := createUnencryptedWallet(t)
 	defer clean()
 
 	dir := filepath.Dir(walletPath)
@@ -1885,7 +1885,7 @@ func isTxConfirmed(t *testing.T, txid string) bool {
 }
 
 // checkCoinhours checks if the address coinhours in transaction are correct
-func checkCoinsAndCoinhours(t *testing.T, tx *webrpc.TxnResult, addr string, coins, coinhours uint64) {
+func checkCoinsAndCoinhours(t *testing.T, tx *webrpc.TxnResult, addr string, coins, coinhours uint64) { // nolint: unparam
 	addrCoinhoursMap := make(map[string][]visor.ReadableTransactionOutput)
 	for _, o := range tx.Transaction.Transaction.Out {
 		addrCoinhoursMap[o.Address] = append(addrCoinhoursMap[o.Address], o)
@@ -1913,7 +1913,7 @@ func checkCoinsAndCoinhours(t *testing.T, tx *webrpc.TxnResult, addr string, coi
 // prepareAndCheckWallet prepares wallet for live testing.
 // Returns *wallet.Wallet, total coin, total hours.
 // Confirms that the wallet meets the minimal requirements of coins and coinhours.
-func prepareAndCheckWallet(t *testing.T, miniCoins, miniCoinHours uint64) (*wallet.Wallet, uint64, uint64) {
+func prepareAndCheckWallet(t *testing.T, miniCoins, miniCoinHours uint64) (*wallet.Wallet, uint64, uint64) { // nolint: unparam
 	walletDir, walletName := getWalletPathFromEnv(t)
 	walletPath := filepath.Join(walletDir, walletName)
 	// Checks if the wallet does exist
@@ -1999,7 +1999,7 @@ func TestStableWalletHistory(t *testing.T) {
 		return
 	}
 
-	_, clean := createUnEncryptedWallet(t)
+	_, clean := createUnencryptedWallet(t)
 	defer clean()
 
 	output, err := exec.Command(binaryPath, "walletHistory").CombinedOutput()
@@ -2203,7 +2203,7 @@ func TestStableGenerateWallet(t *testing.T) {
 			name: "generate wallet with duplicate wallet name",
 			args: []string{},
 			setup: func(t *testing.T) func() {
-				_, clean := createUnEncryptedWallet(t)
+				_, clean := createUnencryptedWallet(t)
 				return clean
 			},
 			errMsg: []byte("integration-test.wlt already exist\n"),
@@ -2422,7 +2422,7 @@ func TestEncryptWallet(t *testing.T) {
 			name: "wallet is not encrypted",
 			args: []string{"-p", "pwd"},
 			setup: func(t *testing.T) func() {
-				_, clean := createUnEncryptedWallet(t)
+				_, clean := createUnencryptedWallet(t)
 				return clean
 			},
 			checkWallet: func(t *testing.T, w *wallet.Wallet) {
@@ -2449,7 +2449,7 @@ func TestEncryptWallet(t *testing.T) {
 			name: "wallet doesn't exist",
 			args: []string{"-p", "pwd"},
 			setup: func(t *testing.T) func() {
-				_, clean := createUnEncryptedWallet(t)
+				_, clean := createUnencryptedWallet(t)
 				os.Setenv("WALLET_NAME", "not-exist.wlt")
 				return clean
 			},
@@ -2524,7 +2524,7 @@ func TestDecryptWallet(t *testing.T) {
 			name: "wallet is not encrypted",
 			args: []string{"-p", "pwd"},
 			setup: func(t *testing.T) func() {
-				_, clean := createUnEncryptedWallet(t)
+				_, clean := createUnencryptedWallet(t)
 				return clean
 			},
 			errMsg: []byte("wallet is not encrypted\n"),
@@ -2595,7 +2595,7 @@ func TestShowSeed(t *testing.T) {
 		{
 			name: "unencrypted wallet",
 			setup: func(t *testing.T) func() {
-				_, clean := createUnEncryptedWallet(t)
+				_, clean := createUnencryptedWallet(t)
 				return clean
 			},
 			expectOutput: []byte("exchange stage green marine palm tobacco decline shadow cereal chapter lamp copy\n"),
@@ -2604,7 +2604,7 @@ func TestShowSeed(t *testing.T) {
 			name: "unencrypted wallet with -j option",
 			args: []string{"-j"},
 			setup: func(t *testing.T) func() {
-				_, clean := createUnEncryptedWallet(t)
+				_, clean := createUnencryptedWallet(t)
 				return clean
 			},
 			expectOutput: []byte("{\n    \"seed\": \"exchange stage green marine palm tobacco decline shadow cereal chapter lamp copy\"\n}\n"),
@@ -2639,7 +2639,7 @@ func TestShowSeed(t *testing.T) {
 		{
 			name: "wallet doesn't exist",
 			setup: func(t *testing.T) func() {
-				_, clean := createUnEncryptedWallet(t)
+				_, clean := createUnencryptedWallet(t)
 				os.Setenv("WALLET_NAME", "not-exist.wlt")
 				return clean
 			},

--- a/src/api/webrpc/outputs_test.go
+++ b/src/api/webrpc/outputs_test.go
@@ -2,7 +2,6 @@ package webrpc
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 	"time"
 
@@ -13,52 +12,6 @@ import (
 	"github.com/skycoin/skycoin/src/testutil"
 	"github.com/skycoin/skycoin/src/visor"
 )
-
-const outputStr = `{
-       "outputs":
-			{
-				"head_outputs": [
-					{
-						"hash": "ca02361ef6d658cac5b5aadcb502b4b6046d1403e0f4b1f16b35c06a3f27e3df",
-						"src_tx": "e00196267e879c76215ccb93d046bd248e2bc5accad93d246ba43c71c42ff44a",
-						"address": "cBnu9sUvv12dovBmjQKTtfE4rbjMmf3fzW",
-						"coins": "4",
-						"hours": 0
-					},
-					{
-						"hash": "22f489be1a2f87ed826c183b516bd10f1703c6591643796f48630ba97db3b16c",
-						"src_tx": "fe50714012b29b3ffe5bc2f8e12a95af35004513d61e329e33b9b2a964ae2924",
-						"address": "cBnu9sUvv12dovBmjQKTtfE4rbjMmf3fzW",
-						"coins": "1",
-						"hours": 0
-					},
-					{
-						"hash": "f34f2f08c0a9bab56920b4ef946c0cb3ce31bbd641e44b23c5c1c39a14c86c86",
-						"src_tx": "059197c06b3a236c550bec377e26401c50ee6480b51206b6f3899ece55209b50",
-						"address": "fyqX5YuwXMUs4GEUE3LjLyhrqvNztFHQ4B",
-						"coins": "53",
-						"hours": 1
-					},
-					{
-						"hash": "86c43aeaa420e17843fee51ec28275726c6422f6bb0f844e70c552d65dd63df8",
-						"src_tx": "bb35c6b277f432c6cf13d4a6b36d64f75cc405bc2b864aad718e53a6cbbd9105",
-						"address": "cBnu9sUvv12dovBmjQKTtfE4rbjMmf3fzW",
-						"coins": "1",
-						"hours": 0
-					}
-				],
-				"outgoing_outputs": [],
-				"incoming_outputs": []
-			}
-    }`
-
-func decodeOutputStr(str string) visor.ReadableOutputSet {
-	outs := OutputsResult{}
-	if err := json.NewDecoder(strings.NewReader(outputStr)).Decode(&outs); err != nil {
-		panic(err)
-	}
-	return outs.Outputs
-}
 
 func filterOut(headTime uint64, outs []coin.UxOut, f func(out coin.UxOut) bool) visor.ReadableOutputSet {
 	os := []coin.UxOut{}

--- a/src/api/webrpc/webrpc_test.go
+++ b/src/api/webrpc/webrpc_test.go
@@ -32,7 +32,7 @@ type fakeGateway struct {
 	uxouts               []coin.UxOut
 }
 
-func (fg fakeGateway) GetLastBlocks(num uint64) (*visor.ReadableBlocks, error) {
+func (fg fakeGateway) GetLastBlocks(num uint64) (*visor.ReadableBlocks, error) { // nolint: unparam
 	var blocks visor.ReadableBlocks
 	if err := json.Unmarshal([]byte(blockString), &blocks); err != nil {
 		return nil, err

--- a/src/cipher/encoder/encoder_test.go
+++ b/src/cipher/encoder/encoder_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/skycoin/skycoin/src/cipher"
 )
 
-func randBytes(n int) []byte {
+func randBytes(n int) []byte { // nolint: unparam
 	const alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 	var bytes = make([]byte, n)
 	rand.Read(bytes)

--- a/src/cipher/encoder/field.go
+++ b/src/cipher/encoder/field.go
@@ -22,7 +22,7 @@ func (s *StructField) String() string {
 }
 
 //TODO: replace fieldType on reflect.Kind
-func getFieldSize(in []byte, d *decoder, fieldType reflect.Kind, s int) (int, error) {
+func getFieldSize(d *decoder, fieldType reflect.Kind, s int) (int, error) {
 	switch fieldType {
 	case reflect.Slice, reflect.String:
 		length := int(leUint32(d.buf[s : s+4]))
@@ -94,7 +94,7 @@ func DeserializeField(in []byte, fields []StructField, fieldName string, field i
 			fd.value(fv)
 			return nil
 		}
-		res, err := getFieldSize(in, d, reflect.Kind(f.Kind), s)
+		res, err := getFieldSize(d, reflect.Kind(f.Kind), s)
 		if err != nil {
 			return err
 		}
@@ -110,7 +110,7 @@ func ParseFields(in []byte, fields []StructField) map[string]string {
 	copy(d.buf, in)
 	s := 0
 	for _, f := range fields {
-		resShift, _ := getFieldSize(in, d, reflect.Kind(f.Kind), s)
+		resShift, _ := getFieldSize(d, reflect.Kind(f.Kind), s)
 		result[f.Name] = getFieldValue(in, d, reflect.Kind(f.Kind), s)
 		s = resShift
 	}

--- a/src/cipher/go-bip39/bip39.go
+++ b/src/cipher/go-bip39/bip39.go
@@ -205,7 +205,7 @@ func addChecksum(data []byte) []byte {
 	return dataBigInt.Bytes()
 }
 
-func padByteSlice(slice []byte, length int) []byte {
+func padByteSlice(slice []byte, length int) []byte { // nolint: unparam
 	newSlice := make([]byte, length-len(slice))
 	return append(newSlice, slice...)
 }

--- a/src/cipher/secp256k1-go/secp256k1-go2/num.go
+++ b/src/cipher/secp256k1-go/secp256k1-go2/num.go
@@ -77,13 +77,13 @@ func (num *Number) splitExp(r1, r2 *Number) {
 	r2.Sub(&bnt1.Int, &bnt2.Int)
 }
 
-func (num *Number) split(rl, rh *Number, bits uint) {
+func (num *Number) split(rl, rh *Number, bits uint) { // nolint: unparam
 	rl.Int.Set(&num.Int)
 	rh.Int.Rsh(&rl.Int, bits)
 	rl.maskBits(bits)
 }
 
-func (num *Number) rsh(bits uint) {
+func (num *Number) rsh(bits uint) { // nolint: unparam
 	num.Rsh(&num.Int, bits)
 }
 
@@ -102,7 +102,7 @@ func (num *Number) IsOdd() bool {
 	return num.Bit(0) != 0
 }
 
-func (num *Number) getBin(le int) []byte {
+func (num *Number) getBin(le int) []byte { // nolint: unparam
 	bts := num.Bytes()
 	if len(bts) > le {
 		panic("buffer too small")

--- a/src/cipher/secp256k1-go/secp256k1-go2/xyz.go
+++ b/src/cipher/secp256k1-go/secp256k1-go2/xyz.go
@@ -79,7 +79,7 @@ func (xyz *XYZ) Equals(b *XYZ) bool {
 	return xyz.X.Equals(&b.X) && xyz.Y.Equals(&b.Y) && xyz.Z.Equals(&b.Z)
 }
 
-func (xyz *XYZ) precomp(w int) (pre []XYZ) {
+func (xyz *XYZ) precomp(w int) (pre []XYZ) { // nolint: unparam
 	var d XYZ
 	pre = make([]XYZ, (1 << (uint(w) - 2)))
 	pre[0] = *xyz

--- a/src/coin/block_test.go
+++ b/src/coin/block_test.go
@@ -62,7 +62,9 @@ func TestNewBlock(t *testing.T) {
 	// valid block is fine
 	fee := uint64(121)
 	currentTime := uint64(133)
-	b, err := NewBlock(prev, currentTime, uxHash, txns, _makeFeeCalc(fee))
+	b, err := NewBlock(prev, currentTime, uxHash, txns, func(t *Transaction) (uint64, error) {
+		return fee, nil
+	})
 	require.NoError(t, err)
 	assert.Equal(t, b.Body.Transactions, txns)
 	assert.Equal(t, b.Head.Fee, fee*uint64(len(txns)))

--- a/src/coin/coin_test.go
+++ b/src/coin/coin_test.go
@@ -25,12 +25,6 @@ func _feeCalc(t *Transaction) (uint64, error) {
 	return 0, nil
 }
 
-func _makeFeeCalc(fee uint64) FeeCalculator {
-	return func(t *Transaction) (uint64, error) {
-		return fee, nil
-	}
-}
-
 func TestAddress1(t *testing.T) {
 	a := "02fa939957e9fc52140e180264e621c2576a1bfe781f88792fb315ca3d1786afb8"
 	b, err := hex.DecodeString(a)
@@ -148,7 +142,7 @@ func _gaddrA2(S []cipher.SecKey, O []UxOut) []int {
 	return I
 }
 
-func _gaddrA3(S []cipher.SecKey, O []UxOut) map[cipher.Address]int {
+func _gaddrA3(S []cipher.SecKey) map[cipher.Address]int {
 	A := _gaddrA1(S)
 	M := make(map[cipher.Address]int) //address to int
 	for i, a := range A {

--- a/src/coin/transactions_test.go
+++ b/src/coin/transactions_test.go
@@ -16,7 +16,7 @@ import (
 	_require "github.com/skycoin/skycoin/src/testutil/require"
 )
 
-func makeTransactionFromUxOut(t *testing.T, ux UxOut, s cipher.SecKey) Transaction {
+func makeTransactionFromUxOut(ux UxOut, s cipher.SecKey) Transaction {
 	tx := Transaction{}
 	tx.PushInput(ux.Hash())
 	tx.PushOutput(makeAddress(), 1e6, 50)
@@ -28,10 +28,10 @@ func makeTransactionFromUxOut(t *testing.T, ux UxOut, s cipher.SecKey) Transacti
 
 func makeTransaction(t *testing.T) Transaction {
 	ux, s := makeUxOutWithSecret(t)
-	return makeTransactionFromUxOut(t, ux, s)
+	return makeTransactionFromUxOut(ux, s)
 }
 
-func makeTransactions(t *testing.T, n int) Transactions {
+func makeTransactions(t *testing.T, n int) Transactions { // nolint: unparam
 	txns := make(Transactions, n)
 	for i := range txns {
 		txns[i] = makeTransaction(t)
@@ -94,7 +94,7 @@ func TestTransactionVerify(t *testing.T) {
 
 	// Duplicate inputs
 	ux, s := makeUxOutWithSecret(t)
-	tx = makeTransactionFromUxOut(t, ux, s)
+	tx = makeTransactionFromUxOut(ux, s)
 	tx.PushInput(tx.In[0])
 	tx.Sigs = nil
 	tx.SignInputs([]cipher.SecKey{s, s})
@@ -162,14 +162,14 @@ func TestTransactionVerifyInput(t *testing.T) {
 
 	// tx.In != tx.Sigs
 	ux, s := makeUxOutWithSecret(t)
-	tx = makeTransactionFromUxOut(t, ux, s)
+	tx = makeTransactionFromUxOut(ux, s)
 	tx.Sigs = []cipher.Sig{}
 	_require.PanicsWithLogMessage(t, "tx.In != tx.Sigs", func() {
 		tx.VerifyInput(UxArray{ux})
 	})
 
 	ux, s = makeUxOutWithSecret(t)
-	tx = makeTransactionFromUxOut(t, ux, s)
+	tx = makeTransactionFromUxOut(ux, s)
 	tx.Sigs = append(tx.Sigs, cipher.Sig{})
 	_require.PanicsWithLogMessage(t, "tx.In != tx.Sigs", func() {
 		tx.VerifyInput(UxArray{ux})
@@ -177,7 +177,7 @@ func TestTransactionVerifyInput(t *testing.T) {
 
 	// tx.InnerHash != tx.HashInner()
 	ux, s = makeUxOutWithSecret(t)
-	tx = makeTransactionFromUxOut(t, ux, s)
+	tx = makeTransactionFromUxOut(ux, s)
 	tx.InnerHash = cipher.SHA256{}
 	_require.PanicsWithLogMessage(t, "Invalid Tx Inner Hash", func() {
 		tx.VerifyInput(UxArray{ux})
@@ -185,21 +185,21 @@ func TestTransactionVerifyInput(t *testing.T) {
 
 	// tx.In does not match uxIn hashes
 	ux, s = makeUxOutWithSecret(t)
-	tx = makeTransactionFromUxOut(t, ux, s)
+	tx = makeTransactionFromUxOut(ux, s)
 	_require.PanicsWithLogMessage(t, "Ux hash mismatch", func() {
 		tx.VerifyInput(UxArray{UxOut{}})
 	})
 
 	// Invalid signature
 	ux, s = makeUxOutWithSecret(t)
-	tx = makeTransactionFromUxOut(t, ux, s)
+	tx = makeTransactionFromUxOut(ux, s)
 	tx.Sigs[0] = cipher.Sig{}
 	err := tx.VerifyInput(UxArray{ux})
 	testutil.RequireError(t, err, "Signature not valid for output being spent")
 
 	// Valid
 	ux, s = makeUxOutWithSecret(t)
-	tx = makeTransactionFromUxOut(t, ux, s)
+	tx = makeTransactionFromUxOut(ux, s)
 	err = tx.VerifyInput(UxArray{ux})
 	require.NoError(t, err)
 }

--- a/src/daemon/gnet/dispatcher.go
+++ b/src/daemon/gnet/dispatcher.go
@@ -45,7 +45,7 @@ func convertToMessage(id int, msg []byte, debugPrint bool) (Message, error) {
 	}
 
 	if debugPrint {
-		logger.Debugf("Convert, Message type %v", t)
+		logger.Debugf("convertToMessage for connection %d, message type %v", id, t)
 	}
 
 	var m Message

--- a/src/daemon/pex/peerlist_test.go
+++ b/src/daemon/pex/peerlist_test.go
@@ -527,9 +527,7 @@ func preparePeerlistFile(t *testing.T) (string, func()) {
 
 func preparePeerlistDir(t *testing.T) (string, func()) {
 	f, err := ioutil.TempDir("", "peerlist")
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	return f, func() {
 		os.Remove(f)

--- a/src/gui/csrf.go
+++ b/src/gui/csrf.go
@@ -104,7 +104,7 @@ func (c *CSRFStore) verifyToken(headerToken string) error {
 // Method: GET
 // Response:
 //  csrf_token: CSRF token to use in POST requests
-func getCSRFToken(gateway Gatewayer, store *CSRFStore) http.HandlerFunc {
+func getCSRFToken(store *CSRFStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			wh.Error405(w)

--- a/src/gui/http.go
+++ b/src/gui/http.go
@@ -12,6 +12,7 @@ import (
 	"unicode"
 
 	"github.com/NYTimes/gziphandler"
+
 	"github.com/skycoin/skycoin/src/api/webrpc"
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/daemon"
@@ -225,7 +226,7 @@ func newServerMux(c muxConfig, gateway Gatewayer, csrfStore *CSRFStore, rpc *web
 	}
 
 	// get the current CSRF token
-	mux.Handle("/csrf", headerCheck(c.host, getCSRFToken(gateway, csrfStore)))
+	mux.Handle("/csrf", headerCheck(c.host, getCSRFToken(csrfStore)))
 
 	webHandler("/version", versionHandler(gateway))
 

--- a/src/gui/integration/integration_test.go
+++ b/src/gui/integration/integration_test.go
@@ -1865,9 +1865,9 @@ func TestLiveWalletSpend(t *testing.T) {
 				for _, o := range tx.Transaction.Out {
 					c, err := droplet.FromString(o.Coins)
 					require.NoError(t, err)
-					coins += c
+					coins, err = coin.AddUint64(coins, c)
+					require.NoError(t, err)
 				}
-				require.Equal(t, totalCoins, coins)
 
 				// Confirms the address balance are equal to the totalCoins
 				coins, _ = getAddressBalance(t, c, w.Entries[0].Address.String())
@@ -3180,7 +3180,7 @@ func getTransaction(t *testing.T, c *gui.Client, txid string) *daemon.Transactio
 
 // getAddressBalance gets balance of given address.
 // Returns coins and coin hours.
-func getAddressBalance(t *testing.T, c *gui.Client, addr string) (uint64, uint64) {
+func getAddressBalance(t *testing.T, c *gui.Client, addr string) (uint64, uint64) { // nolint: unparam
 	bp, err := c.Balance([]string{addr})
 	if err != nil {
 		t.Fatalf("%v", err)

--- a/src/gui/transaction_test.go
+++ b/src/gui/transaction_test.go
@@ -40,11 +40,6 @@ func createUnconfirmedTxn(t *testing.T) visor.UnconfirmedTxn {
 	return ut
 }
 
-func makeTransaction(t *testing.T) coin.Transaction {
-	tx, _ := makeTransactionWithSecret(t)
-	return tx
-}
-
 func makeUxOutWithSecret(t *testing.T) (coin.UxOut, cipher.SecKey) {
 	body, sec := makeUxBodyWithSecret(t)
 	return coin.UxOut{
@@ -61,7 +56,7 @@ func makeAddress() cipher.Address {
 	return cipher.AddressFromPubKey(p)
 }
 
-func makeTransactionWithSecret(t *testing.T) (coin.Transaction, cipher.SecKey) {
+func makeTransaction(t *testing.T) coin.Transaction {
 	tx := coin.Transaction{}
 	ux, s := makeUxOutWithSecret(t)
 
@@ -70,7 +65,7 @@ func makeTransactionWithSecret(t *testing.T) (coin.Transaction, cipher.SecKey) {
 	tx.PushOutput(makeAddress(), 1e6, 50)
 	tx.PushOutput(makeAddress(), 5e6, 50)
 	tx.UpdateHeader()
-	return tx, s
+	return tx
 }
 
 func makeUxBodyWithSecret(t *testing.T) (coin.UxBody, cipher.SecKey) {

--- a/src/gui/wallet_test.go
+++ b/src/gui/wallet_test.go
@@ -2529,7 +2529,7 @@ func TestDecryptWallet(t *testing.T) {
 // makeEntries derives N wallet address entries from given seed
 // Returns set of wallet.Entry and wallet.ReadableEntry, the readable
 // entries' secrets are removed.
-func makeEntries(seed []byte, n int) ([]wallet.Entry, []WalletEntry) {
+func makeEntries(seed []byte, n int) ([]wallet.Entry, []WalletEntry) { // nolint: unparam
 	seckeys := cipher.GenerateDeterministicKeyPairs(seed, n)
 	var entries []wallet.Entry
 	var responseEntries []WalletEntry

--- a/src/util/file/file_test.go
+++ b/src/util/file/file_test.go
@@ -31,7 +31,7 @@ func requireFileContentsBinary(t *testing.T, filename string, contents []byte) {
 	require.True(t, bytes.Equal(b[:n], contents))
 }
 
-func requireFileContents(t *testing.T, filename, contents string) {
+func requireFileContents(t *testing.T, filename, contents string) { // nolint: unparam
 	requireFileContentsBinary(t, filename, []byte(contents))
 }
 

--- a/src/visor/blockchain_verify_test.go
+++ b/src/visor/blockchain_verify_test.go
@@ -162,7 +162,7 @@ func makeTransactionForChain(t *testing.T, tx *dbutil.Tx, bc *Blockchain, ux coi
 	return txn
 }
 
-func makeLostCoinTx(uxs coin.UxArray, keys []cipher.SecKey, toAddr cipher.Address, coins uint64) coin.Transaction {
+func makeLostCoinTx(uxs coin.UxArray, keys []cipher.SecKey, toAddr cipher.Address, coins uint64) coin.Transaction { // nolint: unparam
 	txn := coin.Transaction{}
 	var totalCoins uint64
 	var totalHours uint64
@@ -184,7 +184,7 @@ func makeLostCoinTx(uxs coin.UxArray, keys []cipher.SecKey, toAddr cipher.Addres
 	return txn
 }
 
-func makeDuplicateUxOutTx(uxs coin.UxArray, keys []cipher.SecKey, toAddr cipher.Address, coins uint64) coin.Transaction {
+func makeDuplicateUxOutTx(uxs coin.UxArray, keys []cipher.SecKey, toAddr cipher.Address, coins uint64) coin.Transaction { // nolint: unparam
 	txn := coin.Transaction{}
 	var totalCoins uint64
 	var totalHours uint64
@@ -211,7 +211,7 @@ func makeDuplicateUxOutTx(uxs coin.UxArray, keys []cipher.SecKey, toAddr cipher.
 // The genesis block has only one unspent output, so only one transaction can be made from it.
 // This is useful for when multiple test transactions need to be made from the same block.
 // Coins and hours are distributed equally amongst all new outputs.
-func makeUnspentsTx(t *testing.T, uxs coin.UxArray, keys []cipher.SecKey, toAddr cipher.Address, nUnspents int, maxDivisor uint64) coin.Transaction {
+func makeUnspentsTx(t *testing.T, uxs coin.UxArray, keys []cipher.SecKey, toAddr cipher.Address, nUnspents int, maxDivisor uint64) coin.Transaction { // nolint: unparam
 	// Add inputs to the transaction
 	spendTx := coin.Transaction{}
 	var totalHours uint64
@@ -284,7 +284,7 @@ func makeSpendTxWithFee(t *testing.T, uxs coin.UxArray, keys []cipher.SecKey, to
 }
 
 // makeSpendTxWithHoursBurned creates a txn specified with the total number of hours to burn
-func makeSpendTxWithHoursBurned(t *testing.T, uxs coin.UxArray, keys []cipher.SecKey, toAddr cipher.Address, coins, hoursBurned uint64) coin.Transaction {
+func makeSpendTxWithHoursBurned(t *testing.T, uxs coin.UxArray, keys []cipher.SecKey, toAddr cipher.Address, coins, hoursBurned uint64) coin.Transaction { // nolint: unparam
 	spendTx := coin.Transaction{}
 	var totalHours uint64
 	var totalCoins uint64
@@ -361,6 +361,11 @@ func TestVerifyTransactionAllConstraints(t *testing.T) {
 	txn = makeSpendTxWithHoursBurned(t, uxs, []cipher.SecKey{genSecret}, toAddr, coins, 0)
 	err = verifySingleTxnAllConstraints(txn, DefaultMaxBlockSize)
 	requireSoftViolation(t, "Transaction has zero coinhour fee", err)
+
+	// Invalid transaction fee, part 2
+	txn = makeSpendTxWithHoursBurned(t, uxs, []cipher.SecKey{genSecret}, toAddr, coins, 1)
+	err = verifySingleTxnAllConstraints(txn, DefaultMaxBlockSize)
+	requireSoftViolation(t, "Transaction coinhour fee minimum not met", err)
 
 	// Transaction locking is tested by TestVerifyTransactionIsLocked
 

--- a/src/visor/blockdb/unspent_test.go
+++ b/src/visor/blockdb/unspent_test.go
@@ -27,34 +27,24 @@ type spending struct {
 }
 
 func makeUxBody(t *testing.T) coin.UxBody {
-	body, _ := makeUxBodyWithSecret(t)
-	return body
-}
-
-func makeUxOut(t *testing.T) coin.UxOut {
-	ux, _ := makeUxOutWithSecret(t)
-	return ux
-}
-
-func makeUxBodyWithSecret(t *testing.T) (coin.UxBody, cipher.SecKey) {
-	p, s := cipher.GenerateKeyPair()
+	p, _ := cipher.GenerateKeyPair()
 	return coin.UxBody{
 		SrcTransaction: testutil.RandSHA256(t),
 		Address:        cipher.AddressFromPubKey(p),
 		Coins:          1e6,
 		Hours:          100,
-	}, s
+	}
 }
 
-func makeUxOutWithSecret(t *testing.T) (coin.UxOut, cipher.SecKey) {
-	body, sec := makeUxBodyWithSecret(t)
+func makeUxOut(t *testing.T) coin.UxOut {
+	body := makeUxBody(t)
 	return coin.UxOut{
 		Head: coin.UxHead{
 			Time:  100,
 			BkSeq: 2,
 		},
 		Body: body,
-	}, sec
+	}
 }
 
 func TestNewUnspentPool(t *testing.T) {

--- a/src/visor/readable.go
+++ b/src/visor/readable.go
@@ -175,8 +175,15 @@ func (ros ReadableOutputs) Balance() (wallet.Balance, error) {
 			return wallet.Balance{}, err
 		}
 
-		bal.Coins += coins
-		bal.Hours += out.CalculatedHours
+		bal.Coins, err = coin.AddUint64(bal.Coins, coins)
+		if err != nil {
+			return wallet.Balance{}, err
+		}
+
+		bal.Hours, err = coin.AddUint64(bal.Hours, out.CalculatedHours)
+		if err != nil {
+			return wallet.Balance{}, err
+		}
 	}
 
 	return bal, nil
@@ -243,7 +250,7 @@ func (os ReadableOutputSet) ExpectedOutputs() ReadableOutputs {
 	return append(os.SpendableOutputs(), os.IncomingOutputs...)
 }
 
-// AggregateUnspentOutputs aggregate unspent output
+// AggregateUnspentOutputs builds a map from address to coins
 func (os ReadableOutputSet) AggregateUnspentOutputs() (map[string]uint64, error) {
 	allAccounts := map[string]uint64{}
 	for _, out := range os.HeadOutputs {
@@ -252,7 +259,10 @@ func (os ReadableOutputSet) AggregateUnspentOutputs() (map[string]uint64, error)
 			return nil, err
 		}
 		if _, ok := allAccounts[out.Address]; ok {
-			allAccounts[out.Address] += amt
+			allAccounts[out.Address], err = coin.AddUint64(allAccounts[out.Address], amt)
+			if err != nil {
+				return nil, err
+			}
 		} else {
 			allAccounts[out.Address] = amt
 		}

--- a/src/visor/visor_test.go
+++ b/src/visor/visor_test.go
@@ -484,7 +484,7 @@ func TestVisorInjectTransaction(t *testing.T) {
 	uxs = coin.CreateUnspents(sb.Head, sb.Body.Transactions[0])
 
 	// Check transactions with overflowing output coins fail
-	txn = makeOverflowCoinsSpendTx(t, coin.UxArray{uxs[0]}, []cipher.SecKey{genSecret}, toAddr)
+	txn = makeOverflowCoinsSpendTx(coin.UxArray{uxs[0]}, []cipher.SecKey{genSecret}, toAddr)
 	_, softErr, err = v.InjectTransaction(txn)
 	require.IsType(t, ErrTxnViolatesHardConstraint{}, err)
 	testutil.RequireError(t, err.(ErrTxnViolatesHardConstraint).Err, "Output coins overflow")
@@ -501,7 +501,7 @@ func TestVisorInjectTransaction(t *testing.T) {
 	// Check transactions with overflowing output hours fail
 	// It should not be injected; when injecting a txn, the overflowing output hours is treated
 	// as a hard constraint. It is only a soft constraint when the txn is included in a signed block.
-	txn = makeOverflowHoursSpendTx(t, coin.UxArray{uxs[0]}, []cipher.SecKey{genSecret}, toAddr)
+	txn = makeOverflowHoursSpendTx(coin.UxArray{uxs[0]}, []cipher.SecKey{genSecret}, toAddr)
 	_, softErr, err = v.InjectTransaction(txn)
 	require.Nil(t, softErr)
 	require.IsType(t, ErrTxnViolatesHardConstraint{}, err)
@@ -532,7 +532,7 @@ func TestVisorInjectTransaction(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func makeOverflowCoinsSpendTx(t *testing.T, uxs coin.UxArray, keys []cipher.SecKey, toAddr cipher.Address) coin.Transaction {
+func makeOverflowCoinsSpendTx(uxs coin.UxArray, keys []cipher.SecKey, toAddr cipher.Address) coin.Transaction {
 	spendTx := coin.Transaction{}
 	var totalHours uint64
 	var totalCoins uint64
@@ -553,7 +553,7 @@ func makeOverflowCoinsSpendTx(t *testing.T, uxs coin.UxArray, keys []cipher.SecK
 	return spendTx
 }
 
-func makeOverflowHoursSpendTx(t *testing.T, uxs coin.UxArray, keys []cipher.SecKey, toAddr cipher.Address) coin.Transaction {
+func makeOverflowHoursSpendTx(uxs coin.UxArray, keys []cipher.SecKey, toAddr cipher.Address) coin.Transaction {
 	spendTx := coin.Transaction{}
 	var totalHours uint64
 	var totalCoins uint64
@@ -601,7 +601,7 @@ func TestVisorCalculatePrecision(t *testing.T) {
 	})
 }
 
-func makeTestData(t *testing.T, n int) ([]historydb.Transaction, []coin.SignedBlock, []UnconfirmedTxn, uint64) {
+func makeTestData(t *testing.T, n int) ([]historydb.Transaction, []coin.SignedBlock, []UnconfirmedTxn, uint64) { // nolint: unparam
 	var txs []historydb.Transaction
 	var blocks []coin.SignedBlock
 	var uncfmTxs []UnconfirmedTxn

--- a/src/wallet/service_test.go
+++ b/src/wallet/service_test.go
@@ -2374,7 +2374,7 @@ func TestGetWalletSeed(t *testing.T) {
 	}
 }
 
-func makeUxOut(t *testing.T, s cipher.SecKey, coins, hours uint64) coin.UxOut {
+func makeUxOut(t *testing.T, s cipher.SecKey, coins, hours uint64) coin.UxOut { // nolint: unparam
 	body := makeUxBody(t, s, coins, hours)
 	tm := rand.Int31n(1000)
 	seq := rand.Int31n(100)

--- a/src/wallet/wallet_test.go
+++ b/src/wallet/wallet_test.go
@@ -506,7 +506,7 @@ func TestLockAndUnLock(t *testing.T) {
 	}
 }
 
-func makeWallet(t *testing.T, opts Options, addrNum uint64) *Wallet {
+func makeWallet(t *testing.T, opts Options, addrNum uint64) *Wallet { // nolint: unparam
 	// Create an unlocked wallet, then generate addresses, lock if the options.Encrypt is true.
 	preOpts := opts
 	opts.Encrypt = false


### PR DESCRIPTION
Changes:
- Add unparam linter

Does this change need to mentioned in CHANGELOG.md?
No

unparam ignore directives are added in test methods and some manually-vendor cipher libraries.

The common cases we can ignore are:

* `parameter foo always receives bar` (a function is always called with the same value as one of the arguments, common in test setup methods)
* `parameter result N (type) is never used` (a function's return value is never used, sometimes occurs in test setup methods)

The main case to look for is:

* `parameter foo is unused`

An unused parameter can indicate variable shadowing or failure to use some argument in a function