### PR TITLE
Makes it easy to build release from make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ build-ui:  ## Builds the UI
 build-ui-travis:  ## Builds the UI for travis
 	cd $(GUI_STATIC_DIR) && npm run build-travis
 
-release: ## Build electron and standalone apps. Use osarch=${osarch} to specify the platform. Example: 'make release osarch=darwin/amd64'. Supported architectures are: darwin/amd64 windows/amd64 windows/386 linux/amd64 linux/arm, the builds are located in electron/release folder.
+release: ## Build electron and standalone apps. Use osarch=${osarch} to specify the platform. Example: 'make release osarch=darwin/amd64', multiple platform can be supported in this way: 'make release osarch="darwin/amd64 windows/amd64"'. Supported architectures are: darwin/amd64 windows/amd64 windows/386 linux/amd64 linux/arm, the builds are located in electron/release folder.
 	cd $(ELECTRON_DIR) && ./build.sh ${osarch}
 	@echo release files are in the folder of electron/release
 

--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,15 @@ release: ## Build electron and standalone apps. Use osarch=${osarch} to specify 
 	cd $(ELECTRON_DIR) && ./build.sh ${osarch}
 	@echo release files are in the folder of electron/release
 
+release-bin: ## Build standalone apps. Use osarch=${osarch} to specify the platform. Example: 'make release-bin osarch=darwin/amd64' Supported architectures are the same as 'release' command.
+	cd $(ELECTRON_DIR) && ./build-standalone-release.sh ${osarch}
+	@echo release files are in the folder of electron/release
+
+release-gui: ## Build electron apps. Use osarch=${osarch} to specify the platform. Example: 'make release-gui osarch=darwin/amd64' Supported architectures are the same as 'release' command.
+	cd $(ELECTRON_DIR) && ./build-electron-release.sh ${osarch}
+	@echo release files are in the folder of electron/release
+
+
 clean-release: ## Clean dist files and delete all builds in electron/release
 	rm $(ELECTRON_DIR)/release/*
 

--- a/Makefile
+++ b/Makefile
@@ -197,8 +197,8 @@ build-ui:  ## Builds the UI
 build-ui-travis:  ## Builds the UI for travis
 	cd $(GUI_STATIC_DIR) && npm run build-travis
 
-release: ## Build electron apps, the builds are located in electron/release folder.
-	cd $(ELECTRON_DIR) && ./build.sh
+release: ## Build electron and standalone apps. Use osarch=${osarch} to specify the platform. Example: 'make release osarch=darwin/amd64'. Supported architectures are: darwin/amd64 windows/amd64 windows/386 linux/amd64 linux/arm, the builds are located in electron/release folder.
+	cd $(ELECTRON_DIR) && ./build.sh ${osarch}
 	@echo release files are in the folder of electron/release
 
 clean-release: ## Clean dist files and delete all builds in electron/release

--- a/electron/build-conf.sh
+++ b/electron/build-conf.sh
@@ -19,19 +19,10 @@ ELN_OUTPUT="${ELN_OUTPUT_BASE}/${ELN_VERSION}"
 
 
 if [ -n "$1" ]; then
-    GOX_OSARCH="$1"
+    GOX_OSARCH="$@"
 else
     GOX_OSARCH="linux/amd64 linux/arm windows/amd64 windows/386 darwin/amd64"
 fi
-
-# GOX_OSARCH="linux/amd64 darwin/amd64"
-# GOX_OSARCH="linux/amd64 linux/arm windows/amd64 windows/386 darwin/amd64"
-# GOX_OSARCH="linux/amd64"
-# GOX_OSARCH="darwin/amd64"
-# GOX_OSARCH="windows/amd64"
-# GOX_OSARCH="windows/386"
-# GOX_OSARCH="linux/arm"
-
 
 GOX_OUTPUT=".gox_output"
 

--- a/electron/build-electron-release.sh
+++ b/electron/build-electron-release.sh
@@ -12,9 +12,7 @@ set -e -o pipefail
 # By default builds all architectures.
 # A single arch can be built by specifying it using gox's arch names
 
-if [ -n "$1" ]; then
-    GOX_OSARCH="$1"
-fi
+GOX_OSARCH="$@"
 
 . build-conf.sh "$GOX_OSARCH"
 
@@ -80,7 +78,13 @@ fi
 
 EXE="${PDT_NAME} Setup ${APP_VERSION}.exe"
 if [ -e "$EXE" ]; then
-    mv "$EXE" "${PKG_NAME}-${APP_VERSION}-gui-win-setup.exe"
+    if [ ! -z $WIN32_ELN ] && [ ! -z $WIN64_ELN ]; then
+        mv "$EXE" "${PKG_NAME}-${APP_VERSION}-gui-win-setup.exe"
+    elif [ ! -z $WIN32_ELN ]; then
+        mv "$EXE" "${WIN32_ELN}.exe"
+    elif [ ! -z $WIN64_ELN ]; then
+        mv "$EXE" "${WIN64_ELN}.exe"
+    fi
 fi
 
 # rename dmg file name

--- a/electron/build-standalone-release.sh
+++ b/electron/build-standalone-release.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 set -e -o pipefail
 
- if [ -n "$1" ]; then
-    GOX_OSARCH="$1"
-fi
+GOX_OSARCH="$@"
 
 . build-conf.sh "$GOX_OSARCH"
 

--- a/electron/build.sh
+++ b/electron/build.sh
@@ -3,11 +3,9 @@ set -e -o pipefail
 
 # Builds both the electron and standalone releases
 
-. build-conf.sh "$1"
+GOX_OSARCH="$@"
 
-if [ -n "$1" ]; then
-    GOX_OSARCH="$1"
-fi
+. build-conf.sh "$GOX_OSARCH"
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/electron/compress-electron-release.sh
+++ b/electron/compress-electron-release.sh
@@ -4,9 +4,7 @@ set -e -o pipefail
 # Compresses packaged electron apps after
 # ./package-electron-release.sh is done
 
-if [ -n "$1" ]; then
-    GOX_OSARCH="$1"
-fi
+GOX_OSARCH="$@"
 
 . build-conf.sh "$GOX_OSARCH"
 

--- a/electron/compress-standalone-release.sh
+++ b/electron/compress-standalone-release.sh
@@ -4,9 +4,7 @@ set -e -o pipefail
 # Compresses packaged standalone release after
 # ./package-standalone-release.sh is done
 
-if [ -n "$2" ]; then
-    GOX_OSARCH="$1"
-fi
+GOX_OSARCH="$@"
 
 . build-conf.sh "$GOX_OSARCH"
 

--- a/electron/package-electron-release.sh
+++ b/electron/package-electron-release.sh
@@ -4,9 +4,7 @@ set -e -o pipefail
 # Copies gox-compiled binaries and compiled GUI assets
 # into an electron package
 
-if [ -n "$1" ]; then
-    GOX_OSARCH="$1"
-fi
+GOX_OSARCH="$@"
 
 . build-conf.sh "$GOX_OSARCH"
 

--- a/electron/package-standalone-release.sh
+++ b/electron/package-standalone-release.sh
@@ -3,9 +3,7 @@ set -e -o pipefail
 
 # Builds the release without electron
 
-if [ -n "$1" ]; then
-    GOX_OSARCH="$2"
-fi
+GOX_OSARCH="$@"
 
 echo "In package standalone release: $GOX_OSARCH"
 
@@ -14,18 +12,6 @@ echo "In package standalone release: $GOX_OSARCH"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 pushd "$SCRIPTDIR" >/dev/null
-
-OSX64="${STL_OUTPUT}/${OSX64_STL}"
-WIN64="${STL_OUTPUT}/${WIN64_STL}"
-WIN32="${STL_OUTPUT}/${WIN32_STL}"
-LNX64="${STL_OUTPUT}/${LNX64_STL}"
-LNX_ARM="${STL_OUTPUT}/${LNX_ARM_STL}"
-
-OSX64_SRC="${OSX64}/src"
-WIN64_SRC="${WIN64}/src"
-WIN32_SRC="${WIN32}/src"
-LNX64_SRC="${LNX64}/src"
-LNX_ARM_SRC="${LNX_ARM}/src"
 
 DESTSRCS=()
 
@@ -63,16 +49,43 @@ function copy_if_exists {
 
 echo "Copying ${PKG_NAME} binaries"
 
-# copy binaries
-copy_if_exists "${OSX64_OUT}/${PKG_NAME}" "$OSX64" "$OSX64_SRC"
-copy_if_exists "${WIN64_OUT}/${PKG_NAME}.exe" "$WIN64" "$WIN64_SRC"
-copy_if_exists "${WIN32_OUT}/${PKG_NAME}.exe" "$WIN32" "$WIN32_SRC"
-copy_if_exists "${LNX64_OUT}/${PKG_NAME}" "$LNX64" "$LNX64_SRC"
-copy_if_exists "${LNX_ARM_OUT}/${PKG_NAME}" "$LNX_ARM" "$LNX_ARM_SRC"
+# OS X 
+if [ ! -z "$OSX64_STL" ]; then
+    OSX64="${STL_OUTPUT}/${OSX64_STL}"
+    OSX64_SRC="${OSX64}/src"
+    copy_if_exists "${OSX64_OUT}/${PKG_NAME}" "$OSX64" "$OSX64_SRC"
+fi
+
+# Linux amd64
+if [ ! -z "$LNX64_STL" ]; then
+    LNX64="${STL_OUTPUT}/${LNX64_STL}"
+    LNX64_SRC="${LNX64}/src"
+    copy_if_exists "${LNX64_OUT}/${PKG_NAME}" "$LNX64" "$LNX64_SRC"
+fi
+
+# Linux arm
+if [ ! -z "$LNX_ARM_STL" ]; then
+    LNX_ARM="${STL_OUTPUT}/${LNX_ARM_STL}"
+    LNX_ARM_SRC="${LNX_ARM}/src"
+    copy_if_exists "${LNX_ARM_OUT}/${PKG_NAME}" "$LNX_ARM" "$LNX_ARM_SRC"
+fi
+
+# Windows amd64
+if [ ! -z "$WIN64_STL" ]; then
+    WIN64="${STL_OUTPUT}/${WIN64_STL}"
+    WIN64_SRC="${WIN64}/src"
+    copy_if_exists "${WIN64_OUT}/${PKG_NAME}.exe" "$WIN64" "$WIN64_SRC"
+fi
+
+# Windows 386
+if [ ! -z "$WIN32_STL" ]; then
+    WIN32="${STL_OUTPUT}/${WIN32_STL}"
+    WIN32_SRC="${WIN32}/src"
+    copy_if_exists "${WIN32_OUT}/${PKG_NAME}.exe" "$WIN32" "$WIN32_SRC"
+fi
 
 # Copy the source for reference
 # tar it with filters, move it, then untar in order to do this
 echo "Copying source snapshot"
 
 ./package-source.sh "${DESTSRCS[@]}"
-


### PR DESCRIPTION
Fixes #1736

Changes:
- Update build script to support multiple parameters 
- Add `osarch` parameter to make `release` command
- Add `release-bin` and `release-gui` make command

Does this change need to mentioned in CHANGELOG.md?
No