### PR TITLE
Check blockchain pubkey in INTR message if extra bytes exist

### DIFF
--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -55,7 +55,7 @@ var (
 	ErrDisconnectMaxOutgoingConnectionsReached gnet.DisconnectReason = errors.New("Maximum outgoing connections was reached")
 	// ErrDisconnectBlockchainPubkeyNotMatched is returned when the blockchain pubkey in introduction does not match
 	ErrDisconnectBlockchainPubkeyNotMatched gnet.DisconnectReason = errors.New("Blockchain pubkey in Introduction message is not matched ")
-	// ErrDisconnectInvalidExtraData is returned when extra filed can't be parsed as specific data type.
+	// ErrDisconnectInvalidExtraData is returned when extra field can't be parsed as specific data type.
 	// e.g. ExtraData length in IntroductionMessage is not the same as cipher.PubKey
 	ErrDisconnectInvalidExtraData gnet.DisconnectReason = errors.New("Invalid extra data")
 
@@ -209,6 +209,41 @@ func NewDaemonConfig() DaemonConfig {
 	}
 }
 
+//go:generate go install
+//go:generate goautomock -template=testify Daemoner
+
+// Daemoner Daemon interface
+type Daemoner interface {
+	SendMessage(addr string, msg gnet.Message) error
+	BroadcastMessage(msg gnet.Message) error
+	Disconnect(addr string, r gnet.DisconnectReason) error
+	IsDefaultConnection(addr string) bool
+	IsMaxDefaultConnectionsReached() (bool, error)
+	PexConfig() pex.Config
+	RandomExchangeable(n int) pex.Peers
+	AddPeer(addr string) error
+	AddPeers(addrs []string) int
+	SetHasIncomingPort(addr string) error
+	IncreaseRetryTimes(addr string)
+	ResetRetryTimes(addr string)
+	RecordPeerHeight(addr string, height uint64)
+	GetSignedBlocksSince(seq, count uint64) ([]coin.SignedBlock, error)
+	HeadBkSeq() (uint64, bool, error)
+	ExecuteSignedBlock(b coin.SignedBlock) error
+	GetUnconfirmedUnknown(txns []cipher.SHA256) ([]cipher.SHA256, error)
+	GetUnconfirmedKnown(txns []cipher.SHA256) (coin.Transactions, error)
+	InjectTransaction(txn coin.Transaction) (bool, *visor.ErrTxnViolatesSoftConstraint, error)
+	Mirror() uint32
+	DaemonConfig() DaemonConfig
+	BlockchainPubkey() cipher.PubKey
+	RecordMessageEvent(m AsyncMessage, c *gnet.MessageContext) error
+	RecordConnectionMirror(addr string, mirror uint32) error
+	GetMirrorPort(addr string, mirror uint32) (uint16, bool)
+	RemoveFromExpectingIntroductions(addr string)
+	RequestBlocksFromAddr(addr string) error
+	AnnounceAllTxns() error
+}
+
 // Daemon stateful properties of the daemon
 type Daemon struct {
 	// Daemon configuration
@@ -216,10 +251,10 @@ type Daemon struct {
 
 	// Components
 	Messages *Messages
-	Pool     *Pool
-	Pex      *pex.Pex
+	pool     *Pool
+	pex      *pex.Pex
 	Gateway  *Gateway
-	Visor    *visor.Visor
+	visor    *visor.Visor
 
 	DefaultConnections []string
 
@@ -279,8 +314,8 @@ func NewDaemon(config Config, db *dbutil.DB, defaultConns []string) (*Daemon, er
 	d := &Daemon{
 		Config:   config.Daemon,
 		Messages: NewMessages(config.Messages),
-		Pex:      pex,
-		Visor:    vs,
+		pex:      pex,
+		visor:    vs,
 
 		DefaultConnections: defaultConns,
 
@@ -306,7 +341,7 @@ func NewDaemon(config Config, db *dbutil.DB, defaultConns []string) (*Daemon, er
 
 	d.Gateway = NewGateway(config.Gateway, d)
 	d.Messages.Config.Register()
-	d.Pool = NewPool(config.Pool, d)
+	d.pool = NewPool(config.Pool, d)
 
 	return d, nil
 }
@@ -347,13 +382,13 @@ func (dm *Daemon) Shutdown() {
 	close(dm.quit)
 
 	logger.Info("Shutting down Pool")
-	dm.Pool.Shutdown()
+	dm.pool.Shutdown()
 
 	logger.Info("Shutting down Gateway")
 	dm.Gateway.Shutdown()
 
 	logger.Info("Shutting down Pex")
-	dm.Pex.Shutdown()
+	dm.pex.Shutdown()
 
 	<-dm.done
 }
@@ -364,7 +399,7 @@ func (dm *Daemon) Run() error {
 	defer logger.Info("Daemon closed")
 	defer close(dm.done)
 
-	if err := dm.Visor.Init(); err != nil {
+	if err := dm.visor.Init(); err != nil {
 		logger.WithError(err).Error("visor.Visor.Init failed")
 		return err
 	}
@@ -375,7 +410,7 @@ func (dm *Daemon) Run() error {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if err := dm.Pex.Run(); err != nil {
+		if err := dm.pex.Run(); err != nil {
 			logger.WithError(err).Error("daemon.Pex.Run failed")
 			errC <- err
 		}
@@ -385,12 +420,12 @@ func (dm *Daemon) Run() error {
 	go func() {
 		defer wg.Done()
 		if dm.Config.DisableIncomingConnections {
-			if err := dm.Pool.RunOffline(); err != nil {
+			if err := dm.pool.RunOffline(); err != nil {
 				logger.WithError(err).Error("daemon.Pool.RunOffline failed")
 				errC <- err
 			}
 		} else {
-			if err := dm.Pool.Run(); err != nil {
+			if err := dm.pool.Run(); err != nil {
 				logger.WithError(err).Error("daemon.Pool.Run failed")
 				errC <- err
 			}
@@ -399,7 +434,7 @@ func (dm *Daemon) Run() error {
 
 	blockInterval := time.Duration(dm.Config.BlockCreationInterval)
 	blockCreationTicker := time.NewTicker(time.Second * blockInterval)
-	if !dm.Visor.Config.IsMaster {
+	if !dm.visor.Config.IsMaster {
 		blockCreationTicker.Stop()
 	}
 
@@ -411,9 +446,9 @@ func (dm *Daemon) Run() error {
 	privateConnectionsTicker := time.Tick(dm.Config.PrivateRate)
 	cullInvalidTicker := time.Tick(dm.Config.CullInvalidRate)
 	outgoingConnectionsTicker := time.Tick(dm.Config.OutgoingRate)
-	requestPeersTicker := time.Tick(dm.Pex.Config.RequestRate)
-	clearStaleConnectionsTicker := time.Tick(dm.Pool.Config.ClearStaleRate)
-	idleCheckTicker := time.Tick(dm.Pool.Config.IdleCheckRate)
+	requestPeersTicker := time.Tick(dm.pex.Config.RequestRate)
+	clearStaleConnectionsTicker := time.Tick(dm.pool.Config.ClearStaleRate)
+	idleCheckTicker := time.Tick(dm.pool.Config.IdleCheckRate)
 
 	flushAnnouncedTxnsTicker := time.Tick(dm.Config.FlushAnnouncedTxnsRate)
 
@@ -444,7 +479,7 @@ func (dm *Daemon) Run() error {
 			case <-dm.quit:
 				break loop
 
-			case r := <-dm.Pool.Pool.SendResults:
+			case r := <-dm.pool.Pool.SendResults:
 				// Process message sending results
 				elapser.Register("dm.Pool.Pool.SendResults")
 				if dm.Config.DisableNetworking {
@@ -473,16 +508,16 @@ loop:
 		case <-requestPeersTicker:
 			// Request peers via PEX
 			elapser.Register("requestPeersTicker")
-			if dm.Pex.Config.Disabled {
+			if dm.pex.Config.Disabled {
 				continue
 			}
 
-			if dm.Pex.IsFull() {
+			if dm.pex.IsFull() {
 				continue
 			}
 
 			m := NewGetPeersMessage()
-			if err := dm.Pool.Pool.BroadcastMessage(m); err != nil {
+			if err := dm.pool.Pool.BroadcastMessage(m); err != nil {
 				logger.Error(err)
 			}
 
@@ -490,20 +525,20 @@ loop:
 			// Remove connections that haven't said anything in a while
 			elapser.Register("clearStaleConnectionsTicker")
 			if !dm.Config.DisableNetworking {
-				dm.Pool.clearStaleConnections()
+				dm.pool.clearStaleConnections()
 			}
 
 		case <-idleCheckTicker:
 			// Sends pings as needed
 			elapser.Register("idleCheckTicker")
 			if !dm.Config.DisableNetworking {
-				dm.Pool.sendPings()
+				dm.pool.sendPings()
 			}
 
 		case <-outgoingConnectionsTicker:
 			// Fill up our outgoing connections
 			elapser.Register("outgoingConnectionsTicker")
-			trustPeerNum := len(dm.Pex.Trusted())
+			trustPeerNum := len(dm.pex.Trusted())
 			if !dm.Config.DisableOutgoingConnections &&
 				dm.outgoingConnections.Len() < (dm.Config.OutgoingMax+trustPeerNum) &&
 				dm.pendingConnections.Len() < dm.Config.PendingMax {
@@ -550,7 +585,7 @@ loop:
 			elapser.Register("flushAnnouncedTxnsTicker")
 			txns := dm.announcedTxns.flush()
 
-			if err := dm.Visor.SetTxnsAnnounced(txns); err != nil {
+			if err := dm.visor.SetTxnsAnnounced(txns); err != nil {
 				logger.WithError(err).Error("Failed to set unconfirmed txn announce time")
 				return err
 			}
@@ -572,7 +607,7 @@ loop:
 		case <-blockCreationTicker.C:
 			// Create blocks, if master chain
 			elapser.Register("blockCreationTicker.C")
-			if dm.Visor.Config.IsMaster {
+			if dm.visor.Config.IsMaster {
 				sb, err := dm.CreateAndPublishBlock()
 				if err != nil {
 					logger.Errorf("Failed to create and publish block: %v", err)
@@ -587,7 +622,7 @@ loop:
 		case <-unconfirmedRefreshTicker:
 			elapser.Register("unconfirmedRefreshTicker")
 			// Get the transactions that turn to valid
-			validTxns, err := dm.Visor.RefreshUnconfirmed()
+			validTxns, err := dm.visor.RefreshUnconfirmed()
 			if err != nil {
 				logger.Errorf("dm.Visor.RefreshUnconfirmed failed: %v", err)
 				continue
@@ -598,7 +633,7 @@ loop:
 		case <-unconfirmedRemoveInvalidTicker:
 			elapser.Register("unconfirmedRemoveInvalidTicker")
 			// Remove transactions that become invalid (violating hard constraints)
-			removedTxns, err := dm.Visor.RemoveInvalidUnconfirmed()
+			removedTxns, err := dm.visor.RemoveInvalidUnconfirmed()
 			if err != nil {
 				logger.Errorf("dm.Visor.RemoveInvalidUnconfirmed failed: %v", err)
 				continue
@@ -663,7 +698,7 @@ func (dm *Daemon) connectToPeer(p pex.Peer) error {
 		return errors.New("Not localhost")
 	}
 
-	conned, err := dm.Pool.Pool.IsConnExist(p.Addr)
+	conned, err := dm.pool.Pool.IsConnExist(p.Addr)
 	if err != nil {
 		return err
 	}
@@ -683,7 +718,7 @@ func (dm *Daemon) connectToPeer(p pex.Peer) error {
 	logger.Debugf("Trying to connect to %s", p.Addr)
 	dm.pendingConnections.Add(p.Addr, p)
 	go func() {
-		if err := dm.Pool.Pool.Connect(p.Addr); err != nil {
+		if err := dm.pool.Pool.Connect(p.Addr); err != nil {
 			dm.connectionErrors <- ConnectionError{p.Addr, err}
 		}
 	}()
@@ -696,7 +731,7 @@ func (dm *Daemon) makePrivateConnections() {
 		return
 	}
 
-	peers := dm.Pex.Private()
+	peers := dm.pex.Private()
 	for _, p := range peers {
 		logger.Infof("Private peer attempt: %s", p.Addr)
 		if err := dm.connectToPeer(p); err != nil {
@@ -712,7 +747,7 @@ func (dm *Daemon) connectToTrustPeer() {
 
 	logger.Info("Connect to trusted peers")
 	// Make connections to all trusted peers
-	peers := dm.Pex.TrustedPublic()
+	peers := dm.pex.TrustedPublic()
 	for _, p := range peers {
 		dm.connectToPeer(p)
 	}
@@ -725,12 +760,12 @@ func (dm *Daemon) connectToRandomPeer() {
 	}
 
 	// Make a connection to a random (public) peer
-	peers := dm.Pex.RandomPublic(dm.Config.OutgoingMax)
+	peers := dm.pex.RandomPublic(dm.Config.OutgoingMax)
 	for _, p := range peers {
 		// Check if the peer has public port
 		if p.HasIncomingPort {
 			// Try to connect the peer if it's ip:mirror does not exist
-			if _, exist := dm.getMirrorPort(p.Addr, dm.Messages.Mirror); !exist {
+			if _, exist := dm.GetMirrorPort(p.Addr, dm.Messages.Mirror); !exist {
 				dm.connectToPeer(p)
 				continue
 			}
@@ -742,7 +777,7 @@ func (dm *Daemon) connectToRandomPeer() {
 
 	if len(peers) == 0 {
 		// Reset the retry times of all peers,
-		dm.Pex.ResetAllRetryTimes()
+		dm.pex.ResetAllRetryTimes()
 	}
 }
 
@@ -752,7 +787,7 @@ func (dm *Daemon) handleConnectionError(c ConnectionError) {
 	logger.Debugf("Failed to connect to %s with error: %v", c.Addr, c.Error)
 	dm.pendingConnections.Remove(c.Addr)
 
-	dm.Pex.IncreaseRetryTimes(c.Addr)
+	dm.pex.IncreaseRetryTimes(c.Addr)
 }
 
 // Removes unsolicited connections who haven't sent a version
@@ -762,7 +797,7 @@ func (dm *Daemon) cullInvalidConnections() {
 	now := utc.Now()
 	addrs, err := dm.expectingIntroductions.CullInvalidConns(
 		func(addr string, t time.Time) (bool, error) {
-			conned, err := dm.Pool.Pool.IsConnExist(addr)
+			conned, err := dm.pool.Pool.IsConnExist(addr)
 			if err != nil {
 				return false, err
 			}
@@ -788,7 +823,7 @@ func (dm *Daemon) cullInvalidConnections() {
 	}
 
 	for _, a := range addrs {
-		exist, err := dm.Pool.Pool.IsConnExist(a)
+		exist, err := dm.pool.Pool.IsConnExist(a)
 		if err != nil {
 			logger.Error(err)
 			return
@@ -796,17 +831,17 @@ func (dm *Daemon) cullInvalidConnections() {
 
 		if exist {
 			logger.Infof("Removing %s for not sending a version", a)
-			if err := dm.Pool.Pool.Disconnect(a, ErrDisconnectIntroductionTimeout); err != nil {
+			if err := dm.pool.Pool.Disconnect(a, ErrDisconnectIntroductionTimeout); err != nil {
 				logger.Error(err)
 				return
 			}
-			dm.Pex.RemovePeer(a)
+			dm.pex.RemovePeer(a)
 		}
 	}
 }
 
 func (dm *Daemon) isTrustedPeer(addr string) bool {
-	peer, ok := dm.Pex.GetPeerByAddr(addr)
+	peer, ok := dm.pex.GetPeerByAddr(addr)
 	if !ok {
 		return false
 	}
@@ -814,9 +849,9 @@ func (dm *Daemon) isTrustedPeer(addr string) bool {
 	return peer.Trusted
 }
 
-// Records an AsyncMessage to the messageEvent chan.  Do not access
+// RecordMessageEvent records an AsyncMessage to the messageEvent chan.  Do not access
 // messageEvent directly.
-func (dm *Daemon) recordMessageEvent(m AsyncMessage, c *gnet.MessageContext) error {
+func (dm *Daemon) RecordMessageEvent(m AsyncMessage, c *gnet.MessageContext) error {
 	dm.messageEvents <- MessageEvent{m, c}
 	return nil
 }
@@ -838,7 +873,7 @@ func (dm *Daemon) processMessageEvent(e MessageEvent) {
 	if dm.needsIntro(e.Context.Addr) {
 		_, isIntro := e.Message.(*IntroductionMessage)
 		if !isIntro {
-			dm.Pool.Pool.Disconnect(e.Context.Addr, ErrDisconnectNoIntroduction)
+			dm.pool.Pool.Disconnect(e.Context.Addr, ErrDisconnectNoIntroduction)
 		}
 	}
 	e.Message.Process(dm)
@@ -856,7 +891,7 @@ func (dm *Daemon) onConnect(e ConnectEvent) {
 
 	dm.pendingConnections.Remove(a)
 
-	exist, err := dm.Pool.Pool.IsConnExist(a)
+	exist, err := dm.pool.Pool.IsConnExist(a)
 	if err != nil {
 		logger.Error(err)
 		return
@@ -869,7 +904,7 @@ func (dm *Daemon) onConnect(e ConnectEvent) {
 
 	if dm.ipCountMaxed(a) {
 		logger.Infof("Max connections for %s reached, disconnecting", a)
-		dm.Pool.Pool.Disconnect(a, ErrDisconnectIPLimitReached)
+		dm.pool.Pool.Disconnect(a, ErrDisconnectIPLimitReached)
 		return
 	}
 
@@ -877,7 +912,7 @@ func (dm *Daemon) onConnect(e ConnectEvent) {
 
 	if e.Solicited {
 		// Disconnect if the max outgoing connections is reached
-		n, err := dm.Pool.Pool.OutgoingConnectionsNum()
+		n, err := dm.pool.Pool.OutgoingConnectionsNum()
 		if err != nil {
 			logger.WithError(err).Error("get outgoing connections number failed")
 			return
@@ -885,7 +920,7 @@ func (dm *Daemon) onConnect(e ConnectEvent) {
 
 		if n > dm.Config.OutgoingMax {
 			logger.Warningf("max outgoing connections is reached, disconnecting %v", a)
-			dm.Pool.Pool.Disconnect(a, ErrDisconnectMaxOutgoingConnectionsReached)
+			dm.pool.Pool.Disconnect(a, ErrDisconnectMaxOutgoingConnectionsReached)
 			return
 		}
 
@@ -895,8 +930,8 @@ func (dm *Daemon) onConnect(e ConnectEvent) {
 	dm.expectingIntroductions.Add(a, utc.Now())
 	logger.Debugf("Sending introduction message to %s, mirror:%d", a, dm.Messages.Mirror)
 	// TODO: replace the last paramenter of nil with dm.Config.BlockchainPubkey in v25
-	m := NewIntroductionMessage(dm.Messages.Mirror, dm.Config.Version, dm.Pool.Pool.Config.Port, nil)
-	if err := dm.Pool.Pool.SendMessage(a, m); err != nil {
+	m := NewIntroductionMessage(dm.Messages.Mirror, dm.Config.Version, dm.pool.Pool.Config.Port, nil)
+	if err := dm.pool.Pool.SendMessage(a, m); err != nil {
 		logger.Errorf("Send IntroductionMessage to %s failed: %v", a, err)
 	}
 }
@@ -963,11 +998,11 @@ func (dm *Daemon) removeIPCount(addr string) {
 	dm.ipCounts.Decrease(ip)
 }
 
-// Adds addr + mirror to the connectionMirror mappings
-func (dm *Daemon) recordConnectionMirror(addr string, mirror uint32) error {
+// RecordConnectionMirror adds addr + mirror to the connectionMirror mappings
+func (dm *Daemon) RecordConnectionMirror(addr string, mirror uint32) error {
 	ip, port, err := iputil.SplitAddr(addr)
 	if err != nil {
-		logger.Warningf("recordConnectionMirror called with invalid addr: %v", err)
+		logger.Warningf("RecordConnectionMirror called with invalid addr: %v", err)
 		return err
 	}
 	dm.connectionMirrors.Add(addr, mirror)
@@ -993,8 +1028,8 @@ func (dm *Daemon) removeConnectionMirror(addr string) {
 	dm.connectionMirrors.Remove(addr)
 }
 
-// Returns whether an addr+mirror's port and whether the port exists
-func (dm *Daemon) getMirrorPort(addr string, mirror uint32) (uint16, bool) {
+// GetMirrorPort returns whether an addr+mirror's port and whether the port exists
+func (dm *Daemon) GetMirrorPort(addr string, mirror uint32) (uint16, bool) {
 	ip, _, err := iputil.SplitAddr(addr)
 	if err != nil {
 		logger.Warningf("getMirrorPort called with invalid addr: %v", err)
@@ -1024,7 +1059,7 @@ func (dm *Daemon) RequestBlocks() error {
 		return nil
 	}
 
-	headSeq, ok, err := dm.Visor.HeadBkSeq()
+	headSeq, ok, err := dm.visor.HeadBkSeq()
 	if err != nil {
 		return err
 	}
@@ -1034,7 +1069,7 @@ func (dm *Daemon) RequestBlocks() error {
 
 	m := NewGetBlocksMessage(headSeq, dm.Config.BlocksResponseCount)
 
-	err = dm.Pool.Pool.BroadcastMessage(m)
+	err = dm.pool.Pool.BroadcastMessage(m)
 	if err != nil {
 		logger.Debugf("Broadcast GetBlocksMessage failed: %v", err)
 	}
@@ -1048,7 +1083,7 @@ func (dm *Daemon) AnnounceBlocks() error {
 		return nil
 	}
 
-	headSeq, ok, err := dm.Visor.HeadBkSeq()
+	headSeq, ok, err := dm.visor.HeadBkSeq()
 	if err != nil {
 		return err
 	}
@@ -1058,7 +1093,7 @@ func (dm *Daemon) AnnounceBlocks() error {
 
 	m := NewAnnounceBlocksMessage(headSeq)
 
-	err = dm.Pool.Pool.BroadcastMessage(m)
+	err = dm.pool.Pool.BroadcastMessage(m)
 	if err != nil {
 		logger.Debugf("Broadcast AnnounceBlocksMessage failed: %v", err)
 	}
@@ -1073,7 +1108,7 @@ func (dm *Daemon) AnnounceAllTxns() error {
 	}
 
 	// Get local unconfirmed transaction hashes.
-	hashes, err := dm.Visor.GetAllValidUnconfirmedTxHashes()
+	hashes, err := dm.visor.GetAllValidUnconfirmedTxHashes()
 	if err != nil {
 		return err
 	}
@@ -1083,7 +1118,7 @@ func (dm *Daemon) AnnounceAllTxns() error {
 
 	for _, hs := range hashesSet {
 		m := NewAnnounceTxnsMessage(hs)
-		if err = dm.Pool.Pool.BroadcastMessage(m); err != nil {
+		if err = dm.pool.Pool.BroadcastMessage(m); err != nil {
 			break
 		}
 	}
@@ -1132,7 +1167,7 @@ func (dm *Daemon) AnnounceTxns(txns []cipher.SHA256) error {
 
 	m := NewAnnounceTxnsMessage(txns)
 
-	err := dm.Pool.Pool.BroadcastMessage(m)
+	err := dm.pool.Pool.BroadcastMessage(m)
 	if err != nil {
 		logger.Debugf("Broadcast AnnounceTxnsMessage failed: %v", err)
 	}
@@ -1146,7 +1181,7 @@ func (dm *Daemon) RequestBlocksFromAddr(addr string) error {
 		return errors.New("Outgoing connections disabled")
 	}
 
-	headSeq, ok, err := dm.Visor.HeadBkSeq()
+	headSeq, ok, err := dm.visor.HeadBkSeq()
 	if err != nil {
 		return err
 	}
@@ -1156,7 +1191,7 @@ func (dm *Daemon) RequestBlocksFromAddr(addr string) error {
 
 	m := NewGetBlocksMessage(headSeq, dm.Config.BlocksResponseCount)
 
-	return dm.Pool.Pool.SendMessage(addr, m)
+	return dm.pool.Pool.SendMessage(addr, m)
 }
 
 // InjectBroadcastTransaction injects transaction to the unconfirmed pool and broadcasts it.
@@ -1165,7 +1200,7 @@ func (dm *Daemon) RequestBlocksFromAddr(addr string) error {
 // For transactions received over the network, use InjectTransaction and check the result to
 // decide on repropagation.
 func (dm *Daemon) InjectBroadcastTransaction(txn coin.Transaction) error {
-	if _, err := dm.Visor.InjectTransactionStrict(txn); err != nil {
+	if _, err := dm.visor.InjectTransactionStrict(txn); err != nil {
 		return err
 	}
 
@@ -1178,7 +1213,7 @@ func (dm *Daemon) ResendUnconfirmedTxns() ([]cipher.SHA256, error) {
 		return nil, nil
 	}
 
-	txns, err := dm.Visor.GetAllUnconfirmedTxns()
+	txns, err := dm.visor.GetAllUnconfirmedTxns()
 	if err != nil {
 		return nil, err
 	}
@@ -1201,14 +1236,14 @@ func (dm *Daemon) broadcastTransaction(t coin.Transaction) error {
 	}
 
 	m := NewGiveTxnsMessage(coin.Transactions{t})
-	l, err := dm.Pool.Pool.Size()
+	l, err := dm.pool.Pool.Size()
 	if err != nil {
 		return err
 	}
 
 	logger.Debugf("Broadcasting GiveTxnsMessage to %d conns", l)
 
-	err = dm.Pool.Pool.BroadcastMessage(m)
+	err = dm.pool.Pool.BroadcastMessage(m)
 	if err != nil {
 		logger.Errorf("Broadcast GivenTxnsMessage failed: %v", err)
 	}
@@ -1228,7 +1263,7 @@ func (dm *Daemon) CreateAndPublishBlock() (*coin.SignedBlock, error) {
 		return nil, errors.New("Outgoing connections disabled")
 	}
 
-	sb, err := dm.Visor.CreateAndExecuteBlock()
+	sb, err := dm.visor.CreateAndExecuteBlock()
 	if err != nil {
 		return nil, err
 	}
@@ -1245,5 +1280,136 @@ func (dm *Daemon) broadcastBlock(sb coin.SignedBlock) error {
 	}
 
 	m := NewGiveBlocksMessage([]coin.SignedBlock{sb})
-	return dm.Pool.Pool.BroadcastMessage(m)
+	return dm.pool.Pool.BroadcastMessage(m)
+}
+
+// Mirror returns the message mirror
+func (dm *Daemon) Mirror() uint32 {
+	return dm.Messages.Mirror
+}
+
+// DaemonConfig returns the daemon config
+func (dm *Daemon) DaemonConfig() DaemonConfig {
+	return dm.Config
+}
+
+// BlockchainPubkey returns the blockchain pubkey
+func (dm *Daemon) BlockchainPubkey() cipher.PubKey {
+	return dm.Config.BlockchainPubkey
+}
+
+// RemoveFromExpectingIntroductions removes the peer from expect introduction pool
+func (dm *Daemon) RemoveFromExpectingIntroductions(addr string) {
+	dm.expectingIntroductions.Remove(addr)
+}
+
+// Implements pooler interface
+
+// SendMessage sends a Message to a Connection and pushes the result onto the
+// SendResults channel.
+func (dm *Daemon) SendMessage(addr string, msg gnet.Message) error {
+	return dm.pool.Pool.SendMessage(addr, msg)
+}
+
+// BroadcastMessage sends a Message to all connections in the Pool.
+func (dm *Daemon) BroadcastMessage(msg gnet.Message) error {
+	return dm.pool.Pool.BroadcastMessage(msg)
+}
+
+// Disconnect removes a connection from the pool by address, and passes a Disconnection to
+// the DisconnectCallback
+func (dm *Daemon) Disconnect(addr string, r gnet.DisconnectReason) error {
+	return dm.pool.Pool.Disconnect(addr, r)
+}
+
+// IsDefaultConnection returns if the addr is a default connection
+func (dm *Daemon) IsDefaultConnection(addr string) bool {
+	return dm.pool.Pool.IsDefaultConnection(addr)
+}
+
+// IsMaxDefaultConnectionsReached returns whether the max default connection number was reached.
+func (dm *Daemon) IsMaxDefaultConnectionsReached() (bool, error) {
+	return dm.pool.Pool.IsMaxDefaultConnReached()
+}
+
+// Implements pexer interface
+
+// RandomExchangeable returns N random exchangeable peers
+func (dm *Daemon) RandomExchangeable(n int) pex.Peers {
+	return dm.pex.RandomExchangeable(n)
+}
+
+// PexConfig returns the pex config
+func (dm *Daemon) PexConfig() pex.Config {
+	return dm.pex.Config
+}
+
+// AddPeer adds peer to the pex
+func (dm *Daemon) AddPeer(addr string) error {
+	return dm.pex.AddPeer(addr)
+}
+
+// AddPeers adds peers to the pex
+func (dm *Daemon) AddPeers(addrs []string) int {
+	return dm.pex.AddPeers(addrs)
+}
+
+// SetHasIncomingPort sets the peer public peer
+func (dm *Daemon) SetHasIncomingPort(addr string) error {
+	return dm.pex.SetHasIncomingPort(addr, true)
+}
+
+// IncreaseRetryTimes increases the retry times of given peer
+func (dm *Daemon) IncreaseRetryTimes(addr string) {
+	dm.pex.IncreaseRetryTimes(addr)
+}
+
+// ResetRetryTimes reset the retry times of given peer
+func (dm *Daemon) ResetRetryTimes(addr string) {
+	dm.pex.ResetRetryTimes(addr)
+}
+
+// Implements chain height store
+
+// Record(addr string, height uint64)
+
+// RecordPeerHeight records the height of specific peer
+func (dm *Daemon) RecordPeerHeight(addr string, height uint64) {
+	dm.Heights.Record(addr, height)
+}
+
+// Implements visorer interface
+
+// GetSignedBlocksSince returns N signed blocks since given seq
+func (dm *Daemon) GetSignedBlocksSince(seq, count uint64) ([]coin.SignedBlock, error) {
+	return dm.visor.GetSignedBlocksSince(seq, count)
+}
+
+// HeadBkSeq returns the head block sequence
+func (dm *Daemon) HeadBkSeq() (uint64, bool, error) {
+	return dm.visor.HeadBkSeq()
+}
+
+// ExecuteSignedBlock executes the signed block
+func (dm *Daemon) ExecuteSignedBlock(b coin.SignedBlock) error {
+	return dm.visor.ExecuteSignedBlock(b)
+}
+
+// GetUnconfirmedUnknown returns unconfirmed txn hashes with known ones removed
+func (dm *Daemon) GetUnconfirmedUnknown(txns []cipher.SHA256) ([]cipher.SHA256, error) {
+	return dm.visor.GetUnconfirmedUnknown(txns)
+}
+
+// GetUnconfirmedKnown returns unconfirmed txn hashes with known ones removed
+func (dm *Daemon) GetUnconfirmedKnown(txns []cipher.SHA256) (coin.Transactions, error) {
+	return dm.visor.GetUnconfirmedKnown(txns)
+}
+
+// InjectTransaction records a coin.Transaction to the UnconfirmedTxnPool if the txn is not
+// already in the blockchain.
+// The bool return value is whether or not the transaction was already in the pool.
+// If the transaction violates hard constraints, it is rejected, and error will not be nil.
+// If the transaction only violates soft constraints, it is still injected, and the soft constraint violation is returned.
+func (dm *Daemon) InjectTransaction(txn coin.Transaction) (bool, *visor.ErrTxnViolatesSoftConstraint, error) {
+	return dm.visor.InjectTransaction(txn)
 }

--- a/src/daemon/daemoner_mock_test.go
+++ b/src/daemon/daemoner_mock_test.go
@@ -1,0 +1,568 @@
+/*
+* CODE GENERATED AUTOMATICALLY WITH github.com/ernesto-jimenez/goautomock
+* THIS FILE MUST NEVER BE EDITED MANUALLY
+ */
+
+package daemon
+
+import (
+	"fmt"
+
+	mock "github.com/stretchr/testify/mock"
+
+	cipher "github.com/skycoin/skycoin/src/cipher"
+	coin "github.com/skycoin/skycoin/src/coin"
+	gnet "github.com/skycoin/skycoin/src/daemon/gnet"
+	pex "github.com/skycoin/skycoin/src/daemon/pex"
+	visor "github.com/skycoin/skycoin/src/visor"
+)
+
+// DaemonerMock mock
+type DaemonerMock struct {
+	mock.Mock
+}
+
+func NewDaemonerMock() *DaemonerMock {
+	return &DaemonerMock{}
+}
+
+// AddPeer mocked method
+func (m *DaemonerMock) AddPeer(p0 string) error {
+
+	ret := m.Called(p0)
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// AddPeers mocked method
+func (m *DaemonerMock) AddPeers(p0 []string) int {
+
+	ret := m.Called(p0)
+
+	var r0 int
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case int:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// AnnounceAllTxns mocked method
+func (m *DaemonerMock) AnnounceAllTxns() error {
+
+	ret := m.Called()
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// BlockchainPubkey mocked method
+func (m *DaemonerMock) BlockchainPubkey() cipher.PubKey {
+
+	ret := m.Called()
+
+	var r0 cipher.PubKey
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case cipher.PubKey:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// BroadcastMessage mocked method
+func (m *DaemonerMock) BroadcastMessage(p0 gnet.Message) error {
+
+	ret := m.Called(p0)
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// DaemonConfig mocked method
+func (m *DaemonerMock) DaemonConfig() DaemonConfig {
+
+	ret := m.Called()
+
+	var r0 DaemonConfig
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case DaemonConfig:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// Disconnect mocked method
+func (m *DaemonerMock) Disconnect(p0 string, p1 gnet.DisconnectReason) error {
+
+	ret := m.Called(p0, p1)
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// ExecuteSignedBlock mocked method
+func (m *DaemonerMock) ExecuteSignedBlock(p0 coin.SignedBlock) error {
+
+	ret := m.Called(p0)
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// GetMirrorPort mocked method
+func (m *DaemonerMock) GetMirrorPort(p0 string, p1 uint32) (uint16, bool) {
+
+	ret := m.Called(p0, p1)
+
+	var r0 uint16
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case uint16:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 bool
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case bool:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// GetSignedBlocksSince mocked method
+func (m *DaemonerMock) GetSignedBlocksSince(p0 uint64, p1 uint64) ([]coin.SignedBlock, error) {
+
+	ret := m.Called(p0, p1)
+
+	var r0 []coin.SignedBlock
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case []coin.SignedBlock:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// GetUnconfirmedKnown mocked method
+func (m *DaemonerMock) GetUnconfirmedKnown(p0 []cipher.SHA256) (coin.Transactions, error) {
+
+	ret := m.Called(p0)
+
+	var r0 coin.Transactions
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case coin.Transactions:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// GetUnconfirmedUnknown mocked method
+func (m *DaemonerMock) GetUnconfirmedUnknown(p0 []cipher.SHA256) ([]cipher.SHA256, error) {
+
+	ret := m.Called(p0)
+
+	var r0 []cipher.SHA256
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case []cipher.SHA256:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// HeadBkSeq mocked method
+func (m *DaemonerMock) HeadBkSeq() (uint64, bool, error) {
+
+	ret := m.Called()
+
+	var r0 uint64
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case uint64:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 bool
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case bool:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r2 error
+	switch res := ret.Get(2).(type) {
+	case nil:
+	case error:
+		r2 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1, r2
+
+}
+
+// IncreaseRetryTimes mocked method
+func (m *DaemonerMock) IncreaseRetryTimes(p0 string) {
+
+	m.Called(p0)
+
+}
+
+// InjectTransaction mocked method
+func (m *DaemonerMock) InjectTransaction(p0 coin.Transaction) (bool, *visor.ErrTxnViolatesSoftConstraint, error) {
+
+	ret := m.Called(p0)
+
+	var r0 bool
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case bool:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 *visor.ErrTxnViolatesSoftConstraint
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case *visor.ErrTxnViolatesSoftConstraint:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r2 error
+	switch res := ret.Get(2).(type) {
+	case nil:
+	case error:
+		r2 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1, r2
+
+}
+
+// IsDefaultConnection mocked method
+func (m *DaemonerMock) IsDefaultConnection(p0 string) bool {
+
+	ret := m.Called(p0)
+
+	var r0 bool
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case bool:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// IsMaxDefaultConnectionsReached mocked method
+func (m *DaemonerMock) IsMaxDefaultConnectionsReached() (bool, error) {
+
+	ret := m.Called()
+
+	var r0 bool
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case bool:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	var r1 error
+	switch res := ret.Get(1).(type) {
+	case nil:
+	case error:
+		r1 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0, r1
+
+}
+
+// Mirror mocked method
+func (m *DaemonerMock) Mirror() uint32 {
+
+	ret := m.Called()
+
+	var r0 uint32
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case uint32:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// PexConfig mocked method
+func (m *DaemonerMock) PexConfig() pex.Config {
+
+	ret := m.Called()
+
+	var r0 pex.Config
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case pex.Config:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// RandomExchangeable mocked method
+func (m *DaemonerMock) RandomExchangeable(p0 int) pex.Peers {
+
+	ret := m.Called(p0)
+
+	var r0 pex.Peers
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case pex.Peers:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// RecordConnectionMirror mocked method
+func (m *DaemonerMock) RecordConnectionMirror(p0 string, p1 uint32) error {
+
+	ret := m.Called(p0, p1)
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// RecordMessageEvent mocked method
+func (m *DaemonerMock) RecordMessageEvent(p0 AsyncMessage, p1 *gnet.MessageContext) error {
+
+	ret := m.Called(p0, p1)
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// RecordPeerHeight mocked method
+func (m *DaemonerMock) RecordPeerHeight(p0 string, p1 uint64) {
+
+	m.Called(p0, p1)
+
+}
+
+// RemoveFromExpectingIntroductions mocked method
+func (m *DaemonerMock) RemoveFromExpectingIntroductions(p0 string) {
+
+	m.Called(p0)
+
+}
+
+// RequestBlocksFromAddr mocked method
+func (m *DaemonerMock) RequestBlocksFromAddr(p0 string) error {
+
+	ret := m.Called(p0)
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// ResetRetryTimes mocked method
+func (m *DaemonerMock) ResetRetryTimes(p0 string) {
+
+	m.Called(p0)
+
+}
+
+// SendMessage mocked method
+func (m *DaemonerMock) SendMessage(p0 string, p1 gnet.Message) error {
+
+	ret := m.Called(p0, p1)
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
+// SetHasIncomingPort mocked method
+func (m *DaemonerMock) SetHasIncomingPort(p0 string) error {
+
+	ret := m.Called(p0)
+
+	var r0 error
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case error:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -51,7 +51,7 @@ func NewGateway(c GatewayConfig, d *Daemon) *Gateway {
 	return &Gateway{
 		Config:   c,
 		d:        d,
-		v:        d.Visor,
+		v:        d.visor,
 		requests: make(chan strand.Request, c.BufferSize),
 		quit:     make(chan struct{}),
 	}
@@ -103,18 +103,18 @@ func (gw *Gateway) GetConnections() *Connections {
 }
 
 func (gw *Gateway) getConnections() *Connections {
-	if gw.d.Pool.Pool == nil {
+	if gw.d.pool.Pool == nil {
 		return nil
 	}
 
-	n, err := gw.d.Pool.Pool.Size()
+	n, err := gw.d.pool.Pool.Size()
 	if err != nil {
 		logger.Error(err)
 		return nil
 	}
 
 	conns := make([]*Connection, 0, n)
-	cs, err := gw.d.Pool.Pool.GetConnections()
+	cs, err := gw.d.pool.Pool.GetConnections()
 	if err != nil {
 		logger.Error(err)
 		return nil
@@ -158,11 +158,11 @@ func (gw *Gateway) GetConnection(addr string) *Connection {
 }
 
 func (gw *Gateway) getConnection(addr string) *Connection {
-	if gw.d.Pool.Pool == nil {
+	if gw.d.pool.Pool == nil {
 		return nil
 	}
 
-	c, err := gw.d.Pool.Pool.GetConnection(addr)
+	c, err := gw.d.pool.Pool.GetConnection(addr)
 	if err != nil {
 		logger.Error(err)
 		return nil
@@ -194,7 +194,7 @@ func (gw *Gateway) getConnection(addr string) *Connection {
 func (gw *Gateway) GetTrustConnections() []string {
 	var conn []string
 	gw.strand("GetTrustConnections", func() {
-		conn = gw.d.Pex.Trusted().ToAddrs()
+		conn = gw.d.pex.Trusted().ToAddrs()
 	})
 	return conn
 }
@@ -204,7 +204,7 @@ func (gw *Gateway) GetTrustConnections() []string {
 func (gw *Gateway) GetExchgConnection() []string {
 	var conn []string
 	gw.strand("GetExchgConnection", func() {
-		conn = gw.d.Pex.RandomExchangeable(0).ToAddrs()
+		conn = gw.d.pex.RandomExchangeable(0).ToAddrs()
 	})
 	return conn
 }
@@ -226,7 +226,7 @@ func (gw *Gateway) GetBlockchainProgress() (*BlockchainProgress, error) {
 	var err error
 	gw.strand("GetBlockchainProgress", func() {
 		var headSeq uint64
-		headSeq, _, err = gw.d.Visor.HeadBkSeq()
+		headSeq, _, err = gw.d.visor.HeadBkSeq()
 		if err != nil {
 			return
 		}

--- a/src/daemon/gnet/dispatcher.go
+++ b/src/daemon/gnet/dispatcher.go
@@ -56,13 +56,8 @@ func convertToMessage(id int, msg []byte, debugPrint bool) (Message, error) {
 		return nil, err
 	}
 
-	if debugPrint {
-		mlen := len(msg)
-		if used > mlen {
-			logger.Warn("Receive data with extra fields")
-		} else if used < mlen {
-			logger.Warn("Receive data with fields removed")
-		}
+	if used != len(msg) {
+		return nil, errors.New("Data buffer was not completely decoded")
 	}
 
 	m, succ = (v.Interface()).(Message)

--- a/src/daemon/gnet/dispatcher_test.go
+++ b/src/daemon/gnet/dispatcher_test.go
@@ -70,8 +70,8 @@ func TestConvertToMessageBadDeserialize(t *testing.T) {
 	// Test with too many bytes
 	b := append(DummyPrefix[:], []byte{0, 1, 1, 1}...)
 	m, err := convertToMessage(c.ID, b, testing.Verbose())
-	assert.Nil(t, err)
-	assert.NotNil(t, m)
+	assert.NotNil(t, err)
+	assert.Nil(t, m)
 
 	// Test with not enough bytes
 	b = append([]byte{}, BytePrefix[:]...)

--- a/src/daemon/messages.go
+++ b/src/daemon/messages.go
@@ -275,12 +275,12 @@ func (intro *IntroductionMessage) Handle(mc *gnet.MessageContext, daemon interfa
 		// Checks the genesis hash if not empty
 		if len(intro.Extra) > 0 {
 			var bcPubKey cipher.PubKey
-			if len(intro.Extra) != len(bcPubKey) {
-				logger.Infof("Extra data length does not match that of the cipher.SHA256")
+			if len(intro.Extra) < len(bcPubKey) {
+				logger.Infof("Extra data length does not meet the minimum requirement")
 				d.Disconnect(mc.Addr, ErrDisconnectInvalidExtraData)
 				return ErrDisconnectInvalidExtraData
 			}
-			copy(bcPubKey[:], intro.Extra[:])
+			copy(bcPubKey[:], intro.Extra[:len(bcPubKey)])
 
 			if d.BlockchainPubkey() != bcPubKey {
 				logger.Infof("Blockchain pubkey does not match, local: %s, remote: %s", d.BlockchainPubkey().Hex(), bcPubKey.Hex())

--- a/src/daemon/messages.go
+++ b/src/daemon/messages.go
@@ -132,7 +132,7 @@ func (ipa IPAddr) String() string {
 // Messages should place themselves on the messageEvent channel in their
 // Handle() method required by gnet.
 type AsyncMessage interface {
-	Process(d *Daemon)
+	Process(d Daemoner)
 }
 
 // GetPeersMessage sent to request peers
@@ -151,23 +151,23 @@ func NewGetPeersMessage() *GetPeersMessage {
 func (gpm *GetPeersMessage) Handle(mc *gnet.MessageContext, daemon interface{}) error {
 	// self.connID = mc.ConnID
 	gpm.addr = mc.Addr
-	return daemon.(*Daemon).recordMessageEvent(gpm, mc)
+	return daemon.(Daemoner).RecordMessageEvent(gpm, mc)
 }
 
 // Process Notifies the Pex instance that peers were requested
-func (gpm *GetPeersMessage) Process(d *Daemon) {
-	if d.Pex.Config.Disabled {
+func (gpm *GetPeersMessage) Process(d Daemoner) {
+	if d.PexConfig().Disabled {
 		return
 	}
 
-	peers := d.Pex.RandomExchangeable(d.Pex.Config.ReplyCount)
+	peers := d.RandomExchangeable(d.PexConfig().ReplyCount)
 	if len(peers) == 0 {
 		logger.Debug("We have no peers to send in reply")
 		return
 	}
 
 	m := NewGivePeersMessage(peers)
-	if err := d.Pool.Pool.SendMessage(gpm.addr, m); err != nil {
+	if err := d.SendMessage(gpm.addr, m); err != nil {
 		logger.Errorf("Send GivePeersMessage to %s failed: %v", gpm.addr, err)
 	}
 }
@@ -207,18 +207,18 @@ func (gpm *GivePeersMessage) GetPeers() []string {
 // Handle handle message
 func (gpm *GivePeersMessage) Handle(mc *gnet.MessageContext, daemon interface{}) error {
 	gpm.c = mc
-	return daemon.(*Daemon).recordMessageEvent(gpm, mc)
+	return daemon.(Daemoner).RecordMessageEvent(gpm, mc)
 }
 
 // Process Notifies the Pex instance that peers were received
-func (gpm *GivePeersMessage) Process(d *Daemon) {
-	if d.Pex.Config.Disabled {
+func (gpm *GivePeersMessage) Process(d Daemoner) {
+	if d.PexConfig().Disabled {
 		return
 	}
 	peers := gpm.GetPeers()
 	logger.Debugf("Got these peers via PEX: %s", strings.Join(peers, ", "))
 
-	d.Pex.AddPeers(peers)
+	d.AddPeers(peers)
 }
 
 // IntroductionMessage jan IntroductionMessage is sent on first connect by both parties
@@ -251,22 +251,22 @@ func NewIntroductionMessage(mirror uint32, version int32, port uint16, extra []b
 // need to control the DisconnectReason sent back to gnet.  We still implement
 // Process(), where we do modifications that are not threadsafe
 func (intro *IntroductionMessage) Handle(mc *gnet.MessageContext, daemon interface{}) error {
-	d := daemon.(*Daemon)
+	d := daemon.(Daemoner)
 
 	err := func() error {
 		// Disconnect if this is a self connection (we have the same mirror value)
-		if intro.Mirror == d.Messages.Mirror {
+		if intro.Mirror == d.Mirror() {
 			logger.Infof("Remote mirror value %v matches ours", intro.Mirror)
-			d.Pool.Pool.Disconnect(mc.Addr, ErrDisconnectSelf)
+			d.Disconnect(mc.Addr, ErrDisconnectSelf)
 			return ErrDisconnectSelf
 
 		}
 
 		// Disconnect if not running the same version
-		if intro.Version != d.Config.Version {
+		if intro.Version != d.DaemonConfig().Version {
 			logger.Infof("%s has different version %d. Disconnecting.",
 				mc.Addr, intro.Version)
-			d.Pool.Pool.Disconnect(mc.Addr, ErrDisconnectInvalidVersion)
+			d.Disconnect(mc.Addr, ErrDisconnectInvalidVersion)
 			return ErrDisconnectInvalidVersion
 		}
 
@@ -277,14 +277,14 @@ func (intro *IntroductionMessage) Handle(mc *gnet.MessageContext, daemon interfa
 			var bcPubKey cipher.PubKey
 			if len(intro.Extra) != len(bcPubKey) {
 				logger.Infof("Extra data length does not match that of the cipher.SHA256")
-				d.Pool.Pool.Disconnect(mc.Addr, ErrDisconnectInvalidExtraData)
+				d.Disconnect(mc.Addr, ErrDisconnectInvalidExtraData)
 				return ErrDisconnectInvalidExtraData
 			}
 			copy(bcPubKey[:], intro.Extra[:])
 
-			if d.Config.BlockchainPubkey != bcPubKey {
-				logger.Infof("Blockchain pubkey does not match, local: %s, remote: %s", d.Config.BlockchainPubkey.Hex(), bcPubKey.Hex())
-				d.Pool.Pool.Disconnect(mc.Addr, ErrDisconnectBlockchainPubkeyNotMatched)
+			if d.BlockchainPubkey() != bcPubKey {
+				logger.Infof("Blockchain pubkey does not match, local: %s, remote: %s", d.BlockchainPubkey().Hex(), bcPubKey.Hex())
+				d.Disconnect(mc.Addr, ErrDisconnectBlockchainPubkeyNotMatched)
 				return ErrDisconnectBlockchainPubkeyNotMatched
 			}
 		}
@@ -296,7 +296,7 @@ func (intro *IntroductionMessage) Handle(mc *gnet.MessageContext, daemon interfa
 			// This should never happen, but the program should still work if it
 			// does.
 			logger.Errorf("Invalid Addr() for connection: %s", mc.Addr)
-			d.Pool.Pool.Disconnect(mc.Addr, ErrDisconnectOtherError)
+			d.Disconnect(mc.Addr, ErrDisconnectOtherError)
 			return ErrDisconnectOtherError
 		}
 
@@ -305,8 +305,8 @@ func (intro *IntroductionMessage) Handle(mc *gnet.MessageContext, daemon interfa
 		// connection's port is a random port, it's different from the port
 		// in introduction message.
 		if port == intro.Port {
-			if d.Pool.Pool.IsDefaultConnection(mc.Addr) {
-				reached, err := d.Pool.Pool.IsMaxDefaultConnReached()
+			if d.IsDefaultConnection(mc.Addr) {
+				reached, err := d.IsMaxDefaultConnectionsReached()
 				if err != nil {
 					logger.Errorf("Check IsMaxDefaultConnReached failed: %v", err)
 					return err
@@ -314,25 +314,25 @@ func (intro *IntroductionMessage) Handle(mc *gnet.MessageContext, daemon interfa
 
 				if reached {
 					logger.Debugf("Disconnect %s: maximum default connections reached ", mc.Addr)
-					d.Pool.Pool.Disconnect(mc.Addr, ErrDisconnectMaxDefaultConnectionReached)
+					d.Disconnect(mc.Addr, ErrDisconnectMaxDefaultConnectionReached)
 					return ErrDisconnectMaxDefaultConnectionReached
 				}
 			}
 
-			if err := d.Pex.SetHasIncomingPort(mc.Addr, true); err != nil {
+			if err := d.SetHasIncomingPort(mc.Addr); err != nil {
 				logger.Errorf("Failed to set peer has incoming port status, %v", err)
 			}
 		} else {
-			if err := d.Pex.AddPeer(fmt.Sprintf("%s:%d", ip, intro.Port)); err != nil {
+			if err := d.AddPeer(fmt.Sprintf("%s:%d", ip, intro.Port)); err != nil {
 				logger.Errorf("Failed to add peer: %v", err)
 			}
 		}
 
 		// Disconnect if connected twice to the same peer (judging by ip:mirror)
-		knownPort, exists := d.getMirrorPort(mc.Addr, intro.Mirror)
+		knownPort, exists := d.GetMirrorPort(mc.Addr, intro.Mirror)
 		if exists {
 			logger.Infof("%s is already connected on port %d", mc.Addr, knownPort)
-			d.Pool.Pool.Disconnect(mc.Addr, ErrDisconnectConnectedTwice)
+			d.Disconnect(mc.Addr, ErrDisconnectConnectedTwice)
 			return ErrDisconnectConnectedTwice
 		}
 		return nil
@@ -342,19 +342,19 @@ func (intro *IntroductionMessage) Handle(mc *gnet.MessageContext, daemon interfa
 	intro.c = mc
 
 	if err != nil {
-		d.Pex.IncreaseRetryTimes(mc.Addr)
-		d.expectingIntroductions.Remove(mc.Addr)
+		d.IncreaseRetryTimes(mc.Addr)
+		d.RemoveFromExpectingIntroductions(mc.Addr)
 		return err
 	}
 
-	err = d.recordMessageEvent(intro, mc)
-	d.Pex.ResetRetryTimes(mc.Addr)
+	err = d.RecordMessageEvent(intro, mc)
+	d.ResetRetryTimes(mc.Addr)
 	return err
 }
 
 // Process an event queued by Handle()
-func (intro *IntroductionMessage) Process(d *Daemon) {
-	d.expectingIntroductions.Remove(intro.c.Addr)
+func (intro *IntroductionMessage) Process(d Daemoner) {
+	d.RemoveFromExpectingIntroductions(intro.c.Addr)
 	if !intro.valid {
 		return
 	}
@@ -362,12 +362,12 @@ func (intro *IntroductionMessage) Process(d *Daemon) {
 	a := intro.c.Addr
 
 	// Record their listener, to avoid double connections
-	err := d.recordConnectionMirror(a, intro.Mirror)
+	err := d.RecordConnectionMirror(a, intro.Mirror)
 	if err != nil {
 		// This should never happen, but the program should not allow itself
 		// to be corrupted in case it does
 		logger.Errorf("Invalid port for connection %s", a)
-		d.Pool.Pool.Disconnect(intro.c.Addr, ErrDisconnectOtherError)
+		d.Disconnect(intro.c.Addr, ErrDisconnectOtherError)
 		return
 	}
 
@@ -391,15 +391,15 @@ type PingMessage struct {
 // Handle implements the Messager interface
 func (ping *PingMessage) Handle(mc *gnet.MessageContext, daemon interface{}) error {
 	ping.c = mc
-	return daemon.(*Daemon).recordMessageEvent(ping, mc)
+	return daemon.(Daemoner).RecordMessageEvent(ping, mc)
 }
 
 // Process Sends a PongMessage to the sender of PingMessage
-func (ping *PingMessage) Process(d *Daemon) {
-	if d.Config.LogPings {
+func (ping *PingMessage) Process(d Daemoner) {
+	if d.DaemonConfig().LogPings {
 		logger.Debugf("Reply to ping from %s", ping.c.Addr)
 	}
-	if err := d.Pool.Pool.SendMessage(ping.c.Addr, &PongMessage{}); err != nil {
+	if err := d.SendMessage(ping.c.Addr, &PongMessage{}); err != nil {
 		logger.Errorf("Send PongMessage to %s failed: %v", ping.c.Addr, err)
 	}
 }
@@ -437,20 +437,20 @@ func NewGetBlocksMessage(lastBlock uint64, requestedBlocks uint64) *GetBlocksMes
 func (gbm *GetBlocksMessage) Handle(mc *gnet.MessageContext,
 	daemon interface{}) error {
 	gbm.c = mc
-	return daemon.(*Daemon).recordMessageEvent(gbm, mc)
+	return daemon.(Daemoner).RecordMessageEvent(gbm, mc)
 }
 
 // Process should send number to be requested, with request
-func (gbm *GetBlocksMessage) Process(d *Daemon) {
+func (gbm *GetBlocksMessage) Process(d Daemoner) {
 	// TODO -- we need the sig to be sent with the block, but only the master
 	// can sign blocks.  Thus the sig needs to be stored with the block.
-	if d.Config.DisableNetworking {
+	if d.DaemonConfig().DisableNetworking {
 		return
 	}
 	// Record this as this peer's highest block
-	d.Heights.Record(gbm.c.Addr, gbm.LastBlock)
+	d.RecordPeerHeight(gbm.c.Addr, gbm.LastBlock)
 	// Fetch and return signed blocks since LastBlock
-	blocks, err := d.Visor.GetSignedBlocksSince(gbm.LastBlock, gbm.RequestedBlocks)
+	blocks, err := d.GetSignedBlocksSince(gbm.LastBlock, gbm.RequestedBlocks)
 	if err != nil {
 		logger.Infof("Get signed blocks failed: %v", err)
 		return
@@ -463,7 +463,7 @@ func (gbm *GetBlocksMessage) Process(d *Daemon) {
 	logger.Debugf("Got %d blocks since %d", len(blocks), gbm.LastBlock)
 
 	m := NewGiveBlocksMessage(blocks)
-	if err := d.Pool.Pool.SendMessage(gbm.c.Addr, m); err != nil {
+	if err := d.SendMessage(gbm.c.Addr, m); err != nil {
 		logger.Errorf("Send GiveBlocksMessage to %s failed: %v", gbm.c.Addr, err)
 	}
 }
@@ -484,12 +484,12 @@ func NewGiveBlocksMessage(blocks []coin.SignedBlock) *GiveBlocksMessage {
 // Handle handle message
 func (gbm *GiveBlocksMessage) Handle(mc *gnet.MessageContext, daemon interface{}) error {
 	gbm.c = mc
-	return daemon.(*Daemon).recordMessageEvent(gbm, mc)
+	return daemon.(Daemoner).RecordMessageEvent(gbm, mc)
 }
 
 // Process process message
-func (gbm *GiveBlocksMessage) Process(d *Daemon) {
-	if d.Config.DisableNetworking {
+func (gbm *GiveBlocksMessage) Process(d Daemoner) {
+	if d.DaemonConfig().DisableNetworking {
 		logger.Critical().Info("Visor disabled, ignoring GiveBlocksMessage")
 		return
 	}
@@ -498,7 +498,7 @@ func (gbm *GiveBlocksMessage) Process(d *Daemon) {
 	// It is not necessary that the blocks be executed together in a single transaction.
 
 	processed := 0
-	maxSeq, ok, err := d.Visor.HeadBkSeq()
+	maxSeq, ok, err := d.HeadBkSeq()
 	if err != nil {
 		logger.WithError(err).Error("visor.HeadBkSeq failed")
 		return
@@ -519,7 +519,7 @@ func (gbm *GiveBlocksMessage) Process(d *Daemon) {
 			continue
 		}
 
-		err := d.Visor.ExecuteSignedBlock(b)
+		err := d.ExecuteSignedBlock(b)
 		if err == nil {
 			logger.Critical().Infof("Added new block %d", b.Block.Head.BkSeq)
 			processed++
@@ -534,7 +534,7 @@ func (gbm *GiveBlocksMessage) Process(d *Daemon) {
 		return
 	}
 
-	headBkSeq, ok, err := d.Visor.HeadBkSeq()
+	headBkSeq, ok, err := d.HeadBkSeq()
 	if err != nil {
 		logger.WithError(err).Error("visor.HeadBkSeq failed")
 		return
@@ -552,10 +552,10 @@ func (gbm *GiveBlocksMessage) Process(d *Daemon) {
 
 	// Announce our new blocks to peers
 	m1 := NewAnnounceBlocksMessage(headBkSeq)
-	d.Pool.Pool.BroadcastMessage(m1)
+	d.BroadcastMessage(m1)
 	//request more blocks.
-	m2 := NewGetBlocksMessage(headBkSeq, d.Config.BlocksResponseCount)
-	d.Pool.Pool.BroadcastMessage(m2)
+	m2 := NewGetBlocksMessage(headBkSeq, d.DaemonConfig().BlocksResponseCount)
+	d.BroadcastMessage(m2)
 }
 
 // AnnounceBlocksMessage tells a peer our highest known BkSeq. The receiving peer can choose
@@ -575,16 +575,16 @@ func NewAnnounceBlocksMessage(seq uint64) *AnnounceBlocksMessage {
 // Handle handles message
 func (abm *AnnounceBlocksMessage) Handle(mc *gnet.MessageContext, daemon interface{}) error {
 	abm.c = mc
-	return daemon.(*Daemon).recordMessageEvent(abm, mc)
+	return daemon.(Daemoner).RecordMessageEvent(abm, mc)
 }
 
 // Process process message
-func (abm *AnnounceBlocksMessage) Process(d *Daemon) {
-	if d.Config.DisableNetworking {
+func (abm *AnnounceBlocksMessage) Process(d Daemoner) {
+	if d.DaemonConfig().DisableNetworking {
 		return
 	}
 
-	headBkSeq, ok, err := d.Visor.HeadBkSeq()
+	headBkSeq, ok, err := d.HeadBkSeq()
 	if err != nil {
 		logger.WithError(err).Error("AnnounceBlocksMessage Visor.HeadBkSeq failed")
 		return
@@ -600,8 +600,8 @@ func (abm *AnnounceBlocksMessage) Process(d *Daemon) {
 
 	// TODO: Should this be block get request for current sequence?
 	// If client is not caught up, won't attempt to get block
-	m := NewGetBlocksMessage(headBkSeq, d.Config.BlocksResponseCount)
-	if err := d.Pool.Pool.SendMessage(abm.c.Addr, m); err != nil {
+	m := NewGetBlocksMessage(headBkSeq, d.DaemonConfig().BlocksResponseCount)
+	if err := d.SendMessage(abm.c.Addr, m); err != nil {
 		logger.Errorf("Send GetBlocksMessage to %s failed: %v", abm.c.Addr, err)
 	}
 }
@@ -632,16 +632,16 @@ func (atm *AnnounceTxnsMessage) GetTxns() []cipher.SHA256 {
 // Handle handle message
 func (atm *AnnounceTxnsMessage) Handle(mc *gnet.MessageContext, daemon interface{}) error {
 	atm.c = mc
-	return daemon.(*Daemon).recordMessageEvent(atm, mc)
+	return daemon.(Daemoner).RecordMessageEvent(atm, mc)
 }
 
 // Process process message
-func (atm *AnnounceTxnsMessage) Process(d *Daemon) {
-	if d.Config.DisableNetworking {
+func (atm *AnnounceTxnsMessage) Process(d Daemoner) {
+	if d.DaemonConfig().DisableNetworking {
 		return
 	}
 
-	unknown, err := d.Visor.GetUnconfirmedUnknown(atm.Txns)
+	unknown, err := d.GetUnconfirmedUnknown(atm.Txns)
 	if err != nil {
 		logger.WithError(err).Error("AnnounceTxnsMessage Visor.GetUnconfirmedUnknown failed")
 		return
@@ -652,7 +652,7 @@ func (atm *AnnounceTxnsMessage) Process(d *Daemon) {
 	}
 
 	m := NewGetTxnsMessage(unknown)
-	if err := d.Pool.Pool.SendMessage(atm.c.Addr, m); err != nil {
+	if err := d.SendMessage(atm.c.Addr, m); err != nil {
 		logger.Errorf("Send GetTxnsMessage to %s failed: %v", atm.c.Addr, err)
 	}
 }
@@ -673,17 +673,17 @@ func NewGetTxnsMessage(txns []cipher.SHA256) *GetTxnsMessage {
 // Handle handle message
 func (gtm *GetTxnsMessage) Handle(mc *gnet.MessageContext, daemon interface{}) error {
 	gtm.c = mc
-	return daemon.(*Daemon).recordMessageEvent(gtm, mc)
+	return daemon.(Daemoner).RecordMessageEvent(gtm, mc)
 }
 
 // Process process message
-func (gtm *GetTxnsMessage) Process(d *Daemon) {
-	if d.Config.DisableNetworking {
+func (gtm *GetTxnsMessage) Process(d Daemoner) {
+	if d.DaemonConfig().DisableNetworking {
 		return
 	}
 
 	// Locate all txns from the unconfirmed pool
-	known, err := d.Visor.GetUnconfirmedKnown(gtm.Txns)
+	known, err := d.GetUnconfirmedKnown(gtm.Txns)
 	if err != nil {
 		logger.WithError(err).Error("GetTxnsMessage Visor.GetUnconfirmedKnown failed")
 		return
@@ -694,7 +694,7 @@ func (gtm *GetTxnsMessage) Process(d *Daemon) {
 
 	// Reply to sender with GiveTxnsMessage
 	m := NewGiveTxnsMessage(known)
-	if err := d.Pool.Pool.SendMessage(gtm.c.Addr, m); err != nil {
+	if err := d.SendMessage(gtm.c.Addr, m); err != nil {
 		logger.Errorf("Send GiveTxnsMessage to %s failed: %v", gtm.c.Addr, err)
 	}
 }
@@ -720,12 +720,12 @@ func (gtm *GiveTxnsMessage) GetTxns() []cipher.SHA256 {
 // Handle handle message
 func (gtm *GiveTxnsMessage) Handle(mc *gnet.MessageContext, daemon interface{}) error {
 	gtm.c = mc
-	return daemon.(*Daemon).recordMessageEvent(gtm, mc)
+	return daemon.(Daemoner).RecordMessageEvent(gtm, mc)
 }
 
 // Process process message
-func (gtm *GiveTxnsMessage) Process(d *Daemon) {
-	if d.Config.DisableNetworking {
+func (gtm *GiveTxnsMessage) Process(d Daemoner) {
+	if d.DaemonConfig().DisableNetworking {
 		return
 	}
 
@@ -733,7 +733,7 @@ func (gtm *GiveTxnsMessage) Process(d *Daemon) {
 	// Update unconfirmed pool with these transactions
 	for _, txn := range gtm.Txns {
 		// Only announce transactions that are new to us, so that peers can't spam relays
-		known, softErr, err := d.Visor.InjectTransaction(txn)
+		known, softErr, err := d.InjectTransaction(txn)
 		if err != nil {
 			logger.Warningf("Failed to record transaction %s: %v", txn.Hash().Hex(), err)
 			continue
@@ -752,6 +752,6 @@ func (gtm *GiveTxnsMessage) Process(d *Daemon) {
 	if len(hashes) != 0 {
 		logger.Debugf("Announce %d transactions", len(hashes))
 		m := NewAnnounceTxnsMessage(hashes)
-		d.Pool.Pool.BroadcastMessage(m)
+		d.BroadcastMessage(m)
 	}
 }

--- a/src/daemon/messages_test.go
+++ b/src/daemon/messages_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"testing"
 
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/cipher/encoder"
@@ -13,6 +14,7 @@ import (
 	"github.com/skycoin/skycoin/src/daemon/gnet"
 	"github.com/skycoin/skycoin/src/daemon/pex"
 	"github.com/skycoin/skycoin/src/util"
+	"github.com/stretchr/testify/require"
 )
 
 func setupMsgEncoding() {
@@ -435,4 +437,273 @@ func ExampleAnnounceTxnsMessage() {
 	// 0x002c | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 	// 0x003c | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ... Txns#1
 	// 0x004c |
+}
+
+func TestIntroductionMessage(t *testing.T) {
+	defer gnet.EraseMessages()
+	setupMsgEncoding()
+
+	pubkey, _ := cipher.GenerateKeyPair()
+	pubkey2, _ := cipher.GenerateKeyPair()
+
+	type mirrorPortResult struct {
+		port  uint16
+		exist bool
+	}
+
+	type daemonMockValue struct {
+		version                    uint32
+		mirror                     uint32
+		isDefaultConnection        bool
+		isMaxConnectionsReached    bool
+		isMaxConnectionsReachedErr error
+		setHasIncomingPortErr      error
+		getMirrorPortResult        mirrorPortResult
+		recordMessageEventErr      error
+		pubkey                     cipher.PubKey
+		disconnectReason           gnet.DisconnectReason
+		disconnectErr              error
+		addPeerArg                 string
+		addPeerErr                 error
+	}
+
+	tt := []struct {
+		name      string
+		addr      string
+		mockValue daemonMockValue
+		intro     *IntroductionMessage
+		err       error
+	}{
+		{
+			name: "INTR message without extra bytes",
+			addr: "121.121.121.121:6000",
+			mockValue: daemonMockValue{
+				mirror:  10000,
+				version: 1,
+				getMirrorPortResult: mirrorPortResult{
+					exist: false,
+				},
+			},
+			intro: &IntroductionMessage{
+				Mirror:  10001,
+				Port:    6000,
+				Version: 1,
+				valid:   true,
+			},
+			err: nil,
+		},
+		{
+			name: "INTR message with pubkey",
+			addr: "121.121.121.121:6000",
+			mockValue: daemonMockValue{
+				mirror:  10000,
+				version: 1,
+				getMirrorPortResult: mirrorPortResult{
+					exist: false,
+				},
+				pubkey: pubkey,
+			},
+			intro: &IntroductionMessage{
+				Mirror:  10001,
+				Port:    6000,
+				Version: 1,
+				valid:   true,
+				Extra:   pubkey[:],
+			},
+			err: nil,
+		},
+		{
+			name: "INTR message with pubkey",
+			addr: "121.121.121.121:6000",
+			mockValue: daemonMockValue{
+				mirror:  10000,
+				version: 1,
+				getMirrorPortResult: mirrorPortResult{
+					exist: false,
+				},
+				pubkey: pubkey,
+			},
+			intro: &IntroductionMessage{
+				Mirror:  10001,
+				Port:    6000,
+				Version: 1,
+				valid:   true,
+				Extra:   pubkey[:],
+			},
+			err: nil,
+		},
+		{
+			name: "INTR message with different pubkey",
+			addr: "121.121.121.121:6000",
+			mockValue: daemonMockValue{
+				mirror:  10000,
+				version: 1,
+				getMirrorPortResult: mirrorPortResult{
+					exist: false,
+				},
+				pubkey:           pubkey,
+				disconnectReason: ErrDisconnectBlockchainPubkeyNotMatched,
+			},
+			intro: &IntroductionMessage{
+				Mirror:  10001,
+				Port:    6000,
+				Version: 1,
+				valid:   true,
+				Extra:   pubkey2[:],
+			},
+			err: ErrDisconnectBlockchainPubkeyNotMatched,
+		},
+		{
+			name: "INTR message with invalid pubkey",
+			addr: "121.121.121.121:6000",
+			mockValue: daemonMockValue{
+				mirror:  10000,
+				version: 1,
+				getMirrorPortResult: mirrorPortResult{
+					exist: false,
+				},
+				pubkey:           pubkey,
+				disconnectReason: ErrDisconnectInvalidExtraData,
+			},
+			intro: &IntroductionMessage{
+				Mirror:  10001,
+				Port:    6000,
+				Version: 1,
+				valid:   true,
+				Extra:   []byte("invalid extra data"),
+			},
+			err: ErrDisconnectInvalidExtraData,
+		},
+		{
+			name: "Disconnect self connection",
+			mockValue: daemonMockValue{
+				mirror:           10000,
+				disconnectReason: ErrDisconnectSelf,
+			},
+			intro: &IntroductionMessage{
+				Mirror: 10000,
+			},
+			err: ErrDisconnectSelf,
+		},
+		{
+			name: "Invalid version",
+			mockValue: daemonMockValue{
+				mirror:           10000,
+				version:          1,
+				disconnectReason: ErrDisconnectInvalidVersion,
+			},
+			intro: &IntroductionMessage{
+				Mirror:  10001,
+				Version: 0,
+			},
+			err: ErrDisconnectInvalidVersion,
+		},
+		{
+			name: "Invalid address",
+			addr: "121.121.121.121",
+			mockValue: daemonMockValue{
+				mirror:           10000,
+				version:          1,
+				disconnectReason: ErrDisconnectOtherError,
+				pubkey:           pubkey,
+			},
+			intro: &IntroductionMessage{
+				Mirror:  10001,
+				Version: 1,
+				Port:    6000,
+			},
+			err: ErrDisconnectOtherError,
+		},
+		{
+			name: "Max default connections reached",
+			addr: "121.121.121.121:6000",
+			mockValue: daemonMockValue{
+				mirror:                  10000,
+				version:                 1,
+				disconnectReason:        ErrDisconnectMaxDefaultConnectionReached,
+				isDefaultConnection:     true,
+				isMaxConnectionsReached: true,
+				getMirrorPortResult: mirrorPortResult{
+					exist: false,
+				},
+				pubkey: pubkey,
+			},
+			intro: &IntroductionMessage{
+				Mirror:  10001,
+				Version: 1,
+				Port:    6000,
+			},
+			err: ErrDisconnectMaxDefaultConnectionReached,
+		},
+		{
+			name: "incomming connection",
+			addr: "121.121.121.121:12345",
+			mockValue: daemonMockValue{
+				mirror:                  10000,
+				version:                 1,
+				isDefaultConnection:     true,
+				isMaxConnectionsReached: true,
+				getMirrorPortResult: mirrorPortResult{
+					exist: false,
+				},
+				pubkey:     pubkey,
+				addPeerArg: "121.121.121.121:6000",
+				addPeerErr: nil,
+			},
+			intro: &IntroductionMessage{
+				Mirror:  10001,
+				Version: 1,
+				Port:    6000,
+				valid:   true,
+			},
+		},
+		{
+			name: "Connect twice",
+			addr: "121.121.121.121:6000",
+			mockValue: daemonMockValue{
+				mirror:              10000,
+				version:             1,
+				isDefaultConnection: true,
+				getMirrorPortResult: mirrorPortResult{
+					exist: true,
+				},
+				pubkey:           pubkey,
+				addPeerArg:       "121.121.121.121:6000",
+				addPeerErr:       nil,
+				disconnectReason: ErrDisconnectConnectedTwice,
+			},
+			intro: &IntroductionMessage{
+				Mirror:  10001,
+				Version: 1,
+				Port:    6000,
+			},
+			err: ErrDisconnectConnectedTwice,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			mc := &gnet.MessageContext{Addr: tc.addr}
+			tc.intro.c = mc
+
+			d := NewDaemonerMock()
+			d.On("DaemonConfig").Return(DaemonConfig{Version: int32(tc.mockValue.version)})
+			d.On("Mirror").Return(tc.mockValue.mirror)
+			d.On("IsDefaultConnection", tc.addr).Return(tc.mockValue.isDefaultConnection)
+			d.On("SetHasIncomingPort", tc.addr).Return(tc.mockValue.setHasIncomingPortErr)
+			d.On("GetMirrorPort", tc.addr, tc.intro.Mirror).Return(tc.mockValue.getMirrorPortResult.port, tc.mockValue.getMirrorPortResult.exist)
+			d.On("RecordMessageEvent", tc.intro, mc).Return(tc.mockValue.recordMessageEventErr)
+			d.On("ResetRetryTimes", tc.addr)
+			d.On("BlockchainPubkey").Return(tc.mockValue.pubkey)
+			d.On("Disconnect", tc.addr, tc.mockValue.disconnectReason).Return(tc.mockValue.disconnectErr)
+			d.On("IncreaseRetryTimes", tc.addr)
+			d.On("RemoveFromExpectingIntroductions", tc.addr)
+			d.On("IsMaxDefaultConnectionsReached").Return(tc.mockValue.isMaxConnectionsReached, tc.mockValue.isMaxConnectionsReachedErr)
+			d.On("AddPeer", tc.mockValue.addPeerArg).Return(tc.mockValue.addPeerErr)
+
+			err := tc.intro.Handle(mc, d)
+			require.Equal(t, tc.err, err)
+		})
+	}
+
 }

--- a/src/daemon/messages_test.go
+++ b/src/daemon/messages_test.go
@@ -141,7 +141,7 @@ func GetSHAFromHex(hex string) cipher.SHA256 {
 func ExampleIntroductionMessage() {
 	defer gnet.EraseMessages()
 	setupMsgEncoding()
-	var message = NewIntroductionMessage(1234, 5, 7890)
+	var message = NewIntroductionMessage(1234, 5, 7890, nil)
 	fmt.Println("IntroductionMessage:")
 	var mai = NewMessagesAnnotationsIterator(message)
 	w := bufio.NewWriter(os.Stdout)

--- a/src/daemon/messages_test.go
+++ b/src/daemon/messages_test.go
@@ -533,6 +533,26 @@ func TestIntroductionMessage(t *testing.T) {
 			err: nil,
 		},
 		{
+			name: "INTR message with pubkey and additional data",
+			addr: "121.121.121.121:6000",
+			mockValue: daemonMockValue{
+				mirror:  10000,
+				version: 1,
+				getMirrorPortResult: mirrorPortResult{
+					exist: false,
+				},
+				pubkey: pubkey,
+			},
+			intro: &IntroductionMessage{
+				Mirror:  10001,
+				Port:    6000,
+				Version: 1,
+				valid:   true,
+				Extra:   append(pubkey[:], []byte("additional data")...),
+			},
+			err: nil,
+		},
+		{
 			name: "INTR message with different pubkey",
 			addr: "121.121.121.121:6000",
 			mockValue: daemonMockValue{

--- a/src/skycoin/skycoin.go
+++ b/src/skycoin/skycoin.go
@@ -315,7 +315,7 @@ func (c *Coin) configureDaemon() daemon.Config {
 	dc.Daemon.OutgoingMax = c.config.Node.MaxOutgoingConnections
 	dc.Daemon.DataDirectory = c.config.Node.DataDirectory
 	dc.Daemon.LogPings = !c.config.Node.DisablePingPong
-	dc.Daemon.BlockchainPubkey = cipher.MustPubKeyFromHex(c.config.Node.BlockchainPubkeyStr)
+	dc.Daemon.BlockchainPubkey = c.config.Node.blockchainPubkey
 
 	if c.config.Node.OutgoingConnectionsRate == 0 {
 		c.config.Node.OutgoingConnectionsRate = time.Millisecond

--- a/src/skycoin/skycoin.go
+++ b/src/skycoin/skycoin.go
@@ -315,6 +315,7 @@ func (c *Coin) configureDaemon() daemon.Config {
 	dc.Daemon.OutgoingMax = c.config.Node.MaxOutgoingConnections
 	dc.Daemon.DataDirectory = c.config.Node.DataDirectory
 	dc.Daemon.LogPings = !c.config.Node.DisablePingPong
+	dc.Daemon.BlockchainPubkey = cipher.MustPubKeyFromHex(c.config.Node.BlockchainPubkeyStr)
 
 	if c.config.Node.OutgoingConnectionsRate == 0 {
 		c.config.Node.OutgoingConnectionsRate = time.Millisecond


### PR DESCRIPTION
Fixes: #1517 

Changes:
- Add `ExtraData []byte` field with `omitempty` tag in Introduction message
- Add the message data size checking back
- If `ExtraData` is not empty, then parse it as blockchain pubkey and compare it with local node's blockchain pubkey, disconnect if not match.

Does this change need to mentioned in CHANGELOG.md?
No