### PR TITLE
Improve and fix the profiler options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ docs/libc/xml
 
 # Do not ignore Docker Cloud build
 !hooks/build
+
+*.prof
+*.profile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `csrf_enabled`, `csp_enabled`, `wallet_api_enabled`, `unversioned_api_enabled`, `gui_enabled` and `json_rpc_enabled` configuration settings to the `/api/v1/health` endpoint response
 - Add `verbose` flag to `/api/v1/block`, `/api/v1/blocks`, `/api/v1/last_blocks`, `/api/v1/pendingTxs`, `/api/v1/transaction`, `/api/v1/transactions`, `/api/v1/wallet/transactions` to return verbose block data, which includes the address, coins, hours and calculcated_hours of the block's transaction's inputs
 - Add `encoded` flag to `/api/v1/transaction` to return an encoded transaction
+- Add `-http-prof-host` option to choose the HTTP profiler's bind hostname (defaults to `localhost:6060`)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ scratch, to remedy the rough edges in the Bitcoin design.
         - [Test coverage for the live node](#test-coverage-for-the-live-node)
     - [Formatting](#formatting)
     - [Code Linting](#code-linting)
+    - [Profiling](#profiling)
     - [Dependencies](#dependencies)
         - [Rules](#rules)
         - [Management](#management)
@@ -418,6 +419,30 @@ Run linters:
 ```sh
 make lint
 ```
+
+### Profiling
+
+A full CPU profile of the program from start to finish can be obtained by running the node with the `-profile-cpu` flag.
+Once the node terminates, a profile file is written to `-profile-cpu-file` (defaults to `cpu.prof`).
+This profile can be analyzed with
+
+```sh
+go tool pprof cpu.prof
+```
+
+The HTTP interface for obtaining more profiling data or obtaining data while running can be enabled with `-http-prof`.
+The HTTP profiling interface can be controlling with `-http-prof-host` and listens on `localhost:6060` by default.
+
+See https://golang.org/pkg/net/http/pprof/ for guidance on using the HTTP profiler.
+
+Some useful examples include:
+
+```sh
+go tool pprof http://localhost:6060/debug/pprof/profile?seconds=10
+go tool pprof http://localhost:6060/debug/pprof/heap
+```
+
+A web page interface is provided by http/pprof at http://localhost:6060/debug/pprof/.
 
 ### Dependencies
 

--- a/cmd/newcoin/newcoin.go
+++ b/cmd/newcoin/newcoin.go
@@ -25,7 +25,6 @@ type CoinTemplateParameters struct {
 	Port                int
 	WebInterfacePort    int
 	DataDirectory       string
-	ProfileCPUFile      string
 	GenesisSignatureStr string
 	GenesisAddressStr   string
 	BlockchainPubkeyStr string
@@ -203,7 +202,6 @@ func createCoinCommand() cli.Command {
 				Port:                config.Node.Port,
 				WebInterfacePort:    config.Node.WebInterfacePort,
 				DataDirectory:       "$HOME/." + coinName,
-				ProfileCPUFile:      coinName + ".prof",
 				GenesisSignatureStr: config.Node.GenesisSignatureStr,
 				GenesisAddressStr:   config.Node.GenesisAddressStr,
 				BlockchainPubkeyStr: config.Node.BlockchainPubkeyStr,

--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -67,7 +67,6 @@ var (
 		Port:                6000,
 		WebInterfacePort:    6420,
 		DataDirectory:       "$HOME/.skycoin",
-		ProfileCPUFile:      "skycoin.prof",
 	})
 
 	parseFlags = true

--- a/src/skycoin/config.go
+++ b/src/skycoin/config.go
@@ -127,8 +127,10 @@ type NodeConfig struct {
 	ProfileCPU bool
 	// Where the file is written to
 	ProfileCPUFile string
-	// HTTP profiling interface (see http://golang.org/pkg/net/http/pprof/)
+	// Enable HTTP profiling interface (see http://golang.org/pkg/net/http/pprof/)
 	HTTPProf bool
+	// Expose HTTP profiling on this interface
+	HTTPProfHost string
 
 	DBPath      string
 	DBReadOnly  bool
@@ -240,9 +242,10 @@ func NewNodeConfig(mode string, node NodeParameters) NodeConfig {
 		// Enable cpu profiling
 		ProfileCPU: false,
 		// Where the file is written to
-		ProfileCPUFile: node.ProfileCPUFile,
+		ProfileCPUFile: "cpu.prof",
 		// HTTP profiling interface (see http://golang.org/pkg/net/http/pprof/)
-		HTTPProf: false,
+		HTTPProf:     false,
+		HTTPProfHost: "localhost:6060",
 	}
 
 	nodeConfig.applyConfigMode(mode)
@@ -361,7 +364,8 @@ func (c *NodeConfig) RegisterFlags() {
 	flag.BoolVar(&c.DBReadOnly, "db-read-only", c.DBReadOnly, "open bolt db read-only")
 	flag.BoolVar(&c.ProfileCPU, "profile-cpu", c.ProfileCPU, "enable cpu profiling")
 	flag.StringVar(&c.ProfileCPUFile, "profile-cpu-file", c.ProfileCPUFile, "where to write the cpu profile file")
-	flag.BoolVar(&c.HTTPProf, "http-prof", c.HTTPProf, "Run the http profiling interface")
+	flag.BoolVar(&c.HTTPProf, "http-prof", c.HTTPProf, "run the HTTP profiling interface")
+	flag.StringVar(&c.HTTPProfHost, "http-prof-host", c.HTTPProfHost, "hostname to bind the HTTP profiling interface to")
 	flag.StringVar(&c.LogLevel, "log-level", c.LogLevel, "Choices are: debug, info, warn, error, fatal, panic")
 	flag.BoolVar(&c.ColorLog, "color-log", c.ColorLog, "Add terminal colors to log output")
 	flag.BoolVar(&c.DisablePingPong, "no-ping-log", c.DisablePingPong, `disable "reply to ping" and "received pong" debug log messages`)

--- a/template/coin.template
+++ b/template/coin.template
@@ -62,7 +62,6 @@ var (
 		Port:                {{.Port}},
 		WebInterfacePort:    {{.WebInterfacePort}},
 		DataDirectory:       "{{.DataDirectory}}",
-		ProfileCPUFile:      "{{.ProfileCPUFile}}",
 	})
 
 	parseFlags = true


### PR DESCRIPTION
Changes:

- Improve/fix cpu and http profiling
- Add `-http-prof-host` to choose the HTTP profiling listener host (defaults to `localhost:6060`)
- Document profiler usage

Does this change need to mentioned in CHANGELOG.md?
Yes