### PR TITLE
Fix the e2e test in Travis-Mac

### DIFF
--- a/src/gui/static/protractor.conf.js
+++ b/src/gui/static/protractor.conf.js
@@ -9,7 +9,10 @@ exports.config = {
     './e2e/**/*.e2e-spec.ts'
   ],
   capabilities: {
-    'browserName': 'chrome'
+    'browserName': 'chrome',
+    chromeOptions: {
+      args: ['--no-sandbox', '--headless', '--disable-gpu', 'window-size=1920,1080']
+    }
   },
   directConnect: true,
   baseUrl: 'http://localhost:4200/',


### PR DESCRIPTION
Changes:
- Change the Protractor configuration to make it work correctly in Travis, while using Mac OS.

Does this change need to mentioned in CHANGELOG.md?
No