### PR TITLE
GET /explorer/address add "size", "fee", "calculated_hours"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for decoding map values in cipher binary encoder
 - `-verify-db` option (default true), will verify the database integrity during startup and exit if a problem is found
 - `-reset-corrupt-db` option (default false) will verify the database integrity during startup and reset the db if a problem is found
+- `GET /explorer/address`: add `size` and `fee` to transaction objects and `calculated_hours` to transaction inputs
 
 ### Fixed
 

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1664,7 +1664,7 @@ Result:
         "status": {
             "confirmed": true,
             "unconfirmed": false,
-            "height": 1268,
+            "height": 12639,
             "block_seq": 15493,
             "unknown": false
         },
@@ -1673,6 +1673,8 @@ Result:
         "txid": "6d8e2f8b436a2f38d604b3aa1196ef2176779c5e11e33fbdd09f993fe659c39f",
         "inner_hash": "8da7c64dcedeeb6aa1e0d21fb84a0028dcd68e6801f1a3cc0224fdd50682046f",
         "timestamp": 1518878675,
+        "size": 183,
+        "fee": 126249,
         "sigs": [
             "c60e43980497daad59b4c72a2eac053b1584f960c57a5e6ac8337118dccfcee4045da3f60d9be674867862a13fdd87af90f4b85cbf39913bde13674e0a039b7800"
         ],
@@ -1681,7 +1683,8 @@ Result:
                 "uxid": "349b06e5707f633fd2d8f048b687b40462d875d968b246831434fb5ab5dcac38",
                 "owner": "WzPDgdfL1NzSbX96tscUNXUqtCRLjaBugC",
                 "coins": "125.000000",
