### PR TITLE
Allow POST /wallet/transaction to ignore unconfirmed spends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `GET /explorer/address`: add `fee` to transaction objects and `calculated_hours` to transaction inputs
 - Test data generator and test suite for verification of alternative `cipher` implementations
 - Add `POST /transaction/verify` API endpoint
+- Add `ignore_unconfirmed` option to `POST /api/v1/wallet/transaction` to allow transactions to be created or spent even if there are unspent outputs in the unconfirmed pool.
+- Add `uxouts` to `POST /api/v1/wallet/transaction`, to allow specific unspent outputs to be used in a transaction.
 
 ### Fixed
 

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -658,7 +658,10 @@ Statuses:
     500: other errors
 ```
 
-example, send 1 coin to `2iVtHS5ye99Km5PonsB42No3pQRGEURmxyc` from wallet `2017_05_09_ea42.wlt`:
+
+**This endpoint is deprecated, use [POST /wallet/transaction](#create-transaction)**
+
+Example, send 1 coin to `2iVtHS5ye99Km5PonsB42No3pQRGEURmxyc` from wallet `2017_05_09_ea42.wlt`:
 
 ```sh
 curl -X POST  http://127.0.0.1:6420/api/v1/wallet/spend \
@@ -729,15 +732,17 @@ The `encoded_transaction` can be provided to `POST /api/v1/injectTransaction` to
 
 The request body includes:
 
-* A change address
+* An optional change address
 * A wallet to spend from with the optional ability to restrict which addresses or which unspent outputs in the wallet to use
 * A list of destinations with address and coins specified, as well as optionally specifying hours
 * A configuration for how destination hours are distributed, either manual or automatic
