### PR TITLE
Rename cached peers.txt to peers.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `total_coinhour_supply` and `current_coinhour_supply` to `/coinSupply` endpoint
 - #800, Add entropy parameter to `/wallet/newSeed` endpoint. Entropy can be 128 (default) or 256, corresponding to 12- and 24-word seeds respectively
 - #866, Include coins and hours in `/explorer/address` inputs
+- Rename cached `peers.txt` file to `peers.json`
 
 ### Removed
 

--- a/src/daemon/pex/peerlist.go
+++ b/src/daemon/pex/peerlist.go
@@ -38,16 +38,16 @@ func newPeerlist() peerlist {
 // Filter peers filter
 type Filter func(peer Peer) bool
 
-// loadCachedPeersFile loads peers from the cached peers.txt json file
+// loadCachedPeersFile loads peers from the cached peers.json file
 func loadCachedPeersFile(path string) (map[string]*Peer, error) {
 	peersJSON := make(map[string]PeerJSON)
 	err := file.LoadJSON(path, &peersJSON)
 
 	if os.IsNotExist(err) {
-		logger.WithField("path", path).Info("file does not exist")
+		logger.WithField("path", path).Info("File does not exist")
 		return nil, nil
 	} else if err == io.EOF {
-		logger.WithField("path", path).Error("corrupt or empty file")
+		logger.WithField("path", path).Error("Corrupt or empty file")
 		return nil, nil
 	}
 
@@ -71,7 +71,7 @@ func loadCachedPeersFile(path string) (map[string]*Peer, error) {
 		}
 
 		if a != peer.Addr {
-			logger.Errorf("address key %s does not match Peer.Addr %s", a, peer.Addr)
+			logger.Errorf("Address key %s does not match Peer.Addr %s", a, peer.Addr)
 			continue
 		}
 
@@ -263,7 +263,7 @@ func (pl *peerlist) random(count int, flts ...Filter) Peers {
 }
 
 // save saves known peers to disk as a newline delimited list of addresses to
-// <dir><PeerDatabaseFilename>
+// <dir><PeerCacheFilename>
 func (pl *peerlist) save(fn string) error {
 	// filter the peers that has retrytime > MaxPeerRetryTimes
 	peers := make(map[string]PeerJSON)

--- a/src/daemon/pex/peerlist_test.go
+++ b/src/daemon/pex/peerlist_test.go
@@ -515,9 +515,9 @@ func peersEqualWithSeenAllowedDiff(t *testing.T, expected Peer, actual Peer) {
 	require.Equal(t, expected, actual)
 }
 
-// preparePeerlistFile makes peers.txt in temporary dir,
+// preparePeerlistFile makes peers.json in temporary dir,
 func preparePeerlistFile(t *testing.T) (string, func()) {
-	f, err := ioutil.TempFile("", "peers.txt")
+	f, err := ioutil.TempFile("", PeerCacheFilename)
 	require.NoError(t, err)
 
 	return f.Name(), func() {

--- a/src/skycoin/config.go
+++ b/src/skycoin/config.go
@@ -364,7 +364,7 @@ func (c *Config) register() {
 	flag.BoolVar(&c.Node.ResetCorruptDB, "reset-corrupt-db", c.Node.ResetCorruptDB, "reset the database if corrupted, and continue running instead of exiting")
 
 	flag.BoolVar(&c.Node.DisableDefaultPeers, "disable-default-peers", c.Node.DisableDefaultPeers, "disable the hardcoded default peers")
-	flag.StringVar(&c.Node.CustomPeersFile, "custom-peers-file", c.Node.CustomPeersFile, "load custom peers from a newline separate list of ip:port in a file. Note that this is different from the peers.txt file in the data directory")
+	flag.StringVar(&c.Node.CustomPeersFile, "custom-peers-file", c.Node.CustomPeersFile, "load custom peers from a newline separate list of ip:port in a file. Note that this is different from the peers.json file in the data directory")
 
 	// Key Configuration Data
 	flag.BoolVar(&c.Node.RunMaster, "master", c.Node.RunMaster, "run the daemon as blockchain master server")


### PR DESCRIPTION
Fixes #1794 

Changes:
- Rename cached `peers.txt` to `peers.json`

Does this change need to mentioned in CHANGELOG.md?
Yes