### PR TITLE
Show hours on transaction details page

### DIFF
--- a/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/transaction-info.component.html
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/transaction-info.component.html
@@ -20,10 +20,10 @@
             <span>{{ 'tx.status' | translate }}:</span> <span>{{ (transaction.confirmed ? 'tx.confirmed' : 'tx.pending') | translate }}</span>
           </div>
         </ng-container>
-        <div class="-data" *ngIf="isPreview">
+        <div class="-data">
           <span>{{ 'tx.hours' | translate }}:</span>
           <span>
-            {{ transaction.hoursSent | number:'1.0-6' }} {{ 'tx.hours-sent' | translate }}
+            {{ transaction.hoursSent | number:'1.0-6' }} {{ !isPreview && transaction.balance > 0 ? ('tx.hours-received' | translate) : ('tx.hours-sent' | translate) }}
             |
             {{ transaction.hoursBurned | number:'1.0-6' }} {{ 'tx.hours-burned' | translate }}
           </span>
@@ -60,7 +60,7 @@
           <div class="-data">
             <span>{{ 'tx.coins' | translate }}:</span> {{ input.coins | number:'1.0-6' }}
           </div>
-          <div class="-data" *ngIf="isPreview">
+          <div class="-data">
             <span>{{ 'tx.hours' | translate }}:</span> {{ input.calculated_hours | number:'1.0-6' }}
           </div>
         </div>
@@ -76,7 +76,7 @@
           <div class="-data">
             <span>{{ 'tx.coins' | translate }}:</span> {{ output.coins | number:'1.0-6' }}
           </div>
-          <div class="-data" *ngIf="isPreview">
+          <div class="-data">
             <span>{{ 'tx.hours' | translate }}:</span> {{ output.hours | number:'1.0-6' }}
           </div>
         </div>

--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -222,6 +222,11 @@ export class WalletService {
           );
 
           transaction.balance += calculatedOutputs.reduce((a, b) => a + parseFloat(b.coins), 0) * (outgoing ? -1 : 1);
+          transaction.hoursSent = calculatedOutputs.reduce((a, b) => a + b.hours, 0);
+
+          const inputsHours = transaction.inputs.reduce((a, b) => a + b.calculated_hours, 0);
+          const outputsHours = transaction.outputs.reduce((a, b) => a + b.hours, 0);
+          transaction.hoursBurned = inputsHours - outputsHours;
 
           return transaction;
         });

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -171,6 +171,7 @@
     "id": "Tx ID",
     "show-more": "Show more",
     "hours-sent": "sent",
+    "hours-received": "received",
     "hours-burned": "burned",
     "inputs": "Inputs",
     "outputs": "Outputs",


### PR DESCRIPTION
Fixes #1716 

Changes:
- Show the hours on the inputs and outputs on the transaction history modal window
![hours](https://user-images.githubusercontent.com/34079003/45302721-09832b80-b4e2-11e8-9ebc-586fe998420e.png)

Does this change need to mentioned in CHANGELOG.md?
No