### PR TITLE
Maintain order of addresses in wallet

### DIFF
--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -99,9 +99,11 @@ export class WalletService {
   refreshBalances() {
     this.wallets.first().subscribe(wallets => {
       Observable.forkJoin(wallets.map(wallet => this.retrieveWalletBalance(wallet).map(response => {
-        wallet.addresses = response.addresses;
         wallet.coins = response.coins;
         wallet.hours = response.hours;
+        wallet.addresses = wallet.addresses.map(address => {
+          return response.addresses.find(addr => addr.address === address.address);
+        });
 
         return wallet;
       })))


### PR DESCRIPTION
Fixes #1583

Changes:
- order of addresses in wallet is not updated when refreshing balance