### PR TITLE
Fix flaky test error in TestHistorydbVerifier

### DIFF
--- a/electron/README.md
+++ b/electron/README.md
@@ -122,23 +122,6 @@ To build app in 32 bit from a machine with 64 bit:
 sudo apt-get install --no-install-recommends -y gcc-multilib g++-multilib
 ```
 
-## Setup
-
-Once requirements are installed, node dependencies must be downloaded.
-
-Install yarn:
-
-```sh
-npm install -g yarn
-```
-
-Install dependencies with yarn:
-
-```sh
-yarn install
-```
-
-A folder `node_modules/` should now exist.
 
 ## Building
 

--- a/src/visor/visor_test.go
+++ b/src/visor/visor_test.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"testing"
 	"time"
@@ -253,7 +252,7 @@ func TestHistorydbVerifier(t *testing.T) {
 			}
 
 			// Confirms that the error type is matched
-			require.Equal(t, reflect.TypeOf(tc.expectErr), reflect.TypeOf(err))
+			require.IsType(t, tc.expectErr, err)
 			// Confirms the error message is matched
 			require.Regexp(t, tc.expectErr.Error(), err.Error())
 		})

--- a/src/visor/visor_test.go
+++ b/src/visor/visor_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"testing"
 	"time"
@@ -213,17 +214,17 @@ func TestHistorydbVerifier(t *testing.T) {
 		{
 			name:      "missing uxout",
 			dbPath:    "./testdata/data.db.nouxout",
-			expectErr: historydb.NewErrHistoryDBCorrupted(errors.New("HistoryDB.Verify: transaction input 2f87d77c2a7d00b547db1af50e0ba04bafc5b05711e4939e9ec2640a21127dc0 does not exist in historydb")),
+			expectErr: historydb.NewErrHistoryDBCorrupted(errors.New("HistoryDB.Verify: transaction (input|output) 2f87d77c2a7d00b547db1af50e0ba04bafc5b05711e4939e9ec2640a21127dc0 does not exist in historydb")),
 		},
 		{
 			name:      "missing addr transaction index",
 			dbPath:    "./testdata/data.db.no-addr-txn-index",
-			expectErr: historydb.NewErrHistoryDBCorrupted(errors.New("HistoryDB.Verify: index of address transaction [2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF:98db7eb30e13853d3dd93d5d8b4061596d5d288b6f8b92c4d43c46c6599f67fb] does not exist in historydb")),
+			expectErr: historydb.NewErrHistoryDBCorrupted(errors.New(`HistoryDB.Verify: index of address transaction \[2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF:98db7eb30e13853d3dd93d5d8b4061596d5d288b6f8b92c4d43c46c6599f67fb\] does not exist in historydb`)),
 		},
 		{
 			name:      "missing addr uxout index",
 			dbPath:    "./testdata/data.db.no-addr-uxout-index",
-			expectErr: historydb.NewErrHistoryDBCorrupted(errors.New("HistoryDB.Verify: index of address uxout [2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF:2f87d77c2a7d00b547db1af50e0ba04bafc5b05711e4939e9ec2640a21127dc0] does not exist in historydb")),
+			expectErr: historydb.NewErrHistoryDBCorrupted(errors.New(`HistoryDB.Verify: index of address uxout \[2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF:2f87d77c2a7d00b547db1af50e0ba04bafc5b05711e4939e9ec2640a21127dc0\] does not exist in historydb`)),
 		},
 	}
 
@@ -246,7 +247,15 @@ func TestHistorydbVerifier(t *testing.T) {
 			}
 
 			err = bc.WalkChain(2, f, nil)
-			require.Equal(t, tc.expectErr, err)
+			if tc.expectErr == nil {
+				require.Nil(t, err)
+				return
+			}
+
+			// Confirms that the error type is matched
+			require.Equal(t, reflect.TypeOf(tc.expectErr), reflect.TypeOf(err))
+			// Confirms the error message is matched
+			require.Regexp(t, tc.expectErr.Error(), err.Error())
 		})
 	}
 


### PR DESCRIPTION
Fixes #1742 

Changes:
- Use regexp error to do error match
- Remove ### Setup section in electron/README, electron does not use yarn anymore and the build script will run npm install automatically.

Does this change need to mentioned in CHANGELOG.md?
No