### PR TITLE
[cipher] Fixed #1663 Remove util/logging in cipher

### DIFF
--- a/src/cipher/address.go
+++ b/src/cipher/address.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/skycoin/skycoin/src/cipher/base58"
 )
@@ -64,7 +65,7 @@ func DecodeBase58Address(addr string) (Address, error) {
 func MustDecodeBase58Address(addr string) Address {
 	a, err := DecodeBase58Address(addr)
 	if err != nil {
-		logger.Panicf("Invalid address %s: %v", addr, err)
+		log.Panicf("Invalid address %s: %v", addr, err)
 	}
 	return a
 }
@@ -82,7 +83,7 @@ func BitcoinDecodeBase58Address(addr string) (Address, error) {
 func BitcoinMustDecodeBase58Address(addr string) Address {
 	a, err := BitcoinDecodeBase58Address(addr)
 	if err != nil {
-		logger.Panicf("Invalid address %s: %v", addr, err)
+		log.Panicf("Invalid address %s: %v", addr, err)
 	}
 	return a
 }
@@ -278,7 +279,7 @@ func SecKeyFromWalletImportFormat(input string) (SecKey, error) {
 
 	seckey := b[1:33]
 	if len(seckey) != 32 {
-		logger.Panic("...")
+		log.Panic("...")
 	}
 	return NewSecKey(b[1:33]), nil
 }
@@ -287,7 +288,7 @@ func SecKeyFromWalletImportFormat(input string) (SecKey, error) {
 func MustSecKeyFromWalletImportFormat(input string) SecKey {
 	seckey, err := SecKeyFromWalletImportFormat(input)
 	if err != nil {
-		logger.Panicf("MustSecKeyFromWalletImportFormat, invalid seckey, %v", err)
+		log.Panicf("MustSecKeyFromWalletImportFormat, invalid seckey, %v", err)
 	}
 	return seckey
 }

--- a/src/cipher/crypto.go
+++ b/src/cipher/crypto.go
@@ -13,12 +13,9 @@ import (
 	"github.com/skycoin/skycoin/src/cipher/ripemd160"
 
 	"github.com/skycoin/skycoin/src/cipher/secp256k1-go"
-
-	"github.com/skycoin/skycoin/src/util/logging"
 )
 
 var (
-	logger = logging.MustGetLogger("crypto")
 	// DebugLevel1 debug level one
 	DebugLevel1 = true //checks for extremely unlikely conditions (10e-40)
 	// DebugLevel2 debug level two
@@ -55,7 +52,7 @@ func RandByte(n int) []byte {
 func NewPubKey(b []byte) PubKey {
 	p := PubKey{}
 	if len(b) != len(p) {
-		logger.Panic("Invalid public key length")
+		log.Panic("Invalid public key length")
 	}
 	copy(p[:], b[:])
 	return p
@@ -65,7 +62,7 @@ func NewPubKey(b []byte) PubKey {
 func MustPubKeyFromHex(s string) PubKey {
 	b, err := hex.DecodeString(s)
 	if err != nil {
-		logger.Panic(err)
+		log.Panic(err)
 	}
 	return NewPubKey(b)
 }
@@ -82,11 +79,11 @@ func PubKeyFromHex(s string) (PubKey, error) {
 // PubKeyFromSecKey recovers the public key for a secret key
 func PubKeyFromSecKey(seckey SecKey) PubKey {
 	if seckey == (SecKey{}) {
-		logger.Panic("PubKeyFromSecKey, attempt to load null seckey, unsafe")
+		log.Panic("PubKeyFromSecKey, attempt to load null seckey, unsafe")
 	}
 	b := secp256k1.PubkeyFromSeckey(seckey[:])
 	if b == nil {
-		logger.Panic("PubKeyFromSecKey, pubkey recovery failed. Function " +
+		log.Panic("PubKeyFromSecKey, pubkey recovery failed. Function " +
 			"assumes seckey is valid. Check seckey")
 	}
 	return NewPubKey(b)
@@ -128,7 +125,7 @@ type SecKey [32]byte
 func NewSecKey(b []byte) SecKey {
 	p := SecKey{}
 	if len(b) != len(p) {
-		logger.Panic("Invalid secret key length")
+		log.Panic("Invalid secret key length")
 	}
 	copy(p[:], b[:])
 	return p
@@ -138,7 +135,7 @@ func NewSecKey(b []byte) SecKey {
 func MustSecKeyFromHex(s string) SecKey {
 	b, err := hex.DecodeString(s)
 	if err != nil {
-		logger.Panic(err)
+		log.Panic(err)
 	}
 	return NewSecKey(b)
 }
@@ -164,7 +161,7 @@ func (sk SecKey) Verify() error {
 	if DebugLevel2 {
 		err := TestSecKey(sk)
 		if err != nil {
-			logger.Panic("DebugLevel2, WARNING CRYPTO ARMAGEDDON")
+			log.Panic("DebugLevel2, WARNING CRYPTO ARMAGEDDON")
 		}
 	}
 	return nil
@@ -187,11 +184,11 @@ func (sk SecKey) Hex() string {
 func ECDH(pub PubKey, sec SecKey) []byte {
 
 	if err := pub.Verify(); err != nil {
-		logger.Panic("ECDH invalid pubkey input")
+		log.Panic("ECDH invalid pubkey input")
 	}
 
 	if err := sec.Verify(); err != nil {
-		logger.Panic("ECDH invalid seckey input")
+		log.Panic("ECDH invalid seckey input")
 	}
 
 	buff := secp256k1.ECDH(pub[:], sec[:])
@@ -207,7 +204,7 @@ type Sig [64 + 1]byte //64 byte signature with 1 byte for key recovery
 func NewSig(b []byte) Sig {
 	s := Sig{}
 	if len(b) != len(s) {
-		logger.Panic("Invalid secret key length")
+		log.Panic("Invalid secret key length")
 	}
 	copy(s[:], b[:])
 	return s
@@ -217,10 +214,10 @@ func NewSig(b []byte) Sig {
 func MustSigFromHex(s string) Sig {
 	b, err := hex.DecodeString(s)
 	if err != nil {
-		logger.Panic(err)
+		log.Panic(err)
 	}
 	if len(b) != 65 {
-		logger.Panic("Signature Length is Invalid")
+		log.Panic("Signature Length is Invalid")
 	}
 	return NewSig(b)
 }
@@ -249,14 +246,14 @@ func SignHash(hash SHA256, sec SecKey) Sig {
 	if DebugLevel2 || DebugLevel1 { //!!! Guard against coin loss
 		pubkey, err := PubKeyFromSig(sig, hash)
 		if err != nil {
-			logger.Panic("SignHash, error: pubkey from sig recovery failure")
+			log.Panic("SignHash, error: pubkey from sig recovery failure")
 		}
 		if VerifySignature(pubkey, sig, hash) != nil {
-			logger.Panic("SignHash, error: secp256k1.Sign returned non-null " +
+			log.Panic("SignHash, error: secp256k1.Sign returned non-null " +
 				"invalid non-null signature")
 		}
 		if ChkSig(AddressFromPubKey(pubkey), hash, sig) != nil {
-			logger.Panic("SignHash error: ChkSig failed for signature")
+			log.Panic("SignHash error: ChkSig failed for signature")
 		}
 	}
 	return sig
@@ -292,7 +289,7 @@ func VerifySignedHash(sig Sig, hash SHA256) error {
 	}
 	if secp256k1.VerifySignature(hash[:], sig[:], rawPubKey) != 1 {
 		// If this occurs, secp256k1 is bugged
-		logger.Critical().Error("Recovered public key is not valid for signed hash")
+		log.Printf("Recovered public key is not valid for signed hash")
 		return errors.New("Signature invalid for hash")
 	}
 	return nil
@@ -310,7 +307,7 @@ func VerifySignature(pubkey PubKey, sig Sig, hash SHA256) error {
 	if secp256k1.VerifyPubkey(pubkey[:]) != 1 {
 		if DebugLevel2 {
 			if secp256k1.VerifySignature(hash[:], sig[:], pubkey[:]) == 1 {
-				logger.Panic("VerifySignature warning, ")
+				log.Panic("VerifySignature warning, ")
 			}
 		}
 		return errors.New("VerifySignature, secp256k1.VerifyPubkey failed")
@@ -330,7 +327,7 @@ func GenerateKeyPair() (PubKey, SecKey) {
 
 	if DebugLevel1 {
 		if TestSecKey(NewSecKey(secret)) != nil {
-			logger.Panic("DebugLevel1, GenerateKeyPair, generated private key " +
+			log.Panic("DebugLevel1, GenerateKeyPair, generated private key " +
 				"failed TestSecKey")
 		}
 	}
@@ -345,11 +342,11 @@ func GenerateDeterministicKeyPair(seed []byte) (PubKey, SecKey) {
 	if DebugLevel1 {
 
 		if TestSecKey(NewSecKey(secret)) != nil {
-			logger.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
+			log.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
 				"seckey invalid, failed TestSecKey")
 		}
 		if TestSecKey(NewSecKey(secret)) != nil {
-			logger.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
+			log.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
 				"generated private key failed TestSecKey")
 		}
 		if PubKeyFromSecKey(NewSecKey(secret)) != NewPubKey(public) {
@@ -357,7 +354,7 @@ func GenerateDeterministicKeyPair(seed []byte) (PubKey, SecKey) {
 			//s2 := NewPubKey(public).Hex()
 			//s3 := PubKeyFromSecKey(NewSecKey(secret)).Hex()
 			//log.Printf("sec= %s, pub= %s recpub= %s \n", s1,s2, s3 )
-			logger.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
+			log.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
 				"public key does not match private key")
 		}
 	}
@@ -371,11 +368,11 @@ func DeterministicKeyPairIterator(seed []byte) ([]byte, PubKey, SecKey) {
 	hash, public, secret := secp256k1.DeterministicKeyPairIterator(seed)
 	if DebugLevel1 {
 		if TestSecKey(NewSecKey(secret)) != nil {
-			logger.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
+			log.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
 				"generated private key failed TestSecKey")
 		}
 		if PubKeyFromSecKey(NewSecKey(secret)) != NewPubKey(public) {
-			logger.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
+			log.Panic("DebugLevel1, GenerateDeterministicKeyPair, " +
 				"public key does not match private key")
 		}
 	}


### PR DESCRIPTION
Fixes #1633 

Changes:
-Remove `util/logging` in cipher
-Replaced by `log.Panic` in case of logger.Panic , `log.Printf` in case of `logger.Warning` and `log.Panicf` in case of `logger.Panicf`

Does this change need to mentioned in CHANGELOG.md?
