### PR TITLE
[docker] fixes #1645 - Fix Docker build errors in skycoin/skycoin image due to lib/cgo

### DIFF
--- a/docker/images/mainnet/Dockerfile
+++ b/docker/images/mainnet/Dockerfile
@@ -20,7 +20,10 @@ RUN sh -c \
      fi'
 
 RUN cd $GOPATH/src/github.com/skycoin/skycoin && \
-    GOARCH=$ARCH GOARM=$GOARM CGO_ENABLED=0 GOOS=linux go install -a -installsuffix cgo ./... && \
+    COMMIT=$(git rev-parse HEAD) BRANCH=$(git rev-parse —abbrev-ref HEAD) \
+    GOARCH=$ARCH GOARM=$GOARM CGO_ENABLED=0 GOOS=linux \
+    GOLDFLAGS="-X main.Commit=${COMMIT} -X main.Branch=${BRANCH}" \
+    go build -ldflags "${GOLDFLAGS}" ./cmd/... && \
     sh -c "if test -d $GOPATH/bin/linux_arm ; then mv $GOPATH/bin/linux_arm/* $GOPATH/bin/; fi; \
            if test -d $GOPATH/bin/linux_arm64 ; then mv $GOPATH/bin/linux_arm64/* $GOPATH/bin/; fi"
 

--- a/docker/images/mainnet/Dockerfile
+++ b/docker/images/mainnet/Dockerfile
@@ -20,7 +20,7 @@ RUN sh -c \
      fi'
 
 RUN cd $GOPATH/src/github.com/skycoin/skycoin && \
-    GOARCH=$ARCH GOARM=$GOARM GOOS=linux go install -a -installsuffix cgo ./... && \
+    GOARCH=$ARCH GOARM=$GOARM CGO_ENABLED=0 GOOS=linux go install -a -installsuffix cgo ./... && \
     sh -c "if test -d $GOPATH/bin/linux_arm ; then mv $GOPATH/bin/linux_arm/* $GOPATH/bin/; fi; \
            if test -d $GOPATH/bin/linux_arm64 ; then mv $GOPATH/bin/linux_arm64/* $GOPATH/bin/; fi"
 

--- a/docker/images/mainnet/Dockerfile
+++ b/docker/images/mainnet/Dockerfile
@@ -20,10 +20,10 @@ RUN sh -c \
      fi'
 
 RUN cd $GOPATH/src/github.com/skycoin/skycoin && \
-    COMMIT=$(git rev-parse HEAD) BRANCH=$(git rev-parse —abbrev-ref HEAD) \
+    COMMIT=$(git rev-parse HEAD) BRANCH=$(git rev-parse -—abbrev-ref HEAD) \
     GOARCH=$ARCH GOARM=$GOARM CGO_ENABLED=0 GOOS=linux \
     GOLDFLAGS="-X main.Commit=${COMMIT} -X main.Branch=${BRANCH}" \
-    go build -ldflags "${GOLDFLAGS}" ./cmd/... && \
+    go install -ldflags "${GOLDFLAGS}" ./cmd/... && \
     sh -c "if test -d $GOPATH/bin/linux_arm ; then mv $GOPATH/bin/linux_arm/* $GOPATH/bin/; fi; \
            if test -d $GOPATH/bin/linux_arm64 ; then mv $GOPATH/bin/linux_arm64/* $GOPATH/bin/; fi"
 


### PR DESCRIPTION
Fixes #1645 (see [Docker Cloud build](https://cloud.docker.com/swarm/simelotech/repository/registry-1.docker.io/simelotech/skycoin/builds/a7aabc30-1e03-4701-b05d-06ea9d0a46fd) )

Changes:
- In mainnet `Dockerfile` limit `go install` step to `cmd/...`
- Use commit and branch in `-ldflags` metadata when building Skycoin binary files 

Does this change need to mentioned in CHANGELOG.md?
no