### PR TITLE
Begin migration to /api/v1/ endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add CLI `showSeed` command
 - Add `password` argument to the CLI commands of `addPrivateKey`, `createRawTransaction`, `generateAddresses`, `generateWallet`, `send`
 - Support for decoding map values in cipher binary encoder
-- Expose known block height of peer in brand new `height` field added in responses of `/network/connections` API endpoints
+- Expose known block height of peer in brand new `height` field added in responses of `GET /api/v1/network/connections` API endpoints
 - `-verify-db` option (default true), will verify the database integrity during startup and exit if a problem is found
 - `-reset-corrupt-db` option (default false) will verify the database integrity during startup and reset the db if a problem is found
 
@@ -27,14 +27,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Reduce connection disconnects, improves syncing
 - Fix #1171, update CLI to support wallet encryption
-- Use bolt.Tx correctly for read operations
+- Use `bolt.Tx` correctly for read operations
 
 ### Changed
 
 - JSON 2.0 RPC interface (used by the CLI tool) is now served on the same host interface as the REST API, port `6420`. The additional listener has been removed.
 - CLI's `RPC_ADDR` environment variable must now start with a scheme e.g. `http://127.0.0.1:6420`, previously it did not use a scheme.
 - API response will be gzip compressed if client sends request with 'Accept-Encoding' contains 'gzip' in the header.
-- `/wallet/balance/` and `/balance/` now return an address balance list as well.
+- `GET /api/v1/wallet/balance` and `GET /api/v1/balance` now return an address balance list as well.
+- API endpoints are prefixed with `/api/v1/`. API endpoints without the `/api/v1/` prefix are deprecated but can be enabled with `-enable-unversioned-api`. Please migrate to use `/api/v1/` prefix in URLs.
 
 ### Removed
 

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -3,7 +3,7 @@
 A Skycoin node offers multiple interfaces:
 
 * REST API on port 6420
-* JSON-RPC 2.0 API accessible on /webrpc endpoint **[deprecated]**
+* JSON-RPC 2.0 API accessible on `/api/v1/webrpc` endpoint **[deprecated]**
 
 A CLI tool is provided in `cmd/cli/cli.go`. This tool communicates over the JSON-RPC 2.0 API. In the future it will communicate over the REST API.
 
@@ -103,15 +103,15 @@ To check address outputs, use `skycoin-cli addressOutputs`. If you only want the
 
 #### Using the REST API
 
-To scan the blockchain, call `GET /last_blocks?num=` or `GET /blocks?start=&end=`. There will return block data as JSON
+To scan the blockchain, call `GET /api/v1/last_blocks?num=` or `GET /api/v1/blocks?start=&end=`. There will return block data as JSON
 and new unspent outputs sent to an address can be detected.
 
-To check address outputs, call `GET /outputs?addrs=`. If you only want the balance, you can call `GET /balance?addrs=`.
+To check address outputs, call `GET /api/v1/outputs?addrs=`. If you only want the balance, you can call `GET /api/v1/balance?addrs=`.
 