-                "hours": 34596
+                "hours": 34596,
+                "calculated_hours": 178174
             }
         ],
         "outputs": [

--- a/src/api/client.go
+++ b/src/api/client.go
@@ -739,12 +739,12 @@ func (c *Client) RawTransaction(txid string) (string, error) {
 }
 
 // AddressTransactions makes a request to /explorer/address
-func (c *Client) AddressTransactions(addr string) ([]ReadableTransaction, error) {
+func (c *Client) AddressTransactions(addr string) ([]daemon.ReadableTransaction, error) {
 	v := url.Values{}
 	v.Add("address", addr)
 	endpoint := "/explorer/address?" + v.Encode()
 
-	var b []ReadableTransaction
+	var b []daemon.ReadableTransaction
 	if err := c.Get(endpoint, &b); err != nil {
 		return nil, err
 	}

--- a/src/api/explorer_test.go
+++ b/src/api/explorer_test.go
@@ -16,12 +16,10 @@ import (
 
 	"strconv"
 
-	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/daemon"
 	"github.com/skycoin/skycoin/src/testutil"
 	"github.com/skycoin/skycoin/src/util/droplet"
 	"github.com/skycoin/skycoin/src/visor"
-	"github.com/skycoin/skycoin/src/visor/historydb"
 )
 
 func makeSuccessCoinSupplyResult(t *testing.T, allUnspents visor.ReadableOutputSet) *CoinSupply {
@@ -95,21 +93,16 @@ func makeSuccessCoinSupplyResult(t *testing.T, allUnspents visor.ReadableOutputS
 func TestGetTransactionsForAddress(t *testing.T) {
 	address := testutil.MakeAddress()
 	successAddress := "111111111111111111111691FSP"
-	invalidHash := "cafcb"
 	validHash := "79216473e8f2c17095c6887cc9edca6c023afedfac2e0c5460e8b6f359684f8b"
 	tt := []struct {
-		name                        string
-		method                      string
-		status                      int
-		err                         string
-		addressParam                string
-		gatewayGetAddressTxnsResult *daemon.TransactionResults
-		gatewayGetAddressTxnsErr    error
-		gatewayGetUxOutByIDArg      cipher.SHA256
-		gatewayGetUxOutByIDResult   *historydb.UxOut
-		gatewayGetUxOutByIDErr      error
-		result                      []ReadableTransaction
-		csrfDisabled                bool
+		name                                string
+		method                              string
+		status                              int
+		err                                 string
+		addressParam                        string
+		gatewayGetTransactionsForAddressErr error
+		result                              []daemon.ReadableTransaction
+		csrfDisabled                        bool
 	}{
 		{
 			name:         "405",
@@ -133,89 +126,19 @@ func TestGetTransactionsForAddress(t *testing.T) {
 			addressParam: "badAddress",
 		},
 		{
-			name:                     "500 - gw GetAddressTxns error",
-			method:                   http.MethodGet,
-			status:                   http.StatusInternalServerError,
-			err:                      "500 Internal Server Error - gateway.GetAddressTxns failed: gatewayGetAddressTxnsErr",
-			addressParam:             address.String(),
-			gatewayGetAddressTxnsErr: errors.New("gatewayGetAddressTxnsErr"),
-		},
-		{
-			name:         "500 - cipher.SHA256FromHex(tx.Transaction.In) error",
-			method:       http.MethodGet,
-			status:       http.StatusInternalServerError,
-			err:          "500 Internal Server Error - encoding/hex: odd length hex string",
-			addressParam: address.String(),
-			gatewayGetAddressTxnsResult: &daemon.TransactionResults{
-				Txns: []daemon.TransactionResult{
-					{
-						Transaction: visor.ReadableTransaction{
-							In: []string{
-								invalidHash,
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name:         "500 - GetUxOutByID error",
-			method:       http.MethodGet,
-			status:       http.StatusInternalServerError,
-			err:          "500 Internal Server Error - gatewayGetUxOutByIDErr",
-			addressParam: address.String(),
-			gatewayGetAddressTxnsResult: &daemon.TransactionResults{
-				Txns: []daemon.TransactionResult{
-					{
-						Transaction: visor.ReadableTransaction{
-							In: []string{
-								validHash,
-							},
-						},
-					},
-				},
-			},
-			gatewayGetUxOutByIDArg: testutil.SHA256FromHex(t, validHash),
-			gatewayGetUxOutByIDErr: errors.New("gatewayGetUxOutByIDErr"),
-		},
-		{
-			name:         "500 - GetUxOutByID nil result",
-			method:       http.MethodGet,
-			status:       http.StatusInternalServerError,
-			err:          "500 Internal Server Error - uxout of 79216473e8f2c17095c6887cc9edca6c023afedfac2e0c5460e8b6f359684f8b does not exist in history db",
-			addressParam: address.String(),
-			gatewayGetAddressTxnsResult: &daemon.TransactionResults{
-				Txns: []daemon.TransactionResult{
-					{
-						Transaction: visor.ReadableTransaction{
-							In: []string{
-								validHash,
-							},
-						},
-					},
-				},
-			},
-			gatewayGetUxOutByIDArg: testutil.SHA256FromHex(t, validHash),
+			name:                                "500 - gw GetTransactionsForAddress error",
+			method:                              http.MethodGet,
+			status:                              http.StatusInternalServerError,
+			err:                                 "500 Internal Server Error - gateway.GetTransactionsForAddress failed: gatewayGetTransactionsForAddressErr",
+			addressParam:                        address.String(),
+			gatewayGetTransactionsForAddressErr: errors.New("gatewayGetTransactionsForAddressErr"),
 		},
 		{
 			name:         "200",
 			method:       http.MethodGet,
 			status:       http.StatusOK,
 			addressParam: address.String(),
-			gatewayGetAddressTxnsResult: &daemon.TransactionResults{
-				Txns: []daemon.TransactionResult{
-					{
-						Transaction: visor.ReadableTransaction{
-							In: []string{
-								validHash,
-							},
-						},
-					},
-				},
-			},
-			gatewayGetUxOutByIDArg:    testutil.SHA256FromHex(t, validHash),
-			gatewayGetUxOutByIDResult: &historydb.UxOut{},
-			result: []ReadableTransaction{
+			result: []daemon.ReadableTransaction{
 				{
 					In: []visor.ReadableTransactionInput{
 						{
@@ -234,8 +157,7 @@ func TestGetTransactionsForAddress(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/explorer/address"
 			gateway := NewGatewayerMock()
-			gateway.On("GetAddressTxns", address).Return(tc.gatewayGetAddressTxnsResult, tc.gatewayGetAddressTxnsErr)
-			gateway.On("GetUxOutByID", tc.gatewayGetUxOutByIDArg).Return(tc.gatewayGetUxOutByIDResult, tc.gatewayGetUxOutByIDErr)
+			gateway.On("GetTransactionsForAddress", address).Return(tc.result, tc.gatewayGetTransactionsForAddressErr)
 
 			v := url.Values{}
 			if tc.addressParam != "" {
@@ -267,7 +189,7 @@ func TestGetTransactionsForAddress(t *testing.T) {
 				require.Equal(t, tc.err, strings.TrimSpace(rr.Body.String()), "case: %s, handler returned wrong error message: got `%v`| %s, want `%v`",
 					tc.name, strings.TrimSpace(rr.Body.String()), status, tc.err)
 			} else {
-				var msg []ReadableTransaction
+				var msg []daemon.ReadableTransaction
 				err = json.Unmarshal(rr.Body.Bytes(), &msg)
 				require.NoError(t, err)
 				require.Equal(t, tc.result, msg)

--- a/src/api/gateway.go
+++ b/src/api/gateway.go
@@ -49,7 +49,7 @@ type Gatewayer interface {
 	ResendUnconfirmedTxns() (*daemon.ResendResult, error)
 	GetUxOutByID(id cipher.SHA256) (*historydb.UxOut, error)
 	GetAddrUxOuts(addr []cipher.Address) ([]*historydb.UxOut, error)
-	GetAddressTxns(a cipher.Address) (*daemon.TransactionResults, error)
+	GetTransactionsForAddress(a cipher.Address) ([]daemon.ReadableTransaction, error)
 	GetRichlist(includeDistribution bool) (visor.Richlist, error)
 	GetAddressCount() (uint64, error)
 	GetHealth() (*daemon.Health, error)

--- a/src/api/gatewayer_mock_test.go
+++ b/src/api/gatewayer_mock_test.go
@@ -198,15 +198,15 @@ func (m *GatewayerMock) GetAddressCount() (uint64, error) {
 
 }
 
-// GetAddressTxns mocked method
-func (m *GatewayerMock) GetAddressTxns(p0 cipher.Address) (*daemon.TransactionResults, error) {
+// GetTransactionsForAddress mocked method
+func (m *GatewayerMock) GetTransactionsForAddress(p0 cipher.Address) ([]daemon.ReadableTransaction, error) {
 
 	ret := m.Called(p0)
 
-	var r0 *daemon.TransactionResults
+	var r0 []daemon.ReadableTransaction
 	switch res := ret.Get(0).(type) {
 	case nil:
-	case *daemon.TransactionResults:
+	case []daemon.ReadableTransaction:
 		r0 = res
 	default:
 		panic(fmt.Sprintf("unexpected type: %v", res))

--- a/src/api/integration/integration_test.go
+++ b/src/api/integration/integration_test.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -190,6 +191,27 @@ func updateGoldenFile(t *testing.T, filename string, content interface{}) {
 	require.NoError(t, err)
 }
 
+func checkGoldenFile(t *testing.T, goldenFile string, td TestData) {
+	loadGoldenFile(t, goldenFile, td)
+	require.Equal(t, reflect.Indirect(reflect.ValueOf(td.expected)).Interface(), td.actual)
+
+	// Serialized expected to JSON and compare to the goldenFile's contents
+	// This will detect field changes that could be missed otherwise
+	b, err := json.MarshalIndent(td.expected, "", "\t")
+	require.NoError(t, err)
+
+	goldenFile = filepath.Join(testFixturesDir, goldenFile)
+
+	f, err := os.Open(goldenFile)
+	require.NoError(t, err)
+	defer f.Close()
+
+	c, err := ioutil.ReadAll(f)
+	require.NoError(t, err)
+
+	require.Equal(t, string(c), string(b)+"\n", "json struct output differs from golden file, was a field added to the struct?")
+}
+
 func assertResponseError(t *testing.T, err error, errCode int, errMsg string) {
 	require.Error(t, err)
 	require.IsType(t, api.ClientError{}, err)
@@ -208,9 +230,7 @@ func TestStableCoinSupply(t *testing.T) {
 	require.NoError(t, err)
 
 	var expected api.CoinSupply
-	loadGoldenFile(t, "coinsupply.golden", TestData{cs, &expected})
-
-	require.Equal(t, expected, *cs)
+	checkGoldenFile(t, "coinsupply.golden", TestData{*cs, &expected})
 }
 
 func TestLiveCoinSupply(t *testing.T) {
@@ -308,7 +328,7 @@ func TestStableOutputs(t *testing.T) {
 			require.NoError(t, err)
 
 			var expected visor.ReadableOutputSet
-			loadGoldenFile(t, tc.golden, TestData{outputs, &expected})
+			checkGoldenFile(t, tc.golden, TestData{*outputs, &expected})
 
 			require.Equal(t, len(expected.HeadOutputs), len(outputs.HeadOutputs))
 			require.Equal(t, len(expected.OutgoingOutputs), len(outputs.OutgoingOutputs))
@@ -317,8 +337,6 @@ func TestStableOutputs(t *testing.T) {
 			for i, o := range expected.HeadOutputs {
 				require.Equal(t, o, outputs.HeadOutputs[i], "mismatch at index %d", i)
 			}
-
-			require.Equal(t, expected, *outputs)
 		})
 	}
 }
@@ -429,9 +447,7 @@ func testKnownBlocks(t *testing.T) {
 			require.NotNil(t, b)
 
 			var expected visor.ReadableBlock
-			loadGoldenFile(t, tc.golden, TestData{b, &expected})
-
-			require.Equal(t, expected, *b)
+			checkGoldenFile(t, tc.golden, TestData{*b, &expected})
 		})
 	}
 
@@ -474,9 +490,7 @@ func TestStableBlockchainMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	var expected visor.BlockchainMetadata
-	loadGoldenFile(t, "blockchain-metadata.golden", TestData{metadata, &expected})
-
-	require.Equal(t, expected, *metadata)
+	checkGoldenFile(t, "blockchain-metadata.golden", TestData{*metadata, &expected})
 }
 
 func TestLiveBlockchainMetadata(t *testing.T) {
@@ -503,9 +517,7 @@ func TestStableBlockchainProgress(t *testing.T) {
 	require.NoError(t, err)
 
 	var expected daemon.BlockchainProgress
-	loadGoldenFile(t, "blockchain-progress.golden", TestData{progress, &expected})
-
-	require.Equal(t, expected, *progress)
+	checkGoldenFile(t, "blockchain-progress.golden", TestData{*progress, &expected})
 }
 
 func TestLiveBlockchainProgress(t *testing.T) {
@@ -563,9 +575,7 @@ func TestStableBalance(t *testing.T) {
 			require.NoError(t, err)
 
 			var expected wallet.BalancePair
-			loadGoldenFile(t, tc.golden, TestData{balance, &expected})
-
-			require.Equal(t, expected, *balance)
+			checkGoldenFile(t, tc.golden, TestData{*balance, &expected})
 		})
 	}
 }
@@ -631,9 +641,7 @@ func TestStableUxOut(t *testing.T) {
 			require.NoError(t, err)
 
 			var expected historydb.UxOutJSON
-			loadGoldenFile(t, tc.golden, TestData{ux, &expected})
-
-			require.Equal(t, expected, *ux)
+			checkGoldenFile(t, tc.golden, TestData{*ux, &expected})
 		})
 	}
 
@@ -653,8 +661,7 @@ func TestLiveUxOut(t *testing.T) {
 	require.NoError(t, err)
 
 	var expected historydb.UxOutJSON
-	loadGoldenFile(t, "uxout-spent.golden", TestData{ux, &expected})
-	require.Equal(t, expected, *ux)
+	checkGoldenFile(t, "uxout-spent.golden", TestData{*ux, &expected})
 	require.NotEqual(t, uint64(0), ux.SpentBlockSeq)
 
 	// Scan all uxouts from the result of /outputs
@@ -730,8 +737,7 @@ func TestStableAddressUxOuts(t *testing.T) {
 			}
 			require.NoError(t, err)
 			var expected []*historydb.UxOutJSON
-			loadGoldenFile(t, tc.golden, TestData{ux, &expected})
-			require.Equal(t, expected, ux, tc.name)
+			checkGoldenFile(t, tc.golden, TestData{ux, &expected})
 		})
 	}
 }
@@ -858,9 +864,7 @@ func TestStableBlocks(t *testing.T) {
 				resp := testBlocks(t, tc.start, tc.end)
 
 				var expected visor.ReadableBlocks
-				loadGoldenFile(t, tc.golden, TestData{resp, &expected})
-
-				require.Equal(t, expected, *resp)
+				checkGoldenFile(t, tc.golden, TestData{*resp, &expected})
 			} else {
 				_, err := c.Blocks(tc.start, tc.end)
 				assertResponseError(t, err, tc.errCode, tc.errMsg)
@@ -918,8 +922,7 @@ func TestStableLastBlocks(t *testing.T) {
 	require.NoError(t, err)
 
 	var expected *visor.ReadableBlocks
-	loadGoldenFile(t, "block-last.golden", TestData{blocks, &expected})
-	require.Equal(t, expected, blocks)
+	checkGoldenFile(t, "block-last.golden", TestData{blocks, &expected})
 
 	var prevBlock *visor.ReadableBlock
 	blocks, err = c.LastBlocks(10)
@@ -1015,9 +1018,7 @@ func TestNetworkDefaultConnections(t *testing.T) {
 	sort.Strings(connections)
 
 	var expected []string
-	loadGoldenFile(t, "network-default-connections.golden", TestData{connections, &expected})
-	sort.Strings(expected)
-	require.Equal(t, expected, connections)
+	checkGoldenFile(t, "network-default-connections.golden", TestData{connections, &expected})
 }
 
 func TestNetworkTrustedConnections(t *testing.T) {
@@ -1032,9 +1033,7 @@ func TestNetworkTrustedConnections(t *testing.T) {
 	sort.Strings(connections)
 
 	var expected []string
-	loadGoldenFile(t, "network-trusted-connections.golden", TestData{connections, &expected})
-	sort.Strings(expected)
-	require.Equal(t, expected, connections)
+	checkGoldenFile(t, "network-trusted-connections.golden", TestData{connections, &expected})
 }
 
 func TestStableNetworkExchangeableConnections(t *testing.T) {
@@ -1047,10 +1046,7 @@ func TestStableNetworkExchangeableConnections(t *testing.T) {
 	require.NoError(t, err)
 
 	var expected []string
-	loadGoldenFile(t, "network-exchangeable-connections.golden", TestData{connections, &expected})
-	sort.Strings(connections)
-	sort.Strings(expected)
-	require.Equal(t, expected, connections)
+	checkGoldenFile(t, "network-exchangeable-connections.golden", TestData{connections, &expected})
 }
 
 func TestLiveNetworkExchangeableConnections(t *testing.T) {
@@ -1257,8 +1253,7 @@ func TestStableTransactions(t *testing.T) {
 			}
 
 			var expected *[]daemon.TransactionResult
-			loadGoldenFile(t, tc.goldenFile, TestData{txResult, &expected})
-			require.Equal(t, expected, txResult, "case: "+tc.name)
+			checkGoldenFile(t, tc.goldenFile, TestData{txResult, &expected})
 		})
 	}
 }
@@ -1338,8 +1333,7 @@ func TestStableConfirmedTransactions(t *testing.T) {
 			}
 
 			var expected *[]daemon.TransactionResult
-			loadGoldenFile(t, tc.goldenFile, TestData{txResult, &expected})
-			require.Equal(t, expected, txResult, "case: "+tc.name)
+			checkGoldenFile(t, tc.goldenFile, TestData{txResult, &expected})
 		})
 	}
 }
@@ -1398,8 +1392,7 @@ func TestStableUnconfirmedTransactions(t *testing.T) {
 			}
 
 			var expected *[]daemon.TransactionResult
-			loadGoldenFile(t, tc.goldenFile, TestData{txResult, &expected})
-			require.Equal(t, expected, txResult, "case: "+tc.name)
+			checkGoldenFile(t, tc.goldenFile, TestData{txResult, &expected})
 		})
 	}
 }
@@ -1649,8 +1642,7 @@ func TestStableAddressTransactions(t *testing.T) {
 			require.NoError(t, err)
 
 			var expected []daemon.ReadableTransaction
-			loadGoldenFile(t, tc.golden, TestData{txns, &expected})
-			require.Equal(t, expected, txns)
+			checkGoldenFile(t, tc.golden, TestData{txns, &expected})
 		})
 	}
 }
@@ -1722,8 +1714,7 @@ func TestStableRichlist(t *testing.T) {
 	require.NoError(t, err)
 
 	var expected api.Richlist
-	loadGoldenFile(t, "richlist-default.golden", TestData{richlist, &expected})
-	require.Equal(t, expected, *richlist)
+	checkGoldenFile(t, "richlist-default.golden", TestData{*richlist, &expected})
 
 	richlist, err = c.Richlist(&api.RichlistParams{
 		N:                   0,
@@ -1732,8 +1723,7 @@ func TestStableRichlist(t *testing.T) {
 	require.NoError(t, err)
 
 	expected = api.Richlist{}
-	loadGoldenFile(t, "richlist-all.golden", TestData{richlist, &expected})
-	require.Equal(t, expected, *richlist)
+	checkGoldenFile(t, "richlist-all.golden", TestData{*richlist, &expected})
 
 	richlist, err = c.Richlist(&api.RichlistParams{
 		N:                   0,
@@ -1742,8 +1732,7 @@ func TestStableRichlist(t *testing.T) {
 	require.NoError(t, err)
 
 	expected = api.Richlist{}
-	loadGoldenFile(t, "richlist-all-include-distribution.golden", TestData{richlist, &expected})
-	require.Equal(t, expected, *richlist)
+	checkGoldenFile(t, "richlist-all-include-distribution.golden", TestData{*richlist, &expected})
 
 	richlist, err = c.Richlist(&api.RichlistParams{
 		N:                   8,
@@ -1752,8 +1741,7 @@ func TestStableRichlist(t *testing.T) {
 	require.NoError(t, err)
 
 	expected = api.Richlist{}
-	loadGoldenFile(t, "richlist-8.golden", TestData{richlist, &expected})
-	require.Equal(t, expected, *richlist)
+	checkGoldenFile(t, "richlist-8.golden", TestData{*richlist, &expected})
 
 	richlist, err = c.Richlist(&api.RichlistParams{
 		N:                   150,
@@ -1762,8 +1750,7 @@ func TestStableRichlist(t *testing.T) {
 	require.NoError(t, err)
 
 	expected = api.Richlist{}
-	loadGoldenFile(t, "richlist-150-include-distribution.golden", TestData{richlist, &expected})
-	require.Equal(t, expected, *richlist)
+	checkGoldenFile(t, "richlist-150-include-distribution.golden", TestData{*richlist, &expected})
 }
 
 func TestLiveRichlist(t *testing.T) {
@@ -2857,8 +2844,7 @@ func TestStableWalletBalance(t *testing.T) {
 	require.NoError(t, err)
 
 	var expect wallet.BalancePair
-	loadGoldenFile(t, "wallet-balance.golden", TestData{bp, &expect})
-	require.Equal(t, expect, *bp)
+	checkGoldenFile(t, "wallet-balance.golden", TestData{*bp, &expect})
 }
 
 func TestLiveWalletBalance(t *testing.T) {
@@ -2906,8 +2892,7 @@ func TestStableWalletTransactions(t *testing.T) {
 	require.NoError(t, err)
 
 	var expect api.UnconfirmedTxnsResponse
-	loadGoldenFile(t, "wallet-transactions.golden", TestData{txns, &expect})
-	require.Equal(t, expect, *txns)
+	checkGoldenFile(t, "wallet-transactions.golden", TestData{*txns, &expect})
 }
 
 func TestLiveWalletTransactions(t *testing.T) {

--- a/src/api/integration/integration_test.go
+++ b/src/api/integration/integration_test.go
@@ -1648,7 +1648,7 @@ func TestStableAddressTransactions(t *testing.T) {
 
 			require.NoError(t, err)
 
-			var expected []api.ReadableTransaction
+			var expected []daemon.ReadableTransaction
 			loadGoldenFile(t, tc.golden, TestData{txns, &expected})
 			require.Equal(t, expected, txns)
 		})
@@ -1698,7 +1698,7 @@ func TestLiveAddressTransactions(t *testing.T) {
 
 			require.NoError(t, err)
 
-			var expected []api.ReadableTransaction
+			var expected []daemon.ReadableTransaction
 			loadGoldenFile(t, tc.golden, TestData{txns, &expected})
 
 			// Recaculate the height if it's live test

--- a/src/api/integration/testdata/address-transactions-ALJVNKYL7WGxFBSriiZuwZKWD4b7fbV1od.golden
+++ b/src/api/integration/testdata/address-transactions-ALJVNKYL7WGxFBSriiZuwZKWD4b7fbV1od.golden
@@ -12,6 +12,8 @@
 		"txid": "86564b421cd3d4fe6f5f2d7a3e5db9d6fc340892bddd3a150533dff7036d0efe",
 		"inner_hash": "0f7019627886818d2501af189bbac18e21b8e959891c5b2726f89e29355aa10a",
 		"timestamp": 1427926392,
+		"size": 3846,
+		"fee": 100037880222122,
 		"sigs": [
 			"be602113fe288f750001ab65f254ceedd8b05b1becc456a0a52a0bea10b8280e38d950933992ad3265e1f81d197036fa634b316f08b3b319ffce081aa43f3bb600"
 		],
@@ -20,7 +22,8 @@
 				"uxid": "043836eb6f29aaeb8b9bfce847e07c159c72b25ae17d291f32125e7f1912e2a0",
 				"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 				"coins": "100000000.000000",
-				"hours": 100000000000000
+				"hours": 100000000000000,
+				"calculated_hours": 100037880222222
 			}
 		],
 		"outputs": [

--- a/src/cli/integration/testdata/status-use-csrf.golden
+++ b/src/cli/integration/testdata/status-use-csrf.golden
@@ -1,8 +1,8 @@
 {
-    "running": true,
-    "num_of_blocks": 181,
-    "hash_of_last_block": "63614fdf08b67fcfc99d7b43d115fb9f57eb5c6833acdbdc712ee361f391f292",
-    "time_since_last_block": "",
-    "webrpc_address": "http://127.0.0.1:46420",
-    "use_csrf": true
+	"running": true,
+	"num_of_blocks": 181,
+	"hash_of_last_block": "63614fdf08b67fcfc99d7b43d115fb9f57eb5c6833acdbdc712ee361f391f292",
+	"time_since_last_block": "",
+	"webrpc_address": "http://127.0.0.1:46420",
+	"use_csrf": true
 }

--- a/src/cli/integration/testdata/status.golden
+++ b/src/cli/integration/testdata/status.golden
@@ -4,5 +4,5 @@
 	"hash_of_last_block": "63614fdf08b67fcfc99d7b43d115fb9f57eb5c6833acdbdc712ee361f391f292",
 	"time_since_last_block": "",
 	"webrpc_address": "http://127.0.0.1:46420",
-    "use_csrf": false
+	"use_csrf": false
 }

--- a/src/visor/blockdb/unspent.go
+++ b/src/visor/blockdb/unspent.go
@@ -213,6 +213,8 @@ func NewUnspentPool() *Unspents {
 
 // MaybeBuildIndexes builds indexes if necessary
 func (up *Unspents) MaybeBuildIndexes(tx *dbutil.Tx) error {
+	logger.Info("Unspents.MaybeBuildIndexes")
+
 	// If the addr index is empty, build it
 	length, err := dbutil.Len(tx, UnspentPoolAddrIndexBkt)
 	if err != nil {
@@ -395,7 +397,7 @@ func (up *Unspents) GetUnspentsOfAddrs(tx *dbutil.Tx, addrs []cipher.Address) (c
 		if err != nil {
 			switch e := err.(type) {
 			case ErrUnspentNotExist:
-				logger.Critical().Error("Unspent hash %s indexed under address %s does not exist in unspent pool", e.UxID, addr.String())
+				logger.Critical().Errorf("Unspent hash %s indexed under address %s does not exist in unspent pool", e.UxID, addr.String())
 			}
 			return nil, err
 		}

--- a/src/visor/historydb/historydb.go
+++ b/src/visor/historydb/historydb.go
@@ -189,8 +189,8 @@ func (hd HistoryDB) GetAddrUxOuts(tx *dbutil.Tx, address cipher.Address) ([]*UxO
 	return uxOuts, nil
 }
 
-// GetAddrTxns returns all the address related transactions
-func (hd HistoryDB) GetAddrTxns(tx *dbutil.Tx, address cipher.Address) ([]Transaction, error) {
+// GetAddressTxns returns all the address related transactions
+func (hd HistoryDB) GetAddressTxns(tx *dbutil.Tx, address cipher.Address) ([]Transaction, error) {
 	hashes, err := hd.addrTxns.Get(tx, address)
 	if err != nil {
 		return nil, err

--- a/src/visor/historyer_mock_test.go
+++ b/src/visor/historyer_mock_test.go
@@ -61,8 +61,8 @@ func (m *historyerMock) ForEachTxn(p0 *dbutil.Tx, p1 func(cipher.SHA256, *histor
 
 }
 
-// GetAddrTxns mocked method
-func (m *historyerMock) GetAddrTxns(p0 *dbutil.Tx, p1 cipher.Address) ([]historydb.Transaction, error) {
+// GetAddressTxns mocked method
+func (m *historyerMock) GetAddressTxns(p0 *dbutil.Tx, p1 cipher.Address) ([]historydb.Transaction, error) {
 
 	ret := m.Called(p0, p1)
 

--- a/src/visor/readable.go
+++ b/src/visor/readable.go
@@ -95,21 +95,23 @@ func NewConfirmedTransactionStatus(height uint64, blockSeq uint64) TransactionSt
 
 // ReadableTransactionOutput readable transaction output
 type ReadableTransactionOutput struct {
-	Hash    string `json:"uxid"`
-	Address string `json:"dst"`
-	Coins   string `json:"coins"`
-	Hours   uint64 `json:"hours"`
+	Hash            string `json:"uxid"`
+	Address         string `json:"dst"`
+	Coins           string `json:"coins"`
+	Hours           uint64 `json:"hours"`
+	CalculatedHours uint64 `json:"calculated_hours"`
 }
 
 // ReadableTransactionInput readable transaction input
 type ReadableTransactionInput struct {
-	Hash    string `json:"uxid"`
-	Address string `json:"owner"`
-	Coins   string `json:"coins"`
-	Hours   uint64 `json:"hours"`
+	Hash            string `json:"uxid"`
+	Address         string `json:"owner"`
+	Coins           string `json:"coins"`
+	Hours           uint64 `json:"hours"`
+	CalculatedHours uint64 `json:"calculated_hours"`
 }
 
-// NewReadableTransactionOutput creates readable transaction outputs
+// NewReadableTransactionOutput creates ReadableTransactionOutput
 func NewReadableTransactionOutput(t *coin.TransactionOutput, txid cipher.SHA256) (*ReadableTransactionOutput, error) {
 	coinStr, err := droplet.ToString(t.Coins)
 	if err != nil {
@@ -118,14 +120,14 @@ func NewReadableTransactionOutput(t *coin.TransactionOutput, txid cipher.SHA256)
 
 	return &ReadableTransactionOutput{
 		Hash:    t.UxID(txid).Hex(),
-		Address: t.Address.String(), // Destination Address
+		Address: t.Address.String(),
 		Coins:   coinStr,
 		Hours:   t.Hours,
 	}, nil
 }
 
-// NewReadableTransactionInput creates readable transaction input
-func NewReadableTransactionInput(uxID, ownerAddress string, coins, hours uint64) (*ReadableTransactionInput, error) {
+// NewReadableTransactionInput creates ReadableTransactionInput
+func NewReadableTransactionInput(uxID cipher.SHA256, address cipher.Address, coins, hours, headTime uint64) (*ReadableTransactionInput, error) {
 	coinVal, err := droplet.ToString(coins)
 	if err != nil {
 		logger.Errorf("Failed to convert coins to string: %v", err)
@@ -133,8 +135,8 @@ func NewReadableTransactionInput(uxID, ownerAddress string, coins, hours uint64)
 	}
 
 	return &ReadableTransactionInput{
-		Hash:    uxID,
-		Address: ownerAddress, //Destination Address
+		Hash:    uxID.Hex(),
+		Address: address.String(),
 		Coins:   coinVal,
 		Hours:   hours,
 	}, nil

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -180,7 +180,7 @@ type historyer interface {
 	ParseBlock(tx *dbutil.Tx, b coin.Block) error
 	GetTransaction(tx *dbutil.Tx, hash cipher.SHA256) (*historydb.Transaction, error)
 	GetAddrUxOuts(tx *dbutil.Tx, address cipher.Address) ([]*historydb.UxOut, error)
-	GetAddrTxns(tx *dbutil.Tx, address cipher.Address) ([]historydb.Transaction, error)
+	GetAddressTxns(tx *dbutil.Tx, address cipher.Address) ([]historydb.Transaction, error)
 	NeedsReset(tx *dbutil.Tx) (bool, error)
 	Erase(tx *dbutil.Tx) error
 	ParsedHeight(tx *dbutil.Tx) (uint64, bool, error)
@@ -832,7 +832,7 @@ func (vs *Visor) GetAddressTxns(a cipher.Address) ([]Transaction, error) {
 	var txns []Transaction
 
 	if err := vs.DB.View("GetAddressTxns", func(tx *dbutil.Tx) error {
-		txs, err := vs.history.GetAddrTxns(tx, a)
+		txs, err := vs.history.GetAddressTxns(tx, a)
 		if err != nil {
 			return err
 		}
@@ -1112,7 +1112,7 @@ func (vs *Visor) getTransactionsOfAddrs(tx *dbutil.Tx, addrs []cipher.Address) (
 
 	for _, a := range addrs {
 		var txns []Transaction
-		addrTxns, err := vs.history.GetAddrTxns(tx, a)
+		addrTxns, err := vs.history.GetAddressTxns(tx, a)
 		if err != nil {
 			return nil, err
 		}

--- a/src/visor/visor_test.go
+++ b/src/visor/visor_test.go
@@ -1770,7 +1770,7 @@ func TestGetTransactions(t *testing.T) {
 			his := newHistoryerMock2()
 			uncfmTxPool := NewUnconfirmedTxnPoolerMock2()
 			for addr, txs := range tc.addrTxns {
-				his.On("GetAddrTxns", matchTx, addr).Return(txs.Txs, nil)
+				his.On("GetAddressTxns", matchTx, addr).Return(txs.Txs, nil)
 				his.txs = append(his.txs, txs.Txs...)
 
 				uncfmTxPool.On("GetUnspentsOfAddr", matchTx, addr).Return(makeUncfmUxs(txs.UncfmTxs), nil)


### PR DESCRIPTION
Fixes #920 
Fixes #1479 

Changes:
- Add `calculated_hours` to the inputs in the `/explorer/address` response
- Add `fee` and `size` to the transactions in the `/explorer/address` response
- In integration tests, serialize the struct back to JSON to detect added fields which could be missed if they have empty values like zero

Does this change need to mentioned in CHANGELOG.md?
Yes