### PR TITLE
Add server config settings to /health response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `cli status` return value is now the response from `GET /api/v1/health`, which changes some fields
 - `/api/network/` endpoints will return an empty array for array values instead of `null`
 - `go run cmd/skycoin/skycoin.go` will have exit status 1 on failure and exit status 2 on panic
+- The deprecated JSON 2.0 RPC interface is disabled by default for all run modes, since it is no longer needed for the CLI tool
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `-csv` option to `cli send` and `cli createRawTransaction`, which will send coins to multiple addresses defined in a csv file
 - Add `-disable-default-peers` option to disable the default hardcoded peers and mark all cached peers as untrusted
 - Add `-custom-peers-file` to load peers from disk. This peers file is a newline separate list of `ip:port` strings
+- Add `csrf_enabled`, `csp_enabled`, `wallet_api_enabled`, `unversioned_api_enabled`, `gui_enabled` and `json_rpc_enabled` configuration settings to the `/api/v1/health` endpoint response
 
 ### Fixed
 

--- a/ci-scripts/integration-test-stable.sh
+++ b/ci-scripts/integration-test-stable.sh
@@ -24,6 +24,7 @@ VERBOSE=""
 # run go test with -run flag
 RUN_TESTS=""
 DISABLE_CSRF="-disable-csrf"
+USE_CSRF=""
 
 COMMIT=$(git rev-parse HEAD)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -49,7 +50,7 @@ while getopts "h?t:r:uvc" args; do
     r ) RUN_TESTS="-run ${OPTARG}";;
     u ) UPDATE="--update";;
     v ) VERBOSE="-v";;
-    c ) DISABLE_CSRF="";
+    c ) DISABLE_CSRF=""; USE_CSRF="1";
   esac
 done
 
@@ -93,7 +94,7 @@ set +e
 
 if [[ -z $TEST || $TEST = "api" ]]; then
 
-SKYCOIN_INTEGRATION_TESTS=1 SKYCOIN_INTEGRATION_TEST_MODE=$MODE SKYCOIN_NODE_HOST=$HOST \
+SKYCOIN_INTEGRATION_TESTS=1 SKYCOIN_INTEGRATION_TEST_MODE=$MODE SKYCOIN_NODE_HOST=$HOST USE_CSRF=$USE_CSRF \
     go test ./src/api/integration/... $UPDATE -timeout=3m $VERBOSE $RUN_TESTS
 
 API_FAIL=$?
@@ -102,7 +103,7 @@ fi
 
 if [[ -z $TEST  || $TEST = "cli" ]]; then
 
