### PR TITLE
CLI should have non-zero exit code if command not found

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -278,6 +278,7 @@ func NewApp(cfg Config) (*App, error) {
 	app.CommandNotFound = func(ctx *gcli.Context, command string) {
 		tmp := fmt.Sprintf("{{.HelpName}}: '%s' is not a {{.HelpName}} command. See '{{.HelpName}} --help'.\n", command)
 		gcli.HelpPrinter(app.Writer, tmp, app)
+		gcli.OsExiter(1)
 	}
 
 	rpcClient, err := webrpc.NewClient(cfg.RPCAddress)


### PR DESCRIPTION
Fixes #1314 

Changes:
- exit code 1 for cli if command is not found

Does this change need to mentioned in CHANGELOG.md?
