### PR TITLE
Rename parsed height to parsed block seq

### DIFF
--- a/src/visor/historydb/history_meta.go
+++ b/src/visor/historydb/history_meta.go
@@ -13,8 +13,8 @@ var (
 // historyMeta bucket for storing block history meta info
 type historyMeta struct{}
 
-// Height returns history parsed height
-func (hm *historyMeta) ParsedHeight(tx *dbutil.Tx) (uint64, bool, error) {
+// Height returns history parsed block seq
+func (hm *historyMeta) ParsedBlockSeq(tx *dbutil.Tx) (uint64, bool, error) {
 	v, err := dbutil.GetBucketValue(tx, HistoryMetaBkt, parsedHeightKey)
 	if err != nil {
 		return 0, false, err
@@ -25,8 +25,8 @@ func (hm *historyMeta) ParsedHeight(tx *dbutil.Tx) (uint64, bool, error) {
 	return dbutil.Btoi(v), true, nil
 }
 
-// SetParsedHeight updates history parsed height
-func (hm *historyMeta) SetParsedHeight(tx *dbutil.Tx, h uint64) error {
+// SetParsedHeight updates history parsed block seq
+func (hm *historyMeta) SetParsedBlockSeq(tx *dbutil.Tx, h uint64) error {
 	return dbutil.PutBucketValue(tx, HistoryMetaBkt, parsedHeightKey, dbutil.Itob(h))
 }
 

--- a/src/visor/historydb/history_meta_test.go
+++ b/src/visor/historydb/history_meta_test.go
@@ -15,7 +15,7 @@ func TestHistoryMetaGetSetParsedHeight(t *testing.T) {
 	hm := &historyMeta{}
 
 	err := db.View("", func(tx *dbutil.Tx) error {
-		height, ok, err := hm.ParsedHeight(tx)
+		height, ok, err := hm.ParsedBlockSeq(tx)
 		require.NoError(t, err)
 		require.False(t, ok)
 		require.Equal(t, uint64(0), height)
@@ -24,14 +24,14 @@ func TestHistoryMetaGetSetParsedHeight(t *testing.T) {
 	require.NoError(t, err)
 
 	err = db.Update("", func(tx *dbutil.Tx) error {
-		err := hm.SetParsedHeight(tx, 10)
+		err := hm.SetParsedBlockSeq(tx, 10)
 		require.NoError(t, err)
 		return err
 	})
 	require.NoError(t, err)
 
 	err = db.View("", func(tx *dbutil.Tx) error {
-		height, ok, err := hm.ParsedHeight(tx)
+		height, ok, err := hm.ParsedBlockSeq(tx)
 		require.NoError(t, err)
 		require.True(t, ok)
 		require.Equal(t, uint64(10), height)
@@ -40,14 +40,14 @@ func TestHistoryMetaGetSetParsedHeight(t *testing.T) {
 	require.NoError(t, err)
 
 	err = db.Update("", func(tx *dbutil.Tx) error {
-		err := hm.SetParsedHeight(tx, 0)
+		err := hm.SetParsedBlockSeq(tx, 0)
 		require.NoError(t, err)
 		return err
 	})
 	require.NoError(t, err)
 
 	err = db.View("", func(tx *dbutil.Tx) error {
-		height, ok, err := hm.ParsedHeight(tx)
+		height, ok, err := hm.ParsedBlockSeq(tx)
 		require.NoError(t, err)
 		require.True(t, ok)
 		require.Equal(t, uint64(0), height)

--- a/src/visor/historydb/historydb.go
+++ b/src/visor/historydb/historydb.go
@@ -49,7 +49,7 @@ func New() *HistoryDB {
 // If we have a new added bucket, we need to reset to parse
 // blockchain again to get the new bucket filled.
 func (hd *HistoryDB) NeedsReset(tx *dbutil.Tx) (bool, error) {
-	_, ok, err := hd.historyMeta.ParsedHeight(tx)
+	_, ok, err := hd.historyMeta.ParsedBlockSeq(tx)
 	if err != nil {
 		return false, err
 	} else if !ok {
@@ -165,7 +165,7 @@ func (hd *HistoryDB) ParseBlock(tx *dbutil.Tx, b coin.Block) error {
 		}
 	}
 
-	return hd.SetParsedHeight(tx, b.Seq())
+	return hd.SetParsedBlockSeq(tx, b.Seq())
 }
 
 // GetTransaction get transaction by hash.

--- a/src/visor/historyer_mock_test.go
+++ b/src/visor/historyer_mock_test.go
@@ -214,8 +214,8 @@ func (m *HistoryerMock) ParseBlock(p0 *dbutil.Tx, p1 coin.Block) error {
 
 }
 
-// ParsedHeight mocked method
-func (m *HistoryerMock) ParsedHeight(p0 *dbutil.Tx) (uint64, bool, error) {
+// ParsedBlockSeq mocked method
+func (m *HistoryerMock) ParsedBlockSeq(p0 *dbutil.Tx) (uint64, bool, error) {
 
 	ret := m.Called(p0)
 

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -173,7 +173,7 @@ type Historyer interface {
 	GetAddressTxns(tx *dbutil.Tx, address cipher.Address) ([]historydb.Transaction, error)
 	NeedsReset(tx *dbutil.Tx) (bool, error)
 	Erase(tx *dbutil.Tx) error
-	ParsedHeight(tx *dbutil.Tx) (uint64, bool, error)
+	ParsedBlockSeq(tx *dbutil.Tx) (uint64, bool, error)
 	ForEachTxn(tx *dbutil.Tx, f func(cipher.SHA256, *historydb.Transaction) error) error
 }
 
@@ -365,19 +365,19 @@ func initHistory(tx *dbutil.Tx, bc *Blockchain, history *historydb.HistoryDB) er
 func parseHistoryTo(tx *dbutil.Tx, history *historydb.HistoryDB, bc *Blockchain, height uint64) error {
 	logger.Info("Visor parseHistoryTo")
 
-	parsedHeight, _, err := history.ParsedHeight(tx)
+	parsedBlockSeq, _, err := history.ParsedBlockSeq(tx)
 	if err != nil {
 		return err
 	}
 
-	for i := uint64(0); i < height-parsedHeight; i++ {
-		b, err := bc.GetSignedBlockBySeq(tx, parsedHeight+i+1)
+	for i := uint64(0); i < height-parsedBlockSeq; i++ {
+		b, err := bc.GetSignedBlockBySeq(tx, parsedBlockSeq+i+1)
 		if err != nil {
 			return err
 		}
 
 		if b == nil {
-			return fmt.Errorf("no block exists in depth: %d", parsedHeight+i+1)
+			return fmt.Errorf("no block exists in depth: %d", parsedBlockSeq+i+1)
 		}
 
 		if err := history.ParseBlock(tx, b.Block); err != nil {


### PR DESCRIPTION
Changes:
- Rename parsed height to parsed block seq

Does this change need to mentioned in CHANGELOG.md?
No