### PR TITLE
Show the default wallets/logs folders

### DIFF
--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -212,11 +212,23 @@ function createWindow(url) {
     submenu: [
       {
         label: 'Wallets folder',
-        click: () => shell.showItemInFolder(walletsFolder),
+        click: () => {
+          if (walletsFolder) {
+            shell.showItemInFolder(walletsFolder)
+          } else {
+            shell.showItemInFolder(path.join(app.getPath("home"), '.skycoin', 'wallets'));
+          }
+        },
       },
       {
         label: 'Logs folder',
-        click: () => shell.showItemInFolder(walletsFolder.replace('wallets', 'logs')),
+        click: () => {
+          if (walletsFolder) {
+            shell.showItemInFolder(walletsFolder.replace('wallets', 'logs'))
+          } else {
+            shell.showItemInFolder(path.join(app.getPath("home"), '.skycoin', 'logs'));
+          }
+        },
       },
       {
         label: 'DevTools',


### PR DESCRIPTION
Changes:
- If the electron wallet is starting (the api is not available yet) and the user selects `Show -> Logs folder`, the file explorer is opened, with the `user/.skycoin/logs` folder selected. Previously there was an error:
![logs-error](https://user-images.githubusercontent.com/34079003/43621165-013d7aae-96a4-11e8-9501-02c4c913f36a.png)

- If the electron wallet is starting and the user selects `Show -> Wallets folder`, the file explorer is opened, with the `user/.skycoin/wallets` folder selected.

Please, check this PR on POSIX

Does this change need to mentioned in CHANGELOG.md?
No