### PR TITLE
Limit the connections to default peers

### DIFF
--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -103,7 +103,7 @@ type Config struct {
 	// Maximum outgoing connections to maintain
 	MaxOutgoingConnections int
 	// Maximum default outgoing connections
-	MaxDefaultOutgoingConnections int
+	MaxDefaultPeerOutgoingConnections int
 	// How often to make outgoing connections
 	OutgoingConnectionsRate time.Duration
 	// PeerlistSize represents the maximum number of peers that the pex would maintain
@@ -231,7 +231,7 @@ func (c *Config) register() {
 
 	flag.StringVar(&c.WalletDirectory, "wallet-dir", c.WalletDirectory, "location of the wallet files. Defaults to ~/.skycoin/wallet/")
 	flag.IntVar(&c.MaxOutgoingConnections, "max-outgoing-connections", c.MaxOutgoingConnections, "The maximum outgoing connections allowed")
-	flag.IntVar(&c.MaxDefaultOutgoingConnections, "max-default-outgoing-connections", c.MaxDefaultOutgoingConnections, "The maximum default outgoing connections allowed")
+	flag.IntVar(&c.MaxDefaultPeerOutgoingConnections, "max-default-peer-outgoing-connections", c.MaxDefaultPeerOutgoingConnections, "The maximum default peer outgoing connections allowed")
 	flag.IntVar(&c.PeerlistSize, "peerlist-size", c.PeerlistSize, "The peer list size")
 	flag.DurationVar(&c.OutgoingConnectionsRate, "connection-rate", c.OutgoingConnectionsRate, "How often to make an outgoing connection")
 	flag.BoolVar(&c.LocalhostOnly, "localhost-only", c.LocalhostOnly, "Run on localhost and only connect to localhost peers")
@@ -269,9 +269,9 @@ var devConfig = Config{
 	// MaxOutgoingConnections is the maximum outgoing connections allowed.
 	MaxOutgoingConnections: 16,
 	// MaxDefaultOutgoingConnections is the maximum default outgoing connections allowed.
-	MaxDefaultOutgoingConnections: 1,
-	DownloadPeerList:              false,
-	PeerListURL:                   "https://downloads.skycoin.net/blockchain/peers.txt",
+	MaxDefaultPeerOutgoingConnections: 1,
+	DownloadPeerList:                  false,
+	PeerListURL:                       "https://downloads.skycoin.net/blockchain/peers.txt",
 	// How often to make outgoing connections, in seconds
 	OutgoingConnectionsRate: time.Second * 5,
 	PeerlistSize:            65535,
@@ -507,10 +507,10 @@ func configureDaemon(c *Config) daemon.Config {
 	dc := daemon.NewConfig()
 
 	for _, c := range DefaultConnections {
-		dc.Pool.DefaultConnections[c] = struct{}{}
+		dc.Pool.DefaultPeerConnections[c] = struct{}{}
 	}
 
-	dc.Pool.MaxDefaultOutgoingConnections = c.MaxDefaultOutgoingConnections
+	dc.Pool.MaxDefaultPeerOutgoingConnections = c.MaxDefaultPeerOutgoingConnections
 
 	dc.Pex.DataDirectory = c.DataDirectory
 	dc.Pex.Disabled = c.DisablePEX

--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -47,7 +47,8 @@ var (
 	ErrDisconnectIPLimitReached gnet.DisconnectReason = errors.New("Maximum number of connections for this IP was reached")
 	// ErrDisconnectOtherError this is returned when a seemingly impossible error is encountered
 	// e.g. net.Conn.Addr() returns an invalid ip:port
-	ErrDisconnectOtherError gnet.DisconnectReason = errors.New("Incomprehensible error")
+	ErrDisconnectOtherError                  gnet.DisconnectReason = errors.New("Incomprehensible error")
+	ErrDisconnectMaxDefaultConnectionReached                       = errors.New("Maximum number of default connections was reached")
 
 	logger = logging.MustGetLogger("daemon")
 )

--- a/src/daemon/gnet/pool.go
+++ b/src/daemon/gnet/pool.go
@@ -28,6 +28,7 @@ const (
 	readLoopDurationThreshold       = 10 * time.Second
 	sendInMsgChanDurationThreshold  = 5 * time.Second
 	sendLoopDurationThreshold       = 500 * time.Millisecond
+	defaultMaxDefaultConnNum        = 1
 )
 
 var (
@@ -51,6 +52,8 @@ var (
 	ErrWriteQueueFull = errors.New("Write queue full")
 	// ErrNoReachableConnections when broadcasting a message, no connections were available to send a message to
 	ErrNoReachableConnections = errors.New("All pool connections are unreachable at this time")
+	// ErrMaxDefaultConnectionsReached returns when maximum number of default connections is reached
+	ErrMaxDefaultConnectionsReached = errors.New("maximum number of default outgoing connections was reached")
 	// Logger
 	logger = logging.MustGetLogger("gnet")
 )
@@ -65,6 +68,8 @@ type Config struct {
 	MaxConnections int
 	// Messages greater than length are rejected and the sender disconnected
 	MaxMessageLength int
+	// Maximum allowed default outgoing connection number
+	MaxDefaultOutgoingConnections int
 	// Timeout is the timeout for dialing new connections.  Use a
 	// timeout of 0 to ignore timeout.
 	DialTimeout time.Duration
@@ -85,23 +90,27 @@ type Config struct {
 	ConnectCallback ConnectCallback
 	// Print debug logs
 	DebugPrint bool
+	// Default connections map
+	DefaultConnections map[string]struct{}
 }
 
 // NewConfig returns a Config with defaults set
 func NewConfig() Config {
 	return Config{
-		Address:                  "",
-		Port:                     0,
-		MaxConnections:           128,
-		MaxMessageLength:         256 * 1024,
-		DialTimeout:              time.Second * 30,
-		ReadTimeout:              time.Second * 30,
-		WriteTimeout:             time.Second * 30,
-		SendResultsSize:          2048,
-		ConnectionWriteQueueSize: 128,
-		DisconnectCallback:       nil,
-		ConnectCallback:          nil,
-		DebugPrint:               false,
+		Address:                       "",
+		Port:                          0,
+		MaxConnections:                128,
+		MaxMessageLength:              256 * 1024,
+		MaxDefaultOutgoingConnections: defaultMaxDefaultConnNum,
+		DialTimeout:                   time.Second * 30,
+		ReadTimeout:                   time.Second * 30,
+		WriteTimeout:                  time.Second * 30,
+		SendResultsSize:               2048,
+		ConnectionWriteQueueSize:      128,
+		DisconnectCallback:            nil,
+		ConnectCallback:               nil,
+		DebugPrint:                    false,
+		DefaultConnections:            make(map[string]struct{}),
 	}
 }
 
@@ -177,6 +186,8 @@ type ConnectionPool struct {
 	pool map[int]*Connection
 	// All connections, indexed by address
 	addresses map[string]*Connection
+	// connected default connections
+	defaultConnections map[string]struct{}
 	// User-defined state to be passed into message handlers
 	messageState interface{}
 	// Connection ID counter
@@ -197,15 +208,16 @@ type ConnectionPool struct {
 // will be passed to a Message's Handle().
 func NewConnectionPool(c Config, state interface{}) *ConnectionPool {
 	pool := &ConnectionPool{
-		Config:       c,
-		pool:         make(map[int]*Connection),
-		addresses:    make(map[string]*Connection),
-		SendResults:  make(chan SendResult, c.SendResultsSize),
-		messageState: state,
-		quit:         make(chan struct{}),
-		done:         make(chan struct{}),
-		strandDone:   make(chan struct{}),
-		reqC:         make(chan strand.Request),
+		Config:             c,
+		pool:               make(map[int]*Connection),
+		addresses:          make(map[string]*Connection),
+		defaultConnections: make(map[string]struct{}),
+		SendResults:        make(chan SendResult, c.SendResultsSize),
+		messageState:       state,
+		quit:               make(chan struct{}),
+		done:               make(chan struct{}),
+		strandDone:         make(chan struct{}),
+		reqC:               make(chan strand.Request),
 	}
 
 	return pool
@@ -328,6 +340,15 @@ func (pool *ConnectionPool) NewConnection(conn net.Conn, solicited bool) (*Conne
 		if _, ok := pool.addresses[a]; ok {
 			return fmt.Errorf("Already connected to %s", a)
 		}
+
+		if _, ok := pool.Config.DefaultConnections[a]; ok {
+			if len(pool.defaultConnections) >= pool.Config.MaxDefaultOutgoingConnections && solicited {
+				return ErrMaxDefaultConnectionsReached
+			}
+
+			pool.defaultConnections[a] = struct{}{}
+		}
+
 		pool.connID++
 		nc = NewConnection(pool, pool.connID, conn, pool.Config.ConnectionWriteQueueSize, solicited)
 
@@ -618,6 +639,25 @@ func (pool *ConnectionPool) IsConnExist(addr string) (bool, error) {
 	return exist, nil
 }
 
+// IsDefaultConnection returns if the addr is a default connection
+func (pool *ConnectionPool) IsDefaultConnection(addr string) bool {
+	_, ok := pool.Config.DefaultConnections[addr]
+	return ok
+}
+
+// IsMaxDefaultConnReached returns whether the max default connection number was reached.
+func (pool *ConnectionPool) IsMaxDefaultConnReached() (bool, error) {
+	var reached bool
+	if err := pool.strand("IsDefaultMaxConnReached", func() error {
+		reached = len(pool.defaultConnections) > pool.Config.MaxDefaultOutgoingConnections
+		return nil
+	}); err != nil {
+		return false, err
+	}
+
+	return reached, nil
+}
+
 func (pool *ConnectionPool) updateLastSent(addr string, t time.Time) error {
 	return pool.strand("updateLastSent", func() error {
 		if conn, ok := pool.addresses[addr]; ok {
@@ -664,6 +704,23 @@ func (pool *ConnectionPool) Connect(address string) error {
 		return nil
 	}
 
+	var hitMaxDefaultConnNum bool
+	// Checks if it's one of the default connection
+	if err := pool.strand("Check default connection", func() error {
+		if _, ok := pool.Config.DefaultConnections[address]; ok {
+			hitMaxDefaultConnNum = len(pool.defaultConnections) >= pool.Config.MaxDefaultOutgoingConnections
+		}
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if hitMaxDefaultConnNum {
+		logger.Critical().Infof("ConnectionPool.Connect: %v", ErrMaxDefaultConnectionsReached)
+		return nil
+	}
+
 	logger.Debugf("Making TCP Connection to %s", address)
 	conn, err := net.DialTimeout("tcp", address, pool.Config.DialTimeout)
 	if err != nil {
@@ -700,13 +757,13 @@ func (pool *ConnectionPool) Disconnect(addr string, r DisconnectReason) error {
 
 func (pool *ConnectionPool) disconnect(addr string) bool {
 	conn, ok := pool.addresses[addr]
-
 	if !ok {
 		return false
 	}
 
 	delete(pool.pool, conn.ID)
 	delete(pool.addresses, addr)
+	delete(pool.defaultConnections, addr)
 	if err := conn.Close(); err != nil {
 		logger.Errorf("conn.Close() error address=%s: %v", addr, err)
 	} else {

--- a/src/daemon/messages.go
+++ b/src/daemon/messages.go
@@ -279,6 +279,10 @@ func (intro *IntroductionMessage) Handle(mc *gnet.MessageContext, daemon interfa
 			return ErrDisconnectOtherError
 		}
 
+		// Checks if the introduction message is from outgoing connection.
+		// It's outgoing connection if port == intro.Port, as the incoming
+		// connection's port is a random port, it's different from the port
+		// in introduction message.
 		if port == intro.Port {
 			if d.Pool.Pool.IsDefaultConnection(mc.Addr) {
 				reached, err := d.Pool.Pool.IsMaxDefaultConnReached()

--- a/src/daemon/messages.go
+++ b/src/daemon/messages.go
@@ -280,6 +280,20 @@ func (intro *IntroductionMessage) Handle(mc *gnet.MessageContext, daemon interfa
 		}
 
 		if port == intro.Port {
+			if d.Pool.Pool.IsDefaultConnection(mc.Addr) {
+				reached, err := d.Pool.Pool.IsMaxDefaultConnReached()
+				if err != nil {
+					logger.Errorf("Check IsMaxDefaultConnReached failed: %v", err)
+					return err
+				}
+
+				if reached {
+					logger.Debugf("Disconnect %s: maximum default connections reached ", mc.Addr)
+					d.Pool.Pool.Disconnect(mc.Addr, ErrDisconnectMaxDefaultConnectionReached)
+					return ErrDisconnectMaxDefaultConnectionReached
+				}
+			}
+
 			if err := d.Pex.SetHasIncomingPort(mc.Addr, true); err != nil {
 				logger.Errorf("Failed to set peer has incoming port status, %v", err)
 			}

--- a/src/daemon/pool.go
+++ b/src/daemon/pool.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	"time"
 
-	//"github.com/skycoin/skycoin/src/daemon/gnet"
 	"github.com/skycoin/skycoin/src/daemon/gnet"
 )
 
@@ -24,7 +23,9 @@ type PoolConfig struct {
 	// Buffer size for gnet.ConnectionPool's network Read events
 	EventChannelSize int
 	// Maximum number of connections to maintain
-	MaxConnections int
+	MaxConnections                int
+	MaxDefaultOutgoingConnections int
+	DefaultConnections            map[string]struct{}
 	// These should be assigned by the controlling daemon
 	address string
 	port    int
@@ -34,16 +35,18 @@ type PoolConfig struct {
 func NewPoolConfig() PoolConfig {
 	//defIdleLimit := time.Minute
 	return PoolConfig{
-		port:                6677,
-		address:             "",
-		DialTimeout:         time.Second * 30,
-		MessageHandlingRate: time.Millisecond * 50,
-		PingRate:            5 * time.Second,
-		IdleLimit:           60 * time.Second,
-		IdleCheckRate:       1 * time.Second,
-		ClearStaleRate:      1 * time.Second,
-		EventChannelSize:    4096,
-		MaxConnections:      128,
+		port:                          6677,
+		address:                       "",
+		DialTimeout:                   time.Second * 30,
+		MessageHandlingRate:           time.Millisecond * 50,
+		PingRate:                      5 * time.Second,
+		IdleLimit:                     60 * time.Second,
+		IdleCheckRate:                 1 * time.Second,
+		ClearStaleRate:                1 * time.Second,
+		EventChannelSize:              4096,
+		MaxConnections:                128,
+		MaxDefaultOutgoingConnections: 1,
+		DefaultConnections:            make(map[string]struct{}),
 	}
 }
 
@@ -62,6 +65,8 @@ func NewPool(cfg PoolConfig, d *Daemon) *Pool {
 	gnetCfg.ConnectCallback = d.onGnetConnect
 	gnetCfg.DisconnectCallback = d.onGnetDisconnect
 	gnetCfg.MaxConnections = cfg.MaxConnections
+	gnetCfg.MaxDefaultOutgoingConnections = cfg.MaxDefaultOutgoingConnections
+	gnetCfg.DefaultConnections = cfg.DefaultConnections
 
 	return &Pool{
 		Config: cfg,

--- a/src/daemon/pool.go
+++ b/src/daemon/pool.go
@@ -23,9 +23,9 @@ type PoolConfig struct {
 	// Buffer size for gnet.ConnectionPool's network Read events
 	EventChannelSize int
 	// Maximum number of connections to maintain
-	MaxConnections                int
-	MaxDefaultOutgoingConnections int
-	DefaultConnections            map[string]struct{}
+	MaxConnections                    int
+	MaxDefaultPeerOutgoingConnections int
+	DefaultPeerConnections            map[string]struct{}
 	// These should be assigned by the controlling daemon
 	address string
 	port    int
@@ -35,18 +35,18 @@ type PoolConfig struct {
 func NewPoolConfig() PoolConfig {
 	//defIdleLimit := time.Minute
 	return PoolConfig{
-		port:                          6677,
-		address:                       "",
-		DialTimeout:                   time.Second * 30,
-		MessageHandlingRate:           time.Millisecond * 50,
-		PingRate:                      5 * time.Second,
-		IdleLimit:                     60 * time.Second,
-		IdleCheckRate:                 1 * time.Second,
-		ClearStaleRate:                1 * time.Second,
-		EventChannelSize:              4096,
-		MaxConnections:                128,
-		MaxDefaultOutgoingConnections: 1,
-		DefaultConnections:            make(map[string]struct{}),
+		port:                              6677,
+		address:                           "",
+		DialTimeout:                       time.Second * 30,
+		MessageHandlingRate:               time.Millisecond * 50,
+		PingRate:                          5 * time.Second,
+		IdleLimit:                         60 * time.Second,
+		IdleCheckRate:                     1 * time.Second,
+		ClearStaleRate:                    1 * time.Second,
+		EventChannelSize:                  4096,
+		MaxConnections:                    128,
+		MaxDefaultPeerOutgoingConnections: 1,
+		DefaultPeerConnections:            make(map[string]struct{}),
 	}
 }
 
@@ -65,8 +65,8 @@ func NewPool(cfg PoolConfig, d *Daemon) *Pool {
 	gnetCfg.ConnectCallback = d.onGnetConnect
 	gnetCfg.DisconnectCallback = d.onGnetDisconnect
 	gnetCfg.MaxConnections = cfg.MaxConnections
-	gnetCfg.MaxDefaultOutgoingConnections = cfg.MaxDefaultOutgoingConnections
-	gnetCfg.DefaultConnections = cfg.DefaultConnections
+	gnetCfg.MaxDefaultPeerOutgoingConnections = cfg.MaxDefaultPeerOutgoingConnections
+	gnetCfg.DefaultPeerConnections = cfg.DefaultPeerConnections
 
 	return &Pool{
 		Config: cfg,


### PR DESCRIPTION
Fixes #1367 

Changes:
- Don't  connect to all default peers, add `-max-default-outgoing-connections` flag to config the maximum allowed connections to default peers.

Does this change need to mentioned in CHANGELOG.md?
No