+* Additional options
 
 Example request body with manual hours selection type, unencrypted wallet and all wallet addresses may spend:
 
 ```json
 {
+    "ignore_unconfirmed": false,
     "hours_selection": {
         "type": "manual"
     },
@@ -893,6 +898,14 @@ then all outputs associated with all addresses in the wallet may be chosen from 
 `change_address` is optional.
 If set, it is not required to be an address in the wallet.
 If not set, it will default to one of the addresses associated with the unspent outputs being spent in the transaction.
+
+`ignore_unconfirmed` is optional and defaults to `false`.
+When `false`, the API will return an error if any of the unspent outputs
+associated with the wallet addresses or the wallet outputs appear as spent in
+a transaction in the unconfirmed transaction pool.
+When `true`, the API will ignore unspent outputs that appear as spent in
+a transaction in the unconfirmed transaction pool when building the transaction,
+but not return an error.
 
 Example:
 

--- a/src/api/client.go
+++ b/src/api/client.go
@@ -488,10 +488,11 @@ func (c *Client) Spend(id, dst string, coins uint64, password string) (*SpendRes
 
 // CreateTransactionRequest is sent to /wallet/transaction
 type CreateTransactionRequest struct {
-	HoursSelection HoursSelection                 `json:"hours_selection"`
-	Wallet         CreateTransactionRequestWallet `json:"wallet"`
-	ChangeAddress  *string                        `json:"change_address,omitempty"`
-	To             []Receiver                     `json:"to"`
+	IgnoreUnconfirmed bool                           `json:"ignore_unconfirmed"`
+	HoursSelection    HoursSelection                 `json:"hours_selection"`
+	Wallet            CreateTransactionRequestWallet `json:"wallet"`
+	ChangeAddress     *string                        `json:"change_address,omitempty"`
+	To                []Receiver                     `json:"to"`
 }
 
 // CreateTransactionRequestWallet defines a wallet to spend from and optionally which addresses in the wallet

--- a/src/api/integration/integration_test.go
+++ b/src/api/integration/integration_test.go
@@ -2261,7 +2261,39 @@ func TestLiveWalletCreateTransactionSpecific(t *testing.T) {
 		},
 
 		{
-			name: "valid request, auto one output no change",
+			// NOTE: no reliable way to test the ignore unconfirmed behavior,
+			// this test only checks that if IgnoreUnconfirmed is specified,
+			// the API doesn't throw up some parsing error
+			name: "valid request, manual one output no change, ignore unconfirmed",
+			req: api.CreateTransactionRequest{
+				IgnoreUnconfirmed: true,
+				HoursSelection: api.HoursSelection{
+					Type: wallet.HoursSelectionTypeManual,
+				},
+				Wallet: api.CreateTransactionRequestWallet{
+					ID:       w.Filename(),
+					Password: password,
+				},
+				ChangeAddress: &defaultChangeAddress,
+				To: []api.Receiver{
+					{
+						Address: w.Entries[1].Address.String(),
+						Coins:   toDropletString(totalCoins),
+						Hours:   "1",
+					},
+				},
+			},
+			outputs: []coin.TransactionOutput{
+				{
+					Address: w.Entries[1].Address,
+					Coins:   totalCoins,
+					Hours:   1,
+				},
+			},
+		},
+
+		{
+			name: "valid request, auto one output no change, share factor recalculates to 1.0",
 			req: api.CreateTransactionRequest{
 				HoursSelection: api.HoursSelection{
 					Type:        wallet.HoursSelectionTypeAuto,
@@ -2284,7 +2316,7 @@ func TestLiveWalletCreateTransactionSpecific(t *testing.T) {
 				{
 					Address: w.Entries[1].Address,
 					Coins:   totalCoins,
-					Hours:   remainingHours / 2,
+					Hours:   remainingHours,
 				},
 			},
 		},

--- a/src/api/spend.go
+++ b/src/api/spend.go
@@ -241,10 +241,11 @@ func NewCreatedTransactionInput(out wallet.UxBalance) (*CreatedTransactionInput,
 
 // createTransactionRequest is sent to /wallet/transaction
 type createTransactionRequest struct {
-	HoursSelection hoursSelection                 `json:"hours_selection"`
-	Wallet         createTransactionRequestWallet `json:"wallet"`
-	ChangeAddress  *wh.Address                    `json:"change_address,omitempty"`
-	To             []receiver                     `json:"to"`
+	IgnoreUnconfirmed bool                           `json:"ignore_unconfirmed"`
+	HoursSelection    hoursSelection                 `json:"hours_selection"`
+	Wallet            createTransactionRequestWallet `json:"wallet"`
+	ChangeAddress     *wh.Address                    `json:"change_address,omitempty"`
+	To                []receiver                     `json:"to"`
 }
 
 // createTransactionRequestWallet defines a wallet to spend from and optionally which addresses in the wallet
@@ -439,6 +440,7 @@ func (r createTransactionRequest) ToWalletParams() wallet.CreateTransactionParam
 	}
 
 	return wallet.CreateTransactionParams{
+		IgnoreUnconfirmed: r.IgnoreUnconfirmed,
 		HoursSelection: wallet.HoursSelection{
 			Type:        r.HoursSelection.Type,
 			Mode:        r.HoursSelection.Mode,

--- a/src/cipher/crypto_test.go
+++ b/src/cipher/crypto_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/skycoin/skycoin/src/cipher/ripemd160"
 )
@@ -332,4 +333,12 @@ func TestSecKeyHashTest(t *testing.T) {
 	h := SumSHA256(randBytes(t, 256))
 	assert.Nil(t, TestSecKeyHash(s, h))
 	assert.NotNil(t, TestSecKeyHash(SecKey{}, h))
+}
+
+func TestGenerateDeterministicKeyPairsUsesAllBytes(t *testing.T) {
+	// Tests that if a seed >128 bits is used, the generator does not ignore bits >128
+	seed := "property diet little foster provide disagree witness mountain alley weekend kitten general"
+	seckeys := GenerateDeterministicKeyPairs([]byte(seed), 3)
+	seckeys2 := GenerateDeterministicKeyPairs([]byte(seed[:16]), 3)
+	require.NotEqual(t, seckeys, seckeys2)
 }

--- a/src/visor/visor_test.go
+++ b/src/visor/visor_test.go
@@ -2091,15 +2091,16 @@ func TestGetCreateTransactionAuxs(t *testing.T) {
 	}
 
 	cases := []struct {
-		name   string
-		params wallet.CreateTransactionParams
-		addrs  []cipher.Address
-		auxs   coin.AddressUxOuts
-		err    error
+		name         string
+		params       wallet.CreateTransactionParams
+		addrs        []cipher.Address
+		expectedAuxs coin.AddressUxOuts
+		err          error
 
-		rawTxnsRet     coin.Transactions
-		getArrayInputs []cipher.SHA256
-		getArrayRet    coin.UxArray
+		rawTxnsRet            coin.Transactions
+		getArrayInputs        []cipher.SHA256
+		getArrayRet           coin.UxArray
+		getUnspentsOfAddrsRet coin.AddressUxOuts
 	}{
 		{
 			name:  "all addresses, ok",
@@ -2121,7 +2122,31 @@ func TestGetCreateTransactionAuxs(t *testing.T) {
 					},
 				},
 			},
-			auxs: coin.AddressUxOuts{
+			getUnspentsOfAddrsRet: coin.AddressUxOuts{
+				allAddrs[1]: []coin.UxOut{
+					coin.UxOut{
+						Body: coin.UxBody{
+							SrcTransaction: srcTxns[5],
+							Address:        allAddrs[1],
+						},
+					},
+					coin.UxOut{
+						Body: coin.UxBody{
+							SrcTransaction: srcTxns[5],
+							Address:        allAddrs[1],
+						},
+					},
+				},
+				allAddrs[3]: []coin.UxOut{
+					coin.UxOut{
+						Body: coin.UxBody{
+							SrcTransaction: srcTxns[6],
+							Address:        allAddrs[3],
+						},
+					},
+				},
+			},
+			expectedAuxs: coin.AddressUxOuts{
 				allAddrs[1]: []coin.UxOut{
 					coin.UxOut{
 						Body: coin.UxBody{
@@ -2213,7 +2238,31 @@ func TestGetCreateTransactionAuxs(t *testing.T) {
 					},
 				},
 			},
-			auxs: coin.AddressUxOuts{
+			getUnspentsOfAddrsRet: coin.AddressUxOuts{
+				allAddrs[1]: []coin.UxOut{
+					coin.UxOut{
+						Body: coin.UxBody{
+							SrcTransaction: srcTxns[5],
+							Address:        allAddrs[1],
+						},
+					},
+					coin.UxOut{
+						Body: coin.UxBody{
+							SrcTransaction: srcTxns[5],
+							Address:        allAddrs[1],
+						},
+					},
+				},
+				allAddrs[3]: []coin.UxOut{
+					coin.UxOut{
+						Body: coin.UxBody{
+							SrcTransaction: srcTxns[6],
+							Address:        allAddrs[3],
+						},
+					},
+				},
+			},
+			expectedAuxs: coin.AddressUxOuts{
 				allAddrs[1]: []coin.UxOut{
 					coin.UxOut{
 						Body: coin.UxBody{
@@ -2286,6 +2335,93 @@ func TestGetCreateTransactionAuxs(t *testing.T) {
 		},
 
 		{
+			name: "some addresses, unconfirmed spends ignored",
+			params: wallet.CreateTransactionParams{
+				IgnoreUnconfirmed: true,
+				Wallet: wallet.CreateTransactionWalletParams{
+					Addresses: allAddrs[0:5],
+				},
+			},
+			addrs: allAddrs[0:5],
+			rawTxnsRet: coin.Transactions{
+				coin.Transaction{
+					In: hashes[0:2],
+				},
+			},
+			getArrayInputs: hashes[0:2],
+			getArrayRet: coin.UxArray{
+				coin.UxOut{
+					Body: coin.UxBody{
+						SrcTransaction: srcTxns[4],
+						Address:        testutil.MakeAddress(),
+					},
+				},
+				coin.UxOut{
+					Body: coin.UxBody{
+						SrcTransaction: srcTxns[7],
+						Address:        allAddrs[4],
+					},
+				},
+			},
+			getUnspentsOfAddrsRet: coin.AddressUxOuts{
+				allAddrs[1]: []coin.UxOut{
+					coin.UxOut{
+						Body: coin.UxBody{
+							SrcTransaction: srcTxns[5],
+							Address:        allAddrs[1],
+						},
+					},
+					coin.UxOut{
+						Body: coin.UxBody{
+							SrcTransaction: srcTxns[5],
+							Address:        allAddrs[1],
+						},
+					},
+				},
+				allAddrs[3]: []coin.UxOut{
+					coin.UxOut{
+						Body: coin.UxBody{
+							SrcTransaction: srcTxns[6],
+							Address:        allAddrs[3],
+						},
+					},
+				},
+				allAddrs[4]: []coin.UxOut{
+					coin.UxOut{
+						Body: coin.UxBody{
+							SrcTransaction: srcTxns[7],
+							Address:        allAddrs[4],
+						},
+					},
+				},
+			},
+			expectedAuxs: coin.AddressUxOuts{
+				allAddrs[1]: []coin.UxOut{
+					coin.UxOut{
+						Body: coin.UxBody{
+							SrcTransaction: srcTxns[5],
+							Address:        allAddrs[1],
+						},
+					},
+					coin.UxOut{
+						Body: coin.UxBody{
+							SrcTransaction: srcTxns[5],
+							Address:        allAddrs[1],
+						},
+					},
+				},
+				allAddrs[3]: []coin.UxOut{
+					coin.UxOut{
+						Body: coin.UxBody{
+							SrcTransaction: srcTxns[6],
+							Address:        allAddrs[3],
+						},
+					},
+				},
+			},
+		},
+
+		{
 			name: "some addresses, unknown address",
 			params: wallet.CreateTransactionParams{
 				Wallet: wallet.CreateTransactionWalletParams{
@@ -2332,7 +2468,7 @@ func TestGetCreateTransactionAuxs(t *testing.T) {
 					},
 				},
 			},
-			auxs: coin.AddressUxOuts{
+			expectedAuxs: coin.AddressUxOuts{
 				allAddrs[1]: []coin.UxOut{
 					coin.UxOut{
 						Body: coin.UxBody{
@@ -2372,6 +2508,46 @@ func TestGetCreateTransactionAuxs(t *testing.T) {
 				},
 				coin.Transaction{
 					In: hashes[3:6],
+				},
+			},
+		},
+
+		{
+			name: "uxouts specified, unconfirmed spend ignored",
+			params: wallet.CreateTransactionParams{
+				IgnoreUnconfirmed: true,
+				Wallet: wallet.CreateTransactionWalletParams{
+					UxOuts: hashes[5:10],
+				},
+			},
+			rawTxnsRet: coin.Transactions{
+				coin.Transaction{
+					In: hashes[0:2],
+				},
+				coin.Transaction{
+					In: hashes[2:4],
+				},
+				coin.Transaction{
+					In: hashes[8:10],
+				},
+			},
+			getArrayInputs: hashes[5:8], // the 8th & 9th hash are filtered because it is an unconfirmed spend
+			getArrayRet: coin.UxArray{
+				coin.UxOut{
+					Body: coin.UxBody{
+						SrcTransaction: srcTxns[5],
+						Address:        allAddrs[1],
+					},
+				},
+			},
+			expectedAuxs: coin.AddressUxOuts{
+				allAddrs[1]: []coin.UxOut{
+					coin.UxOut{
+						Body: coin.UxBody{
+							SrcTransaction: srcTxns[5],
+							Address:        allAddrs[1],
+						},
+					},
 				},
 			},
 		},
@@ -2426,8 +2602,8 @@ func TestGetCreateTransactionAuxs(t *testing.T) {
 
 			unconfirmed.On("RawTxns", matchTx).Return(tc.rawTxnsRet, nil)
 			unspent.On("GetArray", matchTx, tc.getArrayInputs).Return(tc.getArrayRet, nil)
-			if tc.auxs != nil {
-				unspent.On("GetUnspentsOfAddrs", matchTx, tc.addrs).Return(tc.auxs, nil)
+			if tc.getUnspentsOfAddrsRet != nil {
+				unspent.On("GetUnspentsOfAddrs", matchTx, tc.addrs).Return(tc.getUnspentsOfAddrsRet, nil)
 			}
 			bc.On("Unspent").Return(unspent)
 
@@ -2445,7 +2621,7 @@ func TestGetCreateTransactionAuxs(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Equal(t, tc.auxs, auxs)
+			require.Equal(t, tc.expectedAuxs, auxs)
 		})
 	}
 }

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -160,10 +160,11 @@ type CreateTransactionWalletParams struct {
 
 // CreateTransactionParams defines control parameters for transaction construction
 type CreateTransactionParams struct {
-	HoursSelection HoursSelection
-	Wallet         CreateTransactionWalletParams
-	ChangeAddress  *cipher.Address
-	To             []coin.TransactionOutput
+	IgnoreUnconfirmed bool
+	HoursSelection    HoursSelection
+	Wallet            CreateTransactionWalletParams
+	ChangeAddress     *cipher.Address
+	To                []coin.TransactionOutput
 }
 
 // Validate validates CreateTransactionParams


### PR DESCRIPTION
Fixes #1584 

Changes:
- Allow `POST /wallet/transactions` to be created even if there are unconfirmed spends. Requires `ignore_unconfirmed` flag to be `true` in the API.  Outputs that appear spent in unconfirmed txns will be excluded from txn constructions.

Does this change need to mentioned in CHANGELOG.md?
Yes