### PR TITLE
fixes #1851 - Correct installation of dep for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,10 +434,10 @@ different version of the `cipher` dependencies than were developed, which could 
 
 Dependencies are managed with [dep](https://github.com/golang/dep).
 
-To install `dep`:
+To [install `dep` for development](https://github.com/golang/dep/blob/master/docs/installation.md#development):
 
 ```sh
-go get -u github.com/golang/dep
+go get -u github.com/golang/dep/cmd/dep
 ```
 
 `dep` vendors all dependencies into the repo.


### PR DESCRIPTION
Fixes #1851 

Changes:
- Correct command for installing `dep`

Does this change need to mentioned in CHANGELOG.md?
No