### PR TITLE
Fix history db resetting bug

### DIFF
--- a/src/visor/historydb/historydb.go
+++ b/src/visor/historydb/historydb.go
@@ -49,9 +49,10 @@ func New() *HistoryDB {
 // If we have a new added bucket, we need to reset to parse
 // blockchain again to get the new bucket filled.
 func (hd *HistoryDB) NeedsReset(tx *dbutil.Tx) (bool, error) {
-	if height, ok, err := hd.historyMeta.ParsedHeight(tx); err != nil {
+	_, ok, err := hd.historyMeta.ParsedHeight(tx)
+	if err != nil {
 		return false, err
-	} else if !ok || height == 0 {
+	} else if !ok {
 		return true, nil
 	}
 


### PR DESCRIPTION
Historydb would be reset if node restarts with only genesis block

Fixes #1664 

Changes:
- Do not reset history db if `parsed height` is `0`, as the genesis block seq is `0`.

Does this change need to mentioned in CHANGELOG.md?
No.
