### PR TITLE
Add Content-Security-Policy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add Dockerfile in docker/images/dev-cli to build a docker image suitable for development.
 - Coin creator tool, `cmd/newcoin`, to quickly bootstrap a new fiber coin
 - Add Dockerfile in `docker/images/dev-dind` to build a docker in docker image based on skycoindev-cli.
+- Add Content-Security-Policy header to http responses
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add Content-Security-Policy header to http responses
+
 ### Fixed
 
 ### Changed
@@ -45,7 +47,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add Dockerfile in docker/images/dev-cli to build a docker image suitable for development.
 - Coin creator tool, `cmd/newcoin`, to quickly bootstrap a new fiber coin
 - Add Dockerfile in `docker/images/dev-dind` to build a docker in docker image based on skycoindev-cli.
-- Add Content-Security-Policy header to http responses
 
 ### Fixed
 

--- a/src/api/address_test.go
+++ b/src/api/address_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	wh "github.com/skycoin/skycoin/src/util/http"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,6 +22,8 @@ func TestVerifyAddress(t *testing.T) {
 		name         string
 		method       string
 		status       int
+		enableCSP    bool
+		csp          string
 		contentType  string
 		csrfDisabled bool
 		httpBody     string
@@ -67,7 +70,6 @@ func TestVerifyAddress(t *testing.T) {
 			}),
 			httpResponse: NewHTTPErrorResponse(http.StatusUnprocessableEntity, "Invalid checksum"),
 		},
