### PR TITLE
[docker] fixes #1824 - Update golang version to 1.11

### DIFF
--- a/docker/images/dev-cli/Dockerfile
+++ b/docker/images/dev-cli/Dockerfile
@@ -1,5 +1,5 @@
 # Creates an image for skycoin development
-FROM golang:1.10.2-stretch
+FROM golang:1.11-stretch
 
 # Installs nodejs and npm. Needed for moxygen.
 

--- a/docker/images/mainnet/Dockerfile
+++ b/docker/images/mainnet/Dockerfile
@@ -1,7 +1,7 @@
 # skycoin build
 # reference https://github.com/skycoin/skycoin
 ARG IMAGE_FROM=busybox
-FROM golang:1.10.1-stretch AS build
+FROM golang:1.11-stretch AS build
 ARG ARCH=amd64
 ARG GOARM
 ARG SKYCOIN_VERSION


### PR DESCRIPTION
Fixes #1824 

Changes:
- Update the golang version to 1.11 in docker images

Does this change need to mentioned in CHANGELOG.md?
No