### PR TITLE
[docker] Fix #1667 Update version of SWIG to 3.0.12 in skycoin/skycoindev-cli docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   If you are using the CLI tool or another API client to communicate with the standalone client, use `-web-interface-port=6420` to continue using port 6420.
   If the program is run from source (e.g. `go run`, `run.sh`, `make run`) there is no change, the API will still be on port 6420.
 - Change number of outgoing connections to 8 from 16
+- Update version of SWIG to 3.0.12
 
 ### Removed
 

--- a/docker/images/dev-cli/Dockerfile
+++ b/docker/images/dev-cli/Dockerfile
@@ -135,7 +135,6 @@ RUN set -ex ; \
     screen \
     sudo \
     doxygen \
-    swig \
     texlive-latex-base \
     ; \
     apt-get clean ; \
@@ -177,6 +176,14 @@ RUN git clone https://github.com/fatih/vim-go /usr/share/vim/vim80/pack/dev/star
     git clone https://github.com/Shougo/vimproc.vim /usr/share/vim/vim80/pack/dev/start/0vimproc && \
     cd /usr/share/vim/vim80/pack/dev/start/0vimproc && make 
 
+# Install SWIG-3.0.12
+RUN cd /tmp/; \
+    wget http://prdownloads.sourceforge.net/swig/swig-3.0.12.tar.gz && \
+    tar -zxf swig-3.0.12.tar.gz ; \
+    cd swig-3.0.12 ;\
+    ./configure --prefix=/usr && make && make install && \
+    rm -rf /tmp/swig-*
+    
 WORKDIR $GOPATH/src/github.com/skycoin
 VOLUME $GOPATH/src/
 


### PR DESCRIPTION

Fixes #1667 

Changes:
- Update SWIG's version to 3.0.12 in skycoindev-cli docker image

Does this change need to mentioned in CHANGELOG.md?
Yes