### PR TITLE
[docker] fixes #1844 - Add gocovmerge package to the development docker image

### DIFF
--- a/docker/images/dev-cli/Dockerfile
+++ b/docker/images/dev-cli/Dockerfile
@@ -200,6 +200,9 @@ RUN cd /tmp/; \
 ENV GOLANGCI_LINT 1.10.2
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v$GOLANGCI_LINT
 
+# Install gocovmerge
+RUN go get -u github.com/wadey/gocovmerge
+
 WORKDIR $GOPATH/src/github.com/skycoin
 VOLUME $GOPATH/src/
 

--- a/docker/images/dev-cli/Dockerfile
+++ b/docker/images/dev-cli/Dockerfile
@@ -201,9 +201,6 @@ RUN cd /tmp/; \
 ENV GOLANGCI_LINT 1.10.2
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v$GOLANGCI_LINT
 
-# Install gocovmerge
-RUN go get -u github.com/wadey/gocovmerge
-
 WORKDIR $GOPATH/src/github.com/skycoin
 VOLUME $GOPATH/src/
 

--- a/docker/images/dev-cli/Dockerfile
+++ b/docker/images/dev-cli/Dockerfile
@@ -172,6 +172,7 @@ RUN go get -u github.com/derekparker/delve/cmd/dlv  && \
     go get -u golang.org/x/tools/cmd/gorename && \
     go get -u github.com/klauspost/asmfmt/cmd/asmfmt && \
     go get -u github.com/vektra/mockery/.../ && \
+    go get -u github.com/wadey/gocovmerge && \
     curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 
 
@@ -199,9 +200,6 @@ RUN cd /tmp/; \
 # Install golangci-lint
 ENV GOLANGCI_LINT 1.10.2
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v$GOLANGCI_LINT
-
-# Install gocovmerge
-RUN go get -u github.com/wadey/gocovmerge
 
 WORKDIR $GOPATH/src/github.com/skycoin
 VOLUME $GOPATH/src/


### PR DESCRIPTION
Fixes #1844 

Changes:
- Add gocovmerge package to the development docker image

Does this change need to mentioned in CHANGELOG.md?
No