### PR TITLE
Fix the add address procedure

### DIFF
--- a/src/gui/static/src/app/services/api.service.ts
+++ b/src/gui/static/src/app/services/api.service.ts
@@ -93,7 +93,13 @@ export class ApiService {
   }
 
   postWalletNewAddress(wallet: Wallet, password?: string): Observable<Address> {
-    return this.post('wallet/newAddress', { id: wallet.filename, password })
+    const params = new Object();
+    params['id'] = wallet.filename;
+    if (password) {
+      params['password'] = password;
+    }
+
+    return this.post('wallet/newAddress', params)
       .map((response: PostWalletNewAddressResponse) => ({ address: response.addresses[0], coins: null, hours: null }));
   }
 


### PR DESCRIPTION
Changes:
- Stops sending the password to the `wallet/newAddress` endpoint if the wallet is not encrypted.

Does this change need to mentioned in CHANGELOG.md?
No