### PR TITLE
Fix explorer address unconfirmed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ lint: ## Run linters. Use make install-linters first.
 		-E gas \
 		-E megacheck \
 		-E misspell \
+		-E nakedret \
 		./...
 	# lib/cgo can't use golint because it needs export directives in function docstrings that do not obey golint rules
 	# deadcode also doesn't make sense for lib/cgo
@@ -154,6 +155,7 @@ lint: ## Run linters. Use make install-linters first.
 		-E gas \
 		-E megacheck \
 		-E misspell \
+		-E nakedret \
 		./lib/cgo/...
 	# The govet version in golangci-lint is out of date and has spurious warnings, run it separately
 	go vet -all ./...

--- a/cmd/address_stats/address_stats.go
+++ b/cmd/address_stats/address_stats.go
@@ -25,10 +25,6 @@ func main() {
 	pkeysStats := flag.Bool("pkeys", false, "create histogram for public keys")
 	hashesStats := flag.Bool("hashes", false, "create histogram for hashes")
 	flag.Parse()
-	var PubKeys []cipher.PubKey
-	var Addresses []string
-	var RawAddresses []cipher.Ripemd160
-	var OutPut []string
 
 	OneByteMap := make(map[byte]int)
 	TwoByteMap := make(map[string]int)
@@ -46,22 +42,26 @@ func main() {
 
 	start := time.Now()
 
+	pubKeys := make([]cipher.PubKey, *examples)
+	rawAddresses := make([]cipher.Ripemd160, *examples)
+	addresses := make([]string, *examples)
+
 	//generate pubkeys
 	for i := 0; i < *examples; i++ {
 		p, _ := cipher.GenerateKeyPair()
-		PubKeys = append(PubKeys, p)
+		pubKeys[i] = p
 	}
 
 	//generate addresses
-	for _, p := range PubKeys {
-		Addresses = append(Addresses, cipher.AddressFromPubKey(p).String())
-		RawAddresses = append(RawAddresses, cipher.AddressFromPubKey(p).Key)
+	for i, p := range pubKeys {
+		addresses[i] = cipher.AddressFromPubKey(p).String()
+		rawAddresses[i] = cipher.AddressFromPubKey(p).Key
 	}
 
-	//analize addresses
-
+	//analyze addresses
+	var output []string
 	if *addrsStats {
-		for _, a := range Addresses {
+		for _, a := range addresses {
 			if _, ok := OneLetterMap[string([]rune(a)[0])]; ok {
 				OneLetterMap[string([]rune(a)[0])]++
 			} else {
@@ -74,30 +74,30 @@ func main() {
 			}
 		}
 
-		OutPut = append(OutPut, "\nAddress 1st letter stat:\n")
+		output = append(output, "\nAddress 1st letter stat:\n")
 		for k, v := range OneLetterMap {
 			formatV := fmt.Sprintf("%d", v)
 			formatV = zeroPadding(len(strconv.Itoa(*examples)), formatV)
 			percent := 100 * float64(v) / float64(*examples)
 			per := fmt.Sprintf("%.2f", percent)
 			s := formatV + " of " + strconv.Itoa(*examples) + ", " + per + "%, [ " + k + " ]\n"
-			OutPut = append(OutPut, s)
+			output = append(output, s)
 		}
 
-		OutPut = append(OutPut, "\nAddress 1-2nd letter stat:\n")
+		output = append(output, "\nAddress 1-2nd letter stat:\n")
 		for k, v := range TwoLetterMap {
 			formatV := fmt.Sprintf("%d", v)
 			formatV = zeroPadding(len(strconv.Itoa(*examples)), formatV)
 			percent := 100 * float64(v) / float64(*examples)
 			per := fmt.Sprintf("%.2f", percent)
 			s := formatV + " of " + strconv.Itoa(*examples) + ", " + per + "%, [ " + k + " ]\n"
-			OutPut = append(OutPut, s)
+			output = append(output, s)
 		}
 
 	}
 
 	if *pkeysStats {
-		for _, p := range PubKeys {
+		for _, p := range pubKeys {
 			//first byte gist
 			if _, ok := OneByteMap[p[0]]; ok {
 				OneByteMap[p[0]]++
@@ -114,7 +114,7 @@ func main() {
 
 		}
 
-		OutPut = append(OutPut, "\nPublic key 1st byte stat:\n")
+		output = append(output, "\nPublic key 1st byte stat:\n")
 		for k, v := range OneByteMap {
 			formatV := fmt.Sprintf("%d", v)
 			formatV = zeroPadding(len(strconv.Itoa(*examples)), formatV)
@@ -124,10 +124,10 @@ func main() {
 			percent := 100 * float64(v) / float64(*examples)
 			per := fmt.Sprintf("%.2f", percent)
 			s := formatV + " of " + strconv.Itoa(*examples) + ", " + per + "%, [ " + bytes + " ]\n"
-			OutPut = append(OutPut, s)
+			output = append(output, s)
 		}
 
-		OutPut = append(OutPut, "\nPublic key 1-2nd byte stat:\n")
+		output = append(output, "\nPublic key 1-2nd byte stat:\n")
 
 		for k, v := range TwoByteMap {
 			formatV := fmt.Sprintf("%d", v)
@@ -136,12 +136,12 @@ func main() {
 			percent := 100 * float64(v) / float64(*examples)
 			per := fmt.Sprintf("%.2f", percent)
 			s := formatV + " of " + strconv.Itoa(*examples) + ", " + per + "%, [ " + bytes + " ]\n"
-			OutPut = append(OutPut, s)
+			output = append(output, s)
 		}
 	}
 
 	if *hashesStats {
-		for _, ra := range RawAddresses {
+		for _, ra := range rawAddresses {
 			if _, ok := OneByteRawMap[ra[0]]; ok {
 				OneByteRawMap[ra[0]]++
 			} else {
@@ -157,7 +157,7 @@ func main() {
 
 		}
 
-		OutPut = append(OutPut, "\nRaw address 1st byte stat:\n")
+		output = append(output, "\nRaw address 1st byte stat:\n")
 		for k, v := range OneByteRawMap {
 			formatV := fmt.Sprintf("%d", v)
 			formatV = zeroPadding(len(strconv.Itoa(*examples)), formatV)
@@ -167,10 +167,10 @@ func main() {
 			percent := 100 * float64(v) / float64(*examples)
 			per := fmt.Sprintf("%.2f", percent)
 			s := formatV + " of " + strconv.Itoa(*examples) + ", " + per + "%, [ " + bytes + " ]\n"
-			OutPut = append(OutPut, s)
+			output = append(output, s)
 		}
 
-		OutPut = append(OutPut, "\nRaw address 1-2nd byte stat:\n")
+		output = append(output, "\nRaw address 1-2nd byte stat:\n")
 		for k, v := range TwoByteRawMap {
 			formatV := fmt.Sprintf("%d", v)
 			formatV = zeroPadding(len(strconv.Itoa(*examples)), formatV)
@@ -178,7 +178,7 @@ func main() {
 			percent := 100 * float64(v) / float64(*examples)
 			per := fmt.Sprintf("%.2f", percent)
 			s := formatV + " of " + strconv.Itoa(*examples) + ", " + per + "%, [ " + bytes + " ]\n"
-			OutPut = append(OutPut, s)
+			output = append(output, s)
 		}
 	}
 	t := time.Now()
@@ -189,7 +189,7 @@ func main() {
 		fmt.Println(err)
 	}
 
-	for _, value := range OutPut {
+	for _, value := range output {
 		fmt.Fprint(f, value)
 	}
 

--- a/src/visor/historydb/historydb.go
+++ b/src/visor/historydb/historydb.go
@@ -185,6 +185,8 @@ func (hd HistoryDB) GetAddrUxOuts(tx *dbutil.Tx, address cipher.Address) ([]*UxO
 
 // GetTransactionsForAddress returns all the address related transactions
 func (hd HistoryDB) GetTransactionsForAddress(tx *dbutil.Tx, address cipher.Address) ([]Transaction, error) {
+
+	logger.Critical().Println("historydb.GetTransactionsForAddress")
 	hashes, err := hd.addrTxns.Get(tx, address)
 	if err != nil {
 		return nil, err

--- a/src/visor/historydb/historydb.go
+++ b/src/visor/historydb/historydb.go
@@ -185,8 +185,6 @@ func (hd HistoryDB) GetAddrUxOuts(tx *dbutil.Tx, address cipher.Address) ([]*UxO
 
 // GetTransactionsForAddress returns all the address related transactions
 func (hd HistoryDB) GetTransactionsForAddress(tx *dbutil.Tx, address cipher.Address) ([]Transaction, error) {
-
-	logger.Critical().Println("historydb.GetTransactionsForAddress")
 	hashes, err := hd.addrTxns.Get(tx, address)
 	if err != nil {
 		return nil, err

--- a/src/visor/historydb/transaction.go
+++ b/src/visor/historydb/transaction.go
@@ -55,7 +55,7 @@ func (txs *transactions) Get(tx *dbutil.Tx, hash cipher.SHA256) (*Transaction, e
 
 // GetSlice returns transactions slice of given hashes
 func (txs *transactions) GetSlice(tx *dbutil.Tx, hashes []cipher.SHA256) ([]Transaction, error) {
-	var txns []Transaction
+	txns := make([]Transaction, 0, len(hashes))
 	for _, h := range hashes {
 		var txn Transaction
 
@@ -63,6 +63,7 @@ func (txs *transactions) GetSlice(tx *dbutil.Tx, hashes []cipher.SHA256) ([]Tran
 			return nil, err
 		} else if !ok {
 			continue
+			// return nil, errors.New("Transaction not found")
 		}
 
 		txns = append(txns, txn)

--- a/src/visor/historydb/transaction.go
+++ b/src/visor/historydb/transaction.go
@@ -6,6 +6,8 @@ package historydb
 // transaction hash, and get the tx value from transactions bucket.
 
 import (
+	"errors"
+
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/cipher/encoder"
 	"github.com/skycoin/skycoin/src/coin"
@@ -62,8 +64,7 @@ func (txs *transactions) GetSlice(tx *dbutil.Tx, hashes []cipher.SHA256) ([]Tran
 		if ok, err := dbutil.GetBucketObjectDecoded(tx, TransactionsBkt, h[:], &txn); err != nil {
 			return nil, err
 		} else if !ok {
-			continue
-			// return nil, errors.New("Transaction not found")
+			return nil, errors.New("Transaction not found")
 		}
 
 		txns = append(txns, txn)

--- a/src/visor/historydb/transaction_test.go
+++ b/src/visor/historydb/transaction_test.go
@@ -1,6 +1,7 @@
 package historydb
 
 import (
+	"errors"
 	"math/rand"
 	"testing"
 	"time"
@@ -87,37 +88,41 @@ func TestTransactionGetSlice(t *testing.T) {
 		name   string
 		hashes []cipher.SHA256
 		expect []Transaction
+		err    error
 	}{
 		{
-			"get one",
-			[]cipher.SHA256{
+			name: "get one",
+			hashes: []cipher.SHA256{
 				txns[0].Hash(),
 			},
-			txns[:1],
+			expect: txns[:1],
 		},
+
 		{
-			"get two",
-			[]cipher.SHA256{
+			name: "get two",
+			hashes: []cipher.SHA256{
 				txns[0].Hash(),
 				txns[1].Hash(),
 			},
-			txns[:2],
+			expect: txns[:2],
 		},
+
 		{
-			"get all",
-			[]cipher.SHA256{
+			name: "get all",
+			hashes: []cipher.SHA256{
 				txns[0].Hash(),
 				txns[1].Hash(),
 				txns[2].Hash(),
 			},
-			txns[:3],
+			expect: txns[:3],
 		},
+
 		{
-			"not exist",
-			[]cipher.SHA256{
+			name: "not exist",
+			hashes: []cipher.SHA256{
 				txns[3].Hash(),
 			},
-			nil,
+			err: errors.New("Transaction not found"),
 		},
 	}
 
@@ -140,6 +145,10 @@ func TestTransactionGetSlice(t *testing.T) {
 			// get slice
 			err = db.View("", func(tx *dbutil.Tx) error {
 				ts, err := txsBkt.GetSlice(tx, tc.hashes)
+				if tc.err != nil {
+					require.Equal(t, tc.err, err)
+					return nil
+				}
 				require.NoError(t, err)
 				require.Equal(t, tc.expect, ts)
 				return nil

--- a/src/visor/readable_verbose.go
+++ b/src/visor/readable_verbose.go
@@ -174,9 +174,9 @@ type ReadableTransactionVerbose struct {
 
 // NewReadableTransactionVerbose creates ReadableTransactionVerbose
 func NewReadableTransactionVerbose(txn Transaction, inputs []ReadableTransactionInput) (ReadableTransactionVerbose, error) {
-	rb, err := NewReadableBlockTransactionVerbose(txn.Txn, inputs, txn.Status.BlockSeq == 0)
+	rb, err := NewReadableBlockTransactionVerbose(txn.Txn, inputs, txn.Status.BlockSeq == 0 && txn.Status.Confirmed)
 	if err != nil {
-		return ReadableTransactionVerbose{}, nil
+		return ReadableTransactionVerbose{}, err
 	}
 
 	return ReadableTransactionVerbose{

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -927,7 +927,7 @@ func (vs *Visor) InjectTransactionStrict(txn coin.Transaction) (bool, error) {
 }
 
 // GetTransactionsForAddress returns the Transactions whose unspents give coins to a cipher.Address.
-// This includes unconfirmed txns' predicted unspents.
+// This includes both confirmed and unconfirmed transactions.
 func (vs *Visor) GetTransactionsForAddress(a cipher.Address) ([]Transaction, error) {
 	var txns map[cipher.Address][]Transaction
 
@@ -1079,8 +1079,6 @@ func NewConfirmedTxFilter(isConfirmed bool) TxFilter {
 }
 
 // GetTransactions returns transactions that can pass the filters.
-// If any 'AddrsFilter' exist, call vs.getTransactionsForAddresses, cause
-// there's an address index of transactions in db which, having address as key and transaction hashes as value.
 // If no filters is provided, returns all transactions.
 func (vs *Visor) GetTransactions(flts []TxFilter) ([]Transaction, error) {
 	var txns []Transaction
@@ -1215,10 +1213,7 @@ func accumulateAddressInFilter(afs []AddrsFilter) []cipher.Address {
 // getTransactionsForAddresses returns all addresses related transactions.
 // Including both confirmed and unconfirmed transactions.
 func (vs *Visor) getTransactionsForAddresses(tx *dbutil.Tx, addrs []cipher.Address) (map[cipher.Address][]Transaction, error) {
-	// Initialize the address transactions map
-	addrTxs := make(map[cipher.Address][]Transaction, len(addrs))
-
-	// Get the head block seq, for calculating the tx status
+	// Get the head block seq, for calculating the txn status
 	headBkSeq, ok, err := vs.Blockchain.HeadSeq(tx)
 
 	if err != nil {
@@ -1228,16 +1223,17 @@ func (vs *Visor) getTransactionsForAddresses(tx *dbutil.Tx, addrs []cipher.Addre
 		return nil, errors.New("No head block seq")
 	}
 
+	ret := make(map[cipher.Address][]Transaction, len(addrs))
 	for _, a := range addrs {
-		var txns []Transaction
 		addrTxns, err := vs.history.GetTransactionsForAddress(tx, a)
 		if err != nil {
 			return nil, err
 		}
 
-		for _, txn := range addrTxns {
+		txns := make([]Transaction, len(addrTxns), len(addrTxns)+4)
+		for i, txn := range addrTxns {
 			if headBkSeq < txn.BlockSeq {
-				err := errors.New("Transaction block sequence is less than the head block sequence")
+				err := errors.New("Transaction block sequence is greater than the head block sequence")
 				logger.Critical().WithError(err).WithFields(logrus.Fields{
 					"headBkSeq":  headBkSeq,
 					"txBlockSeq": txn.BlockSeq,
@@ -1252,14 +1248,14 @@ func (vs *Visor) getTransactionsForAddresses(tx *dbutil.Tx, addrs []cipher.Addre
 			}
 
 			if bk == nil {
-				return nil, fmt.Errorf("block of seq: %d doesn't exist", txn.BlockSeq)
+				return nil, fmt.Errorf("block seq=%d doesn't exist", txn.BlockSeq)
 			}
 
-			txns = append(txns, Transaction{
+			txns[i] = Transaction{
 				Txn:    txn.Tx,
 				Status: NewConfirmedTransactionStatus(h, txn.BlockSeq),
 				Time:   bk.Time(),
-			})
+			}
 		}
 
 		// Look in the unconfirmed pool
@@ -1286,10 +1282,10 @@ func (vs *Visor) getTransactionsForAddresses(tx *dbutil.Tx, addrs []cipher.Addre
 			})
 		}
 
-		addrTxs[a] = txns
+		ret[a] = txns
 	}
 
-	return addrTxs, nil
+	return ret, nil
 }
 
 // traverseTxns traverses transactions in historydb and unconfirmed tx pool in db,

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -2459,7 +2459,7 @@ func (vs *Visor) getUnspentsForSpending(tx *dbutil.Tx, addrs []cipher.Address, i
 func (vs *Visor) GetVerboseTransactionsForAddress(a cipher.Address) ([]ReadableTransactionVerbose, error) {
 	var resTxns []ReadableTransactionVerbose
 
-	if err := vs.DB.View("GetTransactionsForAddress", func(tx *dbutil.Tx) error {
+	if err := vs.DB.View("GetVerboseTransactionsForAddress", func(tx *dbutil.Tx) error {
 		addrTxns, err := vs.getTransactionsForAddresses(tx, []cipher.Address{a})
 		if err != nil {
 			logger.Errorf("GetVerboseTransactionsForAddress: gw.v.GetTransactionsForAddress failed: %v", err)
@@ -2480,7 +2480,6 @@ func (vs *Visor) GetVerboseTransactionsForAddress(a cipher.Address) ([]ReadableT
 		resTxns = make([]ReadableTransactionVerbose, len(txns))
 
 		for i, txn := range txns {
-
 			// If the txn is confirmed, use the time of the block previous
 			// to the block in which the transaction was executed,
 			// else use the head time for unconfirmed blocks.


### PR DESCRIPTION
Fixes #1823 

Changes:
- Fix missing unconfirmed txns from `/api/v1/explorer/address`
- Return an error if `historyTxns.GetSlice` cannot find one of the txns by hash

Does this change need to mentioned in CHANGELOG.md?
No