### PR TITLE
Align amount in transaction history to right side

### DIFF
--- a/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.scss
+++ b/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.scss
@@ -99,7 +99,8 @@
   }
 
   .-balance {
-    width: 100px;
+    width: 200px;
+    text-align: right;
 
     h4 {
       color: #1e2227;


### PR DESCRIPTION
Changes:
- aligns amount (SKY/USD) shown in transaction history to right side to prevent breaking into multiple lines when the text is long
