### PR TITLE
Change to enable message protocol upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - API response will be gzip compressed if client sends request with 'Accept-Encoding' contains 'gzip' in the header.
 - `GET /api/v1/wallet/balance` and `GET /api/v1/balance` now return an address balance list as well.
 - API endpoints are prefixed with `/api/v1/`. API endpoints without the `/api/v1/` prefix are deprecated but can be enabled with `-enable-unversioned-api`. Please migrate to use `/api/v1/` prefix in URLs.
+- Enable message protocol upgrade
 
 ### Removed
 

--- a/src/daemon/gnet/dispatcher.go
+++ b/src/daemon/gnet/dispatcher.go
@@ -55,8 +55,14 @@ func convertToMessage(id int, msg []byte, debugPrint bool) (Message, error) {
 	if err != nil {
 		return nil, err
 	}
-	if used != len(msg) {
-		return nil, errors.New("Data buffer was not completely decoded")
+
+	if debugPrint {
+		mlen := len(msg)
+		if used > mlen {
+			logger.Debug("Receive data with extra fields")
+		} else if used < mlen {
+			logger.Debug("Receive data with fields removed")
+		}
 	}
 
 	m, succ = (v.Interface()).(Message)

--- a/src/daemon/gnet/dispatcher.go
+++ b/src/daemon/gnet/dispatcher.go
@@ -59,9 +59,9 @@ func convertToMessage(id int, msg []byte, debugPrint bool) (Message, error) {
 	if debugPrint {
 		mlen := len(msg)
 		if used > mlen {
-			logger.Debug("Receive data with extra fields")
+			logger.Warn("Receive data with extra fields")
 		} else if used < mlen {
-			logger.Debug("Receive data with fields removed")
+			logger.Warn("Receive data with fields removed")
 		}
 	}
 

--- a/src/daemon/gnet/dispatcher_test.go
+++ b/src/daemon/gnet/dispatcher_test.go
@@ -70,9 +70,8 @@ func TestConvertToMessageBadDeserialize(t *testing.T) {
 	// Test with too many bytes
 	b := append(DummyPrefix[:], []byte{0, 1, 1, 1}...)
 	m, err := convertToMessage(c.ID, b, testing.Verbose())
-	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "Data buffer was not completely decoded")
-	assert.Nil(t, m)
+	assert.Nil(t, err)
+	assert.NotNil(t, m)
 
 	// Test with not enough bytes
 	b = append([]byte{}, BytePrefix[:]...)


### PR DESCRIPTION
Fixes #658 

Changes:
- Update to enable message protocol upgrade

Does this change need to mentioned in CHANGELOG.md?
Yes