### PR TITLE
Resync db when it's corrupted

### DIFF
--- a/src/visor/db.go
+++ b/src/visor/db.go
@@ -161,12 +161,10 @@ func RepairCorruptDB(db *dbutil.DB, pubkey cipher.PubKey, quit chan struct{}) (*
 	switch err.(type) {
 	case nil:
 		return db, nil
-	case blockdb.ErrMissingSignature:
+	case blockdb.ErrMissingSignature,
+		historydb.ErrHistoryDBCorrupted:
 		logger.Critical().Errorf("Database is corrupted, recreating db: %v", err)
 		return resetCorruptDB(db)
-	case historydb.ErrHistoryDBCorrupted:
-		logger.Critical().Errorf("Database is corrupted, rebuilding db: %v", err)
-		return rebuildCorruptDB(db, pubkey, quit)
 	default:
 		return nil, err
 	}

--- a/src/visor/db.go
+++ b/src/visor/db.go
@@ -170,7 +170,7 @@ func RepairCorruptDB(db *dbutil.DB, pubkey cipher.PubKey, quit chan struct{}) (*
 	}
 }
 
-func rebuildCorruptDB(db *dbutil.DB, pubkey cipher.PubKey, quit chan struct{}) (*dbutil.DB, error) {
+func rebuildCorruptDB(db *dbutil.DB, pubkey cipher.PubKey, quit chan struct{}) (*dbutil.DB, error) { //nolint: deadcode
 	history := historydb.New()
 	bc, err := NewBlockchain(db, BlockchainConfig{Pubkey: pubkey})
 	if err != nil {


### PR DESCRIPTION
Fixes #1758

Changes:
- Reset db and resync from scratch when detect db corruption

Does this change need to mentioned in CHANGELOG.md?
No.