### PR TITLE
Address copy button

### DIFF
--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.html
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.html
@@ -5,7 +5,10 @@
       <img src="../../../../../assets/img/qr-code-black.png" (click)="showQrCode($event, address.address)">
       <p class="click-to-copy" [ngClass]="{ copying: address.copying }"
          (click)="copyAddress($event, address)" (mouseleave)="address.copying = false">
-        {{ address.address }} <span data-label="Copied" class="copy-label">Copy</span>
+        {{ address.address }}
+        <span [attr.data-label]="'wallet.address.copied' | translate" class="copy-label">
+          {{ 'wallet.address.copy' | translate }}
+        </span>
       </p>
     </div>
     <div class="hours-column">{{ (address.hours ? address.hours : 0) | number:'1.0-6' }}</div>
@@ -17,7 +20,7 @@
 
   <mat-menu #optionsMenu="matMenu" [overlapTrigger]="false" class="compact">
     <button mat-menu-item (click)="copyAddress($event, address, 1000)">
-      {{ 'wallet.address.' + (address.copying ? 'copied': 'copy') | translate }}
+      {{ 'wallet.address.' + (address.copying ? 'copied': 'copy-address') | translate }}
     </button>
     <button mat-menu-item routerLink="/settings/outputs" [queryParams]="{ addr: address.address }">
       {{ 'wallet.address.outputs' | translate }}

--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.html
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.html
@@ -3,7 +3,10 @@
     <div class="id-column">{{ i + 1 }}</div>
     <div class="address-column">
       <img src="../../../../../assets/img/qr-code-black.png" (click)="showQrCode($event, address.address)">
-      <p>{{ address.address }}</p>
+      <p class="click-to-copy" [ngClass]="{ copying: address.copying }"
+         (click)="copyAddress($event, address)" (mouseleave)="address.copying = false">
+        {{ address.address }} <span data-label="Copied" class="copy-label">Copy</span>
+      </p>
     </div>
     <div class="hours-column">{{ (address.hours ? address.hours : 0) | number:'1.0-6' }}</div>
     <div class="coins-column">{{ (address.coins ? address.coins : 0) | number:'1.0-6' }}</div>
@@ -13,7 +16,7 @@
   </div>
 
   <mat-menu #optionsMenu="matMenu" [overlapTrigger]="false" class="compact">
-    <button mat-menu-item (click)="copyAddress(address, $event)">
+    <button mat-menu-item (click)="copyAddress($event, address, 1000)">
       {{ 'wallet.address.' + (address.copying ? 'copied': 'copy') | translate }}
     </button>
     <button mat-menu-item routerLink="/settings/outputs" [queryParams]="{ addr: address.address }">

--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.scss
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.scss
@@ -30,6 +30,10 @@
       line-height: $row-height;
       margin: 0;
       vertical-align: middle;
+
+      &:hover .copy-label {
+        display: inline-block;
+      }
     }
   }
 
@@ -144,4 +148,53 @@
       }
     }
   }
+}
+
+@keyframes floatup {
+  20% {
+    opacity: .999
+  }
+
+  100% {
+    transform: translate3d(-50%, -17px, 0)
+  }
+}
+
+.click-to-copy {
+  cursor: pointer;
+}
+
+.copy-label {
+  color: #0072ff;
+  display: none;
+  font-size: 12px;
+  line-height: 100%;
+  position: relative;
+  opacity: .999;
+  transition: opacity .2s ease-in-out;
+  top: -1px;
+  padding-left: 10px;
+
+  &.hidden{
+    opacity: .001;
+  }
+
+  &::after {
+    content: attr(data-label);
+    color: #0072ff;
+    display: inline-block;
+    position: absolute;
+    top: -2px;
+    left: 50%;
+    opacity: .001;
+    text-align: center;
+    transform: translate3d(-50%,0,0);
+    backface-visibility: hidden;
+    white-space: nowrap;
+    padding-left: 11px;
+  }
+}
+
+.copying .copy-label::after {
+  animation: floatup .5s ease-in-out;
 }

--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
@@ -84,8 +84,12 @@ export class WalletDetailComponent implements OnInit, OnDestroy {
       });
   }
 
-  copyAddress(address, event) {
+  copyAddress(event, address, duration = 500) {
     event.stopPropagation();
+
+    if (address.copying) {
+      return;
+    }
 
     const selBox = document.createElement('textarea');
 
@@ -106,7 +110,7 @@ export class WalletDetailComponent implements OnInit, OnDestroy {
 
     setTimeout(function() {
       address.copying = false;
-    }, 1000);
+    }, duration);
   }
 
   showQrCode(event, address: string) {

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -128,7 +128,8 @@
     },
 
     "address": {
-      "copy": "Copy address",
+      "copy": "Copy",
+      "copy-address": "Copy address",
       "copied": "Copied!",
       "outputs": "Unspent Outputs"
     }


### PR DESCRIPTION
Fixes #1575

Changes:
- brings back the old "copy" button next to wallet address