### PR TITLE
Report address checksum error before version error

### DIFF
--- a/src/cipher/address.go
+++ b/src/cipher/address.go
@@ -101,9 +101,6 @@ func AddressFromBytes(b []byte) (addr Address, err error) {
 	a := Address{}
 	copy(a.Key[0:20], b[0:20])
 	a.Version = b[20]
-	if a.Version != 0 {
-		return Address{}, errors.New("Invalid version")
-	}
 
 	chksum := a.Checksum()
 	var checksum [4]byte
@@ -111,6 +108,10 @@ func AddressFromBytes(b []byte) (addr Address, err error) {
 
 	if checksum != chksum {
 		return Address{}, errors.New("Invalid checksum")
+	}
+
+	if a.Version != 0 {
+		return Address{}, errors.New("Invalid version")
 	}
 
 	return a, nil

--- a/src/cipher/address.go
+++ b/src/cipher/address.go
@@ -233,9 +233,6 @@ func BitcoinAddressFromBytes(b []byte) (Address, error) {
 	a := Address{}
 	copy(a.Key[0:20], b[1:21])
 	a.Version = b[0]
-	if a.Version != 0 {
-		return Address{}, errors.New("Invalid version")
-	}
 
 	chksum := a.BitcoinChecksum()
 	var checksum [4]byte
@@ -243,6 +240,10 @@ func BitcoinAddressFromBytes(b []byte) (Address, error) {
 
 	if checksum != chksum {
 		return Address{}, errors.New("Invalid checksum")
+	}
+
+	if a.Version != 0 {
+		return Address{}, errors.New("Invalid version")
 	}
 
 	return a, nil

--- a/src/cipher/address_test.go
+++ b/src/cipher/address_test.go
@@ -94,18 +94,48 @@ func TestAddressFromBytes(t *testing.T) {
 	a2, err := AddressFromBytes(a.Bytes())
 	require.NoError(t, err)
 	require.Equal(t, a2, a)
+
 	// Invalid number of bytes
 	b := a.Bytes()
 	_, err = AddressFromBytes(b[:len(b)-2])
-	require.Error(t, err)
+	require.EqualError(t, err, "Invalid address length")
+
 	// Invalid checksum
 	b[len(b)-1] += byte(1)
 	_, err = AddressFromBytes(b)
-	require.Error(t, err)
+	require.EqualError(t, err, "Invalid checksum")
+
+	a.Version = 2
+	b = a.Bytes()
+	_, err = AddressFromBytes(b)
+	require.EqualError(t, err, "Invalid version")
 }
 
-//encode and decode
+func TestBitcoinAddressFromBytes(t *testing.T) {
+	p, _ := GenerateKeyPair()
+	a := AddressFromPubKey(p)
+	a2, err := BitcoinAddressFromBytes(a.BitcoinBytes())
+	require.NoError(t, err)
+	require.Equal(t, a2, a)
+
+	// Invalid number of bytes
+	b := a.BitcoinBytes()
+	_, err = BitcoinAddressFromBytes(b[:len(b)-2])
+	require.EqualError(t, err, "Invalid address length")
+
+	// Invalid checksum
+	b[len(b)-1] += byte(1)
+	_, err = BitcoinAddressFromBytes(b)
+	require.EqualError(t, err, "Invalid checksum")
+
+	a.Version = 2
+	b = a.BitcoinBytes()
+	_, err = BitcoinAddressFromBytes(b)
+	require.EqualError(t, err, "Invalid version")
+}
+
 func TestAddressRoundtrip(t *testing.T) {
+	// Tests encode and decode
 	p, _ := GenerateKeyPair()
 	a := AddressFromPubKey(p)
 	a2, err := AddressFromBytes(a.Bytes())

--- a/src/cli/integration/integration_test.go
+++ b/src/cli/integration/integration_test.go
@@ -460,13 +460,13 @@ func TestVerifyAddress(t *testing.T) {
 			"invalid skycoin address",
 			"2KG9eRXUhx6hrDZvNGB99DKahtrPDQ1W9vn",
 			errors.New("exit status 1"),
-			"Invalid version",
+			"Invalid checksum",
 		},
 		{
 			"invalid bitcoin address",
 			"1Dcb9gpaZpBKmjqjCsiBsP3sBW1md2kEM2",
 			errors.New("exit status 1"),
-			"Invalid version",
+			"Invalid checksum",
 		},
 	}
 


### PR DESCRIPTION
Changes:
- Report an parsed address checksum error before reporting the address version error. The checksum error is more informative about a corrupted address.

Does this change need to mentioned in CHANGELOG.md?
No