### PR TITLE
Run database verification in a separate goroutine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Change number of outgoing connections to 8 from 16
 - Transaction history shows transactions between own addresses
 - Client will only maintain one connection to the default hardcoded peers, instead of all of them
+- Add `initialized` field in `/health` endpoint response, which represents if the database verification is done
 
 ### Removed
 

--- a/src/api/address_test.go
+++ b/src/api/address_test.go
@@ -102,6 +102,7 @@ func TestVerifyAddress(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/api/v2/address/verify"
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 
 			req, err := http.NewRequest(tc.method, endpoint, bytes.NewBufferString(tc.httpBody))
 			require.NoError(t, err)

--- a/src/api/blockchain_test.go
+++ b/src/api/blockchain_test.go
@@ -203,8 +203,8 @@ func TestGetBlock(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			gateway := &GatewayerMock{}
-
+			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("GetSignedBlockByHash", tc.sha256).Return(tc.gatewayGetBlockByHashResult, tc.gatewayGetBlockByHashErr)
 			gateway.On("GetSignedBlockBySeq", tc.seq).Return(tc.gatewayGetBlockBySeqResult, tc.gatewayGetBlockBySeqErr)
 
@@ -331,7 +331,8 @@ func TestGetBlocks(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			gateway := &GatewayerMock{}
+			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("GetBlocks", tc.start, tc.end).Return(tc.gatewayGetBlocksResult, tc.gatewayGetBlocksError)
 
 			endpoint := "/api/v1/blocks"
@@ -449,6 +450,7 @@ func TestGetLastBlocks(t *testing.T) {
 			gateway := NewGatewayerMock()
 
 			gateway.On("GetLastBlocks", tc.num).Return(tc.gatewayGetLastBlocksResult, tc.gatewayGetLastBlocksError)
+			gateway.On("DBVerified").Return(true)
 
 			v := url.Values{}
 			if tc.body.Num != "" {

--- a/src/api/csrf.go
+++ b/src/api/csrf.go
@@ -175,3 +175,21 @@ func OriginRefererCheck(host string, handler http.Handler) http.Handler {
 		handler.ServeHTTP(w, r)
 	})
 }
+
+// DBInitCheck checks if the database verification is done, return 404 if
+// it's not done yet and host is not in the excludeHosts
+func DBInitCheck(endpoint string, gateway Gatewayer, excludeEndpoints map[string]struct{}, handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if gateway.DBVerified() {
+			handler.ServeHTTP(w, r)
+			return
+		}
+
+		if _, ok := excludeEndpoints[endpoint]; ok {
+			handler.ServeHTTP(w, r)
+			return
+		}
+
+		wh.Error404(w, "")
+	})
+}

--- a/src/api/csrf_test.go
+++ b/src/api/csrf_test.go
@@ -144,7 +144,8 @@ func TestCSRFWrapper(t *testing.T) {
 			for _, c := range cases {
 				name := fmt.Sprintf("%s %s %s", method, endpoint, c)
 				t.Run(name, func(t *testing.T) {
-					gateway := &GatewayerMock{}
+					gateway := NewGatewayerMock()
+					gateway.On("DBVerified").Return(true)
 
 					req, err := http.NewRequest(method, endpoint, nil)
 					require.NoError(t, err)
@@ -193,7 +194,8 @@ func TestOriginRefererCheck(t *testing.T) {
 		for _, tc := range cases {
 			name := fmt.Sprintf("%s %s", tc.name, endpoint)
 			t.Run(name, func(t *testing.T) {
-				gateway := &GatewayerMock{}
+				gateway := NewGatewayerMock()
+				gateway.On("DBVerified").Return(true)
 
 				req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 				require.NoError(t, err)
@@ -230,7 +232,8 @@ func TestOriginRefererCheck(t *testing.T) {
 func TestHostCheck(t *testing.T) {
 	for _, endpoint := range endpoints {
 		t.Run(endpoint, func(t *testing.T) {
-			gateway := &GatewayerMock{}
+			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 
 			req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 			require.NoError(t, err)
@@ -264,8 +267,9 @@ func TestCSRF(t *testing.T) {
 	}
 
 	updateWalletLabel := func(csrfToken string) *httptest.ResponseRecorder {
-		gateway := &GatewayerMock{}
+		gateway := NewGatewayerMock()
 		gateway.On("UpdateWalletLabel", "fooid", "foolabel").Return(nil)
+		gateway.On("DBVerified").Return(true)
 
 		endpoint := "/api/v1/wallet/update"
 
@@ -299,7 +303,8 @@ func TestCSRF(t *testing.T) {
 	require.Equal(t, "403 Forbidden - invalid CSRF token\n", rr.Body.String())
 
 	// Make a request to /csrf to get a token
-	gateway := &GatewayerMock{}
+	gateway := NewGatewayerMock()
+	gateway.On("DBVerified").Return(true)
 	handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
 
 	// non-GET request to /csrf is invalid

--- a/src/api/explorer_test.go
+++ b/src/api/explorer_test.go
@@ -158,6 +158,7 @@ func TestGetTransactionsForAddress(t *testing.T) {
 			endpoint := "/api/v1/explorer/address"
 			gateway := NewGatewayerMock()
 			gateway.On("GetTransactionsForAddress", address).Return(tc.result, tc.gatewayGetTransactionsForAddressErr)
+			gateway.On("DBVerified").Return(true)
 
 			v := url.Values{}
 			if tc.addressParam != "" {
@@ -287,6 +288,7 @@ func TestCoinSupply(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/api/v1/coinSupply"
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("GetUnspentOutputs", mock.Anything).Return(tc.gatewayGetUnspentOutputsResult, tc.gatewayGetUnspentOutputsErr)
 
 			req, err := http.NewRequest(tc.method, endpoint, nil)
@@ -499,6 +501,7 @@ func TestGetRichlist(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/api/v1/richlist"
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("GetRichlist", tc.includeDistribution).Return(tc.gatewayGetRichlistResult, tc.gatewayGetRichlistErr)
 
 			v := url.Values{}
@@ -587,6 +590,7 @@ func TestGetAddressCount(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/api/v1/addresscount"
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("GetAddressCount").Return(tc.gatewayGetAddressCountResult, tc.gatewayGetAddressCountErr)
 
 			req, err := http.NewRequest(tc.method, endpoint, nil)

--- a/src/api/gateway.go
+++ b/src/api/gateway.go
@@ -55,4 +55,5 @@ type Gatewayer interface {
 	GetHealth() (*daemon.Health, error)
 	UnloadWallet(id string) error
 	VerifyTxnVerbose(txn *coin.Transaction) ([]wallet.UxBalance, bool, error)
+	DBVerified() bool
 }

--- a/src/api/gatewayer_mock_test.go
+++ b/src/api/gatewayer_mock_test.go
@@ -90,6 +90,24 @@ func (m *GatewayerMock) CreateWallet(p0 string, p1 wallet.Options) (*wallet.Wall
 
 }
 
+// DBVerified mocked method
+func (m *GatewayerMock) DBVerified() bool {
+
+	ret := m.Called()
+
+	var r0 bool
+	switch res := ret.Get(0).(type) {
+	case nil:
+	case bool:
+		r0 = res
+	default:
+		panic(fmt.Sprintf("unexpected type: %v", res))
+	}
+
+	return r0
+
+}
+
 // DecryptWallet mocked method
 func (m *GatewayerMock) DecryptWallet(p0 string, p1 []byte) (*wallet.Wallet, error) {
 

--- a/src/api/health.go
+++ b/src/api/health.go
@@ -21,6 +21,7 @@ type HealthResponse struct {
 	Version            visor.BuildInfo    `json:"version"`
 	OpenConnections    int                `json:"open_connections"`
 	Uptime             wh.Duration        `json:"uptime"`
+	Initialized        bool               `json:"initialized"`
 }
 
 // Returns node health data.
@@ -40,6 +41,11 @@ func healthCheck(gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 
+		if !health.Initialized {
+			wh.SendJSONOr500(logger, w, HealthResponse{})
+			return
+		}
+
 		elapsedBlockTime := time.Now().UTC().Unix() - int64(health.BlockchainMetadata.Head.Time)
 		timeSinceLastBlock := time.Second * time.Duration(elapsedBlockTime)
 
@@ -51,6 +57,7 @@ func healthCheck(gateway Gatewayer) http.HandlerFunc {
 			Version:         health.Version,
 			OpenConnections: health.OpenConnections,
 			Uptime:          wh.FromDuration(health.Uptime),
+			Initialized:     true,
 		})
 	}
 }

--- a/src/api/health_test.go
+++ b/src/api/health_test.go
@@ -71,9 +71,12 @@ func TestHealthCheckHandler(t *testing.T) {
 				OpenConnections:    3,
 				Version:            buildInfo,
 				Uptime:             time.Second * 4,
+				Initialized:        true,
 			}
 
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
+
 			if tc.getHealthErr != nil {
 				gateway.On("GetHealth").Return(nil, tc.getHealthErr)
 			} else {

--- a/src/api/http.go
+++ b/src/api/http.go
@@ -247,11 +247,17 @@ func newServerMux(c muxConfig, gateway Gatewayer, csrfStore *CSRFStore, rpc *web
 		return handler
 	}
 
+	excludeEndpoints := map[string]struct{}{
+		"/api/v1/health": struct{}{},
+	}
+
 	webHandler := func(endpoint string, handler http.Handler) {
 		handler = wh.ElapsedHandler(logger, handler)
 		handler = CSRFCheck(csrfStore, handler)
 		handler = headerCheck(c.host, handler)
 		handler = gziphandler.GzipHandler(handler)
+		handler = DBInitCheck(endpoint, gateway, excludeEndpoints, handler)
+
 		mux.Handle(endpoint, handler)
 	}
 

--- a/src/api/http_test.go
+++ b/src/api/http_test.go
@@ -90,6 +90,7 @@ func TestGetOutputsHandler(t *testing.T) {
 			gateway := NewGatewayerMock()
 			endpoint := "/api/v1/outputs"
 			gateway.On("GetUnspentOutputs", mock.Anything).Return(tc.getUnspentOutputsResponse, tc.getUnspentOutputsError)
+			gateway.On("DBVerified").Return(true)
 
 			v := url.Values{}
 			if tc.httpBody != nil {
@@ -251,6 +252,7 @@ func TestGetBalanceHandler(t *testing.T) {
 			gateway := NewGatewayerMock()
 			endpoint := "/api/v1/balance"
 			gateway.On("GetBalanceOfAddrs", tc.getBalanceOfAddrsArg).Return(tc.getBalanceOfAddrsResponse, tc.getBalanceOfAddrsError)
+			gateway.On("DBVerified").Return(true)
 
 			v := url.Values{}
 			if tc.httpBody != nil {
@@ -338,8 +340,11 @@ func TestEnableGUI(t *testing.T) {
 			req, err := http.NewRequest(http.MethodGet, tc.endpoint, nil)
 			require.NoError(t, err)
 
+			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
+
 			rr := httptest.NewRecorder()
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: tc.appLoc}, nil, &CSRFStore{}, nil)
+			handler := newServerMux(muxConfig{host: configuredHost, appLoc: tc.appLoc}, gateway, &CSRFStore{}, nil)
 			handler.ServeHTTP(rr, req)
 
 			c := Config{
@@ -349,7 +354,7 @@ func TestEnableGUI(t *testing.T) {
 			}
 
 			host := "127.0.0.1:6423"
-			s, err := Create(host, c, nil)
+			s, err := Create(host, c, gateway)
 			require.NoError(t, err)
 
 			wg := sync.WaitGroup{}

--- a/src/api/network_test.go
+++ b/src/api/network_test.go
@@ -120,6 +120,7 @@ func TestConnection(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/api/v1/network/connection"
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("GetConnection", tc.addr).Return(tc.gatewayGetConnectionResult)
 			gateway.On("GetBlockchainProgress").Return(
 				tc.gatewayGetBlockchainProgressResult,
@@ -261,6 +262,7 @@ func TestConnections(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/api/v1/network/connections"
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("GetConnections").Return(tc.gatewayGetConnectionsResult)
 			gateway.On("GetBlockchainProgress").Return(
 				tc.gatewayGetBlockchainProgressResult,
@@ -317,6 +319,7 @@ func TestDefaultConnections(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/api/v1/network/defaultConnections"
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("GetDefaultConnections").Return(tc.gatewayGetDefaultConnectionsResult)
 			req, err := http.NewRequest(tc.method, endpoint, nil)
 			require.NoError(t, err)
@@ -369,6 +372,7 @@ func TestGetTrustConnections(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/api/v1/network/connections/trust"
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("GetTrustConnections").Return(tc.gatewayGetTrustConnectionsResult)
 			req, err := http.NewRequest(tc.method, endpoint, nil)
 			require.NoError(t, err)
@@ -421,6 +425,7 @@ func TestGetExchgConnection(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/api/v1/network/connections/exchange"
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("GetExchgConnection").Return(tc.gatewayGetExchgConnectionResult)
 			req, err := http.NewRequest(tc.method, endpoint, nil)
 			require.NoError(t, err)

--- a/src/api/spend_test.go
+++ b/src/api/spend_test.go
@@ -841,7 +841,8 @@ func TestCreateTransaction(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			gateway := &GatewayerMock{}
+			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 
 			// If the rawRequestBody can be deserialized to CreateTransactionRequest, use it to mock gateway.CreateTransaction
 			serializedBody, err := json.Marshal(tc.body)

--- a/src/api/transaction_test.go
+++ b/src/api/transaction_test.go
@@ -131,6 +131,7 @@ func TestGetPendingTxs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/api/v1/pendingTxs"
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("GetAllUnconfirmedTxns").Return(tc.getAllUnconfirmedTxnsResponse, tc.getAllUnconfirmedTxnsErr)
 
 			req, err := http.NewRequest(tc.method, endpoint, nil)
@@ -264,6 +265,7 @@ func TestGetTransactionByID(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/api/v1/transaction"
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("GetTransaction", tc.getTransactionArg).Return(tc.getTransactionReponse, tc.getTransactionError)
 
 			v := url.Values{}
@@ -395,6 +397,7 @@ func TestInjectTransaction(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/api/v1/injectTransaction"
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("InjectBroadcastTransaction", tc.injectTransactionArg).Return(tc.injectTransactionError)
 
 			req, err := http.NewRequest(tc.method, endpoint, bytes.NewBufferString(tc.httpBody))
@@ -466,6 +469,7 @@ func TestResendUnconfirmedTxns(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/api/v1/resendUnconfirmedTxns"
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("ResendUnconfirmedTxns").Return(tc.resendUnconfirmedTxnsResponse, tc.resendUnconfirmedTxnsErr)
 
 			req, err := http.NewRequest(tc.method, endpoint, bytes.NewBufferString(tc.httpBody))
@@ -590,6 +594,7 @@ func TestGetRawTx(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/api/v1/rawtx"
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("GetTransaction", tc.getTransactionArg).Return(tc.getTransactionResponse, tc.getTransactionError)
 			v := url.Values{}
 			if tc.httpBody != nil {
@@ -747,6 +752,7 @@ func TestGetTransactions(t *testing.T) {
 		endpoint := "/api/v1/transactions"
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("GetTransactions", mock.Anything).Return(tc.getTransactionsResponse, tc.getTransactionsError)
 
 			v := url.Values{}
@@ -991,6 +997,7 @@ func TestVerifyTransaction(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/api/v2/transaction/verify"
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("VerifyTxnVerbose", &tc.gatewayVerifyTxnVerboseArg).Return(tc.gatewayVerifyTxnVerboseResult.Uxouts,
 				tc.gatewayVerifyTxnVerboseResult.IsTxnConfirmed, tc.gatewayVerifyTxnVerboseResult.Err)
 

--- a/src/api/uxout_test.go
+++ b/src/api/uxout_test.go
@@ -118,6 +118,7 @@ func TestGetUxOutByID(t *testing.T) {
 			gateway := NewGatewayerMock()
 			endpoint := "/api/v1/uxout"
 			gateway.On("GetUxOutByID", tc.getGetUxOutByIDArg).Return(tc.getGetUxOutByIDResponse, tc.getGetUxOutByIDError)
+			gateway.On("DBVerified").Return(true)
 
 			v := url.Values{}
 			if tc.httpBody != nil {
@@ -235,6 +236,7 @@ func TestGetAddrUxOuts(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/api/v1/address_uxouts"
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("GetAddrUxOuts", tc.getAddrUxOutsArg).Return(tc.getAddrUxOutsResponse, tc.getAddrUxOutsError)
 
 			v := url.Values{}

--- a/src/api/wallet_test.go
+++ b/src/api/wallet_test.go
@@ -405,11 +405,12 @@ func TestWalletSpendHandler(t *testing.T) {
 				tc.gatewaySpendResult = &coin.Transaction{}
 			}
 
-			gateway := &GatewayerMock{}
+			gateway := NewGatewayerMock()
 			addr, _ := cipher.DecodeBase58Address(tc.dst)
 			gateway.On("Spend", tc.walletID, []byte(tc.password), tc.coins, addr).Return(tc.gatewaySpendResult, tc.gatewaySpendErr)
 			gateway.On("GetWalletBalance", tc.walletID).Return(tc.gatewayGetWalletBalanceResult.BalancePair,
 				tc.gatewayGetWalletBalanceResult.Addresses, tc.gatewayBalanceErr)
+			gateway.On("DBVerified").Return(true)
 
 			endpoint := "/api/v1/wallet/spend"
 
@@ -543,8 +544,9 @@ func TestWalletGet(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			gateway := &GatewayerMock{}
+			gateway := NewGatewayerMock()
 			gateway.On("GetWallet", tc.walletID).Return(&tc.gatewayGetWalletResult, tc.gatewayGetWalletErr)
+			gateway.On("DBVerified").Return(true)
 			v := url.Values{}
 
 			endpoint := "/api/v1/wallet"
@@ -681,7 +683,8 @@ func TestWalletBalanceHandler(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			gateway := &GatewayerMock{}
+			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("GetWalletBalance", tc.walletID).Return(tc.gatewayGetWalletBalanceResult.BalancePair,
 				tc.gatewayGetWalletBalanceResult.Addresses, tc.gatewayBalanceErr)
 
@@ -828,7 +831,8 @@ func TestUpdateWalletLabelHandler(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			gateway := &GatewayerMock{}
+			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("UpdateWalletLabel", tc.walletID, tc.label).Return(tc.gatewayUpdateWalletLabelErr)
 
 			endpoint := "/api/v1/wallet/update"
@@ -948,7 +952,8 @@ func TestWalletTransactionsHandler(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		gateway := &GatewayerMock{}
+		gateway := NewGatewayerMock()
+		gateway.On("DBVerified").Return(true)
 		gateway.On("GetWalletUnconfirmedTxns", tc.walletID).Return(tc.gatewayGetWalletUnconfirmedTxnsResult, tc.gatewayGetWalletUnconfirmedTxnsErr)
 
 		endpoint := "/api/v1/wallet/transactions"
@@ -1233,10 +1238,11 @@ func TestWalletCreateHandler(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			gateway := &GatewayerMock{}
+			gateway := NewGatewayerMock()
 			if tc.options.ScanN == 0 {
 				tc.options.ScanN = 1
 			}
+			gateway.On("DBVerified").Return(true)
 			gateway.On("CreateWallet", "", tc.options).Return(&tc.gatewayCreateWalletResult, tc.gatewayCreateWalletErr)
 			// gateway.On("ScanAheadWalletAddresses", tc.wltName, tc.options.Password, tc.scnN-1).Return(&tc.scanWalletAddressesResult, tc.scanWalletAddressesError)
 
@@ -1372,8 +1378,9 @@ func TestWalletNewSeed(t *testing.T) {
 	// Loop over each test case
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			gateway := &GatewayerMock{}
+			gateway := NewGatewayerMock()
 			gateway.On("IsWalletAPIEnabled").Return(true)
+			gateway.On("DBVerified").Return(true)
 
 			endpoint := "/api/v1/wallet/newSeed"
 
@@ -1533,6 +1540,7 @@ func TestGetWalletSeed(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("GetWalletSeed", tc.wltID, []byte(tc.password)).Return(tc.gatewayReturnArgs...)
 
 			endpoint := "/api/v1/wallet/seed"
@@ -1745,8 +1753,9 @@ func TestWalletNewAddressesHandler(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			gateway := &GatewayerMock{}
+			gateway := NewGatewayerMock()
 			gateway.On("NewAddresses", tc.walletID, []byte(tc.password), tc.n).Return(tc.gatewayNewAddressesResult, tc.gatewayNewAddressesErr)
+			gateway.On("DBVerified").Return(true)
 
 			endpoint := "/api/v1/wallet/newAddress"
 
@@ -1832,8 +1841,9 @@ func TestGetWalletFolderHandler(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		gateway := &GatewayerMock{}
+		gateway := NewGatewayerMock()
 		gateway.On("GetWalletDir").Return(tc.getWalletDirResponse, tc.getWalletDirErr)
+		gateway.On("DBVerified").Return(true)
 
 		endpoint := "/api/v1/wallets/folderName"
 
@@ -2060,8 +2070,9 @@ func TestGetWallets(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		gateway := &GatewayerMock{}
+		gateway := NewGatewayerMock()
 		gateway.On("GetWallets").Return(tc.getWalletsResponse, tc.getWalletsErr)
+		gateway.On("DBVerified").Return(true)
 
 		endpoint := "/api/v1/wallets"
 
@@ -2143,8 +2154,9 @@ func TestWalletUnloadHandler(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			gateway := &GatewayerMock{}
+			gateway := NewGatewayerMock()
 			gateway.On("UnloadWallet", tc.walletID).Return(tc.unloadWalletErr)
+			gateway.On("DBVerified").Return(true)
 
 			endpoint := "/api/v1/wallet/unload"
 			v := url.Values{}
@@ -2296,6 +2308,7 @@ func TestEncryptWallet(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("EncryptWallet", tc.wltID, []byte(tc.password)).Return(tc.gatewayReturn.w, tc.gatewayReturn.err)
 
 			endpoint := "/api/v1/wallet/encrypt"
@@ -2482,6 +2495,7 @@ func TestDecryptWallet(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
 			gateway.On("DecryptWallet", tc.wltID, []byte(tc.password)).Return(tc.gatewayReturn.w, tc.gatewayReturn.err)
 
 			endpoint := "/api/v1/wallet/decrypt"

--- a/src/api/webrpc_test.go
+++ b/src/api/webrpc_test.go
@@ -68,6 +68,8 @@ func TestWebRPC(t *testing.T) {
 			}
 
 			gateway := NewGatewayerMock()
+			gateway.On("DBVerified").Return(true)
+
 			handler := newServerMux(muxConfig{
 				host:            configuredHost,
 				appLoc:          ".",

--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -420,6 +420,11 @@ func (dm *Daemon) Run(db *dbutil.DB) error {
 		return err
 	}
 
+	if err := dm.visor.CreateGenesisBlockIfNotExist(); err != nil {
+		logger.WithError(err).Error("visor.CreateGenesisBlockIfNotExist failed")
+		return err
+	}
+
 	errC := make(chan error, 5)
 	var wg sync.WaitGroup
 

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -209,6 +209,11 @@ func (gw *Gateway) GetExchgConnection() []string {
 	return conn
 }
 
+// DBVerified returns if the database is verified
+func (gw *Gateway) DBVerified() bool {
+	return gw.d.DBVerified()
+}
+
 /* Blockchain & Transaction status */
 
 // BlockchainProgress current sync blockchain status
@@ -1142,10 +1147,17 @@ type Health struct {
 	Version            visor.BuildInfo
 	OpenConnections    int
 	Uptime             time.Duration
+	Initialized        bool
 }
 
 // GetHealth returns statistics about the running node
 func (gw *Gateway) GetHealth() (*Health, error) {
+	if !gw.DBVerified() {
+		return &Health{
+			Initialized: false,
+		}, nil
+	}
+
 	var health *Health
 	var err error
 	gw.strand("GetHealth", func() {
@@ -1162,6 +1174,7 @@ func (gw *Gateway) GetHealth() (*Health, error) {
 			Version:            gw.v.Config.BuildInfo,
 			OpenConnections:    len(conns.Connections),
 			Uptime:             time.Since(gw.v.StartedAt),
+			Initialized:        true,
 		}
 	})
 

--- a/src/skycoin/skycoin.go
+++ b/src/skycoin/skycoin.go
@@ -167,6 +167,7 @@ func (c *Coin) Run() {
 				close(earlyShutdownC)
 				return
 			}
+			c.logger.Info("Checking database done")
 
 			newDB := db
 			if rlt.DB != nil {

--- a/src/skycoin/skycoin.go
+++ b/src/skycoin/skycoin.go
@@ -31,6 +31,13 @@ type Coin struct {
 	logger *logging.Logger
 }
 
+type dbVerifyResult struct {
+	DB  *dbutil.DB
+	Err error
+}
+
+// type
+
 // Run starts the node
 func (c *Coin) Run() {
 	defer func() {
@@ -43,6 +50,7 @@ func (c *Coin) Run() {
 	var d *daemon.Daemon
 	var webInterface *api.Server
 	errC := make(chan error, 10)
+	earlyShutdownC := make(chan struct{})
 
 	if c.config.Node.Version {
 		fmt.Println(c.config.Build.Version)
@@ -106,28 +114,35 @@ func (c *Coin) Run() {
 		return
 	}
 
-	if c.config.Node.ResetCorruptDB {
-		// Check the database integrity and recreate it if necessary
-		c.logger.Info("Checking database and resetting if corrupted")
-		if newDB, err := visor.RepairCorruptDB(db, c.config.Node.blockchainPubkey, quit); err != nil {
-			if err != visor.ErrVerifyStopped {
-				c.logger.Errorf("visor.ResetCorruptDB failed: %v", err)
-			}
-			goto earlyShutdown
-		} else {
-			db = newDB
-		}
-	} else if c.config.Node.VerifyDB {
-		c.logger.Info("Checking database")
-		if err := visor.CheckDatabase(db, c.config.Node.blockchainPubkey, quit); err != nil {
-			if err != visor.ErrVerifyStopped {
-				c.logger.Errorf("visor.CheckDatabase failed: %v", err)
-			}
-			goto earlyShutdown
-		}
-	}
+	dbVerifyDone := make(chan dbVerifyResult, 1)
 
-	d, err = daemon.NewDaemon(dconf, db, c.config.Node.DefaultConnections)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if c.config.Node.ResetCorruptDB {
+			// Check the database integrity and recreate it if necessary
+			c.logger.Info("Checking database and resetting if corrupted")
+			if newDB, err := visor.RepairCorruptDB(db, c.config.Node.blockchainPubkey, quit); err != nil {
+				if err != visor.ErrVerifyStopped {
+					c.logger.Errorf("visor.ResetCorruptDB failed: %v", err)
+				}
+				dbVerifyDone <- dbVerifyResult{Err: err}
+			} else {
+				dbVerifyDone <- dbVerifyResult{DB: newDB}
+			}
+		} else if c.config.Node.VerifyDB {
+			c.logger.Info("Checking database")
+			err := visor.CheckDatabase(db, c.config.Node.blockchainPubkey, quit)
+			if err != nil {
+				if err != visor.ErrVerifyStopped {
+					c.logger.Errorf("visor.CheckDatabase failed: %v", err)
+				}
+			}
+			dbVerifyDone <- dbVerifyResult{Err: err}
+		}
+	}()
+
+	d, err = daemon.NewDaemon(dconf, c.config.Node.DefaultConnections)
 	if err != nil {
 		c.logger.Error(err)
 		goto earlyShutdown
@@ -144,10 +159,24 @@ func (c *Coin) Run() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		select {
+		case <-quit:
+			return
+		case rlt := <-dbVerifyDone:
+			if rlt.Err != nil {
+				close(earlyShutdownC)
+				return
+			}
 
-		if err := d.Run(); err != nil {
-			c.logger.Error(err)
-			errC <- err
+			newDB := db
+			if rlt.DB != nil {
+				newDB = rlt.DB
+			}
+
+			if err := d.Run(newDB); err != nil {
+				c.logger.Error(err)
+				close(earlyShutdownC)
+			}
 		}
 	}()
 
@@ -170,7 +199,6 @@ func (c *Coin) Run() {
 				select {
 				case <-cancelLaunchBrowser:
 					c.logger.Warning("Browser launching cancelled")
-
 					// Wait a moment just to make sure the http interface is up
 				case <-time.After(time.Millisecond * 100):
 					c.logger.Infof("Launching System Browser with %s", fullAddress)
@@ -178,6 +206,7 @@ func (c *Coin) Run() {
 						c.logger.Error(err)
 					}
 				}
+
 			}()
 		}
 	}
@@ -210,6 +239,11 @@ func (c *Coin) Run() {
 
 	select {
 	case <-quit:
+		if !d.DBVerified() {
+			goto earlyShutdown
+		}
+	case <-earlyShutdownC:
+		goto earlyShutdown
 	case err := <-errC:
 		c.logger.Error(err)
 	}

--- a/src/visor/readable_test.go
+++ b/src/visor/readable_test.go
@@ -36,7 +36,9 @@ func setupVisorConfig(t *testing.T) Config {
 func setupVisor(t *testing.T) (*Visor, func()) {
 	db, shutdown := prepareDB(t)
 	vc := setupVisorConfig(t)
-	v, err := NewVisor(vc, db)
+	v, err := NewVisor(vc)
+	require.NoError(t, err)
+	err = v.Init(db)
 	require.NoError(t, err)
 	return v, shutdown
 }

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -312,12 +312,16 @@ func (vs *Visor) Init(db *dbutil.DB) error {
 	}
 
 	vs.Unconfirmed = utp
+	return nil
+}
 
+// CreateGenesisBlockIfNotExist create genesis block if necessary
+func (vs *Visor) CreateGenesisBlockIfNotExist() error {
 	if vs.DB.IsReadOnly() {
 		return nil
 	}
 
-	return vs.DB.Update("visor init", func(tx *dbutil.Tx) error {
+	return vs.DB.Update("visor CreateGenesisBlockIfNotExist", func(tx *dbutil.Tx) error {
 		if err := vs.maybeCreateGenesisBlock(tx); err != nil {
 			return err
 		}

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -232,7 +232,7 @@ type Visor struct {
 }
 
 // NewVisor creates a Visor for managing the blockchain database
-func NewVisor(c Config, db *dbutil.DB) (*Visor, error) {
+func NewVisor(c Config) (*Visor, error) {
 	logger.Info("Creating new visor")
 	if c.IsMaster {
 		logger.Info("Visor is master")
@@ -255,25 +255,40 @@ func NewVisor(c Config, db *dbutil.DB) (*Visor, error) {
 		return nil, err
 	}
 
-	if !db.IsReadOnly() {
-		if err := CreateBuckets(db); err != nil {
+	v := &Visor{
+		Config:    c,
+		Wallets:   wltServ,
+		StartedAt: time.Now(),
+	}
+
+	return v, nil
+}
+
+// Init initializes starts the visor
+func (vs *Visor) Init(db *dbutil.DB) error {
+	logger.Info("Visor init")
+	vs.DB = db
+	if !vs.DB.IsReadOnly() {
+		if err := CreateBuckets(vs.DB); err != nil {
 			logger.WithError(err).Error("CreateBuckets failed")
-			return nil, err
+			return err
 		}
 	}
 
-	bc, err := NewBlockchain(db, BlockchainConfig{
-		Pubkey:      c.BlockchainPubkey,
-		Arbitrating: c.Arbitrating,
+	bc, err := NewBlockchain(vs.DB, BlockchainConfig{
+		Pubkey:      vs.Config.BlockchainPubkey,
+		Arbitrating: vs.Config.Arbitrating,
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
+
+	vs.Blockchain = bc
 
 	history := historydb.New()
 
-	if !db.IsReadOnly() {
-		if err := db.Update("build unspent indexes and init history", func(tx *dbutil.Tx) error {
+	if !vs.DB.IsReadOnly() {
+		if err := vs.DB.Update("build unspent indexes and init history", func(tx *dbutil.Tx) error {
 			headSeq, _, err := bc.HeadSeq(tx)
 			if err != nil {
 				return err
@@ -285,31 +300,18 @@ func NewVisor(c Config, db *dbutil.DB) (*Visor, error) {
 
 			return initHistory(tx, bc, history)
 		}); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	utp, err := NewUnconfirmedTxnPool(db)
+	vs.history = history
+
+	utp, err := NewUnconfirmedTxnPool(vs.DB)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	v := &Visor{
-		Config:      c,
-		DB:          db,
-		Blockchain:  bc,
-		Unconfirmed: utp,
-		history:     history,
-		Wallets:     wltServ,
-		StartedAt:   time.Now(),
-	}
-
-	return v, nil
-}
-
-// Init initializes starts the visor
-func (vs *Visor) Init() error {
-	logger.Info("Visor init")
+	vs.Unconfirmed = utp
 
 	if vs.DB.IsReadOnly() {
 		return nil


### PR DESCRIPTION
Fixes #1564 backend

Changes:
- Run database verification in a separate goroutine
- Return 404 error for all endpoints except `/health` when database is not verified
- Add `Initialized` field in `/health` response, return "initialized": false if db is not verified, and all other fields set as empty.


Does this change need to mentioned in CHANGELOG.md?
Yes