-
 		{
 			name:   "200",
 			method: http.MethodPost,
@@ -81,7 +83,6 @@ func TestVerifyAddress(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name:   "200 - csrf disabled",
 			method: http.MethodPost,
@@ -96,12 +97,28 @@ func TestVerifyAddress(t *testing.T) {
 			},
 			csrfDisabled: true,
 		},
+		{
+			name:      "200 enable CSP",
+			method:    http.MethodPost,
+			status:    http.StatusOK,
+			enableCSP: true,
+			csp:       wh.ContentSecurityPolicy,
+			httpBody: toJSON(VerifyAddressRequest{
+				Address: "7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD",
+			}),
+			httpResponse: HTTPResponse{
+				Data: VerifyAddressResponse{
+					Version: 0,
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/api/v2/address/verify"
 			gateway := NewGatewayerMock()
+			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
 
 			req, err := http.NewRequest(tc.method, endpoint, bytes.NewBufferString(tc.httpBody))
 			require.NoError(t, err)
@@ -126,6 +143,8 @@ func TestVerifyAddress(t *testing.T) {
 			cfg := muxConfig{host: configuredHost, appLoc: "."}
 			handler := newServerMux(cfg, gateway, csrfStore, nil)
 			handler.ServeHTTP(rr, req)
+
+			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 
 			status := rr.Code
 			require.Equal(t, tc.status, status, "case: %s, handler returned wrong status code: got `%v` want `%v`",

--- a/src/api/blockchain_test.go
+++ b/src/api/blockchain_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/coin"
 	"github.com/skycoin/skycoin/src/testutil"
-	wh "github.com/skycoin/skycoin/src/util/http"
 	"github.com/skycoin/skycoin/src/visor"
 )
 
@@ -51,8 +50,6 @@ func TestGetBlock(t *testing.T) {
 		name                        string
 		method                      string
 		status                      int
-		enableCSP                   bool
-		csp                         string
 		err                         string
 		hash                        string
 		sha256                      cipher.SHA256
@@ -201,30 +198,6 @@ func TestGetBlock(t *testing.T) {
 				},
 			},
 		},
-		{
-			name:      "200 - got block by hash with CSP enabled",
-			method:    http.MethodGet,
-			status:    http.StatusOK,
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-			hash:      validHashString,
-			sha256:    validSHA256,
-			gatewayGetBlockByHashResult: &coin.SignedBlock{},
-			response: &visor.ReadableBlock{
-				Head: visor.ReadableBlockHeader{
-					BkSeq:             0x0,
-					BlockHash:         "7b8ec8dd836b564f0c85ad088fc744de820345204e154bc1503e04e9d6fdd9f1",
-					PreviousBlockHash: "0000000000000000000000000000000000000000000000000000000000000000",
-					Time:              0x0,
-					Fee:               0x0,
-					Version:           0x0,
-					BodyHash:          "0000000000000000000000000000000000000000000000000000000000000000",
-				},
-				Body: visor.ReadableBlockBody{
-					Transactions: []visor.ReadableTransaction{},
-				},
-			},
-		},
 	}
 
 	for _, tc := range tt {
@@ -233,7 +206,7 @@ func TestGetBlock(t *testing.T) {
 
 			gateway.On("GetSignedBlockByHash", tc.sha256).Return(tc.gatewayGetBlockByHashResult, tc.gatewayGetBlockByHashErr)
 			gateway.On("GetSignedBlockBySeq", tc.seq).Return(tc.gatewayGetBlockBySeqResult, tc.gatewayGetBlockBySeqErr)
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/block"
 
@@ -262,8 +235,6 @@ func TestGetBlock(t *testing.T) {
 
 			handler.ServeHTTP(rr, req)
 
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
-
 			status := rr.Code
 			require.Equal(t, tc.status, status, "case: %s, handler returned wrong status code: got `%v` want `%v`", tc.name, status, tc.status)
 
@@ -290,8 +261,6 @@ func TestGetBlocks(t *testing.T) {
 		name                   string
 		method                 string
 		status                 int
-		enableCSP              bool
-		csp                    string
 		err                    string
 		body                   *httpBody
 		start                  uint64
@@ -358,28 +327,13 @@ func TestGetBlocks(t *testing.T) {
 			gatewayGetBlocksResult: &visor.ReadableBlocks{Blocks: []visor.ReadableBlock{visor.ReadableBlock{}}},
 			response:               &visor.ReadableBlocks{Blocks: []visor.ReadableBlock{visor.ReadableBlock{}}},
 		},
-		{
-			name:      "200 enable CSP",
-			method:    http.MethodGet,
-			status:    http.StatusOK,
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-			body: &httpBody{
-				Start: "1",
-				End:   "3",
-			},
-			start: 1,
-			end:   3,
-			gatewayGetBlocksResult: &visor.ReadableBlocks{Blocks: []visor.ReadableBlock{visor.ReadableBlock{}}},
-			response:               &visor.ReadableBlocks{Blocks: []visor.ReadableBlock{visor.ReadableBlock{}}},
-		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("GetBlocks", tc.start, tc.end).Return(tc.gatewayGetBlocksResult, tc.gatewayGetBlocksError)
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/blocks"
 
@@ -409,8 +363,6 @@ func TestGetBlocks(t *testing.T) {
 
 			handler.ServeHTTP(rr, req)
 
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
-
 			status := rr.Code
 			require.Equal(t, tc.status, status, "wrong status code: got `%v` want `%v`", status, tc.status)
 
@@ -436,8 +388,6 @@ func TestGetLastBlocks(t *testing.T) {
 		method                     string
 		url                        string
 		status                     int
-		enableCSP                  bool
-		csp                        string
 		err                        string
 		body                       httpBody
 		num                        uint64
@@ -492,17 +442,6 @@ func TestGetLastBlocks(t *testing.T) {
 			},
 			num: 1,
 		},
-		{
-			name:      "200 enable CSP",
-			method:    http.MethodGet,
-			status:    http.StatusOK,
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-			body: httpBody{
-				Num: "1",
-			},
-			num: 1,
-		},
 	}
 
 	for _, tc := range tt {
@@ -511,7 +450,7 @@ func TestGetLastBlocks(t *testing.T) {
 			gateway := NewGatewayerMock()
 
 			gateway.On("GetLastBlocks", tc.num).Return(tc.gatewayGetLastBlocksResult, tc.gatewayGetLastBlocksError)
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 
 			v := url.Values{}
 			if tc.body.Num != "" {
@@ -534,7 +473,6 @@ func TestGetLastBlocks(t *testing.T) {
 			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 
 			status := rr.Code
 			require.Equal(t, tc.status, status, "case: %s, handler returned wrong status code: got `%v` want `%v`", tc.name, status, tc.status)

--- a/src/api/csrf_test.go
+++ b/src/api/csrf_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	wh "github.com/skycoin/skycoin/src/util/http"
 	"github.com/stretchr/testify/require"
 )
 
@@ -146,7 +145,7 @@ func TestCSRFWrapper(t *testing.T) {
 				name := fmt.Sprintf("%s %s %s", method, endpoint, c)
 				t.Run(name, func(t *testing.T) {
 					gateway := &GatewayerMock{}
-					gateway.On("IsCSPEnabled").Return(true)
+					gateway.On("IsCSPEnabled").Return(false)
 
 					req, err := http.NewRequest(method, endpoint, nil)
 					require.NoError(t, err)
@@ -166,7 +165,6 @@ func TestCSRFWrapper(t *testing.T) {
 
 					handler.ServeHTTP(rr, req)
 
-					require.Equal(t, wh.ContentSecurityPolicy, rr.Header().Get("content-security-policy"))
 					status := rr.Code
 					require.Equal(t, http.StatusForbidden, status, "wrong status code: got `%v` want `%v`", status, http.StatusForbidden)
 					require.Equal(t, "403 Forbidden - invalid CSRF token\n", rr.Body.String())
@@ -178,11 +176,9 @@ func TestCSRFWrapper(t *testing.T) {
 
 func TestOriginRefererCheck(t *testing.T) {
 	cases := []struct {
-		name      string
-		origin    string
-		referer   string
-		enableCSP bool
-		csp       string
+		name    string
+		origin  string
+		referer string
 	}{
 		{
 			name:   "mismatched origin header",
@@ -192,12 +188,6 @@ func TestOriginRefererCheck(t *testing.T) {
 			name:    "mismatched referer header",
 			referer: "http://example.com/",
 		},
-		{
-			name:      "mismatched origin header enable CSP",
-			origin:    "http://example.com/",
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-		},
 	}
 
 	for _, endpoint := range endpoints {
@@ -205,7 +195,7 @@ func TestOriginRefererCheck(t *testing.T) {
 			name := fmt.Sprintf("%s %s", tc.name, endpoint)
 			t.Run(name, func(t *testing.T) {
 				gateway := &GatewayerMock{}
-				gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+				gateway.On("IsCSPEnabled").Return(false)
 
 				req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 				require.NoError(t, err)
@@ -231,8 +221,6 @@ func TestOriginRefererCheck(t *testing.T) {
 
 				handler.ServeHTTP(rr, req)
 
-				require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
-
 				status := rr.Code
 				require.Equal(t, http.StatusForbidden, status, "wrong status code: got `%v` want `%v`", status, http.StatusForbidden)
 				require.Equal(t, "403 Forbidden\n", rr.Body.String())
@@ -245,7 +233,7 @@ func TestHostCheck(t *testing.T) {
 	for _, endpoint := range endpoints {
 		t.Run(endpoint, func(t *testing.T) {
 			gateway := &GatewayerMock{}
-			gateway.On("IsCSPEnabled").Return(true)
+			gateway.On("IsCSPEnabled").Return(false)
 
 			req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 			require.NoError(t, err)
@@ -265,7 +253,6 @@ func TestHostCheck(t *testing.T) {
 			}, gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
-			require.Equal(t, wh.ContentSecurityPolicy, rr.Header().Get("content-security-policy"))
 
 			status := rr.Code
 			require.Equal(t, http.StatusForbidden, status, "wrong status code: got `%v` want `%v`", status, http.StatusForbidden)
@@ -282,7 +269,7 @@ func TestCSRF(t *testing.T) {
 	updateWalletLabel := func(csrfToken string) *httptest.ResponseRecorder {
 		gateway := &GatewayerMock{}
 		gateway.On("UpdateWalletLabel", "fooid", "foolabel").Return(nil)
-		gateway.On("IsCSPEnabled").Return(true)
+		gateway.On("IsCSPEnabled").Return(false)
 
 		endpoint := "/api/v1/wallet/update"
 
@@ -306,7 +293,6 @@ func TestCSRF(t *testing.T) {
 		}, gateway, csrfStore, nil)
 
 		handler.ServeHTTP(rr, req)
-		require.Equal(t, wh.ContentSecurityPolicy, rr.Header().Get("content-security-policy"))
 
 		return rr
 	}
@@ -318,7 +304,7 @@ func TestCSRF(t *testing.T) {
 
 	// Make a request to /csrf to get a token
 	gateway := &GatewayerMock{}
-	gateway.On("IsCSPEnabled").Return(true)
+	gateway.On("IsCSPEnabled").Return(false)
 	handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
 
 	// non-GET request to /csrf is invalid
@@ -327,8 +313,6 @@ func TestCSRF(t *testing.T) {
 
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
-
-	require.Equal(t, wh.ContentSecurityPolicy, rr.Header().Get("content-security-policy"))
 
 	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
 	require.Nil(t, csrfStore.token, "csrfStore.token should not be set yet")

--- a/src/api/gateway.go
+++ b/src/api/gateway.go
@@ -55,4 +55,5 @@ type Gatewayer interface {
 	GetHealth() (*daemon.Health, error)
 	UnloadWallet(id string) error
 	VerifyTxnVerbose(txn *coin.Transaction) ([]wallet.UxBalance, bool, error)
+	IsCSPDisabled() bool
 }

--- a/src/api/gateway.go
+++ b/src/api/gateway.go
@@ -55,5 +55,5 @@ type Gatewayer interface {
 	GetHealth() (*daemon.Health, error)
 	UnloadWallet(id string) error
 	VerifyTxnVerbose(txn *coin.Transaction) ([]wallet.UxBalance, bool, error)
-	IsCSPDisabled() bool
+	IsCSPEnabled() bool
 }

--- a/src/api/gatewayer_mock_test.go
+++ b/src/api/gatewayer_mock_test.go
@@ -900,6 +900,24 @@ func (m *GatewayerMock) InjectBroadcastTransaction(p0 coin.Transaction) error {
 
 }
 
+// IsCSPEnabled mocked method
+func (m *GatewayerMock) IsCSPEnabled() bool {
+
+	ret := m.Called()
+
+	var r0 bool
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case bool:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
 // IsWalletAPIEnabled mocked method
 func (m *GatewayerMock) IsWalletAPIEnabled() bool {
 

--- a/src/api/health_test.go
+++ b/src/api/health_test.go
@@ -20,8 +20,6 @@ func TestHealthCheckHandler(t *testing.T) {
 	cases := []struct {
 		name         string
 		method       string
-		enableCSP    bool
-		csp          string
 		code         int
 		getHealthErr error
 	}{
@@ -76,7 +74,7 @@ func TestHealthCheckHandler(t *testing.T) {
 			}
 
 			gateway := NewGatewayerMock()
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 
 			if tc.getHealthErr != nil {
 				gateway.On("GetHealth").Return(nil, tc.getHealthErr)
@@ -95,7 +93,6 @@ func TestHealthCheckHandler(t *testing.T) {
 			}
 			handler := newServerMux(cfg, gateway, &CSRFStore{}, nil)
 			handler.ServeHTTP(rr, req)
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 			if tc.code != http.StatusOK {
 				require.Equal(t, tc.code, rr.Code)
 				return

--- a/src/api/health_test.go
+++ b/src/api/health_test.go
@@ -20,6 +20,8 @@ func TestHealthCheckHandler(t *testing.T) {
 	cases := []struct {
 		name         string
 		method       string
+		enableCSP    bool
+		csp          string
 		code         int
 		getHealthErr error
 	}{
@@ -74,6 +76,8 @@ func TestHealthCheckHandler(t *testing.T) {
 			}
 
 			gateway := NewGatewayerMock()
+			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+
 			if tc.getHealthErr != nil {
 				gateway.On("GetHealth").Return(nil, tc.getHealthErr)
 			} else {
@@ -91,7 +95,7 @@ func TestHealthCheckHandler(t *testing.T) {
 			}
 			handler := newServerMux(cfg, gateway, &CSRFStore{}, nil)
 			handler.ServeHTTP(rr, req)
-
+			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 			if tc.code != http.StatusOK {
 				require.Equal(t, tc.code, rr.Code)
 				return

--- a/src/api/http.go
+++ b/src/api/http.go
@@ -252,6 +252,9 @@ func newServerMux(c muxConfig, gateway Gatewayer, csrfStore *CSRFStore, rpc *web
 		handler = CSRFCheck(csrfStore, handler)
 		handler = headerCheck(c.host, handler)
 		handler = gziphandler.GzipHandler(handler)
+		if !gateway.IsCSPDisabled() {
+			handler = wh.EnableCSPHandler(handler)
+		}
 		mux.Handle(endpoint, handler)
 	}
 

--- a/src/api/http.go
+++ b/src/api/http.go
@@ -268,7 +268,7 @@ func newServerMux(c muxConfig, gateway Gatewayer, csrfStore *CSRFStore, rpc *web
 
 	indexHandler := newIndexHandler(c.appLoc, c.enableGUI)
 	if gateway.IsCSPEnabled() {
-		indexHandler = wh.EnableCSPHandler(indexHandler)
+		indexHandler = wh.CSPHandler(indexHandler)
 	}
 	webHandler("/", indexHandler)
 
@@ -277,7 +277,7 @@ func newServerMux(c muxConfig, gateway Gatewayer, csrfStore *CSRFStore, rpc *web
 
 		fs := http.FileServer(http.Dir(c.appLoc))
 		if gateway.IsCSPEnabled() {
-			fs = wh.EnableCSPHandler(fs)
+			fs = wh.CSPHandler(fs)
 		}
 
 		for _, fileInfo := range fileInfos {

--- a/src/api/spend_test.go
+++ b/src/api/spend_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/skycoin/skycoin/src/coin"
 	"github.com/skycoin/skycoin/src/testutil" //http,json helpers
 	"github.com/skycoin/skycoin/src/util/fee"
-	wh "github.com/skycoin/skycoin/src/util/http"
 	"github.com/skycoin/skycoin/src/visor/blockdb"
 	"github.com/skycoin/skycoin/src/wallet"
 )
@@ -113,8 +112,6 @@ func TestCreateTransaction(t *testing.T) {
 		method                         string
 		body                           *rawRequest
 		status                         int
-		enableCSP                      bool
-		csp                            string
 		err                            string
 		gatewayCreateTransactionResult *coin.Transaction
 		gatewayCreateTransactionInputs []wallet.UxBalance
@@ -840,24 +837,12 @@ func TestCreateTransaction(t *testing.T) {
 			gatewayCreateTransactionErr: wallet.ErrWalletAPIDisabled,
 			err: "403 Forbidden",
 		},
-		{
-			name:      "200 - manual type nonzero hours - csrf disabled - csp enabled",
-			method:    http.MethodPost,
-			body:      validBody,
-			status:    http.StatusOK,
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-			gatewayCreateTransactionResult: txn,
-			gatewayCreateTransactionInputs: inputs,
-			createTransactionResponse:      createTxnResponse,
-			csrfDisabled:                   true,
-		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &GatewayerMock{}
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 
 			// If the rawRequestBody can be deserialized to CreateTransactionRequest, use it to mock gateway.CreateTransaction
 			serializedBody, err := json.Marshal(tc.body)
@@ -898,7 +883,6 @@ func TestCreateTransaction(t *testing.T) {
 
 			handler.ServeHTTP(rr, req)
 
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 			status := rr.Code
 			require.Equal(t, tc.status, status, "case: %s, handler returned wrong status code: got `%v` want `%v`", tc.name, status, tc.status)
 

--- a/src/api/uxout_test.go
+++ b/src/api/uxout_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/testutil"
-	wh "github.com/skycoin/skycoin/src/util/http"
 	"github.com/skycoin/skycoin/src/visor/historydb"
 )
 
@@ -32,8 +31,6 @@ func TestGetUxOutByID(t *testing.T) {
 		method                  string
 		url                     string
 		status                  int
-		enableCSP               bool
-		csp                     string
 		err                     string
 		httpBody                *httpBody
 		uxid                    string
@@ -114,21 +111,6 @@ func TestGetUxOutByID(t *testing.T) {
 			getGetUxOutByIDResponse: &historydb.UxOut{},
 			httpResponse:            historydb.NewUxOutJSON(&historydb.UxOut{}),
 		},
-		{
-			name:      "200 - enable CSP",
-			method:    http.MethodGet,
-			status:    http.StatusOK,
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-			err:       "404 Not Found",
-			httpBody: &httpBody{
-				uxid: validHash,
-			},
-			uxid:                    validHash,
-			getGetUxOutByIDArg:      testutil.SHA256FromHex(t, validHash),
-			getGetUxOutByIDResponse: &historydb.UxOut{},
-			httpResponse:            historydb.NewUxOutJSON(&historydb.UxOut{}),
-		},
 	}
 
 	for _, tc := range tt {
@@ -136,7 +118,7 @@ func TestGetUxOutByID(t *testing.T) {
 			gateway := NewGatewayerMock()
 			endpoint := "/api/v1/uxout"
 			gateway.On("GetUxOutByID", tc.getGetUxOutByIDArg).Return(tc.getGetUxOutByIDResponse, tc.getGetUxOutByIDError)
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 
 			v := url.Values{}
 			if tc.httpBody != nil {
@@ -164,7 +146,6 @@ func TestGetUxOutByID(t *testing.T) {
 			rr := httptest.NewRecorder()
 			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
 			handler.ServeHTTP(rr, req)
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 
 			status := rr.Code
 			require.Equal(t, tc.status, status, "case: %s, handler returned wrong status code: got `%v` want `%v`",
@@ -195,8 +176,6 @@ func TestGetAddrUxOuts(t *testing.T) {
 		method                string
 		url                   string
 		status                int
-		enableCSP             bool
-		csp                   string
 		err                   string
 		httpBody              *httpBody
 		getAddrUxOutsArg      []cipher.Address
@@ -251,19 +230,6 @@ func TestGetAddrUxOuts(t *testing.T) {
 			getAddrUxOutsResponse: []*historydb.UxOut{},
 			httpResponse:          []*historydb.UxOutJSON{},
 		},
-		{
-			name:      "200 - enable CSP",
-			method:    http.MethodGet,
-			status:    http.StatusOK,
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-			httpBody: &httpBody{
-				address: addressForGwResponse.String(),
-			},
-			getAddrUxOutsArg:      []cipher.Address{addressForGwResponse},
-			getAddrUxOutsResponse: []*historydb.UxOut{},
-			httpResponse:          []*historydb.UxOutJSON{},
-		},
 	}
 
 	for _, tc := range tt {
@@ -271,7 +237,7 @@ func TestGetAddrUxOuts(t *testing.T) {
 			endpoint := "/api/v1/address_uxouts"
 			gateway := NewGatewayerMock()
 			gateway.On("GetAddrUxOuts", tc.getAddrUxOutsArg).Return(tc.getAddrUxOutsResponse, tc.getAddrUxOutsError)
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 
 			v := url.Values{}
 			if tc.httpBody != nil {
@@ -297,7 +263,6 @@ func TestGetAddrUxOuts(t *testing.T) {
 			rr := httptest.NewRecorder()
 			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
 			handler.ServeHTTP(rr, req)
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 
 			status := rr.Code
 			require.Equal(t, tc.status, status, "case: %s, handler returned wrong status code: got `%v` want `%v`",

--- a/src/api/wallet_test.go
+++ b/src/api/wallet_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/coin"
 	"github.com/skycoin/skycoin/src/util/fee"
-	wh "github.com/skycoin/skycoin/src/util/http"
 	"github.com/skycoin/skycoin/src/visor"
 	"github.com/skycoin/skycoin/src/wallet"
 )
@@ -39,8 +38,6 @@ func TestWalletSpendHandler(t *testing.T) {
 		method                        string
 		body                          *httpBody
 		status                        int
-		enableCSP                     bool
-		csp                           string
 		err                           string
 		walletID                      string
 		coins                         uint64
@@ -325,35 +322,6 @@ func TestWalletSpendHandler(t *testing.T) {
 			csrfDisabled: true,
 		},
 		{
-			name:   "200 - OK - CSP enabled",
-			method: http.MethodPost,
-			body: &httpBody{
-				WalletID: "1234",
-				Dst:      "2konv5no3DZvSMxf2GPVtAfZinfwqCGhfVQ",
-				Coins:    "12",
-			},
-			status:             http.StatusOK,
-			enableCSP:          true,
-			csp:                wh.ContentSecurityPolicy,
-			walletID:           "1234",
-			coins:              12,
-			dst:                "2konv5no3DZvSMxf2GPVtAfZinfwqCGhfVQ",
-			gatewaySpendResult: &coin.Transaction{},
-			spendResult: &SpendResult{
-				Balance: &wallet.BalancePair{},
-				Transaction: &visor.ReadableTransaction{
-					Length:    0,
-					Type:      0,
-					Hash:      "78877fa898f0b4c45c9c33ae941e40617ad7c8657a307db62bc5691f92f4f60e",
-					InnerHash: "0000000000000000000000000000000000000000000000000000000000000000",
-					Timestamp: 0,
-					Sigs:      []string{},
-					In:        []string{},
-					Out:       []visor.ReadableTransactionOutput{},
-				},
-			},
-		},
-		{
 			name:   "400 - missing password",
 			method: http.MethodPost,
 			body: &httpBody{
@@ -442,7 +410,7 @@ func TestWalletSpendHandler(t *testing.T) {
 			gateway.On("Spend", tc.walletID, []byte(tc.password), tc.coins, addr).Return(tc.gatewaySpendResult, tc.gatewaySpendErr)
 			gateway.On("GetWalletBalance", tc.walletID).Return(tc.gatewayGetWalletBalanceResult.BalancePair,
 				tc.gatewayGetWalletBalanceResult.Addresses, tc.gatewayBalanceErr)
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/spend"
 
@@ -480,8 +448,6 @@ func TestWalletSpendHandler(t *testing.T) {
 
 			handler.ServeHTTP(rr, req)
 
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
-
 			status := rr.Code
 			require.Equal(t, tc.status, status)
 
@@ -514,8 +480,6 @@ func TestWalletGet(t *testing.T) {
 		url                    string
 		body                   *httpBody
 		status                 int
-		enableCSP              bool
-		csp                    string
 		err                    string
 		walletID               string
 		gatewayGetWalletResult wallet.Wallet
@@ -576,29 +540,13 @@ func TestWalletGet(t *testing.T) {
 			},
 			responseBody: WalletResponse{Entries: resEntries[:]},
 		},
-		{
-			name:   "200 - OK - enable CSP",
-			method: http.MethodGet,
-			body: &httpBody{
-				WalletID: "1234",
-			},
-			status:    http.StatusOK,
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-			walletID:  "1234",
-			gatewayGetWalletResult: wallet.Wallet{
-				Meta:    map[string]string{"seed": "seed", "lastSeed": "seed"},
-				Entries: cloneEntries(entries),
-			},
-			responseBody: WalletResponse{Entries: resEntries[:]},
-		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("GetWallet", tc.walletID).Return(&tc.gatewayGetWalletResult, tc.gatewayGetWalletErr)
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 			v := url.Values{}
 
 			endpoint := "/api/v1/wallet"
@@ -625,7 +573,6 @@ func TestWalletGet(t *testing.T) {
 			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 
 			status := rr.Code
 			require.Equal(t, tc.status, status, "case: %s, handler returned wrong status code: got `%v` want `%v`",
@@ -657,8 +604,6 @@ func TestWalletBalanceHandler(t *testing.T) {
 		method                        string
 		body                          *httpBody
 		status                        int
-		enableCSP                     bool
-		csp                           string
 		err                           string
 		walletID                      string
 		gatewayGetWalletBalanceResult BalanceResponse
@@ -734,19 +679,6 @@ func TestWalletBalanceHandler(t *testing.T) {
 			walletID: "foo",
 			result:   &wallet.BalancePair{},
 		},
-		{
-			name:   "200 - OK - enable CSP",
-			method: http.MethodGet,
-			body: &httpBody{
-				WalletID: "foo",
-			},
-			status:    http.StatusOK,
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-			err:       "",
-			walletID:  "foo",
-			result:    &wallet.BalancePair{},
-		},
 	}
 
 	for _, tc := range tt {
@@ -754,7 +686,7 @@ func TestWalletBalanceHandler(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("GetWalletBalance", tc.walletID).Return(tc.gatewayGetWalletBalanceResult.BalancePair,
 				tc.gatewayGetWalletBalanceResult.Addresses, tc.gatewayBalanceErr)
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/balance"
 
@@ -780,7 +712,6 @@ func TestWalletBalanceHandler(t *testing.T) {
 			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 
 			status := rr.Code
 			require.Equal(t, tc.status, status, "case: %s, handler returned wrong status code: got `%v` want `%v`", tc.name, status, tc.status)
@@ -813,8 +744,6 @@ func TestUpdateWalletLabelHandler(t *testing.T) {
 		url                         string
 		body                        *httpBody
 		status                      int
-		enableCSP                   bool
-		csp                         string
 		err                         string
 		walletID                    string
 		label                       string
@@ -898,29 +827,13 @@ func TestUpdateWalletLabelHandler(t *testing.T) {
 			gatewayUpdateWalletLabelErr: nil,
 			responseBody:                "\"success\"",
 		},
-		{
-			name:   "200 OK - enable CSP",
-			method: http.MethodPost,
-			body: &httpBody{
-				WalletID: "foo",
-				Label:    "label",
-			},
-			status:    http.StatusOK,
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-			err:       "",
-			walletID:  "foo",
-			label:     "label",
-			gatewayUpdateWalletLabelErr: nil,
-			responseBody:                "\"success\"",
-		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("UpdateWalletLabel", tc.walletID, tc.label).Return(tc.gatewayUpdateWalletLabelErr)
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/update"
 
@@ -947,7 +860,6 @@ func TestUpdateWalletLabelHandler(t *testing.T) {
 			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 
 			status := rr.Code
 			require.Equal(t, tc.status, status, "case: %s, handler returned wrong status code: got `%v` want `%v`",
@@ -974,8 +886,6 @@ func TestWalletTransactionsHandler(t *testing.T) {
 		method                                string
 		body                                  *httpBody
 		status                                int
-		enableCSP                             bool
-		csp                                   string
 		err                                   string
 		walletID                              string
 		gatewayGetWalletUnconfirmedTxnsResult []visor.UnconfirmedTxn
@@ -1039,26 +949,12 @@ func TestWalletTransactionsHandler(t *testing.T) {
 			gatewayGetWalletUnconfirmedTxnsResult: make([]visor.UnconfirmedTxn, 1),
 			responseBody:                          UnconfirmedTxnsResponse{Transactions: []visor.ReadableUnconfirmedTxn{*unconfirmedTxn}},
 		},
-		{
-			name:   "200 - OK - enable CSP",
-			method: http.MethodGet,
-			body: &httpBody{
-				WalletID: "foo",
-			},
-			status:    http.StatusOK,
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-			err:       "",
-			walletID:  "foo",
-			gatewayGetWalletUnconfirmedTxnsResult: make([]visor.UnconfirmedTxn, 1),
-			responseBody:                          UnconfirmedTxnsResponse{Transactions: []visor.ReadableUnconfirmedTxn{*unconfirmedTxn}},
-		},
 	}
 
 	for _, tc := range tt {
 		gateway := &GatewayerMock{}
 		gateway.On("GetWalletUnconfirmedTxns", tc.walletID).Return(tc.gatewayGetWalletUnconfirmedTxnsResult, tc.gatewayGetWalletUnconfirmedTxnsErr)
-		gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+		gateway.On("IsCSPEnabled").Return(false)
 
 		endpoint := "/api/v1/wallet/transactions"
 
@@ -1083,7 +979,6 @@ func TestWalletTransactionsHandler(t *testing.T) {
 		handler := newServerMux(mxConfig, gateway, csrfStore, nil)
 
 		handler.ServeHTTP(rr, req)
-		require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 
 		status := rr.Code
 		require.Equal(t, tc.status, status, "case: %s, handler returned wrong status code: got `%v` want `%v`",
@@ -1118,8 +1013,6 @@ func TestWalletCreateHandler(t *testing.T) {
 		method                    string
 		body                      *httpBody
 		status                    int
-		enableCSP                 bool
-		csp                       string
 		err                       string
 		wltName                   string
 		options                   wallet.Options
@@ -1287,42 +1180,6 @@ func TestWalletCreateHandler(t *testing.T) {
 			csrfDisabled: true,
 		},
 		{
-			name:   "200 - OK - CSRF disabled - CSP enabled",
-			method: http.MethodPost,
-			body: &httpBody{
-				Seed:  "foo",
-				Label: "bar",
-				ScanN: "2",
-			},
-			status:    http.StatusOK,
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-			err:       "",
-			wltName:   "filename",
-			options: wallet.Options{
-				Label:    "bar",
-				Seed:     "foo",
-				Password: []byte{},
-				ScanN:    2,
-			},
-			gatewayCreateWalletResult: wallet.Wallet{
-				Meta: map[string]string{
-					"filename": "filename",
-				},
-			},
-			scanWalletAddressesResult: wallet.Wallet{
-				Meta: map[string]string{
-					"filename": "filename",
-				},
-			},
-			responseBody: WalletResponse{
-				Meta: WalletMeta{
-					Filename: "filename",
-				},
-			},
-			csrfDisabled: true,
-		},
-		{
 			name:   "200 - OK - Encrypted",
 			method: http.MethodPost,
 			body: &httpBody{
@@ -1387,7 +1244,7 @@ func TestWalletCreateHandler(t *testing.T) {
 			}
 			gateway.On("CreateWallet", "", tc.options).Return(&tc.gatewayCreateWalletResult, tc.gatewayCreateWalletErr)
 			// gateway.On("ScanAheadWalletAddresses", tc.wltName, tc.options.Password, tc.scnN-1).Return(&tc.scanWalletAddressesResult, tc.scanWalletAddressesError)
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/create"
 
@@ -1429,7 +1286,6 @@ func TestWalletCreateHandler(t *testing.T) {
 			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 
 			status := rr.Code
 			require.Equal(t, tc.status, status, "case: %s, handler returned wrong status code: got `%v` want `%v`",
@@ -1459,8 +1315,6 @@ func TestWalletNewSeed(t *testing.T) {
 		method    string
 		body      *httpBody
 		status    int
-		enableCSP bool
-		csp       string
 		err       string
 		entropy   string
 		resultLen int
@@ -1519,18 +1373,6 @@ func TestWalletNewSeed(t *testing.T) {
 			entropy:   "256",
 			resultLen: 24,
 		},
-		{
-			name:   "200 - OK | 24 word seed - enable CSP",
-			method: http.MethodGet,
-			body: &httpBody{
-				Entropy: "256",
-			},
-			status:    http.StatusOK,
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-			entropy:   "256",
-			resultLen: 24,
-		},
 	}
 
 	// Loop over each test case
@@ -1538,7 +1380,7 @@ func TestWalletNewSeed(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("IsWalletAPIEnabled").Return(true)
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/newSeed"
 
@@ -1566,7 +1408,6 @@ func TestWalletNewSeed(t *testing.T) {
 			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 
 			status := rr.Code
 			require.Equal(t, tc.status, status, "case: %s, handler returned wrong status code: got `%v` expected `%v`", tc.name, status, tc.status)
@@ -1601,8 +1442,6 @@ func TestGetWalletSeed(t *testing.T) {
 		wltID             string
 		password          string
 		gatewayReturnArgs []interface{}
-		enableCSP         bool
-		csp               string
 		expectStatus      int
 		expectSeed        string
 		expectErr         string
@@ -1632,20 +1471,6 @@ func TestGetWalletSeed(t *testing.T) {
 			expectStatus: http.StatusOK,
 			expectSeed:   "seed",
 			csrfDisabled: true,
-		},
-		{
-			name:     "200 - OK - CSP enabled",
-			method:   http.MethodPost,
-			wltID:    "wallet.wlt",
-			password: "pwd",
-			gatewayReturnArgs: []interface{}{
-				"seed",
-				nil,
-			},
-			enableCSP:    true,
-			csp:          wh.ContentSecurityPolicy,
-			expectStatus: http.StatusOK,
-			expectSeed:   "seed",
 		},
 		{
 			name:              "400 - missing wallet id ",
@@ -1716,7 +1541,7 @@ func TestGetWalletSeed(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := NewGatewayerMock()
 			gateway.On("GetWalletSeed", tc.wltID, []byte(tc.password)).Return(tc.gatewayReturnArgs...)
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/seed"
 
@@ -1739,7 +1564,6 @@ func TestGetWalletSeed(t *testing.T) {
 			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 
 			status := rr.Code
 			require.Equal(t, tc.expectStatus, status)
@@ -1787,8 +1611,6 @@ func TestWalletNewAddressesHandler(t *testing.T) {
 		name                      string
 		method                    string
 		body                      *httpBody
-		enableCSP                 bool
-		csp                       string
 		status                    int
 		err                       string
 		walletID                  string
@@ -1927,29 +1749,13 @@ func TestWalletNewAddressesHandler(t *testing.T) {
 			responseBody:              responseAddresses,
 			csrfDisabled:              true,
 		},
-		{
-			name:   "200 - OK - CSRF disabled - CSP enabled",
-			method: http.MethodPost,
-			body: &httpBody{
-				ID:  "foo",
-				Num: "1",
-			},
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-			status:    http.StatusOK,
-			walletID:  "foo",
-			n:         1,
-			gatewayNewAddressesResult: addrs,
-			responseBody:              responseAddresses,
-			csrfDisabled:              true,
-		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("NewAddresses", tc.walletID, []byte(tc.password), tc.n).Return(tc.gatewayNewAddressesResult, tc.gatewayNewAddressesErr)
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/newAddress"
 
@@ -1980,7 +1786,6 @@ func TestWalletNewAddressesHandler(t *testing.T) {
 			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 
 			status := rr.Code
 			require.Equal(t, tc.status, status, "wrong status code: got `%v` want `%v`", status, tc.status)
@@ -2005,8 +1810,6 @@ func TestGetWalletFolderHandler(t *testing.T) {
 	tt := []struct {
 		name                 string
 		method               string
-		enableCSP            bool
-		csp                  string
 		status               int
 		err                  string
 		getWalletDirResponse string
@@ -2029,17 +1832,6 @@ func TestGetWalletFolderHandler(t *testing.T) {
 			},
 		},
 		{
-			name:                 "200 - enable CSP",
-			method:               http.MethodGet,
-			enableCSP:            true,
-			csp:                  wh.ContentSecurityPolicy,
-			status:               http.StatusOK,
-			getWalletDirResponse: "/wallet/folder/address",
-			httpResponse: WalletFolder{
-				Address: "/wallet/folder/address",
-			},
-		},
-		{
 			name:            "403 - wallet API disabled",
 			method:          http.MethodGet,
 			status:          http.StatusForbidden,
@@ -2051,7 +1843,7 @@ func TestGetWalletFolderHandler(t *testing.T) {
 	for _, tc := range tt {
 		gateway := &GatewayerMock{}
 		gateway.On("GetWalletDir").Return(tc.getWalletDirResponse, tc.getWalletDirErr)
-		gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+		gateway.On("IsCSPEnabled").Return(false)
 		endpoint := "/api/v1/wallets/folderName"
 
 		req, err := http.NewRequest(tc.method, endpoint, nil)
@@ -2066,7 +1858,6 @@ func TestGetWalletFolderHandler(t *testing.T) {
 		handler := newServerMux(mxConfig, gateway, csrfStore, nil)
 
 		handler.ServeHTTP(rr, req)
-		require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 
 		status := rr.Code
 		require.Equal(t, tc.status, status, "case: %s, handler returned wrong status code: got `%v` want `%v`",
@@ -2100,8 +1891,6 @@ func TestGetWallets(t *testing.T) {
 	cases := []struct {
 		name               string
 		method             string
-		enableCSP          bool
-		csp                string
 		status             int
 		err                string
 		getWalletsResponse wallet.Wallets
@@ -2273,152 +2062,12 @@ func TestGetWallets(t *testing.T) {
 				},
 			},
 		},
-		{
-			name:      "200 - enable CSP",
-			method:    http.MethodGet,
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-			status:    http.StatusOK,
-			getWalletsResponse: wallet.Wallets{
-				"foofilename": {
-					Meta: map[string]string{
-						"foo":        "bar",
-						"seed":       "fooseed",
-						"lastSeed":   "foolastseed",
-						"coin":       "foocoin",
-						"filename":   "foofilename",
-						"label":      "foolabel",
-						"type":       "footype",
-						"version":    "fooversion",
-						"cryptoType": "foocryptotype",
-						"tm":         "345678",
-						"encrypted":  "true",
-					},
-					Entries: []wallet.Entry{
-						{
-							Address: addrs[0],
-							Public:  pubkeys[0],
-							Secret:  seckeys[0],
-						},
-					},
-				},
-				"foofilename2": {
-					Meta: map[string]string{
-						"foo":        "bar2",
-						"seed":       "fooseed2",
-						"lastSeed":   "foolastseed2",
-						"coin":       "foocoin",
-						"filename":   "foofilename2",
-						"label":      "foolabel2",
-						"type":       "footype",
-						"version":    "fooversion",
-						"cryptoType": "foocryptotype",
-						"tm":         "123456",
-						"encrypted":  "false",
-					},
-					Entries: []wallet.Entry{
-						{
-							Address: addrs[1],
-							Public:  pubkeys[1],
-							Secret:  seckeys[1],
-						},
-					},
-				},
-				"foofilename3": {
-					Meta: map[string]string{
-						"foo":        "bar3",
-						"seed":       "fooseed3",
-						"lastSeed":   "foolastseed3",
-						"coin":       "foocoin",
-						"filename":   "foofilename3",
-						"label":      "foolabel3",
-						"type":       "footype",
-						"version":    "fooversion",
-						"cryptoType": "foocryptotype",
-						"tm":         "234567",
-						"encrypted":  "true",
-					},
-					Entries: []wallet.Entry{
-						{
-							Address: addrs[2],
-							Public:  pubkeys[2],
-							Secret:  seckeys[2],
-						},
-						{
-							Address: addrs[3],
-							Public:  pubkeys[3],
-							Secret:  seckeys[3],
-						},
-					},
-				},
-			},
-			httpResponse: []*WalletResponse{
-				{
-					Meta: WalletMeta{
-						Coin:       "foocoin",
-						Filename:   "foofilename2",
-						Label:      "foolabel2",
-						Type:       "footype",
-						Version:    "fooversion",
-						CryptoType: "foocryptotype",
-						Timestamp:  123456,
-						Encrypted:  false,
-					},
-					Entries: []WalletEntry{
-						{
-							Address: addrs[1].String(),
-							Public:  pubkeys[1].Hex(),
-						},
-					},
-				},
-				{
-					Meta: WalletMeta{
-						Coin:       "foocoin",
-						Filename:   "foofilename3",
-						Label:      "foolabel3",
-						Type:       "footype",
-						Version:    "fooversion",
-						CryptoType: "foocryptotype",
-						Timestamp:  234567,
-						Encrypted:  true,
-					},
-					Entries: []WalletEntry{
-						{
-							Address: addrs[2].String(),
-							Public:  pubkeys[2].Hex(),
-						},
-						{
-							Address: addrs[3].String(),
-							Public:  pubkeys[3].Hex(),
-						},
-					},
-				},
-				{
-					Meta: WalletMeta{
-						Coin:       "foocoin",
-						Filename:   "foofilename",
-						Label:      "foolabel",
-						Type:       "footype",
-						Version:    "fooversion",
-						CryptoType: "foocryptotype",
-						Timestamp:  345678,
-						Encrypted:  true,
-					},
-					Entries: []WalletEntry{
-						{
-							Address: addrs[0].String(),
-							Public:  pubkeys[0].Hex(),
-						},
-					},
-				},
-			},
-		},
 	}
 
 	for _, tc := range cases {
 		gateway := &GatewayerMock{}
 		gateway.On("GetWallets").Return(tc.getWalletsResponse, tc.getWalletsErr)
-		gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+		gateway.On("IsCSPEnabled").Return(false)
 
 		endpoint := "/api/v1/wallets"
 
@@ -2434,7 +2083,6 @@ func TestGetWallets(t *testing.T) {
 		handler := newServerMux(mxConfig, gateway, csrfStore, nil)
 
 		handler.ServeHTTP(rr, req)
-		require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 
 		status := rr.Code
 		require.Equal(t, tc.status, status, "case: %s, handler returned wrong status code: got `%v` want `%v`",
@@ -2457,8 +2105,6 @@ func TestWalletUnloadHandler(t *testing.T) {
 	tt := []struct {
 		name            string
 		method          string
-		enableCSP       bool
-		csp             string
 		status          int
 		err             string
 		walletID        string
@@ -2499,21 +2145,13 @@ func TestWalletUnloadHandler(t *testing.T) {
 			walletID:     "wallet.wlt",
 			csrfDisabled: true,
 		},
-		{
-			name:      "200 - ok - enable CSP",
-			method:    http.MethodPost,
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-			status:    http.StatusOK,
-			walletID:  "wallet.wlt",
-		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("UnloadWallet", tc.walletID).Return(tc.unloadWalletErr)
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/unload"
 			v := url.Values{}
@@ -2536,7 +2174,6 @@ func TestWalletUnloadHandler(t *testing.T) {
 			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 
 			status := rr.Code
 			require.Equal(t, tc.status, status, "wrong status code: got `%v` want `%v`", status, tc.status)
@@ -2561,8 +2198,6 @@ func TestEncryptWallet(t *testing.T) {
 		wltID         string
 		password      string
 		gatewayReturn gatewayReturnPair
-		enableCSP     bool
-		csp           string
 		status        int
 		expectWallet  WalletResponse
 		expectErr     string
@@ -2585,34 +2220,6 @@ func TestEncryptWallet(t *testing.T) {
 				},
 			},
 			status: http.StatusOK,
-			expectWallet: WalletResponse{
-				Meta: WalletMeta{
-					Filename:  "wallet.wlt",
-					Encrypted: true,
-				},
-				Entries: responseEntries,
-			},
-		},
-		{
-			name:     "200 - OK - enable CSP",
-			method:   http.MethodPost,
-			wltID:    "wallet.wlt",
-			password: "pwd",
-			gatewayReturn: gatewayReturnPair{
-				w: &wallet.Wallet{
-					Meta: map[string]string{
-						"filename":  "wallet.wlt",
-						"seed":      "seed",
-						"lastSeed":  "lastSeed",
-						"secrets":   "secrets",
-						"encrypted": "true",
-					},
-					Entries: cloneEntries(entries),
-				},
-			},
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-			status:    http.StatusOK,
 			expectWallet: WalletResponse{
 				Meta: WalletMeta{
 					Filename:  "wallet.wlt",
@@ -2697,7 +2304,7 @@ func TestEncryptWallet(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := NewGatewayerMock()
 			gateway.On("EncryptWallet", tc.wltID, []byte(tc.password)).Return(tc.gatewayReturn.w, tc.gatewayReturn.err)
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/encrypt"
 			v := url.Values{}
@@ -2717,7 +2324,6 @@ func TestEncryptWallet(t *testing.T) {
 			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 
 			status := rr.Code
 			require.Equal(t, tc.status, status, "wrong status code: got `%v` want `%v`, body: %v", status, tc.status, rr.Body.String())
@@ -2751,8 +2357,6 @@ func TestDecryptWallet(t *testing.T) {
 		wltID         string
 		password      string
 		gatewayReturn gatewayReturnPair
-		enableCSP     bool
-		csp           string
 		status        int
 		expectWallet  WalletResponse
 		expectErr     string
@@ -2776,34 +2380,6 @@ func TestDecryptWallet(t *testing.T) {
 				},
 			},
 			status: http.StatusOK,
-			expectWallet: WalletResponse{
-				Meta: WalletMeta{
-					Filename:  "wallet",
-					Encrypted: false,
-				},
-				Entries: responseEntries,
-			},
-		},
-		{
-			name:     "200 OK - enable CSP",
-			method:   http.MethodPost,
-			wltID:    "wallet.wlt",
-			password: "pwd",
-			gatewayReturn: gatewayReturnPair{
-				w: &wallet.Wallet{
-					Meta: map[string]string{
-						"filename":  "wallet",
-						"seed":      "seed",
-						"lastSeed":  "lastSeed",
-						"secrets":   "",
-						"encrypted": "false",
-					},
-					Entries: cloneEntries(entries),
-				},
-			},
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-			status:    http.StatusOK,
 			expectWallet: WalletResponse{
 				Meta: WalletMeta{
 					Filename:  "wallet",
@@ -2915,7 +2491,7 @@ func TestDecryptWallet(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := NewGatewayerMock()
 			gateway.On("DecryptWallet", tc.wltID, []byte(tc.password)).Return(tc.gatewayReturn.w, tc.gatewayReturn.err)
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/decrypt"
 			v := url.Values{}
@@ -2935,7 +2511,6 @@ func TestDecryptWallet(t *testing.T) {
 			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 
 			status := rr.Code
 			require.Equal(t, tc.status, status, "wrong status code: got `%v` want `%v`", status, tc.status)

--- a/src/api/webrpc_test.go
+++ b/src/api/webrpc_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/skycoin/skycoin/src/api/webrpc"
-	wh "github.com/skycoin/skycoin/src/util/http"
 )
 
 func TestWebRPC(t *testing.T) {
@@ -20,33 +19,14 @@ func TestWebRPC(t *testing.T) {
 	}
 
 	cases := []struct {
-		name      string
-		enableCSP bool
-		csp       string
-		status    int
-		args      args
-		want      webrpc.Response
+		name   string
+		status int
+		args   args
+		want   webrpc.Response
 	}{
 		{
 			name:   "http GET",
 			status: http.StatusOK,
-			args: args{
-				httpMethod: http.MethodGet,
-				req:        webrpc.Request{},
-			},
-			want: webrpc.Response{
-				Jsonrpc: "2.0",
-				Error: &webrpc.RPCError{
-					Code:    webrpc.ErrCodeInvalidRequest,
-					Message: webrpc.ErrMsgNotPost,
-				},
-			},
-		},
-		{
-			name:      "http GET - enable CSP",
-			enableCSP: true,
-			csp:       wh.ContentSecurityPolicy,
-			status:    http.StatusOK,
 			args: args{
 				httpMethod: http.MethodGet,
 				req:        webrpc.Request{},
@@ -87,7 +67,7 @@ func TestWebRPC(t *testing.T) {
 			}
 
 			gateway := NewGatewayerMock()
-			gateway.On("IsCSPEnabled").Return(tc.enableCSP)
+			gateway.On("IsCSPEnabled").Return(false)
 			handler := newServerMux(muxConfig{
 				host:            configuredHost,
 				appLoc:          ".",
@@ -96,7 +76,6 @@ func TestWebRPC(t *testing.T) {
 
 			rr := httptest.NewRecorder()
 			handler.ServeHTTP(rr, req)
-			require.Equal(t, tc.csp, rr.Header().Get("content-security-policy"))
 
 			require.Equal(t, tc.status, rr.Code)
 

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -22,6 +22,7 @@ type GatewayConfig struct {
 	BufferSize      int
 	EnableWalletAPI bool
 	EnableGUI       bool
+	DisabledCSP     bool
 }
 
 // NewGatewayConfig create and init an GatewayConfig
@@ -30,6 +31,7 @@ func NewGatewayConfig() GatewayConfig {
 		BufferSize:      32,
 		EnableWalletAPI: false,
 		EnableGUI:       false,
+		DisabledCSP:     false,
 	}
 }
 
@@ -1178,4 +1180,9 @@ func (gw *Gateway) VerifyTxnVerbose(txn *coin.Transaction) ([]wallet.UxBalance, 
 		uxs, isTxnConfirmed, err = gw.v.VerifyTxnVerbose(txn)
 	})
 	return uxs, isTxnConfirmed, err
+}
+
+// IsCSPDisabled returns if the csp is disabled
+func (gw *Gateway) IsCSPDisabled() bool {
+	return gw.Config.DisabledCSP
 }

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -1182,7 +1182,7 @@ func (gw *Gateway) VerifyTxnVerbose(txn *coin.Transaction) ([]wallet.UxBalance, 
 	return uxs, isTxnConfirmed, err
 }
 
-// IsCSPDisabled returns if the csp is disabled
-func (gw *Gateway) IsCSPDisabled() bool {
-	return gw.Config.DisabledCSP
+// IsCSPEnabled returns if the csp is enabled
+func (gw *Gateway) IsCSPEnabled() bool {
+	return !gw.Config.DisabledCSP
 }

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -22,7 +22,7 @@ type GatewayConfig struct {
 	BufferSize      int
 	EnableWalletAPI bool
 	EnableGUI       bool
-	DisabledCSP     bool
+	DisableCSP      bool
 }
 
 // NewGatewayConfig create and init an GatewayConfig
@@ -31,7 +31,7 @@ func NewGatewayConfig() GatewayConfig {
 		BufferSize:      32,
 		EnableWalletAPI: false,
 		EnableGUI:       false,
-		DisabledCSP:     false,
+		DisableCSP:      false,
 	}
 }
 
@@ -1184,5 +1184,5 @@ func (gw *Gateway) VerifyTxnVerbose(txn *coin.Transaction) ([]wallet.UxBalance, 
 
 // IsCSPEnabled returns if the csp is enabled
 func (gw *Gateway) IsCSPEnabled() bool {
-	return !gw.Config.DisabledCSP
+	return !gw.Config.DisableCSP
 }

--- a/src/skycoin/config.go
+++ b/src/skycoin/config.go
@@ -48,6 +48,8 @@ type NodeConfig struct {
 	EnableSeedAPI bool
 	// Enable unversioned API endpoints (without the /api/v1 prefix)
 	EnableUnversionedAPI bool
+	// Disable CSP disable content-security-policy in http response
+	DisableCSP bool
 
 	// Only run on localhost and only connect to others on localhost
 	LocalhostOnly bool
@@ -170,6 +172,8 @@ func NewNodeConfig(mode string, node NodeParameters) *NodeConfig {
 		EnableSeedAPI: false,
 		// Disable CSRF check in the wallet API
 		DisableCSRF: false,
+		// DisableCSP disable content-security-policy in http reponse
+		DisableCSP: false,
 		// Only run on localhost and only connect to others on localhost
 		LocalhostOnly: false,
 		// Which address to serve on. Leave blank to automatically assign to a
@@ -320,6 +324,7 @@ func (c *Config) register() {
 	flag.BoolVar(&c.Node.EnableUnversionedAPI, "enable-unversioned-api", c.Node.EnableUnversionedAPI, "Enable the deprecated unversioned API endpoints without /api/v1 prefix")
 	flag.BoolVar(&c.Node.DisableCSRF, "disable-csrf", c.Node.DisableCSRF, "disable CSRF check")
 	flag.BoolVar(&c.Node.EnableSeedAPI, "enable-seed-api", c.Node.EnableSeedAPI, "enable /api/v1/wallet/seed api")
+	flag.BoolVar(&c.Node.DisableCSP, "disable-csp", c.Node.DisableCSP, "disable content-security-policy in http response")
 	flag.StringVar(&c.Node.Address, "address", c.Node.Address, "IP Address to run application on. Leave empty to default to a public interface")
 	flag.IntVar(&c.Node.Port, "port", c.Node.Port, "Port to run application on")
 
@@ -379,6 +384,7 @@ func (n *NodeConfig) applyConfigMode(configMode string) {
 		n.EnableSeedAPI = true
 		n.LaunchBrowser = true
 		n.DisableCSRF = false
+		n.DisableCSP = false
 		n.DownloadPeerList = true
 		n.RPCInterface = false
 		n.WebInterface = true

--- a/src/skycoin/skycoin.go
+++ b/src/skycoin/skycoin.go
@@ -342,7 +342,7 @@ func (c *Coin) configureDaemon() daemon.Config {
 	dc.Visor.EnableSeedAPI = c.config.Node.EnableSeedAPI
 
 	dc.Gateway.EnableWalletAPI = c.config.Node.EnableWalletAPI
-	dc.Gateway.DisabledCSP = c.config.Node.DisableCSP
+	dc.Gateway.DisableCSP = c.config.Node.DisableCSP
 
 	// Initialize wallet default crypto type
 	cryptoType, err := wallet.CryptoTypeFromString(c.config.Node.WalletCryptoType)

--- a/src/skycoin/skycoin.go
+++ b/src/skycoin/skycoin.go
@@ -342,6 +342,7 @@ func (c *Coin) configureDaemon() daemon.Config {
 	dc.Visor.EnableSeedAPI = c.config.Node.EnableSeedAPI
 
 	dc.Gateway.EnableWalletAPI = c.config.Node.EnableWalletAPI
+	dc.Gateway.DisabledCSP = c.config.Node.DisableCSP
 
 	// Initialize wallet default crypto type
 	cryptoType, err := wallet.CryptoTypeFromString(c.config.Node.WalletCryptoType)

--- a/src/util/http/handler.go
+++ b/src/util/http/handler.go
@@ -9,6 +9,10 @@ import (
 	"github.com/skycoin/skycoin/src/util/logging"
 )
 
+// ContentSecurityPolicy represents the value of content-security-policy
+// header in http response
+const ContentSecurityPolicy = "script-src 'self' 127.0.0.1"
+
 // HostCheck checks that the request's Host header is 127.0.0.1:$port or localhost:$port
 // if the HTTP interface host is also a localhost address.
 // This prevents DNS rebinding attacks, where an attacker uses a DNS rebinding service
@@ -50,7 +54,7 @@ func HostCheck(logger *logging.Logger, host string, handler http.Handler) http.H
 // EnableCSPHandler enables CSP
 func EnableCSPHandler(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Security-Policy", "script-src 'self' 127.0.0.1")
+		w.Header().Set("Content-Security-Policy", ContentSecurityPolicy)
 		handler.ServeHTTP(w, r)
 	})
 }

--- a/src/util/http/handler.go
+++ b/src/util/http/handler.go
@@ -51,8 +51,8 @@ func HostCheck(logger *logging.Logger, host string, handler http.Handler) http.H
 	})
 }
 
-// EnableCSPHandler enables CSP
-func EnableCSPHandler(handler http.Handler) http.Handler {
+// CSPHandler enables CSP
+func CSPHandler(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Security-Policy", ContentSecurityPolicy)
 		handler.ServeHTTP(w, r)

--- a/src/util/http/handler.go
+++ b/src/util/http/handler.go
@@ -46,3 +46,11 @@ func HostCheck(logger *logging.Logger, host string, handler http.Handler) http.H
 		handler.ServeHTTP(w, r)
 	})
 }
+
+// EnableCSPHandler enables CSP
+func EnableCSPHandler(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Security-Policy", "script-src 'self' 127.0.0.1")
+		handler.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
Fixes #1426 

Changes:
- Add Content-Security-Policy: script-src 'self' 127.0.0.1" header to http responses 
- Add `disable-csp` cli option and set as `false` by default

Does this change need to mentioned in CHANGELOG.md?
Yes.