-* [`/last_blocks` docs](src/api/README.md#get-last-n-blocks)
-* [`/blocks` docs](src/api/README.md#get-blocks-in-specific-range)
-* [`/outputs` docs](src/api/README.md#get-unspent-output-set-of-address-or-hash)
-* [`/balance` docs](src/api/README.md#get-balance-of-addresses)
+* [`GET /api/v1/last_blocks` docs](src/api/README.md#get-last-n-blocks)
+* [`GET /api/v1/blocks` docs](src/api/README.md#get-blocks-in-specific-range)
+* [`GET /api/v1/outputs` docs](src/api/README.md#get-unspent-output-set-of-address-or-hash)
+* [`GET /api/v1/balance` docs](src/api/README.md#get-balance-of-addresses)
 
 #### Using skycoin as a library in a Go application
 
@@ -171,6 +171,7 @@ directly, see [Skycoin CLI Godoc](https://godoc.org/github.com/skycoin/skycoin/s
 A REST API client is also available: [Skycoin REST API Client Godoc](https://godoc.org/github.com/skycoin/skycoin/src/api#Client).
 
 #### Coinhours
+
 Transaction fees in skycoin is paid in coinhours and is currently set to `50%`,
 every transaction created burns `50%` of the total coinhours in all the input
 unspents.
@@ -183,7 +184,8 @@ which are then converted to `coinhours`, `1` coinhour = `3600` coinseconds.
 > Note: Coinhours don't have decimals and only show up in whole numbers.
 
 ##### REST API
-When using the `REST API` the coinhours are distributed as follows:
+
+When using the REST API the coinhours are distributed as follows:
 - 50% of the total coinhours in the unspents being used are burned.
 - 25% of the coinhours go to the the change address along with the remaining coins
 - 25% of the coinhours are split equally between the receivers
@@ -195,7 +197,8 @@ The sending address will be left with `5` skycoins and `12` coinhours which
 will then be sent to the change address.
 
 ##### CLI
-When using the `CLI` the amount of coinhours sent to the receiver is capped to
+
+When using the CLI the amount of coinhours sent to the receiver is capped to
 the number of coins they receive with a minimum of `1` coinhour for transactions
 with `<1` skycoin being sent.
 
@@ -245,7 +248,7 @@ Not implemented
 
 #### Using the REST API
 
-* `/network/connections`
+* `GET /api/v1/network/connections`
 
 #### Using skycoin as a library in a Go application
 
@@ -263,9 +266,10 @@ skycoin-cli status
 
 A method similar to `skycoin-cli status` is not implemented, but these endpoints can be used:
 
-* `/version`
-* `/blockchain/metadata`
-* `/blockchain/progress`
+* `GET /api/v1/health`
+* `GET /api/v1/version`
+* `GET /api/v1/blockchain/metadata`
+* `GET /api/v1/blockchain/progress`
 
 #### Using skycoin as a library in a Go application
 

--- a/ci-scripts/integration-test-disable-seed-api.sh
+++ b/ci-scripts/integration-test-disable-seed-api.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Runs "disable-seed-api"-mode tests against a skycoin node configured with -enable-seed-api=false
-# and /wallet/seed api endpoint should return 403 forbidden error.
+# and /api/v1/wallet/seed api endpoint should return 403 forbidden error.
 
 #Set Script Name variable
 SCRIPT=`basename ${BASH_SOURCE[0]}`

--- a/ci-scripts/integration-test-disable-wallet-api.sh
+++ b/ci-scripts/integration-test-disable-wallet-api.sh
@@ -71,6 +71,7 @@ echo "starting skycoin node in background with http listener on $HOST"
                       -launch-browser=false \
                       -data-dir="$DATA_DIR" \
                       -wallet-dir="$WALLET_DIR" \
+                      -enable-unversioned-api=true \
                       -enable-wallet-api=false &
 SKYCOIN_PID=$!
 

--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -90,8 +90,10 @@ type Config struct {
 	EnableGUI bool
 	// Disable CSRF check in the wallet API
 	DisableCSRF bool
-	// Enable /wallet/seed API endpoint
+	// Enable /api/v1/wallet/seed API endpoint
 	EnableSeedAPI bool
+	// Enable unversioned API endpoints (without the /api/v1 prefix)
+	EnableUnversionedAPI bool
 
 	// Only run on localhost and only connect to others on localhost
 	LocalhostOnly bool
@@ -186,8 +188,9 @@ func (c *Config) register() {
 	flag.BoolVar(&c.DisableNetworking, "disable-networking", c.DisableNetworking, "Disable all network activity")
 	flag.BoolVar(&c.EnableWalletAPI, "enable-wallet-api", c.EnableWalletAPI, "Enable the wallet API")
 	flag.BoolVar(&c.EnableGUI, "enable-gui", c.EnableGUI, "Enable GUI")
+	flag.BoolVar(&c.EnableUnversionedAPI, "enable-unversioned-api", c.EnableUnversionedAPI, "Enable the deprecated unversioned API endpoints without /api/v1 prefix")
 	flag.BoolVar(&c.DisableCSRF, "disable-csrf", c.DisableCSRF, "disable CSRF check")
-	flag.BoolVar(&c.EnableSeedAPI, "enable-seed-api", c.EnableSeedAPI, "enable /wallet/seed api")
+	flag.BoolVar(&c.EnableSeedAPI, "enable-seed-api", c.EnableSeedAPI, "enable /api/v1/wallet/seed api")
 	flag.StringVar(&c.Address, "address", c.Address, "IP Address to run application on. Leave empty to default to a public interface")
 	flag.IntVar(&c.Port, "port", c.Port, "Port to run application on")
 
@@ -252,6 +255,8 @@ var devConfig = Config{
 	EnableWalletAPI: false,
 	// Enable GUI
 	EnableGUI: false,
+	// Enable unversioned API
+	EnableUnversionedAPI: false,
 	// Enable seed API
 	EnableSeedAPI: false,
 	// Disable CSRF check in the wallet API
@@ -429,14 +434,15 @@ func createGUI(c *Config, d *daemon.Daemon, host string) (*api.Server, error) {
 	var err error
 
 	config := api.Config{
-		StaticDir:       c.GUIDirectory,
-		DisableCSRF:     c.DisableCSRF,
-		EnableWalletAPI: c.EnableWalletAPI,
-		EnableJSON20RPC: c.RPCInterface,
-		EnableGUI:       c.EnableGUI,
-		ReadTimeout:     c.ReadTimeout,
-		WriteTimeout:    c.WriteTimeout,
-		IdleTimeout:     c.IdleTimeout,
+		StaticDir:            c.GUIDirectory,
+		DisableCSRF:          c.DisableCSRF,
+		EnableWalletAPI:      c.EnableWalletAPI,
+		EnableJSON20RPC:      c.RPCInterface,
+		EnableGUI:            c.EnableGUI,
+		EnableUnversionedAPI: c.EnableUnversionedAPI,
+		ReadTimeout:          c.ReadTimeout,
+		WriteTimeout:         c.WriteTimeout,
+		IdleTimeout:          c.IdleTimeout,
 	}
 
 	if c.WebInterfaceHTTPS {

--- a/run.sh
+++ b/run.sh
@@ -15,6 +15,7 @@ go run -ldflags "${GOLDFLAGS}" cmd/skycoin/skycoin.go \
     -launch-browser=true \
     -enable-wallet-api=true \
     -enable-gui=true \
+    -enable-unversioned-api=true \
     -rpc-interface=false \
     -log-level=debug \
     $@

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -63,7 +63,7 @@ A REST API implemented in Go is available, see [Skycoin REST API Client Godoc](h
 
 ## CSRF
 
-All `POST`, `PUT` and `DELETE` requests require a CSRF token, obtained with a `GET /csrf` call.
+All `POST`, `PUT` and `DELETE` requests require a CSRF token, obtained with a `GET /api/v1/csrf` call.
 The token must be placed in the `X-CSRF-Token` header. A token is only valid
 for 30 seconds and it is expected that the client obtains a new CSRF token
 for each request. Requesting a CSRF token invalidates any previous CSRF token.
@@ -74,14 +74,14 @@ as the response body.
 ### Get current csrf token
 
 ```
-URI: /csrf
+URI: /api/v1/csrf
 Method: GET
 ```
 
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/csrf
+curl http://127.0.0.1:6420/api/v1/csrf
 ```
 
 Result:
@@ -97,14 +97,14 @@ Result:
 ### Health check
 
 ```
-URI: /health
+URI: /api/v1/health
 Method: GET
 ```
 
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/health
+curl http://127.0.0.1:6420/api/v1/health
 ```
 
 Response:
@@ -140,14 +140,14 @@ Response:
 ### Get node version info
 
 ```
-URI: /version
+URI: /api/v1/version
 Method: GET
 ```
 
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/version
+curl http://127.0.0.1:6420/api/v1/version
 ```
 
 Result:
@@ -162,7 +162,7 @@ Result:
 ### Get balance of addresses
 
 ```
-URI: /balance
+URI: /api/v1/balance
 Method: GET
 Args:
     addrs: comma-separated list of addresses. must contain at least one address
@@ -171,7 +171,7 @@ Args:
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/balance\?addrs\=7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD,nu7eSpT6hr5P21uzw7bnbxm83B6ywSjHdq
+curl http://127.0.0.1:6420/api/v1/balance\?addrs\=7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD,nu7eSpT6hr5P21uzw7bnbxm83B6ywSjHdq
 ```
 
 Result:
@@ -214,7 +214,7 @@ Result:
 ### Get unspent output set of address or hash
 
 ```
-URI: /outputs
+URI: /api/v1/outputs
 Method: GET
 Args:
     addrs: address list, joined with ","
@@ -226,13 +226,13 @@ Addrs and hashes cannot be combined.
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/outputs?addrs=6dkVxyKFbFKg9Vdg6HPg1UANLByYRqkrdY
+curl http://127.0.0.1:6420/api/v1/outputs?addrs=6dkVxyKFbFKg9Vdg6HPg1UANLByYRqkrdY
 ```
 
 or
 
 ```sh
-curl http://127.0.0.1:6420/outputs?hashes=7669ff7350d2c70a88093431a7b30d3e69dda2319dcb048aa80fa0d19e12ebe0
+curl http://127.0.0.1:6420/api/v1/outputs?hashes=7669ff7350d2c70a88093431a7b30d3e69dda2319dcb048aa80fa0d19e12ebe0
 ```
 
 Result:
@@ -261,7 +261,7 @@ Result:
 ### Get wallet
 
 ```
-URI: /wallet
+URI: /api/v1/wallet
 Method: GET
 Args:
     id: Wallet ID [required]
@@ -270,7 +270,7 @@ Args:
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/wallet?id=2017_11_25_e5fb.wlt
+curl http://127.0.0.1:6420/api/v1/wallet?id=2017_11_25_e5fb.wlt
 ```
 
 Result:
@@ -303,7 +303,7 @@ Result:
 ### Get wallet transactions
 
 ```
-URI: /wallet/transactions
+URI: /api/v1/wallet/transactions
 Method: GET
 Args:
 	id: Wallet ID
@@ -314,7 +314,7 @@ Returns all pending transaction for all addresses by selected Wallet
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/wallet/transactions?id=2017_11_25_e5fb.wlt
+curl http://127.0.0.1:6420/api/v1/wallet/transactions?id=2017_11_25_e5fb.wlt
 ```
 
 Result:
@@ -363,14 +363,14 @@ Result:
 ### Get wallets
 
 ```
-URI: /wallets
+URI: /api/v1/wallets
 Method: GET
 ```
 
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/wallets
+curl http://127.0.0.1:6420/api/v1/wallets
 ```
 
 Result:
@@ -405,14 +405,14 @@ Result:
 ### Get wallet folder name
 
 ```
-URI: /wallets/folderName
+URI: /api/v1/wallets/folderName
 Method: GET
 ```
 
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/wallets/folderName
+curl http://127.0.0.1:6420/api/v1/wallets/folderName
 ```
 
 Result:
@@ -426,7 +426,7 @@ Result:
 ### Generate wallet seed
 
 ```
-URI: /wallet/newSeed
+URI: /api/v1/wallet/newSeed
 Method: GET
 Args:
     entropy: seed entropy [optional]
@@ -437,7 +437,7 @@ Args:
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/wallet/newSeed
+curl http://127.0.0.1:6420/api/v1/wallet/newSeed
 ```
 
 Result:
@@ -451,7 +451,7 @@ Result:
 ### Create a wallet from seed
 
 ```
-URI: /wallet/create
+URI: /api/v1/wallet/create
 Method: POST
 Args:
     seed: wallet seed [required]
@@ -464,7 +464,7 @@ Args:
 Example:
 
 ```sh
-curl -X POST http://127.0.0.1:6420/wallet/create \
+curl -X POST http://127.0.0.1:6420/api/v1/wallet/create \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'seed=$seed' \
  -d 'label=$label' \
@@ -498,7 +498,7 @@ Result:
 ### Generate new address in wallet
 
 ```
-URI: /wallet/newAddress
+URI: /api/v1/wallet/newAddress
 Method: POST
 Args:
     id: wallet file name
@@ -509,7 +509,7 @@ Args:
 Example:
 
 ```sh
-curl -X POST http://127.0.0.1:6420/wallet/newAddress \
+curl -X POST http://127.0.0.1:6420/api/v1/wallet/newAddress \
  -H 'Content-Type: x-www-form-urlencoded' \
  -d 'id=2017_05_09_d554.wlt' \
  -d 'num=2' \
@@ -529,7 +529,7 @@ Result:
 ### Updates wallet label
 
 ```
-URI: /wallet/update
+URI: /api/v1/wallet/update
 Method: POST
 Args:
     id: wallet file name
@@ -539,7 +539,7 @@ Args:
 Example:
 
 ```sh
-curl -X POST http://127.0.0.1:6420/wallet/update \
+curl -X POST http://127.0.0.1:6420/api/v1/wallet/update \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'id=$id' \
  -d 'label=$label'
@@ -554,7 +554,7 @@ Result:
 ### Get wallet balance
 
 ```
-URI: /wallet/balance
+URI: /api/v1/wallet/balance
 Method: GET
 Args:
     id: wallet file name
@@ -563,7 +563,7 @@ Args:
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/wallet/balance?id=2018_03_07_3088.wlt
+curl http://127.0.0.1:6420/api/v1/wallet/balance?id=2018_03_07_3088.wlt
 ```
 
 Result:
@@ -636,7 +636,7 @@ Result:
 ### Spend coins from wallet
 
 ```
-URI: /wallet/spend
+URI: /api/v1/wallet/spend
 Method: POST
 Args:
     id: wallet id
@@ -660,7 +660,7 @@ Statuses:
 example, send 1 coin to `2iVtHS5ye99Km5PonsB42No3pQRGEURmxyc` from wallet `2017_05_09_ea42.wlt`:
 
 ```sh
-curl -X POST  http://127.0.0.1:6420/wallet/spend \
+curl -X POST  http://127.0.0.1:6420/api/v1/wallet/spend \
   -H 'Content-Type: application/x-www-form-urlencoded' \
   -d 'id=2017_05_09_ea42.wlt' \
   -d 'dst=2iVtHS5ye99Km5PonsB42No3pQRGEURmxyc' \
@@ -717,14 +717,14 @@ Result:
 ### Create transaction
 
 ```
-URI: /wallet/transaction
+URI: /api/v1/wallet/transaction
 Method: POST
 Content-Type: application/json
 Args: JSON body, see examples
 ```
 
 Creates a transaction, returning the transaction preview and the encoded, serialized transaction.
-The `encoded_transaction` can be provided to `POST /injectTransaction` to broadcast it to the network.
+The `encoded_transaction` can be provided to `POST /api/v1/injectTransaction` to broadcast it to the network.
 
 The request body includes:
 
@@ -855,7 +855,7 @@ for spending. To control which addresses may spend, specify the addresses in thi
 Example:
 
 ```sh
-curl -X POST http://127.0.0.1:6420/wallet/transaction -H 'content-type: application/json' -d '{
+curl -X POST http://127.0.0.1:6420/api/v1/wallet/transaction -H 'content-type: application/json' -d '{
     "hours_selection": {
         "type": "auto",
         "mode": "share",
@@ -928,7 +928,7 @@ Result:
 ### Unload wallet
 
 ```
-URI: /wallet/unload
+URI: /api/v1/wallet/unload
 Method: POST
 Args:
     id: wallet file name
@@ -937,7 +937,7 @@ Args:
 Example:
 
 ```sh
-curl -X POST http://127.0.0.1:6420/wallet/unload \
+curl -X POST http://127.0.0.1:6420/api/v1/wallet/unload \
  -H 'Content-Type: x-www-form-urlencoded' \
  -d 'id=2017_05_09_d554.wlt'
 ```
@@ -945,7 +945,7 @@ curl -X POST http://127.0.0.1:6420/wallet/unload \
 ### Encrypt wallet
 
 ```
-URI: /wallet/encrypt
+URI: /api/v1/wallet/encrypt
 Method: POST
 Args:
     id: wallet id
@@ -955,7 +955,7 @@ Args:
 Example:
 
 ```sh
-curl -X POST http://127.0.0.1:6420/wallet/encrypt \
+curl -X POST http://127.0.0.1:6420/api/v1/wallet/encrypt \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'id=test.wlt' \
  -d 'password=$password'
@@ -987,7 +987,7 @@ Result:
 ### Decrypt wallet
 
 ```
-URI: /wallet/decrypt
+URI: /api/v1/wallet/decrypt
 Method: POST
 Args:
     id: wallet id
@@ -997,7 +997,7 @@ Args:
 Example:
 
 ```sh
-curl -X POST http://127.0.0.1:6420/wallet/decrypt \
+curl -X POST http://127.0.0.1:6420/api/v1/wallet/decrypt \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'id=test.wlt' \
  -d 'password=$password'
@@ -1031,7 +1031,7 @@ Result:
 This endpoint is supported only when `-enable-seed-api` option is enabled and the wallet is encrypted.
 
 ```
-URI: /wallet/seed
+URI: /api/v1/wallet/seed
 Method: POST
 Args:
     id: wallet id
@@ -1041,7 +1041,7 @@ Args:
 Example:
 
 ```sh
-curl -X POST http://127.0.0.1:6420/wallet/seed \
+curl -X POST http://127.0.0.1:6420/api/v1/wallet/seed \
  -H 'Content-type: application/x-www-form-urlencoded' \
  -d 'id=test.wlt' \
  -d 'password=$password'
@@ -1060,14 +1060,14 @@ Result:
 ### Get unconfirmed transactions
 
 ```
-URI: /pendingTxs
+URI: /api/v1/pendingTxs
 Method: GET
 ```
 
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/pendingTxs
+curl http://127.0.0.1:6420/api/v1/pendingTxs
 ```
 
 Result:
@@ -1114,7 +1114,7 @@ Result:
 ### Get transaction info by id
 
 ```
-URI: /transaction
+URI: /api/v1/transaction
 Method: GET
 Args:
     txid: transaction id
@@ -1123,7 +1123,7 @@ Args:
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/transaction?txid=a6446654829a4a844add9f181949d12f8291fdd2c0fcb22200361e90e814e2d3
+curl http://127.0.0.1:6420/api/v1/transaction?txid=a6446654829a4a844add9f181949d12f8291fdd2c0fcb22200361e90e814e2d3
 ```
 
 Result:
@@ -1164,14 +1164,14 @@ Result:
 ### Get raw transaction by id
 
 ```
-URI: /rawtx
+URI: /api/v1/rawtx
 Method: GET
 ```
 
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/rawtx?txid=a6446654829a4a844add9f181949d12f8291fdd2c0fcb22200361e90e814e2d3
+curl http://127.0.0.1:6420/api/v1/rawtx?txid=a6446654829a4a844add9f181949d12f8291fdd2c0fcb22200361e90e814e2d3
 ```
 
 Result:
@@ -1183,7 +1183,7 @@ Result:
 ### Inject raw transaction
 
 ```
-URI: /injectTransaction
+URI: /api/v1/injectTransaction
 Method: POST
 Content-Type: application/json
 Body: {"rawtx": "raw transaction"}
@@ -1199,7 +1199,7 @@ This can happen if the node's network has recently become unavailable but its co
 Example:
 
 ```sh
-curl -X POST http://127.0.0.1:6420/injectTransaction -H 'content-type: application/json' -d '{
+curl -X POST http://127.0.0.1:6420/api/v1/injectTransaction -H 'content-type: application/json' -d '{
     "rawtx":"dc0000000008b507528697b11340f5a3fcccbff031c487bad59d26c2bdaea0cd8a0199a1720100000017f36c9d8bce784df96a2d6848f1b7a8f5c890986846b7c53489eb310090b91143c98fd233830055b5959f60030b3ca08d95f22f6b96ba8c20e548d62b342b5e0001000000ec9cf2f6052bab24ec57847c72cfb377c06958a9e04a077d07b6dd5bf23ec106020000000072116096fe2207d857d18565e848b403807cd825c044840300000000330100000000000000575e472f8c5295e8fa644e9bc5e06ec10351c65f40420f000000000066020000000000000"
 }'
 ```
@@ -1213,7 +1213,7 @@ Result:
 ### Get transactions that are addresses related
 
 ```
-URI: /transactions
+URI: /api/v1/transactions
 Method: GET
 Args:
 	addrs: Comma seperated addresses [optional, returns all transactions if no address is provided]
@@ -1223,18 +1223,18 @@ Args:
 To get address related confirmed transactions:
 
 ```sh
-curl http://127.0.0.1:6420/transactions?addrs=7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD,6dkVxyKFbFKg9Vdg6HPg1UANLByYRqkrdY&confirmed=1
+curl http://127.0.0.1:6420/api/v1/transactions?addrs=7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD,6dkVxyKFbFKg9Vdg6HPg1UANLByYRqkrdY&confirmed=1
 ```
 
 To get address related unconfirmed transactions:
 ```sh
-curl http://127.0.0.1:6420/transactions?addrs=7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD,6dkVxyKFbFKg9Vdg6HPg1UANLByYRqkrdY&confirmed=0
+curl http://127.0.0.1:6420/api/v1/transactions?addrs=7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD,6dkVxyKFbFKg9Vdg6HPg1UANLByYRqkrdY&confirmed=0
 ```
 
 To get all addresses related transactions:
 
 ```sh
-curl http://127.0.0.1:6420/transactions?addrs=7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD,6dkVxyKFbFKg9Vdg6HPg1UANLByYRqkrdY
+curl http://127.0.0.1:6420/api/v1/transactions?addrs=7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD,6dkVxyKFbFKg9Vdg6HPg1UANLByYRqkrdY
 ```
 
 
@@ -1355,14 +1355,14 @@ Result:
 ### Resend unconfirmed transactions
 
 ```
-URI: /resendUnconfirmedTxns
+URI: /api/v1/resendUnconfirmedTxns
 Method: GET
 ```
 
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/resendUnconfirmedTxns
+curl http://127.0.0.1:6420/api/v1/resendUnconfirmedTxns
 ```
 
 Result:
@@ -1388,7 +1388,7 @@ Method: GET
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/blockchain/metadata
+curl http://127.0.0.1:6420/api/v1/blockchain/metadata
 ```
 
 Result:
@@ -1412,14 +1412,14 @@ Result:
 ### Get blockchain progress
 
 ```
-URI: /blockchain/progress
+URI: /api/v1/blockchain/progress
 Method: GET
 ```
 
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/blockchain/progress
+curl http://127.0.0.1:6420/api/v1/blockchain/progress
 ```
 
 Result:
@@ -1444,7 +1444,7 @@ Result:
 ### Get block by hash or seq
 
 ```
-URI: /block
+URI: /api/v1/block
 Method: GET
 Args:
     hash: get block by hash
@@ -1452,13 +1452,13 @@ Args:
 ```
 
 ```sh
-curl http://127.0.0.1:6420/block?hash=6eafd13ab6823223b714246b32c984b56e0043412950faf17defdbb2cbf3fe30
+curl http://127.0.0.1:6420/api/v1/block?hash=6eafd13ab6823223b714246b32c984b56e0043412950faf17defdbb2cbf3fe30
 ```
 
 or
 
 ```sh
-curl http://127.0.0.1:6420/block?seq=2760
+curl http://127.0.0.1:6420/api/v1/block?seq=2760
 ```
 
 Result:
@@ -1511,7 +1511,7 @@ Result:
 ### Get blocks in specific range
 
 ```
-URI: /blocks
+URI: /api/v1/blocks
 Method: GET
 Args:
     start: start seq
@@ -1521,7 +1521,7 @@ Args:
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/blocks?start=1&end=2
+curl http://127.0.0.1:6420/api/v1/blocks?start=1&end=2
 ```
 
 Result:
@@ -1608,7 +1608,7 @@ Result:
 ### Get last N blocks
 
 ```
-URI: /last_blocks
+URI: /api/v1/last_blocks
 Method: GET
 Args:
     num: number of most recent blocks to return
@@ -1617,7 +1617,7 @@ Args:
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/last_blocks?num=2
+curl http://127.0.0.1:6420/api/v1/last_blocks?num=2
 ```
 
 Result:
@@ -1718,7 +1718,7 @@ Result:
 ### Get address affected transactions
 
 ```
-URI: /explorer/address
+URI: /api/v1/explorer/address
 Method: GET
 Args:
     address
@@ -1727,7 +1727,7 @@ Args:
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/explorer/address?address=2NfNKsaGJEndpSajJ6TsKJfsdDjW2gFsjXg
+curl http://127.0.0.1:6420/api/v1/explorer/address?address=2NfNKsaGJEndpSajJ6TsKJfsdDjW2gFsjXg
 ```
 
 Result:
@@ -1775,7 +1775,7 @@ Result:
 ### Get uxout
 
 ```
-URI: /uxout
+URI: /api/v1/uxout
 Method: GET
 Args:
     uxid
@@ -1784,7 +1784,7 @@ Args:
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/uxout?uxid=8b64d9b058e10472b9457fd2d05a1d89cbbbd78ce1d97b16587d43379271bed1
+curl http://127.0.0.1:6420/api/v1/uxout?uxid=8b64d9b058e10472b9457fd2d05a1d89cbbbd78ce1d97b16587d43379271bed1
 ```
 
 Result:
@@ -1806,7 +1806,7 @@ Result:
 ### Get address affected uxouts
 
 ```
-URI: /address_uxouts
+URI: /api/v1/address_uxouts
 Method: GET
 Args:
     address
@@ -1815,7 +1815,7 @@ Args:
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/address_uxouts?address=6dkVxyKFbFKg9Vdg6HPg1UANLByYRqkrdY
+curl http://127.0.0.1:6420/api/v1/address_uxouts?address=6dkVxyKFbFKg9Vdg6HPg1UANLByYRqkrdY
 ```
 
 Result:
@@ -1841,14 +1841,14 @@ Result:
 ### Coin supply
 
 ```
-URI: /coinSupply
+URI: /api/v1/coinSupply
 Method: GET
 ```
 
 Example:
 
 ```sh
-curl http://127.0.0.1:6420/coinSupply
+curl http://127.0.0.1:6420/api/v1/coinSupply
 ```
 
 Result:
@@ -1970,7 +1970,7 @@ Result:
 ### Richlist show top N addresses by uxouts
 
 ```
-URI: /richlist
+URI: /api/v1/richlist
 Method: GET
 Args:
     n: top N addresses, [default 20, returns all if <= 0].
@@ -1980,7 +1980,7 @@ Args:
 Example:
 
 ```sh
-curl "http://127.0.0.1:6420/richlist?n=4&include-distribution=true"
+curl "http://127.0.0.1:6420/api/v1/richlist?n=4&include-distribution=true"
 ```
 
 Result:
@@ -2015,14 +2015,14 @@ Result:
 ### Count unique addresses
 
 ```
-URI: /addresscount
+URI: /api/v1/addresscount
 Method: GET
 ```
 
 Example:
 
 ```sh
-curl "http://127.0.0.1:6420/addresscount"
+curl "http://127.0.0.1:6420/api/v1/addresscount"
 ```
 
 Result:
@@ -2038,7 +2038,7 @@ Result:
 ### Get information for a specific connection
 
 ```
-URI: /network/connection
+URI: /api/v1/network/connection
 Method: GET
 Args:
     addr: ip:port address of a known connection
@@ -2047,7 +2047,7 @@ Args:
 Example:
 
 ```sh
-curl 'http://127.0.0.1:6420/network/connection?addr=176.9.84.75:6000'
+curl 'http://127.0.0.1:6420/api/v1/network/connection?addr=176.9.84.75:6000'
 ```
 
 Result:
@@ -2069,14 +2069,14 @@ Result:
 ### Get a list of all connections
 
 ```
-URI: /network/connections
+URI: /api/v1/network/connections
 Method: GET
 ```
 
 Example:
 
 ```sh
-curl 'http://127.0.0.1:6420/network/connections'
+curl 'http://127.0.0.1:6420/api/v1/network/connections'
 ```
 
 Result:
@@ -2125,14 +2125,14 @@ Result:
 ### Get a list of all default connections
 
 ```
-URI: /network/defaultConnections
+URI: /api/v1/network/defaultConnections
 Method: GET
 ```
 
 Example:
 
 ```sh
-curl 'http://127.0.0.1:6420/network/defaultConnections'
+curl 'http://127.0.0.1:6420/api/v1/network/defaultConnections'
 ```
 
 Result:
@@ -2153,14 +2153,14 @@ Result:
 ### Get a list of all trusted connections
 
 ```
-URI: /network/connections/trust
+URI: /api/v1/network/connections/trust
 Method: GET
 ```
 
 Example:
 
 ```sh
-curl 'http://127.0.0.1:6420/network/connections/trust'
+curl 'http://127.0.0.1:6420/api/v1/network/connections/trust'
 ```
 
 Result:
@@ -2181,14 +2181,14 @@ Result:
 ### Get a list of all connections discovered through peer exchange
 
 ```
-URI: /network/connections/exchange
+URI: /api/v1/network/connections/exchange
 Method: GET
 ```
 
 Example:
 
 ```sh
-curl 'http://127.0.0.1:6420/network/connections/exchange'
+curl 'http://127.0.0.1:6420/api/v1/network/connections/exchange'
 ```
 
 Result:

--- a/src/api/blockchain_test.go
+++ b/src/api/blockchain_test.go
@@ -208,7 +208,7 @@ func TestGetBlock(t *testing.T) {
 			gateway.On("GetSignedBlockByHash", tc.sha256).Return(tc.gatewayGetBlockByHashResult, tc.gatewayGetBlockByHashErr)
 			gateway.On("GetSignedBlockBySeq", tc.seq).Return(tc.gatewayGetBlockBySeqResult, tc.gatewayGetBlockBySeqErr)
 
-			endpoint := "/block"
+			endpoint := "/api/v1/block"
 
 			v := url.Values{}
 			if tc.hash != "" {
@@ -334,7 +334,7 @@ func TestGetBlocks(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("GetBlocks", tc.start, tc.end).Return(tc.gatewayGetBlocksResult, tc.gatewayGetBlocksError)
 
-			endpoint := "/blocks"
+			endpoint := "/api/v1/blocks"
 
 			v := url.Values{}
 			if tc.body != nil {
@@ -445,7 +445,7 @@ func TestGetLastBlocks(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			endpoint := "/last_blocks"
+			endpoint := "/api/v1/last_blocks"
 			gateway := NewGatewayerMock()
 
 			gateway.On("GetLastBlocks", tc.num).Return(tc.gatewayGetLastBlocksResult, tc.gatewayGetLastBlocksError)

--- a/src/api/client.go
+++ b/src/api/client.go
@@ -106,18 +106,18 @@ func (c *Client) get(endpoint string) (*http.Response, error) {
 }
 
 // PostForm makes a POST request to an endpoint with body of "application/x-www-form-urlencoded" formated data.
-func (c *Client) PostForm(endpoints string, body io.Reader, obj interface{}) error {
-	return c.post(endpoints, "application/x-www-form-urlencoded", body, obj)
+func (c *Client) PostForm(endpoint string, body io.Reader, obj interface{}) error {
+	return c.post(endpoint, "application/x-www-form-urlencoded", body, obj)
 }
 
 // PostJSON makes a POST request to an endpoint with body of json data.
-func (c *Client) PostJSON(endpoints string, reqObj, respObj interface{}) error {
+func (c *Client) PostJSON(endpoint string, reqObj, respObj interface{}) error {
 	body, err := json.Marshal(reqObj)
 	if err != nil {
 		return err
 	}
 
-	return c.post(endpoints, "application/json", bytes.NewReader(body), respObj)
+	return c.post(endpoint, "application/json", bytes.NewReader(body), respObj)
 }
 
 // Post makes a POST request to an endpoint. Caller must close response body.
@@ -170,7 +170,7 @@ func (c *Client) post(endpoint string, contentType string, body io.Reader, obj i
 
 // CSRF returns a CSRF token. If CSRF is disabled on the node, returns an empty string and nil error.
 func (c *Client) CSRF() (string, error) {
-	resp, err := c.get("/csrf")
+	resp, err := c.get("/api/v1/csrf")
 	if err != nil {
 		return "", err
 	}
@@ -208,29 +208,29 @@ func (c *Client) CSRF() (string, error) {
 	return token, nil
 }
 
-// Version makes a request to /version
+// Version makes a request to GET /api/v1/version
 func (c *Client) Version() (*visor.BuildInfo, error) {
 	var bi visor.BuildInfo
-	if err := c.Get("/version", &bi); err != nil {
+	if err := c.Get("/api/v1/version", &bi); err != nil {
 		return nil, err
 	}
 	return &bi, nil
 }
 
-// Outputs makes a request to /outputs
+// Outputs makes a request to GET /api/v1/outputs
 func (c *Client) Outputs() (*visor.ReadableOutputSet, error) {
 	var o visor.ReadableOutputSet
-	if err := c.Get("/outputs", &o); err != nil {
+	if err := c.Get("/api/v1/outputs", &o); err != nil {
 		return nil, err
 	}
 	return &o, nil
 }
 
-// OutputsForAddresses makes a request to /outputs?addrs=xxx
+// OutputsForAddresses makes a request to GET /api/v1/outputs?addrs=xxx
 func (c *Client) OutputsForAddresses(addrs []string) (*visor.ReadableOutputSet, error) {
 	v := url.Values{}
 	v.Add("addrs", strings.Join(addrs, ","))
-	endpoint := "/outputs?" + v.Encode()
+	endpoint := "/api/v1/outputs?" + v.Encode()
 
 	var o visor.ReadableOutputSet
 	if err := c.Get(endpoint, &o); err != nil {
@@ -239,11 +239,11 @@ func (c *Client) OutputsForAddresses(addrs []string) (*visor.ReadableOutputSet, 
 	return &o, nil
 }
 
-// OutputsForHashes makes a request to /outputs?hashes=zzz
+// OutputsForHashes makes a request to GET /api/v1/outputs?hashes=zzz
 func (c *Client) OutputsForHashes(hashes []string) (*visor.ReadableOutputSet, error) {
 	v := url.Values{}
 	v.Add("hashes", strings.Join(hashes, ","))
-	endpoint := "/outputs?" + v.Encode()
+	endpoint := "/api/v1/outputs?" + v.Encode()
 
 	var o visor.ReadableOutputSet
 	if err := c.Get(endpoint, &o); err != nil {
@@ -252,20 +252,20 @@ func (c *Client) OutputsForHashes(hashes []string) (*visor.ReadableOutputSet, er
 	return &o, nil
 }
 
-// CoinSupply makes a request to /coinSupply
+// CoinSupply makes a request to GET /api/v1/coinSupply
 func (c *Client) CoinSupply() (*CoinSupply, error) {
 	var cs CoinSupply
-	if err := c.Get("/coinSupply", &cs); err != nil {
+	if err := c.Get("/api/v1/coinSupply", &cs); err != nil {
 		return nil, err
 	}
 	return &cs, nil
 }
 
-// BlockByHash makes a request to /block?hash=xxx
+// BlockByHash makes a request to GET /api/v1/block?hash=xxx
 func (c *Client) BlockByHash(hash string) (*visor.ReadableBlock, error) {
 	v := url.Values{}
 	v.Add("hash", hash)
-	endpoint := "/block?" + v.Encode()
+	endpoint := "/api/v1/block?" + v.Encode()
 
 	var b visor.ReadableBlock
 	if err := c.Get(endpoint, &b); err != nil {
@@ -274,11 +274,11 @@ func (c *Client) BlockByHash(hash string) (*visor.ReadableBlock, error) {
 	return &b, nil
 }
 
-// BlockBySeq makes a request to /block?seq=xxx
+// BlockBySeq makes a request to GET /api/v1/block?seq=xxx
 func (c *Client) BlockBySeq(seq uint64) (*visor.ReadableBlock, error) {
 	v := url.Values{}
 	v.Add("seq", fmt.Sprint(seq))
-	endpoint := "/block?" + v.Encode()
+	endpoint := "/api/v1/block?" + v.Encode()
 
 	var b visor.ReadableBlock
 	if err := c.Get(endpoint, &b); err != nil {
@@ -287,12 +287,12 @@ func (c *Client) BlockBySeq(seq uint64) (*visor.ReadableBlock, error) {
 	return &b, nil
 }
 
-// Blocks makes a request to /blocks
+// Blocks makes a request to GET /api/v1/blocks
 func (c *Client) Blocks(start, end int) (*visor.ReadableBlocks, error) {
 	v := url.Values{}
 	v.Add("start", fmt.Sprint(start))
 	v.Add("end", fmt.Sprint(end))
-	endpoint := "/blocks?" + v.Encode()
+	endpoint := "/api/v1/blocks?" + v.Encode()
 
 	var b visor.ReadableBlocks
 	if err := c.Get(endpoint, &b); err != nil {
@@ -301,11 +301,11 @@ func (c *Client) Blocks(start, end int) (*visor.ReadableBlocks, error) {
 	return &b, nil
 }
 
-// LastBlocks makes a request to /last_blocks
+// LastBlocks makes a request to GET /api/v1/last_blocks
 func (c *Client) LastBlocks(n int) (*visor.ReadableBlocks, error) {
 	v := url.Values{}
 	v.Add("num", fmt.Sprint(n))
-	endpoint := "/last_blocks?" + v.Encode()
+	endpoint := "/api/v1/last_blocks?" + v.Encode()
 
 	var b visor.ReadableBlocks
 	if err := c.Get(endpoint, &b); err != nil {
@@ -314,29 +314,29 @@ func (c *Client) LastBlocks(n int) (*visor.ReadableBlocks, error) {
 	return &b, nil
 }
 
-// BlockchainMetadata makes a request to /blockchain/metadata
+// BlockchainMetadata makes a request to GET /api/v1/blockchain/metadata
 func (c *Client) BlockchainMetadata() (*visor.BlockchainMetadata, error) {
 	var b visor.BlockchainMetadata
-	if err := c.Get("/blockchain/metadata", &b); err != nil {
+	if err := c.Get("/api/v1/blockchain/metadata", &b); err != nil {
 		return nil, err
 	}
 	return &b, nil
 }
 
-// BlockchainProgress makes a request to /blockchain/progress
+// BlockchainProgress makes a request to GET /api/v1/blockchain/progress
 func (c *Client) BlockchainProgress() (*daemon.BlockchainProgress, error) {
 	var b daemon.BlockchainProgress
-	if err := c.Get("/blockchain/progress", &b); err != nil {
+	if err := c.Get("/api/v1/blockchain/progress", &b); err != nil {
 		return nil, err
 	}
 	return &b, nil
 }
 
-// Balance makes a request to /balance?addrs=xxx
+// Balance makes a request to GET /api/v1/balance?addrs=xxx
 func (c *Client) Balance(addrs []string) (*wallet.BalancePair, error) {
 	v := url.Values{}
 	v.Add("addrs", strings.Join(addrs, ","))
-	endpoint := "/balance?" + v.Encode()
+	endpoint := "/api/v1/balance?" + v.Encode()
 
 	var b wallet.BalancePair
 	if err := c.Get(endpoint, &b); err != nil {
@@ -345,11 +345,11 @@ func (c *Client) Balance(addrs []string) (*wallet.BalancePair, error) {
 	return &b, nil
 }
 
-// UxOut makes a request to /uxout?uxid=xxx
+// UxOut makes a request to GET /api/v1/uxout?uxid=xxx
 func (c *Client) UxOut(uxID string) (*historydb.UxOutJSON, error) {
 	v := url.Values{}
 	v.Add("uxid", uxID)
-	endpoint := "/uxout?" + v.Encode()
+	endpoint := "/api/v1/uxout?" + v.Encode()
 
 	var b historydb.UxOutJSON
 	if err := c.Get(endpoint, &b); err != nil {
@@ -358,11 +358,11 @@ func (c *Client) UxOut(uxID string) (*historydb.UxOutJSON, error) {
 	return &b, nil
 }
 
-// AddressUxOuts makes a request to /address_uxouts
+// AddressUxOuts makes a request to GET /api/v1/address_uxouts
 func (c *Client) AddressUxOuts(addr string) ([]*historydb.UxOutJSON, error) {
 	v := url.Values{}
 	v.Add("address", addr)
-	endpoint := "/address_uxouts?" + v.Encode()
+	endpoint := "/api/v1/address_uxouts?" + v.Encode()
 
 	var b []*historydb.UxOutJSON
 	if err := c.Get(endpoint, &b); err != nil {
@@ -371,11 +371,11 @@ func (c *Client) AddressUxOuts(addr string) ([]*historydb.UxOutJSON, error) {
 	return b, nil
 }
 
-// Wallet makes a request to /wallet
+// Wallet makes a request to GET /api/v1/wallet
 func (c *Client) Wallet(id string) (*WalletResponse, error) {
 	v := url.Values{}
 	v.Add("id", id)
-	endpoint := "/wallet?" + v.Encode()
+	endpoint := "/api/v1/wallet?" + v.Encode()
 
 	var wr WalletResponse
 	if err := c.Get(endpoint, &wr); err != nil {
@@ -385,18 +385,18 @@ func (c *Client) Wallet(id string) (*WalletResponse, error) {
 	return &wr, nil
 }
 
-// Wallets makes a request to /wallets
+// Wallets makes a request to GET /api/v1/wallets
 func (c *Client) Wallets() ([]*WalletResponse, error) {
 	var wrs []*WalletResponse
-	if err := c.Get("/wallets", &wrs); err != nil {
+	if err := c.Get("/api/v1/wallets", &wrs); err != nil {
 		return nil, err
 	}
 
 	return wrs, nil
 }
 
-// CreateUnencryptedWallet makes a request to /wallet/create and create
-// a wallet without no encryption
+// CreateUnencryptedWallet makes a request to POST /api/v1/wallet/create and creates
+// a wallet without encryption.
 // If scanN is <= 0, the scan number defaults to 1
 func (c *Client) CreateUnencryptedWallet(seed, label string, scanN int) (*WalletResponse, error) {
 	v := url.Values{}
@@ -409,13 +409,13 @@ func (c *Client) CreateUnencryptedWallet(seed, label string, scanN int) (*Wallet
 	}
 
 	var w WalletResponse
-	if err := c.PostForm("/wallet/create", strings.NewReader(v.Encode()), &w); err != nil {
+	if err := c.PostForm("/api/v1/wallet/create", strings.NewReader(v.Encode()), &w); err != nil {
 		return nil, err
 	}
 	return &w, nil
 }
 
-// CreateEncryptedWallet makes a request to /wallet/create and try to create
+// CreateEncryptedWallet makes a request to POST /api/v1/wallet/create and try to create
 // a wallet with encryption.
 // If scanN is <= 0, the scan number defaults to 1
 func (c *Client) CreateEncryptedWallet(seed, label, password string, scanN int) (*WalletResponse, error) {
@@ -430,13 +430,13 @@ func (c *Client) CreateEncryptedWallet(seed, label, password string, scanN int) 
 	}
 
 	var w WalletResponse
-	if err := c.PostForm("/wallet/create", strings.NewReader(v.Encode()), &w); err != nil {
+	if err := c.PostForm("/api/v1/wallet/create", strings.NewReader(v.Encode()), &w); err != nil {
 		return nil, err
 	}
 	return &w, nil
 }
 
-// NewWalletAddress makes a request to /wallet/newAddress
+// NewWalletAddress makes a request to POST /api/v1/wallet/newAddress
 // if n is <= 0, defaults to 1
 func (c *Client) NewWalletAddress(id string, n int, password string) ([]string, error) {
 	v := url.Values{}
@@ -450,17 +450,17 @@ func (c *Client) NewWalletAddress(id string, n int, password string) ([]string, 
 	var obj struct {
 		Addresses []string `json:"addresses"`
 	}
-	if err := c.PostForm("/wallet/newAddress", strings.NewReader(v.Encode()), &obj); err != nil {
+	if err := c.PostForm("/api/v1/wallet/newAddress", strings.NewReader(v.Encode()), &obj); err != nil {
 		return nil, err
 	}
 	return obj.Addresses, nil
 }
 
-// WalletBalance makes a request to /wallet/balance
+// WalletBalance makes a request to GET /api/v1/wallet/balance
 func (c *Client) WalletBalance(id string) (*BalanceResponse, error) {
 	v := url.Values{}
 	v.Add("id", id)
-	endpoint := "/wallet/balance?" + v.Encode()
+	endpoint := "/api/v1/wallet/balance?" + v.Encode()
 
 	var b BalanceResponse
 	if err := c.Get(endpoint, &b); err != nil {
@@ -469,7 +469,7 @@ func (c *Client) WalletBalance(id string) (*BalanceResponse, error) {
 	return &b, nil
 }
 
-// Spend makes a request to /wallet/spend
+// Spend makes a request to POST /api/v1/wallet/spend
 func (c *Client) Spend(id, dst string, coins uint64, password string) (*SpendResult, error) {
 	v := url.Values{}
 	v.Add("id", id)
@@ -478,7 +478,7 @@ func (c *Client) Spend(id, dst string, coins uint64, password string) (*SpendRes
 	v.Add("password", password)
 
 	var r SpendResult
-	endpoint := "/wallet/spend"
+	endpoint := "/api/v1/wallet/spend"
 	if err := c.PostForm(endpoint, strings.NewReader(v.Encode()), &r); err != nil {
 		return nil, err
 	}
@@ -515,10 +515,10 @@ type Receiver struct {
 	Hours   string `json:"hours,omitempty"`
 }
 
-// CreateTransaction makes a request to POST /wallet/transaction
+// CreateTransaction makes a request to POST /api/v1/wallet/transaction
 func (c *Client) CreateTransaction(req CreateTransactionRequest) (*CreateTransactionResponse, error) {
 	var r CreateTransactionResponse
-	endpoint := "/wallet/transaction"
+	endpoint := "/api/v1/wallet/transaction"
 	if err := c.PostJSON(endpoint, req, &r); err != nil {
 		return nil, err
 	}
@@ -526,11 +526,11 @@ func (c *Client) CreateTransaction(req CreateTransactionRequest) (*CreateTransac
 	return &r, nil
 }
 
-// WalletTransactions makes a request to /wallet/transactions
+// WalletTransactions makes a request to GET /api/v1/wallet/transactions
 func (c *Client) WalletTransactions(id string) (*UnconfirmedTxnsResponse, error) {
 	v := url.Values{}
 	v.Add("id", id)
-	endpoint := "/wallet/transactions?" + v.Encode()
+	endpoint := "/api/v1/wallet/transactions?" + v.Encode()
 
 	var utx *UnconfirmedTxnsResponse
 	if err := c.Get(endpoint, &utx); err != nil {
@@ -539,30 +539,30 @@ func (c *Client) WalletTransactions(id string) (*UnconfirmedTxnsResponse, error)
 	return utx, nil
 }
 
-// UpdateWallet makes a request to /wallet/update
+// UpdateWallet makes a request to POST /api/v1/wallet/update
 func (c *Client) UpdateWallet(id, label string) error {
 	v := url.Values{}
 	v.Add("id", id)
 	v.Add("label", label)
 
-	return c.PostForm("/wallet/update", strings.NewReader(v.Encode()), nil)
+	return c.PostForm("/api/v1/wallet/update", strings.NewReader(v.Encode()), nil)
 }
 
-// WalletFolderName makes a request to /wallets/folderName
+// WalletFolderName makes a request to GET /api/v1/wallets/folderName
 func (c *Client) WalletFolderName() (*WalletFolder, error) {
 	var w WalletFolder
-	if err := c.Get("/wallets/folderName", &w); err != nil {
+	if err := c.Get("/api/v1/wallets/folderName", &w); err != nil {
 		return nil, err
 	}
 	return &w, nil
 }
 
-// NewSeed makes a request to /wallet/newSeed
+// NewSeed makes a request to GET /api/v1/wallet/newSeed
 // entropy must be 128 or 256
 func (c *Client) NewSeed(entropy int) (string, error) {
 	v := url.Values{}
 	v.Add("entropy", fmt.Sprint(entropy))
-	endpoint := "/wallet/newSeed?" + v.Encode()
+	endpoint := "/api/v1/wallet/newSeed?" + v.Encode()
 
 	var r struct {
 		Seed string `json:"seed"`
@@ -573,7 +573,7 @@ func (c *Client) NewSeed(entropy int) (string, error) {
 	return r.Seed, nil
 }
 
-// GetWalletSeed makes a request to /wallet/seed
+// GetWalletSeed makes a request to POST /api/v1/wallet/seed
 func (c *Client) GetWalletSeed(id string, password string) (string, error) {
 	v := url.Values{}
 	v.Add("id", id)
@@ -582,18 +582,18 @@ func (c *Client) GetWalletSeed(id string, password string) (string, error) {
 	var r struct {
 		Seed string `json:"seed"`
 	}
-	if err := c.PostForm("/wallet/seed", strings.NewReader(v.Encode()), &r); err != nil {
+	if err := c.PostForm("/api/v1/wallet/seed", strings.NewReader(v.Encode()), &r); err != nil {
 		return "", err
 	}
 
 	return r.Seed, nil
 }
 
-// NetworkConnection makes a request to /network/connection
+// NetworkConnection makes a request to GET /api/v1/network/connection
 func (c *Client) NetworkConnection(addr string) (*daemon.Connection, error) {
 	v := url.Values{}
 	v.Add("addr", addr)
-	endpoint := "/network/connection?" + v.Encode()
+	endpoint := "/api/v1/network/connection?" + v.Encode()
 
 	var dc daemon.Connection
 	if err := c.Get(endpoint, &dc); err != nil {
@@ -602,56 +602,56 @@ func (c *Client) NetworkConnection(addr string) (*daemon.Connection, error) {
 	return &dc, nil
 }
 
-// NetworkConnections makes a request to /network/connections
+// NetworkConnections makes a request to GET /api/v1/network/connections
 func (c *Client) NetworkConnections() (*Connections, error) {
 	var dc Connections
-	if err := c.Get("/network/connections", &dc); err != nil {
+	if err := c.Get("/api/v1/network/connections", &dc); err != nil {
 		return nil, err
 	}
 	return &dc, nil
 }
 
-// NetworkDefaultConnections makes a request to /network/defaultConnections
+// NetworkDefaultConnections makes a request to GET /api/v1/network/defaultConnections
 func (c *Client) NetworkDefaultConnections() ([]string, error) {
 	var dc []string
-	if err := c.Get("/network/defaultConnections", &dc); err != nil {
+	if err := c.Get("/api/v1/network/defaultConnections", &dc); err != nil {
 		return nil, err
 	}
 	return dc, nil
 }
 
-// NetworkTrustedConnections makes a request to /network/connections/trust
+// NetworkTrustedConnections makes a request to GET /api/v1/network/connections/trust
 func (c *Client) NetworkTrustedConnections() ([]string, error) {
 	var dc []string
-	if err := c.Get("/network/connections/trust", &dc); err != nil {
+	if err := c.Get("/api/v1/network/connections/trust", &dc); err != nil {
 		return nil, err
 	}
 	return dc, nil
 }
 
-// NetworkExchangeableConnections makes a request to /network/connections/exchange
+// NetworkExchangeableConnections makes a request to GET /api/v1/network/connections/exchange
 func (c *Client) NetworkExchangeableConnections() ([]string, error) {
 	var dc []string
-	if err := c.Get("/network/connections/exchange", &dc); err != nil {
+	if err := c.Get("/api/v1/network/connections/exchange", &dc); err != nil {
 		return nil, err
 	}
 	return dc, nil
 }
 
-// PendingTransactions makes a request to /pendingTxs
+// PendingTransactions makes a request to GET /api/v1/pendingTxs
 func (c *Client) PendingTransactions() ([]*visor.ReadableUnconfirmedTxn, error) {
 	var v []*visor.ReadableUnconfirmedTxn
-	if err := c.Get("/pendingTxs", &v); err != nil {
+	if err := c.Get("/api/v1/pendingTxs", &v); err != nil {
 		return nil, err
 	}
 	return v, nil
 }
 
-// Transaction makes a request to /transaction
+// Transaction makes a request to GET /api/v1/transaction
 func (c *Client) Transaction(txid string) (*daemon.TransactionResult, error) {
 	v := url.Values{}
 	v.Add("txid", txid)
-	endpoint := "/transaction?" + v.Encode()
+	endpoint := "/api/v1/transaction?" + v.Encode()
 
 	var r daemon.TransactionResult
 	if err := c.Get(endpoint, &r); err != nil {
@@ -660,11 +660,11 @@ func (c *Client) Transaction(txid string) (*daemon.TransactionResult, error) {
 	return &r, nil
 }
 
-// Transactions makes a request to /transactions
+// Transactions makes a request to GET /api/v1/transactions
 func (c *Client) Transactions(addrs []string) (*[]daemon.TransactionResult, error) {
 	v := url.Values{}
 	v.Add("addrs", strings.Join(addrs, ","))
-	endpoint := "/transactions?" + v.Encode()
+	endpoint := "/api/v1/transactions?" + v.Encode()
 
 	var r []daemon.TransactionResult
 	if err := c.Get(endpoint, &r); err != nil {
@@ -673,12 +673,12 @@ func (c *Client) Transactions(addrs []string) (*[]daemon.TransactionResult, erro
 	return &r, nil
 }
 
-// ConfirmedTransactions makes a request to /transactions?confirmed=true
+// ConfirmedTransactions makes a request to GET /api/v1/transactions?confirmed=true
 func (c *Client) ConfirmedTransactions(addrs []string) (*[]daemon.TransactionResult, error) {
 	v := url.Values{}
 	v.Add("addrs", strings.Join(addrs, ","))
 	v.Add("confirmed", "true")
-	endpoint := "/transactions?" + v.Encode()
+	endpoint := "/api/v1/transactions?" + v.Encode()
 
 	var r []daemon.TransactionResult
 	if err := c.Get(endpoint, &r); err != nil {
@@ -687,12 +687,12 @@ func (c *Client) ConfirmedTransactions(addrs []string) (*[]daemon.TransactionRes
 	return &r, nil
 }
 
-// UnconfirmedTransactions makes a request to /transactions?confirmed=false
+// UnconfirmedTransactions makes a request to GET /api/v1/transactions?confirmed=false
 func (c *Client) UnconfirmedTransactions(addrs []string) (*[]daemon.TransactionResult, error) {
 	v := url.Values{}
 	v.Add("addrs", strings.Join(addrs, ","))
 	v.Add("confirmed", "false")
-	endpoint := "/transactions?" + v.Encode()
+	endpoint := "/api/v1/transactions?" + v.Encode()
 
 	var r []daemon.TransactionResult
 	if err := c.Get(endpoint, &r); err != nil {
@@ -701,7 +701,7 @@ func (c *Client) UnconfirmedTransactions(addrs []string) (*[]daemon.TransactionR
 	return &r, nil
 }
 
-// InjectTransaction makes a request to /injectTransaction
+// InjectTransaction makes a request to POST /api/v1/injectTransaction
 func (c *Client) InjectTransaction(rawTx string) (string, error) {
 	v := struct {
 		Rawtx string `json:"rawtx"`
@@ -710,26 +710,26 @@ func (c *Client) InjectTransaction(rawTx string) (string, error) {
 	}
 
 	var txid string
-	if err := c.PostJSON("/injectTransaction", v, &txid); err != nil {
+	if err := c.PostJSON("/api/v1/injectTransaction", v, &txid); err != nil {
 		return "", err
 	}
 	return txid, nil
 }
 
-// ResendUnconfirmedTransactions makes a request to /resendUnconfirmedTxns
+// ResendUnconfirmedTransactions makes a request to GET /api/v1/resendUnconfirmedTxns
 func (c *Client) ResendUnconfirmedTransactions() (*daemon.ResendResult, error) {
 	var r daemon.ResendResult
-	if err := c.Get("/resendUnconfirmedTxns", &r); err != nil {
+	if err := c.Get("/api/v1/resendUnconfirmedTxns", &r); err != nil {
 		return nil, err
 	}
 	return &r, nil
 }
 
-// RawTransaction makes a request to /rawtx
+// RawTransaction makes a request to GET /api/v1/rawtx
 func (c *Client) RawTransaction(txid string) (string, error) {
 	v := url.Values{}
 	v.Add("txid", txid)
-	endpoint := "/rawtx?" + v.Encode()
+	endpoint := "/api/v1/rawtx?" + v.Encode()
 
 	var rawTx string
 	if err := c.Get(endpoint, &rawTx); err != nil {
@@ -738,11 +738,11 @@ func (c *Client) RawTransaction(txid string) (string, error) {
 	return rawTx, nil
 }
 
-// AddressTransactions makes a request to /explorer/address
+// AddressTransactions makes a request to GET /api/v1/explorer/address
 func (c *Client) AddressTransactions(addr string) ([]ReadableTransaction, error) {
 	v := url.Values{}
 	v.Add("address", addr)
-	endpoint := "/explorer/address?" + v.Encode()
+	endpoint := "/api/v1/explorer/address?" + v.Encode()
 
 	var b []ReadableTransaction
 	if err := c.Get(endpoint, &b); err != nil {
@@ -757,15 +757,15 @@ type RichlistParams struct {
 	IncludeDistribution bool
 }
 
-// Richlist makes a request to /richlist
+// Richlist makes a request to GET /api/v1/richlist
 func (c *Client) Richlist(params *RichlistParams) (*Richlist, error) {
-	endpoint := "/richlist"
+	endpoint := "/api/v1/richlist"
 
 	if params != nil {
 		v := url.Values{}
 		v.Add("n", fmt.Sprint(params.N))
 		v.Add("include-distribution", fmt.Sprint(params.IncludeDistribution))
-		endpoint = "/richlist?" + v.Encode()
+		endpoint = "/api/v1/richlist?" + v.Encode()
 	}
 
 	var r Richlist
@@ -775,55 +775,55 @@ func (c *Client) Richlist(params *RichlistParams) (*Richlist, error) {
 	return &r, nil
 }
 
-// AddressCount makes a request to /addresscount
+// AddressCount makes a request to GET /api/v1/addresscount
 func (c *Client) AddressCount() (uint64, error) {
 	var r struct {
 		Count uint64 `json:"count"`
 	}
-	if err := c.Get("/addresscount", &r); err != nil {
+	if err := c.Get("/api/v1/addresscount", &r); err != nil {
 		return 0, err
 	}
 	return r.Count, nil
 
 }
 
-// UnloadWallet makes a request to /wallet/unload
+// UnloadWallet makes a request to POST /api/v1/wallet/unload
 func (c *Client) UnloadWallet(id string) error {
 	v := url.Values{}
 	v.Add("id", id)
-	return c.PostForm("/wallet/unload", strings.NewReader(v.Encode()), nil)
+	return c.PostForm("/api/v1/wallet/unload", strings.NewReader(v.Encode()), nil)
 }
 
-// Health makes a request to /health
+// Health makes a request to GET /api/v1/health
 func (c *Client) Health() (*HealthResponse, error) {
 	var r HealthResponse
-	if err := c.Get("/health", &r); err != nil {
+	if err := c.Get("/api/v1/health", &r); err != nil {
 		return nil, err
 	}
 
 	return &r, nil
 }
 
-// EncryptWallet encrypts specific wallet with given password
+// EncryptWallet makes a request to POST /api/v1/wallet/encrypt to encrypt a specific wallet with the given password
 func (c *Client) EncryptWallet(id string, password string) (*WalletResponse, error) {
 	v := url.Values{}
 	v.Add("id", id)
 	v.Add("password", password)
 	var wlt WalletResponse
-	if err := c.PostForm("/wallet/encrypt", strings.NewReader(v.Encode()), &wlt); err != nil {
+	if err := c.PostForm("/api/v1/wallet/encrypt", strings.NewReader(v.Encode()), &wlt); err != nil {
 		return nil, err
 	}
 
 	return &wlt, nil
 }
 
-// DecryptWallet decrypts wallet by making a request to /wallet/decrypt
+// DecryptWallet makes a request to POST /api/v1/wallet/decrypt to decrypt a wallet
 func (c *Client) DecryptWallet(id string, password string) (*WalletResponse, error) {
 	v := url.Values{}
 	v.Add("id", id)
 	v.Add("password", password)
 	var wlt WalletResponse
-	if err := c.PostForm("/wallet/decrypt", strings.NewReader(v.Encode()), &wlt); err != nil {
+	if err := c.PostForm("/api/v1/wallet/decrypt", strings.NewReader(v.Encode()), &wlt); err != nil {
 		return nil, err
 	}
 

--- a/src/api/csrf.go
+++ b/src/api/csrf.go
@@ -68,7 +68,6 @@ func (c *CSRFStore) setToken(token CSRFToken) {
 // expired checks if token expiry time is greater than current time
 func (c *CSRFStore) expired() bool {
 	return c.token == nil || time.Now().After(c.token.ExpiresAt)
-
 }
 
 // verifyToken checks that the given token is same as the internal token
@@ -100,7 +99,7 @@ func (c *CSRFStore) verifyToken(headerToken string) error {
 }
 
 // Creates a new CSRF token. Previous CSRF tokens are invalidated by this call.
-// URI: /csrf
+// URI: /api/v1/csrf
 // Method: GET
 // Response:
 //  csrf_token: CSRF token to use in POST requests

--- a/src/api/csrf_test.go
+++ b/src/api/csrf_test.go
@@ -89,6 +89,47 @@ var endpoints = []string{
 	"/wallets",
 	"/wallets/folderName",
 	"/webrpc",
+
+	"/api/v1/address_uxouts",
+	"/api/v1/addresscount",
+	"/api/v1/balance",
+	"/api/v1/block",
+	"/api/v1/blockchain/metadata",
+	"/api/v1/blockchain/progress",
+	"/api/v1/blocks",
+	"/api/v1/coinSupply",
+	"/api/v1/explorer/address",
+	"/api/v1/health",
+	"/api/v1/injectTransaction",
+	"/api/v1/last_blocks",
+	"/api/v1/version",
+	"/api/v1/network/connection",
+	"/api/v1/network/connections",
+	"/api/v1/network/connections/exchange",
+	"/api/v1/network/connections/trust",
+	"/api/v1/network/defaultConnections",
+	"/api/v1/outputs",
+	"/api/v1/pendingTxs",
+	"/api/v1/rawtx",
+	"/api/v1/richlist",
+	"/api/v1/resendUnconfirmedTxns",
+	"/api/v1/transaction",
+	"/api/v1/transactions",
+	"/api/v1/uxout",
+	"/api/v1/wallet",
+	"/api/v1/wallet/balance",
+	"/api/v1/wallet/create",
+	"/api/v1/wallet/newAddress",
+	"/api/v1/wallet/newSeed",
+	"/api/v1/wallet/seed",
+	"/api/v1/wallet/spend",
+	"/api/v1/wallet/transaction",
+	"/api/v1/wallet/transactions",
+	"/api/v1/wallet/unload",
+	"/api/v1/wallet/update",
+	"/api/v1/wallets",
+	"/api/v1/wallets/folderName",
+	"/api/v1/webrpc",
 }
 
 func TestCSRFWrapper(t *testing.T) {
@@ -112,9 +153,10 @@ func TestCSRFWrapper(t *testing.T) {
 
 					rr := httptest.NewRecorder()
 					handler := newServerMux(muxConfig{
-						host:            configuredHost,
-						appLoc:          ".",
-						enableJSON20RPC: true,
+						host:                 configuredHost,
+						appLoc:               ".",
+						enableJSON20RPC:      true,
+						enableUnversionedAPI: true,
 					}, gateway, csrfStore, nil)
 
 					handler.ServeHTTP(rr, req)
@@ -222,7 +264,7 @@ func TestCSRF(t *testing.T) {
 		gateway := &GatewayerMock{}
 		gateway.On("UpdateWalletLabel", "fooid", "foolabel").Return(nil)
 
-		endpoint := "/wallet/update"
+		endpoint := "/api/v1/wallet/update"
 
 		v := url.Values{}
 		v.Add("id", "fooid")
@@ -258,7 +300,7 @@ func TestCSRF(t *testing.T) {
 	handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
 
 	// non-GET request to /csrf is invalid
-	req, err := http.NewRequest(http.MethodPost, "/csrf", nil)
+	req, err := http.NewRequest(http.MethodPost, "/api/v1/csrf", nil)
 	require.NoError(t, err)
 
 	rr = httptest.NewRecorder()
@@ -270,7 +312,7 @@ func TestCSRF(t *testing.T) {
 	// CSRF disabled 404s
 	csrfStore.Enabled = false
 
-	req, err = http.NewRequest(http.MethodGet, "/csrf", nil)
+	req, err = http.NewRequest(http.MethodGet, "/api/v1/csrf", nil)
 	require.NoError(t, err)
 
 	rr = httptest.NewRecorder()
@@ -282,7 +324,7 @@ func TestCSRF(t *testing.T) {
 	csrfStore.Enabled = true
 
 	// Request a CSRF token, use it in a request
-	req, err = http.NewRequest(http.MethodGet, "/csrf", nil)
+	req, err = http.NewRequest(http.MethodGet, "/api/v1/csrf", nil)
 	require.NoError(t, err)
 
 	rr = httptest.NewRecorder()
@@ -297,7 +339,7 @@ func TestCSRF(t *testing.T) {
 	token := msg["csrf_token"]
 	require.NotEmpty(t, token)
 
-	req, err = http.NewRequest(http.MethodPost, "/version", nil)
+	req, err = http.NewRequest(http.MethodPost, "/api/v1/version", nil)
 	require.NoError(t, err)
 
 	rr = httptest.NewRecorder()
@@ -309,7 +351,7 @@ func TestCSRF(t *testing.T) {
 
 	// Make another call to /csrf, this will invalidate the first token
 	// Request a CSRF token, use it in a request
-	req, err = http.NewRequest(http.MethodGet, "/csrf", nil)
+	req, err = http.NewRequest(http.MethodGet, "/api/v1/csrf", nil)
 	require.NoError(t, err)
 
 	rr = httptest.NewRecorder()

--- a/src/api/explorer_test.go
+++ b/src/api/explorer_test.go
@@ -232,7 +232,7 @@ func TestGetTransactionsForAddress(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			endpoint := "/explorer/address"
+			endpoint := "/api/v1/explorer/address"
 			gateway := NewGatewayerMock()
 			gateway.On("GetAddressTxns", address).Return(tc.gatewayGetAddressTxnsResult, tc.gatewayGetAddressTxnsErr)
 			gateway.On("GetUxOutByID", tc.gatewayGetUxOutByIDArg).Return(tc.gatewayGetUxOutByIDResult, tc.gatewayGetUxOutByIDErr)
@@ -363,7 +363,7 @@ func TestCoinSupply(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			endpoint := "/coinSupply"
+			endpoint := "/api/v1/coinSupply"
 			gateway := NewGatewayerMock()
 			gateway.On("GetUnspentOutputs", mock.Anything).Return(tc.gatewayGetUnspentOutputsResult, tc.gatewayGetUnspentOutputsErr)
 
@@ -575,7 +575,7 @@ func TestGetRichlist(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			endpoint := "/richlist"
+			endpoint := "/api/v1/richlist"
 			gateway := NewGatewayerMock()
 			gateway.On("GetRichlist", tc.includeDistribution).Return(tc.gatewayGetRichlistResult, tc.gatewayGetRichlistErr)
 
@@ -663,7 +663,7 @@ func TestGetAddressCount(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			endpoint := "/addresscount"
+			endpoint := "/api/v1/addresscount"
 			gateway := NewGatewayerMock()
 			gateway.On("GetAddressCount").Return(tc.gatewayGetAddressCountResult, tc.gatewayGetAddressCountErr)
 

--- a/src/api/health.go
+++ b/src/api/health.go
@@ -24,7 +24,7 @@ type HealthResponse struct {
 }
 
 // Returns node health data.
-// URI: /health
+// URI: /api/v1/health
 // Method: GET
 func healthCheck(gateway Gatewayer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/src/api/health_test.go
+++ b/src/api/health_test.go
@@ -80,7 +80,7 @@ func TestHealthCheckHandler(t *testing.T) {
 				gateway.On("GetHealth").Return(health, nil)
 			}
 
-			endpoint := "/health"
+			endpoint := "/api/v1/health"
 			req, err := http.NewRequest(tc.method, endpoint, nil)
 			require.NoError(t, err)
 

--- a/src/api/http.go
+++ b/src/api/http.go
@@ -44,21 +44,23 @@ type Server struct {
 
 // Config configures Server
 type Config struct {
-	StaticDir       string
-	DisableCSRF     bool
-	EnableWalletAPI bool
-	EnableJSON20RPC bool
-	EnableGUI       bool
-	ReadTimeout     time.Duration
-	WriteTimeout    time.Duration
-	IdleTimeout     time.Duration
+	StaticDir            string
+	DisableCSRF          bool
+	EnableWalletAPI      bool
+	EnableJSON20RPC      bool
+	EnableGUI            bool
+	EnableUnversionedAPI bool
+	ReadTimeout          time.Duration
+	WriteTimeout         time.Duration
+	IdleTimeout          time.Duration
 }
 
 type muxConfig struct {
-	host            string
-	appLoc          string
-	enableGUI       bool
-	enableJSON20RPC bool
+	host                 string
+	appLoc               string
+	enableGUI            bool
+	enableJSON20RPC      bool
+	enableUnversionedAPI bool
 }
 
 func create(host string, c Config, gateway Gatewayer) (*Server, error) {
@@ -101,10 +103,11 @@ func create(host string, c Config, gateway Gatewayer) (*Server, error) {
 	}
 
 	mc := muxConfig{
-		host:            host,
-		appLoc:          appLoc,
-		enableGUI:       c.EnableGUI,
-		enableJSON20RPC: c.EnableJSON20RPC,
+		host:                 host,
+		appLoc:               appLoc,
+		enableGUI:            c.EnableGUI,
+		enableJSON20RPC:      c.EnableJSON20RPC,
+		enableUnversionedAPI: c.EnableUnversionedAPI,
 	}
 
 	srvMux := newServerMux(mc, gateway, csrfStore, rpc)
@@ -200,12 +203,18 @@ func newServerMux(c muxConfig, gateway Gatewayer, csrfStore *CSRFStore, rpc *web
 	}
 
 	webHandler := func(endpoint string, handler http.Handler) {
-
 		handler = wh.ElapsedHandler(logger, handler)
 		handler = CSRFCheck(csrfStore, handler)
 		handler = headerCheck(c.host, handler)
 		handler = gziphandler.GzipHandler(handler)
 		mux.Handle(endpoint, handler)
+	}
+
+	webHandlerV1 := func(endpoint string, handler http.Handler) {
+		if c.enableUnversionedAPI {
+			webHandler(endpoint, handler)
+		}
+		webHandler("/api/v1"+endpoint, handler)
 	}
 
 	webHandler("/", newIndexHandler(c.appLoc, c.enableGUI))
@@ -222,19 +231,20 @@ func newServerMux(c muxConfig, gateway Gatewayer, csrfStore *CSRFStore, rpc *web
 	}
 
 	if c.enableJSON20RPC {
-		webHandler("/webrpc", http.HandlerFunc(rpc.Handler))
+		webHandlerV1("/webrpc", http.HandlerFunc(rpc.Handler))
 	}
 
 	// get the current CSRF token
 	mux.Handle("/csrf", headerCheck(c.host, getCSRFToken(csrfStore)))
+	mux.Handle("/api/v1/csrf", headerCheck(c.host, getCSRFToken(csrfStore)))
 
-	webHandler("/version", versionHandler(gateway))
+	webHandlerV1("/version", versionHandler(gateway))
 
 	// get set of unspent outputs
-	webHandler("/outputs", getOutputsHandler(gateway))
+	webHandlerV1("/outputs", getOutputsHandler(gateway))
 
 	// get balance of addresses
-	webHandler("/balance", getBalanceHandler(gateway))
+	webHandlerV1("/balance", getBalanceHandler(gateway))
 
 	// Wallet interface
 
@@ -242,7 +252,7 @@ func newServerMux(c muxConfig, gateway Gatewayer, csrfStore *CSRFStore, rpc *web
 	// Method: GET
 	// Args:
 	//      id - Wallet ID [required]
-	webHandler("/wallet", walletGet(gateway))
+	webHandlerV1("/wallet", walletGet(gateway))
 
 	// Loads wallet from seed, will scan ahead N address and
 	// load addresses till the last one that have coins.
@@ -251,16 +261,16 @@ func newServerMux(c muxConfig, gateway Gatewayer, csrfStore *CSRFStore, rpc *web
 	//     seed: wallet seed [required]
 	//     label: wallet label [required]
 	//     scan: the number of addresses to scan ahead for balances [optional, must be > 0]
-	webHandler("/wallet/create", walletCreate(gateway))
+	webHandlerV1("/wallet/create", walletCreate(gateway))
 
-	webHandler("/wallet/newAddress", walletNewAddresses(gateway))
+	webHandlerV1("/wallet/newAddress", walletNewAddresses(gateway))
 
 	// Returns the confirmed and predicted balance for a specific wallet.
 	// The predicted balance is the confirmed balance minus any pending
 	// spent amount.
 	// GET arguments:
 	//      id: Wallet ID
-	webHandler("/wallet/balance", walletBalanceHandler(gateway))
+	webHandlerV1("/wallet/balance", walletBalanceHandler(gateway))
 
 	// Sends coins&hours to another address.
 	// POST arguments:
@@ -269,116 +279,116 @@ func newServerMux(c muxConfig, gateway Gatewayer, csrfStore *CSRFStore, rpc *web
 	//  dst: Destination address
 	//  Returns total amount spent if successful, otherwise error describing
 	//  failure status.
-	webHandler("/wallet/spend", walletSpendHandler(gateway))
+	webHandlerV1("/wallet/spend", walletSpendHandler(gateway))
 
 	// Creates a transaction from a wallet
-	webHandler("/wallet/transaction", createTransactionHandler(gateway))
+	webHandlerV1("/wallet/transaction", createTransactionHandler(gateway))
 
 	// GET Arguments:
 	//      id: Wallet ID
 	// Returns all pending transanction for all addresses by selected Wallet
-	webHandler("/wallet/transactions", walletTransactionsHandler(gateway))
+	webHandlerV1("/wallet/transactions", walletTransactionsHandler(gateway))
 
 	// Update wallet label
 	// POST Arguments:
 	//     id: wallet id
 	//     label: wallet label
-	webHandler("/wallet/update", walletUpdateHandler(gateway))
+	webHandlerV1("/wallet/update", walletUpdateHandler(gateway))
 
 	// Returns all loaded wallets
 	// returns sensitive information
-	webHandler("/wallets", walletsHandler(gateway))
+	webHandlerV1("/wallets", walletsHandler(gateway))
 
 	// Returns wallets directory path
-	webHandler("/wallets/folderName", getWalletFolder(gateway))
+	webHandlerV1("/wallets/folderName", getWalletFolder(gateway))
 
 	// Generate wallet seed
 	// GET Arguments:
 	//     entropy: entropy bitsize.
-	webHandler("/wallet/newSeed", newWalletSeed(gateway))
+	webHandlerV1("/wallet/newSeed", newWalletSeed(gateway))
 
 	// Gets seed of wallet of given id
 	// GET Arguments:
 	//     id: wallet id
 	//     password: wallet password
-	webHandler("/wallet/seed", walletSeedHandler(gateway))
+	webHandlerV1("/wallet/seed", walletSeedHandler(gateway))
 
 	// unload wallet
 	// POST Argument:
 	//         id: wallet id
-	webHandler("/wallet/unload", walletUnloadHandler(gateway))
+	webHandlerV1("/wallet/unload", walletUnloadHandler(gateway))
 
 	// Encrypts wallet
 	// POST arguments:
 	//     id: wallet id
 	//     password: wallet password
 	// Returns an encrypted wallet json without sensitive data
-	webHandler("/wallet/encrypt", walletEncryptHandler(gateway))
+	webHandlerV1("/wallet/encrypt", walletEncryptHandler(gateway))
 
 	// Decrypts wallet
 	// POST arguments:
 	//     id: wallet id
 	//     password: wallet password
-	webHandler("/wallet/decrypt", walletDecryptHandler(gateway))
+	webHandlerV1("/wallet/decrypt", walletDecryptHandler(gateway))
 
 	// Blockchain interface
 
-	webHandler("/blockchain/metadata", blockchainHandler(gateway))
-	webHandler("/blockchain/progress", blockchainProgressHandler(gateway))
+	webHandlerV1("/blockchain/metadata", blockchainHandler(gateway))
+	webHandlerV1("/blockchain/progress", blockchainProgressHandler(gateway))
 
 	// get block by hash or seq
-	webHandler("/block", getBlock(gateway))
+	webHandlerV1("/block", getBlock(gateway))
 	// get blocks in specific range
-	webHandler("/blocks", getBlocks(gateway))
+	webHandlerV1("/blocks", getBlocks(gateway))
 	// get last N blocks
-	webHandler("/last_blocks", getLastBlocks(gateway))
+	webHandlerV1("/last_blocks", getLastBlocks(gateway))
 
 	// Network stats interface
-	webHandler("/network/connection", connectionHandler(gateway))
-	webHandler("/network/connections", connectionsHandler(gateway))
-	webHandler("/network/defaultConnections", defaultConnectionsHandler(gateway))
-	webHandler("/network/connections/trust", trustConnectionsHandler(gateway))
-	webHandler("/network/connections/exchange", exchgConnectionsHandler(gateway))
+	webHandlerV1("/network/connection", connectionHandler(gateway))
+	webHandlerV1("/network/connections", connectionsHandler(gateway))
+	webHandlerV1("/network/defaultConnections", defaultConnectionsHandler(gateway))
+	webHandlerV1("/network/connections/trust", trustConnectionsHandler(gateway))
+	webHandlerV1("/network/connections/exchange", exchgConnectionsHandler(gateway))
 
 	// Transaction handler
 
 	// get set of pending transactions
-	webHandler("/pendingTxs", getPendingTxs(gateway))
+	webHandlerV1("/pendingTxs", getPendingTxs(gateway))
 	// get txn by txid
-	webHandler("/transaction", getTransactionByID(gateway))
+	webHandlerV1("/transaction", getTransactionByID(gateway))
 
 	// Health check handler
-	webHandler("/health", healthCheck(gateway))
+	webHandlerV1("/health", healthCheck(gateway))
 
 	// Returns transactions that match the filters.
 	// Method: GET
 	// Args:
 	//     addrs: Comma seperated addresses [optional, returns all transactions if no address is provided]
 	//     confirmed: Whether the transactions should be confirmed [optional, must be 0 or 1; if not provided, returns all]
-	webHandler("/transactions", getTransactions(gateway))
+	webHandlerV1("/transactions", getTransactions(gateway))
 	// inject a transaction into network
-	webHandler("/injectTransaction", injectTransaction(gateway))
-	webHandler("/resendUnconfirmedTxns", resendUnconfirmedTxns(gateway))
+	webHandlerV1("/injectTransaction", injectTransaction(gateway))
+	webHandlerV1("/resendUnconfirmedTxns", resendUnconfirmedTxns(gateway))
 	// get raw tx by txid.
-	webHandler("/rawtx", getRawTx(gateway))
+	webHandlerV1("/rawtx", getRawTx(gateway))
 
 	// UxOut api handler
 
 	// get uxout by id.
-	webHandler("/uxout", getUxOutByID(gateway))
+	webHandlerV1("/uxout", getUxOutByID(gateway))
 	// get all the address affected uxouts.
-	webHandler("/address_uxouts", getAddrUxOuts(gateway))
+	webHandlerV1("/address_uxouts", getAddrUxOuts(gateway))
 
 	// Explorer handler
 
 	// get set of pending transactions
-	webHandler("/explorer/address", getTransactionsForAddress(gateway))
+	webHandlerV1("/explorer/address", getTransactionsForAddress(gateway))
 
-	webHandler("/coinSupply", getCoinSupply(gateway))
+	webHandlerV1("/coinSupply", getCoinSupply(gateway))
 
-	webHandler("/richlist", getRichlist(gateway))
+	webHandlerV1("/richlist", getRichlist(gateway))
 
-	webHandler("/addresscount", getAddressCount(gateway))
+	webHandlerV1("/addresscount", getAddressCount(gateway))
 
 	return mux
 }
@@ -424,7 +434,7 @@ func splitCommaString(s string) []string {
 }
 
 // getOutputsHandler returns UxOuts filtered by a set of addresses or a set of hashes
-// URI: /outputs
+// URI: /api/v1/outputs
 // Method: GET
 // Args:
 //    addrs: comma-separated list of addresses

--- a/src/api/http_test.go
+++ b/src/api/http_test.go
@@ -88,7 +88,7 @@ func TestGetOutputsHandler(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := NewGatewayerMock()
-			endpoint := "/outputs"
+			endpoint := "/api/v1/outputs"
 			gateway.On("GetUnspentOutputs", mock.Anything).Return(tc.getUnspentOutputsResponse, tc.getUnspentOutputsError)
 
 			v := url.Values{}
@@ -249,7 +249,7 @@ func TestGetBalanceHandler(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := NewGatewayerMock()
-			endpoint := "/balance"
+			endpoint := "/api/v1/balance"
 			gateway.On("GetBalanceOfAddrs", tc.getBalanceOfAddrsArg).Return(tc.getBalanceOfAddrsResponse, tc.getBalanceOfAddrsError)
 
 			v := url.Values{}

--- a/src/api/network_test.go
+++ b/src/api/network_test.go
@@ -118,7 +118,7 @@ func TestConnection(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			endpoint := "/network/connection"
+			endpoint := "/api/v1/network/connection"
 			gateway := NewGatewayerMock()
 			gateway.On("GetConnection", tc.addr).Return(tc.gatewayGetConnectionResult)
 			gateway.On("GetBlockchainProgress").Return(
@@ -259,7 +259,7 @@ func TestConnections(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			endpoint := "/network/connections"
+			endpoint := "/api/v1/network/connections"
 			gateway := NewGatewayerMock()
 			gateway.On("GetConnections").Return(tc.gatewayGetConnectionsResult)
 			gateway.On("GetBlockchainProgress").Return(
@@ -315,7 +315,7 @@ func TestDefaultConnections(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			endpoint := "/network/defaultConnections"
+			endpoint := "/api/v1/network/defaultConnections"
 			gateway := NewGatewayerMock()
 			gateway.On("GetDefaultConnections").Return(tc.gatewayGetDefaultConnectionsResult)
 			req, err := http.NewRequest(tc.method, endpoint, nil)
@@ -367,7 +367,7 @@ func TestGetTrustConnections(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			endpoint := "/network/connections/trust"
+			endpoint := "/api/v1/network/connections/trust"
 			gateway := NewGatewayerMock()
 			gateway.On("GetTrustConnections").Return(tc.gatewayGetTrustConnectionsResult)
 			req, err := http.NewRequest(tc.method, endpoint, nil)
@@ -419,7 +419,7 @@ func TestGetExchgConnection(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			endpoint := "/network/connections/exchange"
+			endpoint := "/api/v1/network/connections/exchange"
 			gateway := NewGatewayerMock()
 			gateway.On("GetExchgConnection").Return(tc.gatewayGetExchgConnectionResult)
 			req, err := http.NewRequest(tc.method, endpoint, nil)

--- a/src/api/spend_test.go
+++ b/src/api/spend_test.go
@@ -775,7 +775,7 @@ func TestCreateTransaction(t *testing.T) {
 				gateway.On("CreateTransaction", body.ToWalletParams()).Return(tc.gatewayCreateTransactionResult, tc.gatewayCreateTransactionInputs, tc.gatewayCreateTransactionErr)
 			}
 
-			endpoint := "/wallet/transaction"
+			endpoint := "/api/v1/wallet/transaction"
 
 			requestJSON, err := json.Marshal(tc.body)
 			require.NoError(t, err)

--- a/src/api/transaction.go
+++ b/src/api/transaction.go
@@ -88,7 +88,7 @@ func getTransactionByID(gate Gatewayer) http.HandlerFunc {
 
 // Returns transactions that match the filters.
 // Method: GET
-// URI: /transactions
+// URI: /api/v1/transactions
 // Args:
 //     addrs: Comma seperated addresses [optional, returns all transactions if no address provided]
 //     confirmed: Whether the transactions should be confirmed [optional, must be 0 or 1; if not provided, returns all]

--- a/src/api/transaction_test.go
+++ b/src/api/transaction_test.go
@@ -140,7 +140,7 @@ func TestGetPendingTxs(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			endpoint := "/pendingTxs"
+			endpoint := "/api/v1/pendingTxs"
 			gateway := NewGatewayerMock()
 			gateway.On("GetAllUnconfirmedTxns").Return(tc.getAllUnconfirmedTxnsResponse, tc.getAllUnconfirmedTxnsErr)
 
@@ -273,7 +273,7 @@ func TestGetTransactionByID(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			endpoint := "/transaction"
+			endpoint := "/api/v1/transaction"
 			gateway := NewGatewayerMock()
 			gateway.On("GetTransaction", tc.getTransactionArg).Return(tc.getTransactionReponse, tc.getTransactionError)
 
@@ -418,7 +418,7 @@ func TestInjectTransaction(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			endpoint := "/injectTransaction"
+			endpoint := "/api/v1/injectTransaction"
 			gateway := NewGatewayerMock()
 			gateway.On("InjectBroadcastTransaction", tc.injectTransactionArg).Return(tc.injectTransactionError)
 
@@ -489,7 +489,7 @@ func TestResendUnconfirmedTxns(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			endpoint := "/resendUnconfirmedTxns"
+			endpoint := "/api/v1/resendUnconfirmedTxns"
 			gateway := NewGatewayerMock()
 			gateway.On("ResendUnconfirmedTxns").Return(tc.resendUnconfirmedTxnsResponse, tc.resendUnconfirmedTxnsErr)
 
@@ -613,7 +613,7 @@ func TestGetRawTx(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			endpoint := "/rawtx"
+			endpoint := "/api/v1/rawtx"
 			gateway := NewGatewayerMock()
 			gateway.On("GetTransaction", tc.getTransactionArg).Return(tc.getTransactionResponse, tc.getTransactionError)
 			v := url.Values{}
@@ -769,7 +769,7 @@ func TestGetTransactions(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		endpoint := "/transactions"
+		endpoint := "/api/v1/transactions"
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := NewGatewayerMock()
 			gateway.On("GetTransactions", mock.Anything).Return(tc.getTransactionsResponse, tc.getTransactionsError)

--- a/src/api/uxout_test.go
+++ b/src/api/uxout_test.go
@@ -116,7 +116,7 @@ func TestGetUxOutByID(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := NewGatewayerMock()
-			endpoint := "/uxout"
+			endpoint := "/api/v1/uxout"
 			gateway.On("GetUxOutByID", tc.getGetUxOutByIDArg).Return(tc.getGetUxOutByIDResponse, tc.getGetUxOutByIDError)
 
 			v := url.Values{}
@@ -233,7 +233,7 @@ func TestGetAddrUxOuts(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			endpoint := "/address_uxouts"
+			endpoint := "/api/v1/address_uxouts"
 			gateway := NewGatewayerMock()
 			gateway.On("GetAddrUxOuts", tc.getAddrUxOutsArg).Return(tc.getAddrUxOutsResponse, tc.getAddrUxOutsError)
 

--- a/src/api/wallet.go
+++ b/src/api/wallet.go
@@ -103,7 +103,7 @@ func NewWalletResponse(w *wallet.Wallet) (*WalletResponse, error) {
 
 // Returns the wallet's balance, both confirmed and predicted.  The predicted
 // balance is the confirmed balance minus the pending spends.
-// URI: /wallet/balance
+// URI: /api/v1/wallet/balance
 // Method: GET
 // Args:
 //     id: wallet id [required]
@@ -144,7 +144,7 @@ func walletBalanceHandler(gateway Gatewayer) http.HandlerFunc {
 
 // Returns the balance of one or more addresses, both confirmed and predicted.  The predicted
 // balance is the confirmed balance minus the pending spends.
-// URI: /balance
+// URI: /api/v1/balance
 // Method: GET
 // Args:
 //     addrs: command separated list of addresses [required]
@@ -211,7 +211,7 @@ func getBalanceHandler(gateway Gatewayer) http.HandlerFunc {
 
 // Creates and broadcasts a transaction sending money from one of our wallets
 // to destination address.
-// URI: /wallet/spend
+// URI: /api/v1/wallet/spend
 // Method: POST
 // Args:
 //     id: wallet id
@@ -419,7 +419,7 @@ func walletCreate(gateway Gatewayer) http.HandlerFunc {
 }
 
 // Genreates new addresses
-// URI: /wallet/newAddress
+// URI: /api/v1/wallet/newAddress
 // Method: POST
 // Args:
 //     id: wallet id [required]
@@ -482,7 +482,7 @@ func walletNewAddresses(gateway Gatewayer) http.HandlerFunc {
 }
 
 // Update wallet label
-// URI: /wallet/update
+// URI: /api/v1/wallet/update
 // Method: POST
 // Args:
 //     id: wallet id [required]
@@ -526,7 +526,7 @@ func walletUpdateHandler(gateway Gatewayer) http.HandlerFunc {
 }
 
 // Returns a wallet by id
-// URI: /wallet
+// URI: /api/v1/wallet
 // Method: GET
 // Args:
 //     id: wallet id [required]
@@ -563,7 +563,7 @@ func walletGet(gateway Gatewayer) http.HandlerFunc {
 }
 
 // Returns JSON of unconfirmed transactions for user's wallet
-// URI: /wallet/transactions
+// URI: /api/v1/wallet/transactions
 // Method: GET
 // Args:
 //     id: wallet id [required]
@@ -608,7 +608,7 @@ func walletTransactionsHandler(gateway Gatewayer) http.HandlerFunc {
 }
 
 // Returns all loaded wallets
-// URI: /wallets
+// URI: /api/v1/wallets
 // Method: GET
 func walletsHandler(gateway Gatewayer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -653,7 +653,7 @@ type WalletFolder struct {
 }
 
 // Returns the wallet directory path
-// URI: /wallets/folderName
+// URI: /api/v1/wallets/folderName
 // Method: GET
 func getWalletFolder(gateway Gatewayer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -680,7 +680,7 @@ func getWalletFolder(gateway Gatewayer) http.HandlerFunc {
 }
 
 // Generates wallet seed
-// URI: /wallet/newSeed
+// URI: /api/v1/wallet/newSeed
 // Method: GET
 // Args:
 //     entropy: entropy bitsize [optional, default value of 128 will be used if not set]
@@ -737,7 +737,7 @@ func newWalletSeed(gateway Gatewayer) http.HandlerFunc {
 }
 
 // Returns seed of wallet of given id
-// URI: /wallet/seed
+// URI: /api/v1/wallet/seed
 // Method: POST
 // Args:
 //     id: wallet id
@@ -788,7 +788,7 @@ func walletSeedHandler(gateway Gatewayer) http.HandlerFunc {
 }
 
 // Unloads wallet from the wallet service
-// URI: /wallet/unload
+// URI: /api/v1/wallet/unload
 // Method: POST
 // Args:
 //     id: wallet id
@@ -817,7 +817,7 @@ func walletUnloadHandler(gateway Gatewayer) http.HandlerFunc {
 }
 
 // Encrypts wallet
-// URI: /wallet/encrypt
+// URI: /api/v1/wallet/encrypt
 // Method: POST
 // Args:
 //     id: wallet id
@@ -868,7 +868,7 @@ func walletEncryptHandler(gateway Gatewayer) http.HandlerFunc {
 }
 
 // Decrypts wallet
-// URI: /wallet/decrypt
+// URI: /api/v1/wallet/decrypt
 // Method: POST
 // Args:
 //     id: wallet id

--- a/src/api/wallet_test.go
+++ b/src/api/wallet_test.go
@@ -411,7 +411,7 @@ func TestWalletSpendHandler(t *testing.T) {
 			gateway.On("GetWalletBalance", tc.walletID).Return(tc.gatewayGetWalletBalanceResult.BalancePair,
 				tc.gatewayGetWalletBalanceResult.Addresses, tc.gatewayBalanceErr)
 
-			endpoint := "/wallet/spend"
+			endpoint := "/api/v1/wallet/spend"
 
 			v := url.Values{}
 			if tc.body != nil {
@@ -547,7 +547,7 @@ func TestWalletGet(t *testing.T) {
 			gateway.On("GetWallet", tc.walletID).Return(&tc.gatewayGetWalletResult, tc.gatewayGetWalletErr)
 			v := url.Values{}
 
-			endpoint := "/wallet"
+			endpoint := "/api/v1/wallet"
 
 			if tc.body != nil {
 				if tc.body.WalletID != "" {
@@ -685,7 +685,7 @@ func TestWalletBalanceHandler(t *testing.T) {
 			gateway.On("GetWalletBalance", tc.walletID).Return(tc.gatewayGetWalletBalanceResult.BalancePair,
 				tc.gatewayGetWalletBalanceResult.Addresses, tc.gatewayBalanceErr)
 
-			endpoint := "/wallet/balance"
+			endpoint := "/api/v1/wallet/balance"
 
 			v := url.Values{}
 			if tc.body != nil {
@@ -831,7 +831,7 @@ func TestUpdateWalletLabelHandler(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("UpdateWalletLabel", tc.walletID, tc.label).Return(tc.gatewayUpdateWalletLabelErr)
 
-			endpoint := "/wallet/update"
+			endpoint := "/api/v1/wallet/update"
 
 			v := url.Values{}
 			if tc.body != nil {
@@ -951,7 +951,7 @@ func TestWalletTransactionsHandler(t *testing.T) {
 		gateway := &GatewayerMock{}
 		gateway.On("GetWalletUnconfirmedTxns", tc.walletID).Return(tc.gatewayGetWalletUnconfirmedTxnsResult, tc.gatewayGetWalletUnconfirmedTxnsErr)
 
-		endpoint := "/wallet/transactions"
+		endpoint := "/api/v1/wallet/transactions"
 
 		v := url.Values{}
 		if tc.body != nil {
@@ -1240,7 +1240,7 @@ func TestWalletCreateHandler(t *testing.T) {
 			gateway.On("CreateWallet", "", tc.options).Return(&tc.gatewayCreateWalletResult, tc.gatewayCreateWalletErr)
 			// gateway.On("ScanAheadWalletAddresses", tc.wltName, tc.options.Password, tc.scnN-1).Return(&tc.scanWalletAddressesResult, tc.scanWalletAddressesError)
 
-			endpoint := "/wallet/create"
+			endpoint := "/api/v1/wallet/create"
 
 			v := url.Values{}
 			if tc.body != nil {
@@ -1375,7 +1375,7 @@ func TestWalletNewSeed(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("IsWalletAPIEnabled").Return(true)
 
-			endpoint := "/wallet/newSeed"
+			endpoint := "/api/v1/wallet/newSeed"
 
 			// Add request parameters to url
 			v := url.Values{}
@@ -1535,7 +1535,7 @@ func TestGetWalletSeed(t *testing.T) {
 			gateway := NewGatewayerMock()
 			gateway.On("GetWalletSeed", tc.wltID, []byte(tc.password)).Return(tc.gatewayReturnArgs...)
 
-			endpoint := "/wallet/seed"
+			endpoint := "/api/v1/wallet/seed"
 
 			v := url.Values{}
 			v.Add("id", tc.wltID)
@@ -1748,7 +1748,7 @@ func TestWalletNewAddressesHandler(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("NewAddresses", tc.walletID, []byte(tc.password), tc.n).Return(tc.gatewayNewAddressesResult, tc.gatewayNewAddressesErr)
 
-			endpoint := "/wallet/newAddress"
+			endpoint := "/api/v1/wallet/newAddress"
 
 			v := url.Values{}
 			if tc.body != nil {
@@ -1835,7 +1835,7 @@ func TestGetWalletFolderHandler(t *testing.T) {
 		gateway := &GatewayerMock{}
 		gateway.On("GetWalletDir").Return(tc.getWalletDirResponse, tc.getWalletDirErr)
 
-		endpoint := "/wallets/folderName"
+		endpoint := "/api/v1/wallets/folderName"
 
 		req, err := http.NewRequest(tc.method, endpoint, nil)
 		require.NoError(t, err)
@@ -2063,7 +2063,7 @@ func TestGetWallets(t *testing.T) {
 		gateway := &GatewayerMock{}
 		gateway.On("GetWallets").Return(tc.getWalletsResponse, tc.getWalletsErr)
 
-		endpoint := "/wallets"
+		endpoint := "/api/v1/wallets"
 
 		req, err := http.NewRequest(tc.method, endpoint, nil)
 		require.NoError(t, err)
@@ -2146,7 +2146,7 @@ func TestWalletUnloadHandler(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("UnloadWallet", tc.walletID).Return(tc.unloadWalletErr)
 
-			endpoint := "/wallet/unload"
+			endpoint := "/api/v1/wallet/unload"
 			v := url.Values{}
 			v.Add("id", tc.walletID)
 
@@ -2298,7 +2298,7 @@ func TestEncryptWallet(t *testing.T) {
 			gateway := NewGatewayerMock()
 			gateway.On("EncryptWallet", tc.wltID, []byte(tc.password)).Return(tc.gatewayReturn.w, tc.gatewayReturn.err)
 
-			endpoint := "/wallet/encrypt"
+			endpoint := "/api/v1/wallet/encrypt"
 			v := url.Values{}
 			v.Add("id", tc.wltID)
 			v.Add("password", tc.password)
@@ -2484,7 +2484,7 @@ func TestDecryptWallet(t *testing.T) {
 			gateway := NewGatewayerMock()
 			gateway.On("DecryptWallet", tc.wltID, []byte(tc.password)).Return(tc.gatewayReturn.w, tc.gatewayReturn.err)
 
-			endpoint := "/wallet/decrypt"
+			endpoint := "/api/v1/wallet/decrypt"
 			v := url.Values{}
 			v.Add("id", tc.wltID)
 			v.Add("password", tc.password)

--- a/src/api/webrpc/client.go
+++ b/src/api/webrpc/client.go
@@ -250,7 +250,7 @@ func do(httpClient *http.Client, rpcReq *Request, rpcAddress, csrf string) (*Res
 		return nil, err
 	}
 
-	url := rpcAddress + "webrpc"
+	url := rpcAddress + "api/v1/webrpc"
 	body := bytes.NewBuffer(d)
 	req, err := http.NewRequest(http.MethodPost, url, body)
 	if err != nil {

--- a/src/api/webrpc/client_test.go
+++ b/src/api/webrpc/client_test.go
@@ -23,7 +23,7 @@ func TestClientGetUnspentOutputs(t *testing.T) {
 	s := setupWebRPC(t)
 
 	mux := http.NewServeMux()
-	mux.Handle("/webrpc", http.HandlerFunc(s.Handler))
+	mux.Handle("/api/v1/webrpc", http.HandlerFunc(s.Handler))
 
 	headTime := uint64(time.Now().UTC().Unix())
 	uxouts := make([]coin.UxOut, 5)
@@ -66,7 +66,7 @@ func TestClientGetUnspentOutputs(t *testing.T) {
 			body, err := json.Marshal(rpcReq)
 			require.NoError(t, err)
 
-			req, err := http.NewRequest(http.MethodPost, "/webrpc", bytes.NewReader(body))
+			req, err := http.NewRequest(http.MethodPost, "/api/v1/webrpc", bytes.NewReader(body))
 			require.NoError(t, err)
 
 			rr := httptest.NewRecorder()
@@ -115,7 +115,7 @@ func TestClientInjectTransaction(t *testing.T) {
 	s := setupWebRPC(t)
 
 	mux := http.NewServeMux()
-	mux.Handle("/webrpc", http.HandlerFunc(s.Handler))
+	mux.Handle("/api/v1/webrpc", http.HandlerFunc(s.Handler))
 
 	s.Gateway.(*fakeGateway).injectRawTxMap = map[string]bool{
 		rawTxID: true,
@@ -128,7 +128,7 @@ func TestClientInjectTransaction(t *testing.T) {
 	body, err := json.Marshal(rpcReq)
 	require.NoError(t, err)
 
-	req, err := http.NewRequest(http.MethodPost, "/webrpc", bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, "/api/v1/webrpc", bytes.NewReader(body))
 	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()
@@ -154,7 +154,7 @@ func TestClientGetStatus(t *testing.T) {
 	s := setupWebRPC(t)
 
 	mux := http.NewServeMux()
-	mux.Handle("/webrpc", http.HandlerFunc(s.Handler))
+	mux.Handle("/api/v1/webrpc", http.HandlerFunc(s.Handler))
 
 	rpcReq, err := NewRequest("get_status", nil, "1")
 	require.NoError(t, err)
@@ -162,7 +162,7 @@ func TestClientGetStatus(t *testing.T) {
 	body, err := json.Marshal(rpcReq)
 	require.NoError(t, err)
 
-	req, err := http.NewRequest(http.MethodPost, "/webrpc", bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, "/api/v1/webrpc", bytes.NewReader(body))
 	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()
@@ -192,7 +192,7 @@ func TestClientGetTransactionByID(t *testing.T) {
 	s := setupWebRPC(t)
 
 	mux := http.NewServeMux()
-	mux.Handle("/webrpc", http.HandlerFunc(s.Handler))
+	mux.Handle("/api/v1/webrpc", http.HandlerFunc(s.Handler))
 
 	cases := []struct {
 		name                string
@@ -231,7 +231,7 @@ func TestClientGetTransactionByID(t *testing.T) {
 			body, err := json.Marshal(rpcReq)
 			require.NoError(t, err)
 
-			req, err := http.NewRequest(http.MethodPost, "/webrpc", bytes.NewReader(body))
+			req, err := http.NewRequest(http.MethodPost, "/api/v1/webrpc", bytes.NewReader(body))
 			require.NoError(t, err)
 
 			rr := httptest.NewRecorder()
@@ -270,7 +270,7 @@ func TestClientGetAddressUxOuts(t *testing.T) {
 	s := setupWebRPC(t)
 
 	mux := http.NewServeMux()
-	mux.Handle("/webrpc", http.HandlerFunc(s.Handler))
+	mux.Handle("/api/v1/webrpc", http.HandlerFunc(s.Handler))
 
 	cases := []struct {
 		name   string
@@ -299,7 +299,7 @@ func TestClientGetAddressUxOuts(t *testing.T) {
 			body, err := json.Marshal(rpcReq)
 			require.NoError(t, err)
 
-			req, err := http.NewRequest(http.MethodPost, "/webrpc", bytes.NewReader(body))
+			req, err := http.NewRequest(http.MethodPost, "/api/v1/webrpc", bytes.NewReader(body))
 			require.NoError(t, err)
 
 			rr := httptest.NewRecorder()
@@ -334,7 +334,7 @@ func TestClientGetBlocks(t *testing.T) {
 	s := setupWebRPC(t)
 
 	mux := http.NewServeMux()
-	mux.Handle("/webrpc", http.HandlerFunc(s.Handler))
+	mux.Handle("/api/v1/webrpc", http.HandlerFunc(s.Handler))
 
 	// blockString borrowed from block_test.go
 	rpcReq, err := NewRequest("get_blocks", []uint64{0, 1}, "1")
@@ -343,7 +343,7 @@ func TestClientGetBlocks(t *testing.T) {
 	body, err := json.Marshal(rpcReq)
 	require.NoError(t, err)
 
-	req, err := http.NewRequest(http.MethodPost, "/webrpc", bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, "/api/v1/webrpc", bytes.NewReader(body))
 	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()
@@ -372,7 +372,7 @@ func TestClientGetBlocksBySeq(t *testing.T) {
 	gatewayerMock.On("GetBlocksInDepth", []uint64{454}).Return(decodeBlock(blockString), nil)
 
 	mux := http.NewServeMux()
-	mux.Handle("/webrpc", http.HandlerFunc(s.Handler))
+	mux.Handle("/api/v1/webrpc", http.HandlerFunc(s.Handler))
 
 	// blockString and seq borrowed from block_test.go
 	var seq uint64 = 454
@@ -382,7 +382,7 @@ func TestClientGetBlocksBySeq(t *testing.T) {
 	body, err := json.Marshal(rpcReq)
 	require.NoError(t, err)
 
-	req, err := http.NewRequest(http.MethodPost, "/webrpc", bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, "/api/v1/webrpc", bytes.NewReader(body))
 	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()
@@ -407,7 +407,7 @@ func TestClientGetLastBlocks(t *testing.T) {
 	s := setupWebRPC(t)
 
 	mux := http.NewServeMux()
-	mux.Handle("/webrpc", http.HandlerFunc(s.Handler))
+	mux.Handle("/api/v1/webrpc", http.HandlerFunc(s.Handler))
 
 	var n uint64 = 1
 	rpcReq, err := NewRequest("get_lastblocks", []uint64{n}, "1")
@@ -416,7 +416,7 @@ func TestClientGetLastBlocks(t *testing.T) {
 	body, err := json.Marshal(rpcReq)
 	require.NoError(t, err)
 
-	req, err := http.NewRequest(http.MethodPost, "/webrpc", bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, "/api/v1/webrpc", bytes.NewReader(body))
 	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()

--- a/src/api/webrpc_test.go
+++ b/src/api/webrpc_test.go
@@ -60,7 +60,7 @@ func TestWebRPC(t *testing.T) {
 			d, err := json.Marshal(tc.args.req)
 			require.NoError(t, err)
 
-			req, err := http.NewRequest(tc.args.httpMethod, "/webrpc", bytes.NewBuffer(d))
+			req, err := http.NewRequest(tc.args.httpMethod, "/api/v1/webrpc", bytes.NewBuffer(d))
 			require.NoError(t, err)
 
 			csrfStore := &CSRFStore{

--- a/src/gui/static/e2e-proxy.config.js
+++ b/src/gui/static/e2e-proxy.config.js
@@ -2,7 +2,7 @@ const PROXY_CONFIG = {
   "/api/*": {
     "target": "http://127.0.0.1:46420",
     "pathRewrite": {
-      "^/api" : ""
+      "^/api" : "/api/v1"
     },
     "secure": false,
     "logLevel": "debug",


### PR DESCRIPTION
Fixes #1444 

Changes:
- Register all API endpoints with `/api/v1` prefix.  
- Endpoints may still be registered without the prefix by using `-enable-unversioned-api`
- The frontend client needs to update the endpoints, then `run.sh` can remove `-enable-unversioned-api=true`

Does this change need to mentioned in CHANGELOG.md?
Yes