### PR TITLE
Don't specify change_address

### DIFF
--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -138,7 +138,6 @@ export class WalletService {
           mode: 'share',
           share_factor: '0.5',
         },
-        change_address: wallet.addresses[0].address,
         wallet: {
           id: wallet.filename,
           password,


### PR DESCRIPTION
Fixes #1552

Changes:
- change_address is not specified when creating transaction