-SKYCOIN_INTEGRATION_TESTS=1 SKYCOIN_INTEGRATION_TEST_MODE=$MODE RPC_ADDR=$RPC_ADDR \
+SKYCOIN_INTEGRATION_TESTS=1 SKYCOIN_INTEGRATION_TEST_MODE=$MODE RPC_ADDR=$RPC_ADDR USE_CSRF=$USE_CSRF \
     go test ./src/cli/integration/... $UPDATE -timeout=3m $VERBOSE $RUN_TESTS
 
 CLI_FAIL=$?

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -7,36 +7,36 @@ The CLI command APIs can be used directly from a Go application, see [Skycoin CL
 <!-- MarkdownTOC autolink="true" bracket="round" levels="1,2,3" -->
 
 - [Install](#install)
-    - [Enable command autocomplete](#enable-command-autocomplete)
+	- [Enable command autocomplete](#enable-command-autocomplete)
 - [Environment Setting](#environment-setting)
-    - [RPC_ADDR](#rpc_addr)
-    - [WALLET_DIR](#wallet_dir)
-    - [WALLET_NAME](#wallet_name)
+	- [RPC_ADDR](#rpc_addr)
+	- [WALLET_DIR](#wallet_dir)
+	- [WALLET_NAME](#wallet_name)
 - [Usage](#usage)
-    - [Add Private Key](#add-private-key)
-    - [Check address balance](#check-address-balance)
-    - [Generate new addresses](#generate-new-addresses)
-    - [Check address outputs](#check-address-outputs)
-    - [Check block data](#check-block-data)
-    - [Check database integrity](#check-database-integrity)
-    - [Create a raw transaction](#create-a-raw-transaction)
-    - [Decode a raw transaction](#decode-a-raw-transaction)
-    - [Broadcast a raw transaction](#broadcast-a-raw-transaction)
-    - [Generate a wallet](#generate-a-wallet)
-    - [Generate addresses for a wallet](#generate-addresses-for-a-wallet)
-    - [Last blocks](#last-blocks)
-    - [List wallet addresses](#list-wallet-addresses)
-    - [List wallets](#list-wallets)
-    - [Send](#send)
-    - [Show Config](#show-config)
-    - [Status](#status)
-    - [Get transaction](#get-transaction)
-    - [Verify address](#verify-address)
-    - [Check wallet balance](#check-wallet-balance)
-    - [See wallet directory](#see-wallet-directory)
-    - [List wallet transaction history](#list-wallet-transaction-history)
-    - [List wallet outputs](#list-wallet-outputs)
-    - [CLI version](#cli-version)
+	- [Add Private Key](#add-private-key)
+	- [Check address balance](#check-address-balance)
+	- [Generate new addresses](#generate-new-addresses)
+	- [Check address outputs](#check-address-outputs)
+	- [Check block data](#check-block-data)
+	- [Check database integrity](#check-database-integrity)
+	- [Create a raw transaction](#create-a-raw-transaction)
+	- [Decode a raw transaction](#decode-a-raw-transaction)
+	- [Broadcast a raw transaction](#broadcast-a-raw-transaction)
+	- [Generate a wallet](#generate-a-wallet)
+	- [Generate addresses for a wallet](#generate-addresses-for-a-wallet)
+	- [Last blocks](#last-blocks)
+	- [List wallet addresses](#list-wallet-addresses)
+	- [List wallets](#list-wallets)
+	- [Send](#send)
+	- [Show Config](#show-config)
+	- [Status](#status)
+	- [Get transaction](#get-transaction)
+	- [Verify address](#verify-address)
+	- [Check wallet balance](#check-wallet-balance)
+	- [See wallet directory](#see-wallet-directory)
+	- [List wallet transaction history](#list-wallet-transaction-history)
+	- [List wallet outputs](#list-wallet-outputs)
+	- [CLI version](#cli-version)
 - [Note](#note)
 
 <!-- /MarkdownTOC -->
@@ -1532,10 +1532,16 @@ $ skycoin-cli status
         "version": {
             "version": "0.24.1",
             "commit": "620405485d3276c16c0379bc3b88b588e34c45e1",
-            "branch": "bulk-send"
+            "branch": "develop"
         },
         "open_connections": 8,
-        "uptime": "4h1m23.697072461s"
+        "uptime": "4h1m23.697072461s",
+        "csrf_enabled": true,
+        "csp_enabled": true,
+        "wallet_api_enabled": true,
+        "gui_enabled": true,
+        "unversioned_api_enabled": false,
+        "json_rpc_enabled": false
     },
     "cli_config": {
         "webrpc_address": "http://127.0.0.1:6420"

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -57,59 +57,59 @@ However, any changes to the API will be recorded in the [changelog](../../CHANGE
 <!-- MarkdownTOC autolink="true" bracket="round" levels="1,2,3,4,5" -->
 
 - [CSRF](#csrf)
-    - [Get current csrf token](#get-current-csrf-token)
+	- [Get current csrf token](#get-current-csrf-token)
 - [General system checks](#general-system-checks)
-    - [Health check](#health-check)
+	- [Health check](#health-check)
+	- [Version info](#version-info)
 - [Simple query APIs](#simple-query-apis)
-    - [Get node version info](#get-node-version-info)
-    - [Get balance of addresses](#get-balance-of-addresses)
-    - [Get unspent output set of address or hash](#get-unspent-output-set-of-address-or-hash)
-    - [Verify an address](#verify-an-address)
+	- [Get balance of addresses](#get-balance-of-addresses)
+	- [Get unspent output set of address or hash](#get-unspent-output-set-of-address-or-hash)
+	- [Verify an address](#verify-an-address)
 - [Wallet APIs](#wallet-apis)
-    - [Get wallet](#get-wallet)
-    - [Get wallet transactions](#get-wallet-transactions)
-    - [Get wallets](#get-wallets)
-    - [Get wallet folder name](#get-wallet-folder-name)
-    - [Generate wallet seed](#generate-wallet-seed)
-    - [Create a wallet from seed](#create-a-wallet-from-seed)
-    - [Generate new address in wallet](#generate-new-address-in-wallet)
-    - [Updates wallet label](#updates-wallet-label)
-    - [Get wallet balance](#get-wallet-balance)
-    - [Spend coins from wallet](#spend-coins-from-wallet)
-    - [Create transaction](#create-transaction)
-    - [Unload wallet](#unload-wallet)
-    - [Encrypt wallet](#encrypt-wallet)
-    - [Decrypt wallet](#decrypt-wallet)
-    - [Get wallet seed](#get-wallet-seed)
+	- [Get wallet](#get-wallet)
+	- [Get wallet transactions](#get-wallet-transactions)
+	- [Get wallets](#get-wallets)
+	- [Get wallet folder name](#get-wallet-folder-name)
+	- [Generate wallet seed](#generate-wallet-seed)
+	- [Create a wallet from seed](#create-a-wallet-from-seed)
+	- [Generate new address in wallet](#generate-new-address-in-wallet)
+	- [Updates wallet label](#updates-wallet-label)
+	- [Get wallet balance](#get-wallet-balance)
+	- [Spend coins from wallet](#spend-coins-from-wallet)
+	- [Create transaction](#create-transaction)
+	- [Unload wallet](#unload-wallet)
+	- [Encrypt wallet](#encrypt-wallet)
+	- [Decrypt wallet](#decrypt-wallet)
+	- [Get wallet seed](#get-wallet-seed)
 - [Transaction APIs](#transaction-apis)
-    - [Get unconfirmed transactions](#get-unconfirmed-transactions)
-    - [Get transaction info by id](#get-transaction-info-by-id)
-    - [Get raw transaction by id](#get-raw-transaction-by-id)
-    - [Inject raw transaction](#inject-raw-transaction)
-    - [Get transactions that are addresses related](#get-transactions-that-are-addresses-related)
-    - [Resend unconfirmed transactions](#resend-unconfirmed-transactions)
-    - [Verify encoded transaction](#verify-encoded-transaction)
+	- [Get unconfirmed transactions](#get-unconfirmed-transactions)
+	- [Get transaction info by id](#get-transaction-info-by-id)
+	- [Get raw transaction by id](#get-raw-transaction-by-id)
+	- [Inject raw transaction](#inject-raw-transaction)
+	- [Get transactions that are addresses related](#get-transactions-that-are-addresses-related)
+	- [Resend unconfirmed transactions](#resend-unconfirmed-transactions)
+	- [Verify encoded transaction](#verify-encoded-transaction)
 - [Block APIs](#block-apis)
-    - [Get blockchain metadata](#get-blockchain-metadata)
-    - [Get blockchain progress](#get-blockchain-progress)
-    - [Get block by hash or seq](#get-block-by-hash-or-seq)
-    - [Get blocks in specific range](#get-blocks-in-specific-range)
-    - [Get last N blocks](#get-last-n-blocks)
+	- [Get blockchain metadata](#get-blockchain-metadata)
+	- [Get blockchain progress](#get-blockchain-progress)
+	- [Get block by hash or seq](#get-block-by-hash-or-seq)
+	- [Get blocks in specific range](#get-blocks-in-specific-range)
+	- [Get last N blocks](#get-last-n-blocks)
 - [Explorer APIs](#explorer-apis)
-    - [Get address affected transactions](#get-address-affected-transactions)
+	- [Get address affected transactions](#get-address-affected-transactions)
 - [Uxout APIs](#uxout-apis)
-    - [Get uxout](#get-uxout)
-    - [Get historical unspent outputs for an address](#get-historical-unspent-outputs-for-an-address)
+	- [Get uxout](#get-uxout)
+	- [Get historical unspent outputs for an address](#get-historical-unspent-outputs-for-an-address)
 - [Coin supply related information](#coin-supply-related-information)
-    - [Coin supply](#coin-supply)
-    - [Richlist show top N addresses by uxouts](#richlist-show-top-n-addresses-by-uxouts)
-    - [Count unique addresses](#count-unique-addresses)
+	- [Coin supply](#coin-supply)
+	- [Richlist show top N addresses by uxouts](#richlist-show-top-n-addresses-by-uxouts)
+	- [Count unique addresses](#count-unique-addresses)
 - [Network status](#network-status)
-    - [Get information for a specific connection](#get-information-for-a-specific-connection)
-    - [Get a list of all connections](#get-a-list-of-all-connections)
-    - [Get a list of all default connections](#get-a-list-of-all-default-connections)
-    - [Get a list of all trusted connections](#get-a-list-of-all-trusted-connections)
-    - [Get a list of all connections discovered through peer exchange](#get-a-list-of-all-connections-discovered-through-peer-exchange)
+	- [Get information for a specific connection](#get-information-for-a-specific-connection)
+	- [Get a list of all connections](#get-a-list-of-all-connections)
+	- [Get a list of all default connections](#get-a-list-of-all-default-connections)
+	- [Get a list of all trusted connections](#get-a-list-of-all-trusted-connections)
+	- [Get a list of all connections discovered through peer exchange](#get-a-list-of-all-connections-discovered-through-peer-exchange)
 
 <!-- /MarkdownTOC -->
 
@@ -165,31 +165,35 @@ Response:
 {
     "blockchain": {
         "head": {
-            "seq": 21175,
-            "block_hash": "8a3e0aac619551ae009cfb28c2b36bb1300925f74da770d1512072314f6a4c80",
-            "previous_block_hash": "001eb7911b6a6ab7c75feb88726dd2bc8b87133aebc82201c4404537eb74f7ac",
-            "timestamp": 1523168686,
-            "fee": 2,
+            "seq": 53522,
+            "block_hash": "95fa50f505c02589faf598bfc8ac44b9e3c7f25690a0a16725b63836459c1b5f",
+            "previous_block_hash": "d3af6cc4e65ac650d73835681075a95ba59743721506b6fc1d891e7b7d8f7900",
+            "timestamp": 1535002265,
+            "fee": 7064,
             "version": 0,
-            "tx_body_hash": "36be8d70d1e9f70b340ea7ecf0b247c27086bad10568044c1196fe150f6cea1b"
+            "tx_body_hash": "1ed5bee9c6cfe96a971232e8fee0d2b90d1e0c14867dd8505d0897476ec47e31"
         },
-        "unspents": 14750,
-        "unconfirmed": 0,
-        "time_since_last_block": "12m6s"
+        "unspents": 34159,
+        "unconfirmed": 1,
+        "time_since_last_block": "6m47s"
     },
     "version": {
-        "version": "0.23.0",
-        "commit": "f61b4319c2f146a5ad86f7cbda26a1ba6a09998d",
+        "version": "0.24.1",
+        "commit": "991b8c0cfe7ca4aed41d6c4bc960b61e9612c516",
         "branch": "develop"
     },
-    "open_connections": 30,
-    "uptime": "13.686460853s"
+    "open_connections": 5,
+    "uptime": "11.158716091s",
+    "csrf_enabled": true,
+    "csp_enabled": true,
+    "wallet_api_enabled": true,
+    "gui_enabled": true,
+    "unversioned_api_enabled": false,
+    "json_rpc_enabled": false
 }
 ```
 
-## Simple query APIs
-
-### Get node version info
+### Version info
 
 ```
 URI: /api/v1/version
@@ -207,9 +211,13 @@ Result:
 ```json
 {
     "version": "0.20.0",
-    "commit": "cc733e9922d85c359f5f183d3a3a6e42c73ccb16"
+    "commit": "cc733e9922d85c359f5f183d3a3a6e42c73ccb16",
+    "branch": "develop"
 }
 ```
+
+
+## Simple query APIs
 
 ### Get balance of addresses
 

--- a/src/api/address_test.go
+++ b/src/api/address_test.go
@@ -100,7 +100,6 @@ func TestVerifyAddress(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := "/api/v2/address/verify"
 			gateway := NewGatewayerMock()
-			gateway.On("IsCSPEnabled").Return(false)
 
 			req, err := http.NewRequest(tc.method, endpoint, bytes.NewBufferString(tc.httpBody))
 			require.NoError(t, err)
@@ -122,8 +121,7 @@ func TestVerifyAddress(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			cfg := muxConfig{host: configuredHost, appLoc: "."}
-			handler := newServerMux(cfg, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 			handler.ServeHTTP(rr, req)
 
 			status := rr.Code

--- a/src/api/blockchain_test.go
+++ b/src/api/blockchain_test.go
@@ -206,7 +206,6 @@ func TestGetBlock(t *testing.T) {
 
 			gateway.On("GetSignedBlockByHash", tc.sha256).Return(tc.gatewayGetBlockByHashResult, tc.gatewayGetBlockByHashErr)
 			gateway.On("GetSignedBlockBySeq", tc.seq).Return(tc.gatewayGetBlockBySeqResult, tc.gatewayGetBlockBySeqErr)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/block"
 
@@ -231,7 +230,7 @@ func TestGetBlock(t *testing.T) {
 			setCSRFParameters(csrfStore, tokenValid, req)
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
 
@@ -333,7 +332,6 @@ func TestGetBlocks(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("GetBlocks", tc.start, tc.end).Return(tc.gatewayGetBlocksResult, tc.gatewayGetBlocksError)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/blocks"
 
@@ -359,7 +357,7 @@ func TestGetBlocks(t *testing.T) {
 			setCSRFParameters(csrfStore, tokenValid, req)
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
 
@@ -450,7 +448,6 @@ func TestGetLastBlocks(t *testing.T) {
 			gateway := NewGatewayerMock()
 
 			gateway.On("GetLastBlocks", tc.num).Return(tc.gatewayGetLastBlocksResult, tc.gatewayGetLastBlocksError)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			v := url.Values{}
 			if tc.body.Num != "" {
@@ -470,7 +467,7 @@ func TestGetLastBlocks(t *testing.T) {
 
 			rr := httptest.NewRecorder()
 
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
 

--- a/src/api/csrf_test.go
+++ b/src/api/csrf_test.go
@@ -145,7 +145,6 @@ func TestCSRFWrapper(t *testing.T) {
 				name := fmt.Sprintf("%s %s %s", method, endpoint, c)
 				t.Run(name, func(t *testing.T) {
 					gateway := &GatewayerMock{}
-					gateway.On("IsCSPEnabled").Return(false)
 
 					req, err := http.NewRequest(method, endpoint, nil)
 					require.NoError(t, err)
@@ -161,6 +160,7 @@ func TestCSRFWrapper(t *testing.T) {
 						appLoc:               ".",
 						enableJSON20RPC:      true,
 						enableUnversionedAPI: true,
+						disableCSP:           true,
 					}, gateway, csrfStore, nil)
 
 					handler.ServeHTTP(rr, req)
@@ -195,7 +195,6 @@ func TestOriginRefererCheck(t *testing.T) {
 			name := fmt.Sprintf("%s %s", tc.name, endpoint)
 			t.Run(name, func(t *testing.T) {
 				gateway := &GatewayerMock{}
-				gateway.On("IsCSPEnabled").Return(false)
 
 				req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 				require.NoError(t, err)
@@ -217,6 +216,7 @@ func TestOriginRefererCheck(t *testing.T) {
 					host:            configuredHost,
 					appLoc:          ".",
 					enableJSON20RPC: true,
+					disableCSP:      true,
 				}, gateway, csrfStore, nil)
 
 				handler.ServeHTTP(rr, req)
@@ -233,7 +233,6 @@ func TestHostCheck(t *testing.T) {
 	for _, endpoint := range endpoints {
 		t.Run(endpoint, func(t *testing.T) {
 			gateway := &GatewayerMock{}
-			gateway.On("IsCSPEnabled").Return(false)
 
 			req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 			require.NoError(t, err)
@@ -250,6 +249,7 @@ func TestHostCheck(t *testing.T) {
 				host:            configuredHost,
 				appLoc:          ".",
 				enableJSON20RPC: true,
+				disableCSP:      true,
 			}, gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
@@ -269,7 +269,6 @@ func TestCSRF(t *testing.T) {
 	updateWalletLabel := func(csrfToken string) *httptest.ResponseRecorder {
 		gateway := &GatewayerMock{}
 		gateway.On("UpdateWalletLabel", "fooid", "foolabel").Return(nil)
-		gateway.On("IsCSPEnabled").Return(false)
 
 		endpoint := "/api/v1/wallet/update"
 
@@ -290,6 +289,7 @@ func TestCSRF(t *testing.T) {
 			host:            configuredHost,
 			appLoc:          ".",
 			enableJSON20RPC: true,
+			disableCSP:      true,
 		}, gateway, csrfStore, nil)
 
 		handler.ServeHTTP(rr, req)
@@ -304,8 +304,7 @@ func TestCSRF(t *testing.T) {
 
 	// Make a request to /csrf to get a token
 	gateway := &GatewayerMock{}
-	gateway.On("IsCSPEnabled").Return(false)
-	handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
+	handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 	// non-GET request to /csrf is invalid
 	req, err := http.NewRequest(http.MethodPost, "/api/v1/csrf", nil)

--- a/src/api/explorer_test.go
+++ b/src/api/explorer_test.go
@@ -158,7 +158,6 @@ func TestGetTransactionsForAddress(t *testing.T) {
 			endpoint := "/api/v1/explorer/address"
 			gateway := NewGatewayerMock()
 			gateway.On("GetTransactionsForAddress", address).Return(tc.result, tc.gatewayGetTransactionsForAddressErr)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			v := url.Values{}
 			if tc.addressParam != "" {
@@ -180,7 +179,7 @@ func TestGetTransactionsForAddress(t *testing.T) {
 			} else {
 				setCSRFParameters(csrfStore, tokenInvalid, req)
 			}
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 			handler.ServeHTTP(rr, req)
 
 			status := rr.Code
@@ -289,7 +288,6 @@ func TestCoinSupply(t *testing.T) {
 			endpoint := "/api/v1/coinSupply"
 			gateway := NewGatewayerMock()
 			gateway.On("GetUnspentOutputs", mock.Anything).Return(tc.gatewayGetUnspentOutputsResult, tc.gatewayGetUnspentOutputsErr)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			req, err := http.NewRequest(tc.method, endpoint, nil)
 			require.NoError(t, err)
@@ -303,7 +301,7 @@ func TestCoinSupply(t *testing.T) {
 			} else {
 				setCSRFParameters(csrfStore, tokenInvalid, req)
 			}
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 			handler.ServeHTTP(rr, req)
 
 			status := rr.Code
@@ -502,7 +500,6 @@ func TestGetRichlist(t *testing.T) {
 			endpoint := "/api/v1/richlist"
 			gateway := NewGatewayerMock()
 			gateway.On("GetRichlist", tc.includeDistribution).Return(tc.gatewayGetRichlistResult, tc.gatewayGetRichlistErr)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			v := url.Values{}
 			if tc.httpParams != nil {
@@ -529,7 +526,7 @@ func TestGetRichlist(t *testing.T) {
 			} else {
 				setCSRFParameters(csrfStore, tokenInvalid, req)
 			}
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 			handler.ServeHTTP(rr, req)
 
 			status := rr.Code
@@ -591,7 +588,6 @@ func TestGetAddressCount(t *testing.T) {
 			endpoint := "/api/v1/addresscount"
 			gateway := NewGatewayerMock()
 			gateway.On("GetAddressCount").Return(tc.gatewayGetAddressCountResult, tc.gatewayGetAddressCountErr)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			req, err := http.NewRequest(tc.method, endpoint, nil)
 			require.NoError(t, err)
@@ -605,7 +601,7 @@ func TestGetAddressCount(t *testing.T) {
 			} else {
 				setCSRFParameters(csrfStore, tokenInvalid, req)
 			}
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 			handler.ServeHTTP(rr, req)
 
 			status := rr.Code

--- a/src/api/gateway.go
+++ b/src/api/gateway.go
@@ -55,5 +55,4 @@ type Gatewayer interface {
 	GetHealth() (*daemon.Health, error)
 	UnloadWallet(id string) error
 	VerifyTxnVerbose(txn *coin.Transaction) ([]wallet.UxBalance, bool, error)
-	IsCSPEnabled() bool
 }

--- a/src/api/gatewayer_mock_test.go
+++ b/src/api/gatewayer_mock_test.go
@@ -900,24 +900,6 @@ func (m *GatewayerMock) InjectBroadcastTransaction(p0 coin.Transaction) error {
 
 }
 
-// IsCSPEnabled mocked method
-func (m *GatewayerMock) IsCSPEnabled() bool {
-
-	ret := m.Called()
-
-	var r0 bool
-	switch res := ret.Get(0).(type) {
-	case nil:
-	case bool:
-		r0 = res
-	default:
-		panic(fmt.Sprintf("unexpected type: %v", res))
-	}
-
-	return r0
-
-}
-
 // IsWalletAPIEnabled mocked method
 func (m *GatewayerMock) IsWalletAPIEnabled() bool {
 

--- a/src/api/health.go
+++ b/src/api/health.go
@@ -17,16 +17,22 @@ type BlockchainMetadata struct {
 
 // HealthResponse is returned by the /health endpoint
 type HealthResponse struct {
-	BlockchainMetadata BlockchainMetadata `json:"blockchain"`
-	Version            visor.BuildInfo    `json:"version"`
-	OpenConnections    int                `json:"open_connections"`
-	Uptime             wh.Duration        `json:"uptime"`
+	BlockchainMetadata    BlockchainMetadata `json:"blockchain"`
+	Version               visor.BuildInfo    `json:"version"`
+	OpenConnections       int                `json:"open_connections"`
+	Uptime                wh.Duration        `json:"uptime"`
+	CSRFEnabled           bool               `json:"csrf_enabled"`
+	CSPEnabled            bool               `json:"csp_enabled"`
+	WalletAPIEnabled      bool               `json:"wallet_api_enabled"`
+	GUIEnabled            bool               `json:"gui_enabled"`
+	UnversionedAPIEnabled bool               `json:"unversioned_api_enabled"`
+	JSON20RPCEnabled      bool               `json:"json_rpc_enabled"`
 }
 
-// Returns node health data.
+// healthHandler returns node health data
 // URI: /api/v1/health
 // Method: GET
-func healthCheck(gateway Gatewayer) http.HandlerFunc {
+func healthHandler(c muxConfig, csrfStore *CSRFStore, gateway Gatewayer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			wh.Error405(w)
@@ -48,9 +54,15 @@ func healthCheck(gateway Gatewayer) http.HandlerFunc {
 				BlockchainMetadata: health.BlockchainMetadata,
 				TimeSinceLastBlock: wh.FromDuration(timeSinceLastBlock),
 			},
-			Version:         health.Version,
-			OpenConnections: health.OpenConnections,
-			Uptime:          wh.FromDuration(health.Uptime),
+			Version:               health.Version,
+			OpenConnections:       health.OpenConnections,
+			Uptime:                wh.FromDuration(health.Uptime),
+			CSRFEnabled:           csrfStore.Enabled,
+			CSPEnabled:            !c.disableCSP,
+			UnversionedAPIEnabled: c.enableUnversionedAPI,
+			GUIEnabled:            c.enableGUI,
+			JSON20RPCEnabled:      c.enableJSON20RPC,
+			WalletAPIEnabled:      gateway.IsWalletAPIEnabled(),
 		})
 	}
 }

--- a/src/api/health_test.go
+++ b/src/api/health_test.go
@@ -18,26 +18,50 @@ import (
 func TestHealthCheckHandler(t *testing.T) {
 
 	cases := []struct {
-		name         string
-		method       string
-		code         int
-		getHealthErr error
+		name             string
+		method           string
+		code             int
+		getHealthErr     error
+		cfg              muxConfig
+		csrfEnabled      bool
+		walletAPIEnabled bool
 	}{
 		{
 			name:   "valid response",
 			method: http.MethodGet,
 			code:   http.StatusOK,
+			cfg:    defaultMuxConfig(),
 		},
+
 		{
 			name:   "403 method not allowed",
 			method: http.MethodPost,
 			code:   http.StatusMethodNotAllowed,
+			cfg:    defaultMuxConfig(),
 		},
+
 		{
 			name:         "gateway.GetHealth error",
 			method:       http.MethodGet,
 			code:         http.StatusInternalServerError,
 			getHealthErr: errors.New("GetHealth failed"),
+			cfg:          defaultMuxConfig(),
+		},
+
+		{
+			name:   "valid response, opposite config",
+			method: http.MethodGet,
+			code:   http.StatusOK,
+			cfg: muxConfig{
+				host:                 configuredHost,
+				appLoc:               ".",
+				disableCSP:           false,
+				enableGUI:            true,
+				enableUnversionedAPI: true,
+				enableJSON20RPC:      true,
+			},
+			csrfEnabled:      true,
+			walletAPIEnabled: true,
 		},
 	}
 
@@ -74,7 +98,7 @@ func TestHealthCheckHandler(t *testing.T) {
 			}
 
 			gateway := NewGatewayerMock()
-			gateway.On("IsCSPEnabled").Return(false)
+			gateway.On("IsWalletAPIEnabled").Return(tc.walletAPIEnabled)
 
 			if tc.getHealthErr != nil {
 				gateway.On("GetHealth").Return(nil, tc.getHealthErr)
@@ -86,12 +110,12 @@ func TestHealthCheckHandler(t *testing.T) {
 			req, err := http.NewRequest(tc.method, endpoint, nil)
 			require.NoError(t, err)
 
-			rr := httptest.NewRecorder()
-			cfg := muxConfig{
-				host:   configuredHost,
-				appLoc: ".",
+			csrfStore := &CSRFStore{
+				Enabled: tc.csrfEnabled,
 			}
-			handler := newServerMux(cfg, gateway, &CSRFStore{}, nil)
+
+			rr := httptest.NewRecorder()
+			handler := newServerMux(tc.cfg, gateway, csrfStore, nil)
 			handler.ServeHTTP(rr, req)
 			if tc.code != http.StatusOK {
 				require.Equal(t, tc.code, rr.Code)
@@ -115,6 +139,13 @@ func TestHealthCheckHandler(t *testing.T) {
 			require.Equal(t, unspents, r.BlockchainMetadata.Unspents)
 			require.True(t, r.BlockchainMetadata.TimeSinceLastBlock.Duration > time.Duration(0))
 			require.Equal(t, metadata.Head, r.BlockchainMetadata.Head)
+
+			require.Equal(t, tc.csrfEnabled, r.CSRFEnabled)
+			require.Equal(t, !tc.cfg.disableCSP, r.CSPEnabled)
+			require.Equal(t, tc.cfg.enableUnversionedAPI, r.UnversionedAPIEnabled)
+			require.Equal(t, tc.cfg.enableGUI, r.GUIEnabled)
+			require.Equal(t, tc.cfg.enableJSON20RPC, r.JSON20RPCEnabled)
+			require.Equal(t, tc.walletAPIEnabled, r.WalletAPIEnabled)
 		})
 	}
 }

--- a/src/api/integration/integration_test.go
+++ b/src/api/integration/integration_test.go
@@ -3982,6 +3982,14 @@ func TestStableHealth(t *testing.T) {
 	// The stable node is always run with the commit and branch ldflags, so they should appear
 	require.NotEmpty(t, r.Version.Commit)
 	require.NotEmpty(t, r.Version.Branch)
+
+	// CSRF can be on or off depending on the test mode
+	// require.False(t, r.CSRFEnabled)
+	require.True(t, r.CSPEnabled)
+	require.True(t, r.WalletAPIEnabled)
+	require.False(t, r.UnversionedAPIEnabled)
+	require.False(t, r.GUIEnabled)
+	require.True(t, r.JSON20RPCEnabled)
 }
 
 func TestLiveHealth(t *testing.T) {

--- a/src/api/integration/integration_test.go
+++ b/src/api/integration/integration_test.go
@@ -100,6 +100,17 @@ func enabled() bool {
 	return os.Getenv("SKYCOIN_INTEGRATION_TESTS") == "1"
 }
 
+func useCSRF(t *testing.T) bool {
+	x := os.Getenv("USE_CSRF")
+	if x == "" {
+		return false
+	}
+
+	useCSRF, err := strconv.ParseBool(x)
+	require.NoError(t, err)
+	return useCSRF
+}
+
 func doStable(t *testing.T) bool {
 	if enabled() && mode(t) == testModeStable {
 		return true
@@ -3983,8 +3994,7 @@ func TestStableHealth(t *testing.T) {
 	require.NotEmpty(t, r.Version.Commit)
 	require.NotEmpty(t, r.Version.Branch)
 
-	// CSRF can be on or off depending on the test mode
-	// require.False(t, r.CSRFEnabled)
+	require.Equal(t, useCSRF(t), r.CSRFEnabled)
 	require.True(t, r.CSPEnabled)
 	require.True(t, r.WalletAPIEnabled)
 	require.False(t, r.UnversionedAPIEnabled)

--- a/src/api/integration/integration_test.go
+++ b/src/api/integration/integration_test.go
@@ -3989,7 +3989,7 @@ func TestStableHealth(t *testing.T) {
 	require.True(t, r.WalletAPIEnabled)
 	require.False(t, r.UnversionedAPIEnabled)
 	require.False(t, r.GUIEnabled)
-	require.True(t, r.JSON20RPCEnabled)
+	require.False(t, r.JSON20RPCEnabled)
 }
 
 func TestLiveHealth(t *testing.T) {

--- a/src/api/network_test.go
+++ b/src/api/network_test.go
@@ -125,7 +125,6 @@ func TestConnection(t *testing.T) {
 				tc.gatewayGetBlockchainProgressResult,
 				tc.gatewayGetBlockchainProgressError,
 			)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			v := url.Values{}
 			if tc.addr != "" {
@@ -138,7 +137,7 @@ func TestConnection(t *testing.T) {
 			require.NoError(t, err)
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, &CSRFStore{}, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, &CSRFStore{}, nil)
 			handler.ServeHTTP(rr, req)
 
 			status := rr.Code
@@ -268,13 +267,12 @@ func TestConnections(t *testing.T) {
 				tc.gatewayGetBlockchainProgressResult,
 				tc.gatewayGetBlockchainProgressError,
 			)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			req, err := http.NewRequest(tc.method, endpoint, nil)
 			require.NoError(t, err)
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, &CSRFStore{}, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, &CSRFStore{}, nil)
 			handler.ServeHTTP(rr, req)
 
 			status := rr.Code
@@ -322,12 +320,11 @@ func TestDefaultConnections(t *testing.T) {
 			endpoint := "/api/v1/network/defaultConnections"
 			gateway := NewGatewayerMock()
 			gateway.On("GetDefaultConnections").Return(tc.gatewayGetDefaultConnectionsResult)
-			gateway.On("IsCSPEnabled").Return(false)
 			req, err := http.NewRequest(tc.method, endpoint, nil)
 			require.NoError(t, err)
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, &CSRFStore{}, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, &CSRFStore{}, nil)
 			handler.ServeHTTP(rr, req)
 
 			status := rr.Code
@@ -375,12 +372,11 @@ func TestGetTrustConnections(t *testing.T) {
 			endpoint := "/api/v1/network/connections/trust"
 			gateway := NewGatewayerMock()
 			gateway.On("GetTrustConnections").Return(tc.gatewayGetTrustConnectionsResult)
-			gateway.On("IsCSPEnabled").Return(false)
 			req, err := http.NewRequest(tc.method, endpoint, nil)
 			require.NoError(t, err)
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, &CSRFStore{}, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, &CSRFStore{}, nil)
 			handler.ServeHTTP(rr, req)
 
 			status := rr.Code
@@ -428,12 +424,11 @@ func TestGetExchgConnection(t *testing.T) {
 			endpoint := "/api/v1/network/connections/exchange"
 			gateway := NewGatewayerMock()
 			gateway.On("GetExchgConnection").Return(tc.gatewayGetExchgConnectionResult)
-			gateway.On("IsCSPEnabled").Return(false)
 			req, err := http.NewRequest(tc.method, endpoint, nil)
 			require.NoError(t, err)
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, &CSRFStore{}, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, &CSRFStore{}, nil)
 			handler.ServeHTTP(rr, req)
 
 			status := rr.Code

--- a/src/api/outputs.go
+++ b/src/api/outputs.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/daemon"
+	wh "github.com/skycoin/skycoin/src/util/http"
+)
+
+// getOutputsHandler returns UxOuts filtered by a set of addresses or a set of hashes
+// URI: /api/v1/outputs
+// Method: GET
+// Args:
+//    addrs: comma-separated list of addresses
+//    hashes: comma-separated list of uxout hashes
+// If neither addrs nor hashes are specificed, return all unspent outputs.
+// If only one filter is specified, then return outputs match the filter.
+// Both filters cannot be specified.
+func getOutputsHandler(gateway Gatewayer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			wh.Error405(w)
+			return
+		}
+
+		var addrs []string
+		var hashes []string
+
+		addrStr := r.FormValue("addrs")
+		hashStr := r.FormValue("hashes")
+
+		if addrStr != "" && hashStr != "" {
+			wh.Error400(w, "addrs and hashes cannot be specified together")
+			return
+		}
+
+		filters := []daemon.OutputsFilter{}
+
+		if addrStr != "" {
+			addrs = splitCommaString(addrStr)
+
+			for _, a := range addrs {
+				if _, err := cipher.DecodeBase58Address(a); err != nil {
+					wh.Error400(w, "addrs contains invalid address")
+					return
+				}
+			}
+
+			if len(addrs) > 0 {
+				filters = append(filters, daemon.FbyAddresses(addrs))
+			}
+		}
+
+		if hashStr != "" {
+			hashes = splitCommaString(hashStr)
+			if len(hashes) > 0 {
+				filters = append(filters, daemon.FbyHashes(hashes))
+			}
+		}
+
+		outs, err := gateway.GetUnspentOutputs(filters...)
+		if err != nil {
+			err = fmt.Errorf("get unspent outputs failed: %v", err)
+			wh.Error500(w, err.Error())
+			return
+		}
+
+		wh.SendJSONOr500(logger, w, outs)
+	}
+}

--- a/src/api/spend_test.go
+++ b/src/api/spend_test.go
@@ -842,7 +842,6 @@ func TestCreateTransaction(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &GatewayerMock{}
-			gateway.On("IsCSPEnabled").Return(false)
 
 			// If the rawRequestBody can be deserialized to CreateTransactionRequest, use it to mock gateway.CreateTransaction
 			serializedBody, err := json.Marshal(tc.body)
@@ -879,7 +878,7 @@ func TestCreateTransaction(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
 

--- a/src/api/transaction_test.go
+++ b/src/api/transaction_test.go
@@ -132,7 +132,6 @@ func TestGetPendingTxs(t *testing.T) {
 			endpoint := "/api/v1/pendingTxs"
 			gateway := NewGatewayerMock()
 			gateway.On("GetAllUnconfirmedTxns").Return(tc.getAllUnconfirmedTxnsResponse, tc.getAllUnconfirmedTxnsErr)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			req, err := http.NewRequest(tc.method, endpoint, nil)
 			require.NoError(t, err)
@@ -142,7 +141,7 @@ func TestGetPendingTxs(t *testing.T) {
 			}
 			setCSRFParameters(csrfStore, tokenValid, req)
 
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 			rr := httptest.NewRecorder()
 			handler.ServeHTTP(rr, req)
 
@@ -266,7 +265,6 @@ func TestGetTransactionByID(t *testing.T) {
 			endpoint := "/api/v1/transaction"
 			gateway := NewGatewayerMock()
 			gateway.On("GetTransaction", tc.getTransactionArg).Return(tc.getTransactionReponse, tc.getTransactionError)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			v := url.Values{}
 			if tc.httpBody != nil {
@@ -287,7 +285,7 @@ func TestGetTransactionByID(t *testing.T) {
 			setCSRFParameters(csrfStore, tokenValid, req)
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 			handler.ServeHTTP(rr, req)
 
 			status := rr.Code
@@ -399,7 +397,6 @@ func TestInjectTransaction(t *testing.T) {
 			endpoint := "/api/v1/injectTransaction"
 			gateway := NewGatewayerMock()
 			gateway.On("InjectBroadcastTransaction", tc.injectTransactionArg).Return(tc.injectTransactionError)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			req, err := http.NewRequest(tc.method, endpoint, bytes.NewBufferString(tc.httpBody))
 			require.NoError(t, err)
@@ -414,7 +411,7 @@ func TestInjectTransaction(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 			handler.ServeHTTP(rr, req)
 
 			status := rr.Code
@@ -471,7 +468,6 @@ func TestResendUnconfirmedTxns(t *testing.T) {
 			endpoint := "/api/v1/resendUnconfirmedTxns"
 			gateway := NewGatewayerMock()
 			gateway.On("ResendUnconfirmedTxns").Return(tc.resendUnconfirmedTxnsResponse, tc.resendUnconfirmedTxnsErr)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			req, err := http.NewRequest(tc.method, endpoint, bytes.NewBufferString(tc.httpBody))
 			require.NoError(t, err)
@@ -482,7 +478,7 @@ func TestResendUnconfirmedTxns(t *testing.T) {
 			setCSRFParameters(csrfStore, tokenValid, req)
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 			handler.ServeHTTP(rr, req)
 
 			status := rr.Code
@@ -596,7 +592,6 @@ func TestGetRawTx(t *testing.T) {
 			endpoint := "/api/v1/rawtx"
 			gateway := NewGatewayerMock()
 			gateway.On("GetTransaction", tc.getTransactionArg).Return(tc.getTransactionResponse, tc.getTransactionError)
-			gateway.On("IsCSPEnabled").Return(false)
 			v := url.Values{}
 			if tc.httpBody != nil {
 				if tc.httpBody.txid != "" {
@@ -616,7 +611,7 @@ func TestGetRawTx(t *testing.T) {
 			setCSRFParameters(csrfStore, tokenValid, req)
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 			handler.ServeHTTP(rr, req)
 
 			status := rr.Code
@@ -754,7 +749,6 @@ func TestGetTransactions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := NewGatewayerMock()
 			gateway.On("GetTransactions", mock.Anything).Return(tc.getTransactionsResponse, tc.getTransactionsError)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			v := url.Values{}
 			if tc.httpBody != nil {
@@ -778,7 +772,7 @@ func TestGetTransactions(t *testing.T) {
 			setCSRFParameters(csrfStore, tokenValid, req)
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
 
@@ -1000,7 +994,6 @@ func TestVerifyTransaction(t *testing.T) {
 			gateway := NewGatewayerMock()
 			gateway.On("VerifyTxnVerbose", &tc.gatewayVerifyTxnVerboseArg).Return(tc.gatewayVerifyTxnVerboseResult.Uxouts,
 				tc.gatewayVerifyTxnVerboseResult.IsTxnConfirmed, tc.gatewayVerifyTxnVerboseResult.Err)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			req, err := http.NewRequest(tc.method, endpoint, bytes.NewBufferString(tc.httpBody))
 			require.NoError(t, err)
@@ -1016,7 +1009,7 @@ func TestVerifyTransaction(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 			handler.ServeHTTP(rr, req)
 
 			status := rr.Code

--- a/src/api/uxout_test.go
+++ b/src/api/uxout_test.go
@@ -118,7 +118,6 @@ func TestGetUxOutByID(t *testing.T) {
 			gateway := NewGatewayerMock()
 			endpoint := "/api/v1/uxout"
 			gateway.On("GetUxOutByID", tc.getGetUxOutByIDArg).Return(tc.getGetUxOutByIDResponse, tc.getGetUxOutByIDError)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			v := url.Values{}
 			if tc.httpBody != nil {
@@ -144,7 +143,7 @@ func TestGetUxOutByID(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 			handler.ServeHTTP(rr, req)
 
 			status := rr.Code
@@ -237,7 +236,6 @@ func TestGetAddrUxOuts(t *testing.T) {
 			endpoint := "/api/v1/address_uxouts"
 			gateway := NewGatewayerMock()
 			gateway.On("GetAddrUxOuts", tc.getAddrUxOutsArg).Return(tc.getAddrUxOutsResponse, tc.getAddrUxOutsError)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			v := url.Values{}
 			if tc.httpBody != nil {
@@ -261,7 +259,7 @@ func TestGetAddrUxOuts(t *testing.T) {
 				setCSRFParameters(csrfStore, tokenInvalid, req)
 			}
 			rr := httptest.NewRecorder()
-			handler := newServerMux(muxConfig{host: configuredHost, appLoc: "."}, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 			handler.ServeHTTP(rr, req)
 
 			status := rr.Code

--- a/src/api/version.go
+++ b/src/api/version.go
@@ -1,0 +1,21 @@
+package api
+
+import (
+	"net/http"
+
+	wh "github.com/skycoin/skycoin/src/util/http"
+)
+
+// versionHandler returns the application version info
+// URI: /api/v1/version
+// Method: GET
+func versionHandler(gateway Gatewayer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			wh.Error405(w)
+			return
+		}
+
+		wh.SendJSONOr500(logger, w, gateway.GetBuildInfo())
+	}
+}

--- a/src/api/wallet_test.go
+++ b/src/api/wallet_test.go
@@ -21,10 +21,6 @@ import (
 	"github.com/skycoin/skycoin/src/wallet"
 )
 
-const configuredHost = "127.0.0.1:6420"
-
-var mxConfig = muxConfig{host: configuredHost, appLoc: "."}
-
 func TestWalletSpendHandler(t *testing.T) {
 	type httpBody struct {
 		WalletID string
@@ -410,7 +406,6 @@ func TestWalletSpendHandler(t *testing.T) {
 			gateway.On("Spend", tc.walletID, []byte(tc.password), tc.coins, addr).Return(tc.gatewaySpendResult, tc.gatewaySpendErr)
 			gateway.On("GetWalletBalance", tc.walletID).Return(tc.gatewayGetWalletBalanceResult.BalancePair,
 				tc.gatewayGetWalletBalanceResult.Addresses, tc.gatewayBalanceErr)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/spend"
 
@@ -444,7 +439,7 @@ func TestWalletSpendHandler(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
 
@@ -546,7 +541,6 @@ func TestWalletGet(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("GetWallet", tc.walletID).Return(&tc.gatewayGetWalletResult, tc.gatewayGetWalletErr)
-			gateway.On("IsCSPEnabled").Return(false)
 			v := url.Values{}
 
 			endpoint := "/api/v1/wallet"
@@ -570,7 +564,7 @@ func TestWalletGet(t *testing.T) {
 			setCSRFParameters(csrfStore, tokenValid, req)
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
 
@@ -686,7 +680,6 @@ func TestWalletBalanceHandler(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("GetWalletBalance", tc.walletID).Return(tc.gatewayGetWalletBalanceResult.BalancePair,
 				tc.gatewayGetWalletBalanceResult.Addresses, tc.gatewayBalanceErr)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/balance"
 
@@ -709,7 +702,7 @@ func TestWalletBalanceHandler(t *testing.T) {
 			setCSRFParameters(csrfStore, tokenValid, req)
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
 
@@ -833,7 +826,6 @@ func TestUpdateWalletLabelHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("UpdateWalletLabel", tc.walletID, tc.label).Return(tc.gatewayUpdateWalletLabelErr)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/update"
 
@@ -857,7 +849,7 @@ func TestUpdateWalletLabelHandler(t *testing.T) {
 			setCSRFParameters(csrfStore, tokenValid, req)
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
 
@@ -954,7 +946,6 @@ func TestWalletTransactionsHandler(t *testing.T) {
 	for _, tc := range tt {
 		gateway := &GatewayerMock{}
 		gateway.On("GetWalletUnconfirmedTxns", tc.walletID).Return(tc.gatewayGetWalletUnconfirmedTxnsResult, tc.gatewayGetWalletUnconfirmedTxnsErr)
-		gateway.On("IsCSPEnabled").Return(false)
 
 		endpoint := "/api/v1/wallet/transactions"
 
@@ -976,7 +967,7 @@ func TestWalletTransactionsHandler(t *testing.T) {
 		setCSRFParameters(csrfStore, tokenValid, req)
 
 		rr := httptest.NewRecorder()
-		handler := newServerMux(mxConfig, gateway, csrfStore, nil)
+		handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 		handler.ServeHTTP(rr, req)
 
@@ -1244,7 +1235,6 @@ func TestWalletCreateHandler(t *testing.T) {
 			}
 			gateway.On("CreateWallet", "", tc.options).Return(&tc.gatewayCreateWalletResult, tc.gatewayCreateWalletErr)
 			// gateway.On("ScanAheadWalletAddresses", tc.wltName, tc.options.Password, tc.scnN-1).Return(&tc.scanWalletAddressesResult, tc.scanWalletAddressesError)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/create"
 
@@ -1283,7 +1273,7 @@ func TestWalletCreateHandler(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
 
@@ -1380,7 +1370,6 @@ func TestWalletNewSeed(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("IsWalletAPIEnabled").Return(true)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/newSeed"
 
@@ -1405,7 +1394,7 @@ func TestWalletNewSeed(t *testing.T) {
 			setCSRFParameters(csrfStore, tokenValid, req)
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
 
@@ -1537,7 +1526,6 @@ func TestGetWalletSeed(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := NewGatewayerMock()
 			gateway.On("GetWalletSeed", tc.wltID, []byte(tc.password)).Return(tc.gatewayReturnArgs...)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/seed"
 
@@ -1557,7 +1545,7 @@ func TestGetWalletSeed(t *testing.T) {
 			setCSRFParameters(csrfStore, tokenValid, req)
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
 
@@ -1751,7 +1739,6 @@ func TestWalletNewAddressesHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("NewAddresses", tc.walletID, []byte(tc.password), tc.n).Return(tc.gatewayNewAddressesResult, tc.gatewayNewAddressesErr)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/newAddress"
 
@@ -1779,7 +1766,7 @@ func TestWalletNewAddressesHandler(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
 
@@ -1839,7 +1826,6 @@ func TestGetWalletFolderHandler(t *testing.T) {
 	for _, tc := range tt {
 		gateway := &GatewayerMock{}
 		gateway.On("GetWalletDir").Return(tc.getWalletDirResponse, tc.getWalletDirErr)
-		gateway.On("IsCSPEnabled").Return(false)
 		endpoint := "/api/v1/wallets/folderName"
 
 		req, err := http.NewRequest(tc.method, endpoint, nil)
@@ -1851,7 +1837,7 @@ func TestGetWalletFolderHandler(t *testing.T) {
 		setCSRFParameters(csrfStore, tokenValid, req)
 
 		rr := httptest.NewRecorder()
-		handler := newServerMux(mxConfig, gateway, csrfStore, nil)
+		handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 		handler.ServeHTTP(rr, req)
 
@@ -2063,7 +2049,6 @@ func TestGetWallets(t *testing.T) {
 	for _, tc := range cases {
 		gateway := &GatewayerMock{}
 		gateway.On("GetWallets").Return(tc.getWalletsResponse, tc.getWalletsErr)
-		gateway.On("IsCSPEnabled").Return(false)
 
 		endpoint := "/api/v1/wallets"
 
@@ -2076,7 +2061,7 @@ func TestGetWallets(t *testing.T) {
 		setCSRFParameters(csrfStore, tokenValid, req)
 
 		rr := httptest.NewRecorder()
-		handler := newServerMux(mxConfig, gateway, csrfStore, nil)
+		handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 		handler.ServeHTTP(rr, req)
 
@@ -2147,7 +2132,6 @@ func TestWalletUnloadHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &GatewayerMock{}
 			gateway.On("UnloadWallet", tc.walletID).Return(tc.unloadWalletErr)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/unload"
 			v := url.Values{}
@@ -2167,7 +2151,7 @@ func TestWalletUnloadHandler(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
 
@@ -2300,7 +2284,6 @@ func TestEncryptWallet(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := NewGatewayerMock()
 			gateway.On("EncryptWallet", tc.wltID, []byte(tc.password)).Return(tc.gatewayReturn.w, tc.gatewayReturn.err)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/encrypt"
 			v := url.Values{}
@@ -2317,7 +2300,7 @@ func TestEncryptWallet(t *testing.T) {
 			setCSRFParameters(csrfStore, tokenValid, req)
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
 
@@ -2487,7 +2470,6 @@ func TestDecryptWallet(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := NewGatewayerMock()
 			gateway.On("DecryptWallet", tc.wltID, []byte(tc.password)).Return(tc.gatewayReturn.w, tc.gatewayReturn.err)
-			gateway.On("IsCSPEnabled").Return(false)
 
 			endpoint := "/api/v1/wallet/decrypt"
 			v := url.Values{}
@@ -2504,7 +2486,7 @@ func TestDecryptWallet(t *testing.T) {
 			setCSRFParameters(csrfStore, tokenValid, req)
 
 			rr := httptest.NewRecorder()
-			handler := newServerMux(mxConfig, gateway, csrfStore, nil)
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
 
 			handler.ServeHTTP(rr, req)
 

--- a/src/api/webrpc_test.go
+++ b/src/api/webrpc_test.go
@@ -67,7 +67,6 @@ func TestWebRPC(t *testing.T) {
 			}
 
 			gateway := NewGatewayerMock()
-			gateway.On("IsCSPEnabled").Return(false)
 			handler := newServerMux(muxConfig{
 				host:            configuredHost,
 				appLoc:          ".",

--- a/src/cli/integration/integration_test.go
+++ b/src/cli/integration/integration_test.go
@@ -1118,6 +1118,9 @@ func TestStableStatus(t *testing.T) {
 	ret.Status.Uptime = wh.FromDuration(time.Duration(0))
 
 	goldenFile := "status.golden"
+	if useCSRF(t) {
+		goldenFile = "status-csrf-enabled.golden"
+	}
 
 	var expect cli.StatusResult
 	td := TestData{ret, &expect}

--- a/src/cli/integration/testdata/status-csrf-enabled.golden
+++ b/src/cli/integration/testdata/status-csrf-enabled.golden
@@ -1,0 +1,34 @@
+{
+	"status": {
+		"blockchain": {
+			"head": {
+				"seq": 180,
+				"block_hash": "63614fdf08b67fcfc99d7b43d115fb9f57eb5c6833acdbdc712ee361f391f292",
+				"previous_block_hash": "93fce3f520d9ec5b5c29226ad39fb61e3b9a92464fdec87d6805cf8e8e782959",
+				"timestamp": 1431574528,
+				"fee": 2265261,
+				"version": 0,
+				"tx_body_hash": "0a610a34a8408effe8f2f70e4a85a3a8f4aca923f43e10a8a6e08cf410d7a35d"
+			},
+			"unspents": 218,
+			"unconfirmed": 0,
+			"time_since_last_block": "0s"
+		},
+		"version": {
+			"version": "",
+			"commit": "",
+			"branch": ""
+		},
+		"open_connections": 0,
+		"uptime": "0s",
+		"csrf_enabled": true,
+		"csp_enabled": true,
+		"wallet_api_enabled": true,
+		"gui_enabled": false,
+		"unversioned_api_enabled": false,
+		"json_rpc_enabled": false
+	},
+	"cli_config": {
+		"webrpc_address": "http://127.0.0.1:1024"
+	}
+}

--- a/src/cli/integration/testdata/status.golden
+++ b/src/cli/integration/testdata/status.golden
@@ -20,7 +20,13 @@
 			"branch": ""
 		},
 		"open_connections": 0,
-		"uptime": "0s"
+		"uptime": "0s",
+		"csrf_enabled": false,
+		"csp_enabled": true,
+		"wallet_api_enabled": true,
+		"gui_enabled": false,
+		"unversioned_api_enabled": false,
+		"json_rpc_enabled": false
 	},
 	"cli_config": {
 		"webrpc_address": "http://127.0.0.1:1024"

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -21,8 +21,6 @@ import (
 type GatewayConfig struct {
 	BufferSize      int
 	EnableWalletAPI bool
-	EnableGUI       bool
-	DisableCSP      bool
 }
 
 // NewGatewayConfig create and init an GatewayConfig
@@ -30,8 +28,6 @@ func NewGatewayConfig() GatewayConfig {
 	return GatewayConfig{
 		BufferSize:      32,
 		EnableWalletAPI: false,
-		EnableGUI:       false,
-		DisableCSP:      false,
 	}
 }
 
@@ -1180,9 +1176,4 @@ func (gw *Gateway) VerifyTxnVerbose(txn *coin.Transaction) ([]wallet.UxBalance, 
 		uxs, isTxnConfirmed, err = gw.v.VerifyTxnVerbose(txn)
 	})
 	return uxs, isTxnConfirmed, err
-}
-
-// IsCSPEnabled returns if the csp is enabled
-func (gw *Gateway) IsCSPEnabled() bool {
-	return !gw.Config.DisableCSP
 }

--- a/src/skycoin/config.go
+++ b/src/skycoin/config.go
@@ -77,6 +77,7 @@ type NodeConfig struct {
 	WebInterfaceKey   string
 	WebInterfaceHTTPS bool
 
+	// Enable the deprecated JSON 2.0 RPC interface
 	RPCInterface bool
 
 	// Launch System Default Browser after client startup
@@ -205,7 +206,7 @@ func NewNodeConfig(mode string, node NodeParameters) *NodeConfig {
 		WebInterfaceKey:   "",
 		WebInterfaceHTTPS: false,
 
-		RPCInterface: true,
+		RPCInterface: false,
 
 		LaunchBrowser: false,
 		// Data directory holds app data
@@ -344,7 +345,7 @@ func (c *Config) register() {
 	flag.StringVar(&c.Node.WebInterfaceKey, "web-interface-key", c.Node.WebInterfaceKey, "key.pem file for web interface HTTPS. If not provided, will use key.pem in -data-directory")
 	flag.BoolVar(&c.Node.WebInterfaceHTTPS, "web-interface-https", c.Node.WebInterfaceHTTPS, "enable HTTPS for web interface")
 
-	flag.BoolVar(&c.Node.RPCInterface, "rpc-interface", c.Node.RPCInterface, "enable the rpc interface")
+	flag.BoolVar(&c.Node.RPCInterface, "rpc-interface", c.Node.RPCInterface, "enable the deprecated JSON 2.0 RPC interface")
 
 	flag.BoolVar(&c.Node.LaunchBrowser, "launch-browser", c.Node.LaunchBrowser, "launch system default webbrowser at client startup")
 	flag.BoolVar(&c.Node.PrintWebInterfaceAddress, "print-web-interface-address", c.Node.PrintWebInterfaceAddress, "print configured web interface address and exit")

--- a/src/skycoin/skycoin.go
+++ b/src/skycoin/skycoin.go
@@ -328,7 +328,6 @@ func (c *Coin) ConfigureDaemon() daemon.Config {
 	dc.Visor.EnableSeedAPI = c.config.Node.EnableSeedAPI
 
 	dc.Gateway.EnableWalletAPI = c.config.Node.EnableWalletAPI
-	dc.Gateway.DisableCSP = c.config.Node.DisableCSP
 
 	// Initialize wallet default crypto type
 	cryptoType, err := wallet.CryptoTypeFromString(c.config.Node.WalletCryptoType)
@@ -348,7 +347,7 @@ func (c *Coin) createGUI(d *daemon.Daemon, host string) (*api.Server, error) {
 	config := api.Config{
 		StaticDir:            c.config.Node.GUIDirectory,
 		DisableCSRF:          c.config.Node.DisableCSRF,
-		EnableWalletAPI:      c.config.Node.EnableWalletAPI,
+		DisableCSP:           c.config.Node.DisableCSP,
 		EnableJSON20RPC:      c.config.Node.RPCInterface,
 		EnableGUI:            c.config.Node.EnableGUI,
 		EnableUnversionedAPI: c.config.Node.EnableUnversionedAPI,


### PR DESCRIPTION
Fixes #1784 

Changes:
- Add `csrf_enabled`, `csp_enabled`, `wallet_api_enabled`, `unversioned_api_enabled`, `gui_enabled` and `json_rpc_enabled` configuration settings to the `/api/v1/health` endpoint response
- Remove `gateway.IsCSPEnabled()`; this setting does not need to be outside of the `api` package
- Disable the JSON 2.0 RPC interface by default in the server run mode

Does this change need to mentioned in CHANGELOG.md?
Yes