### PR TITLE
Disable color log on windows by default

### DIFF
--- a/src/daemon/gnet/pool.go
+++ b/src/daemon/gnet/pool.go
@@ -649,7 +649,9 @@ func (pool *ConnectionPool) IsDefaultConnection(addr string) bool {
 func (pool *ConnectionPool) IsMaxDefaultConnReached() (bool, error) {
 	var reached bool
 	if err := pool.strand("IsDefaultMaxConnReached", func() error {
-		reached = len(pool.defaultPeerConnections) > pool.Config.MaxDefaultPeerOutgoingConnections
+		l := len(pool.defaultPeerConnections)
+		logger.Debugf("%d/%d default connections in use", l, pool.Config.MaxDefaultPeerOutgoingConnections)
+		reached = l > pool.Config.MaxDefaultPeerOutgoingConnections
 		return nil
 	}); err != nil {
 		return false, err

--- a/src/daemon/messages.go
+++ b/src/daemon/messages.go
@@ -313,7 +313,6 @@ func (intro *IntroductionMessage) Handle(mc *gnet.MessageContext, daemon interfa
 				}
 
 				if reached {
-					logger.Debugf("Disconnect %s: maximum default connections reached ", mc.Addr)
 					d.Disconnect(mc.Addr, ErrDisconnectMaxDefaultConnectionReached)
 					return ErrDisconnectMaxDefaultConnectionReached
 				}

--- a/src/skycoin/config.go
+++ b/src/skycoin/config.go
@@ -3,6 +3,7 @@ package skycoin
 import (
 	"flag"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -376,6 +377,9 @@ func (c *Config) register() {
 }
 
 func (n *NodeConfig) applyConfigMode(configMode string) {
+	if runtime.GOOS == "windows" {
+		n.ColorLog = false
+	}
 	switch configMode {
 	case "":
 	case "STANDALONE_CLIENT":
@@ -389,7 +393,6 @@ func (n *NodeConfig) applyConfigMode(configMode string) {
 		n.RPCInterface = false
 		n.WebInterface = true
 		n.LogToFile = false
-		n.ColorLog = true
 		n.ResetCorruptDB = true
 		n.WebInterfacePort = 0 // randomize web interface port
 	default:


### PR DESCRIPTION
Changes:
- Disable color log on windows by default, the color log setting makes the log show bad character.
- Remove log of max default connections reached

Does this change need to mentioned in CHANGELOG.md?
No