### PR TITLE
[docker] fixes # 1840 - Add GolangCI-Lint package to docker image

### DIFF
--- a/docker/images/dev-cli/Dockerfile
+++ b/docker/images/dev-cli/Dockerfile
@@ -196,6 +196,10 @@ RUN cd /tmp/; \
     ./configure --prefix=/usr && make && make install && \
     rm -rf /tmp/swig-*
 
+# Install golangci-lint
+ENV GOLANGCI_LINT 1.10.2
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v$GOLANGCI_LINT
+
 WORKDIR $GOPATH/src/github.com/skycoin
 VOLUME $GOPATH/src/
 


### PR DESCRIPTION
Fixes #1840 

Changes:
- Add GolangCI-Lint package to docker image

Does this change need to mentioned in CHANGELOG.md?
No