### PR TITLE
Select how many addresses to add

### DIFF
--- a/src/gui/static/e2e/wallets.po.ts
+++ b/src/gui/static/e2e/wallets.po.ts
@@ -78,8 +78,12 @@ export class WalletsPage {
     return element.all(by.css('.-record')).count().then(originalCount => {
       return element(by.css('.-new-address')).click().then(() => {
         return browser.sleep(2000).then(() => {
-          return element.all(by.css('.-record')).count().then(newCount => {
-            return newCount > originalCount;
+          return element(by.buttonText('Create')).click().then(() => {
+            return browser.sleep(2000).then(() => {
+              return element.all(by.css('.-record')).count().then(newCount => {
+                return newCount > originalCount;
+              });
+            });
           });
         });
       });

--- a/src/gui/static/src/app/app.module.ts
+++ b/src/gui/static/src/app/app.module.ts
@@ -71,6 +71,7 @@ import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { AppTranslateLoader } from './app.translate-loader';
 import { NavBarService } from './services/nav-bar.service';
 import { LoadingContentComponent } from './components/layout/loading-content/loading-content.component';
+import { NumberOfAddressesComponent } from './components/pages/wallets/number-of-addresses/number-of-addresses';
 
 
 const ROUTES = [
@@ -170,6 +171,7 @@ const ROUTES = [
     TransactionInfoComponent,
     SendFormAdvancedComponent,
     LoadingContentComponent,
+    NumberOfAddressesComponent,
   ],
   entryComponents: [
     AddDepositAddressComponent,
@@ -181,6 +183,7 @@ const ROUTES = [
     OnboardingSafeguardComponent,
     PasswordDialogComponent,
     SeedModalComponent,
+    NumberOfAddressesComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/gui/static/src/app/components/pages/wallets/number-of-addresses/number-of-addresses.css
+++ b/src/gui/static/src/app/components/pages/wallets/number-of-addresses/number-of-addresses.css
@@ -1,0 +1,7 @@
+mat-input-container {
+  width: 100%;
+}
+
+.-buttons {
+  text-align: center;
+}

--- a/src/gui/static/src/app/components/pages/wallets/number-of-addresses/number-of-addresses.html
+++ b/src/gui/static/src/app/components/pages/wallets/number-of-addresses/number-of-addresses.html
@@ -1,0 +1,16 @@
+<app-modal [headline]="'wallet.add-addresses.title' | translate" [dialog]="dialogRef">
+  <div [formGroup]="form">
+    <div class="form-field">
+      <label for="quantity">{{ 'wallet.add-addresses.name-quantity' | translate }}</label>
+      <input formControlName="quantity" id="quantity" type="number" min="1" max="100" (keydown.enter)="continue()">
+    </div>
+  </div>
+  <div class="-buttons">
+    <app-button (action)="closePopup()">
+      {{ 'wallet.add-addresses.cancel-button' | translate }}
+    </app-button>
+    <app-button (action)="continue()" class="primary" [disabled]="!form.valid" #button>
+      {{ 'wallet.add-addresses.create-button' | translate }}
+    </app-button>
+  </div>
+</app-modal>

--- a/src/gui/static/src/app/components/pages/wallets/number-of-addresses/number-of-addresses.spec.ts
+++ b/src/gui/static/src/app/components/pages/wallets/number-of-addresses/number-of-addresses.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NumberOfAddressesComponent } from './number-of-addresses';
+
+describe('NumberOfAddressesComponent', () => {
+  let component: NumberOfAddressesComponent;
+  let fixture: ComponentFixture<NumberOfAddressesComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ NumberOfAddressesComponent ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NumberOfAddressesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/gui/static/src/app/components/pages/wallets/number-of-addresses/number-of-addresses.ts
+++ b/src/gui/static/src/app/components/pages/wallets/number-of-addresses/number-of-addresses.ts
@@ -1,0 +1,40 @@
+import { Component, OnInit, Inject, ViewChild } from '@angular/core';
+import { FormBuilder, FormGroup, FormControl } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+import { ButtonComponent } from '../../../layout/button/button.component';
+
+@Component({
+  selector: 'app-number-of-addresses',
+  templateUrl: './number-of-addresses.html',
+  styleUrls: ['./number-of-addresses.css'],
+})
+export class NumberOfAddressesComponent implements OnInit {
+  @ViewChild('button') button: ButtonComponent;
+  form: FormGroup;
+
+  constructor(
+    public dialogRef: MatDialogRef<NumberOfAddressesComponent>,
+    private formBuilder: FormBuilder,
+  ) {}
+
+  ngOnInit() {
+    this.form = new FormGroup({});
+    this.form.addControl('quantity', new FormControl(1, [this.validateQuantity]));
+  }
+
+  closePopup() {
+    this.dialogRef.close();
+  }
+
+  continue() {
+    this.dialogRef.close(Math.round(Number(this.form.value.quantity)));
+  }
+
+  private validateQuantity(control: FormControl) {
+    if (control.value < 1 || control.value > 100 || Number(control.value) !== Math.round(Number(control.value))) {
+      return { invalid: true };
+    }
+
+    return null;
+  }
+}

--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
@@ -8,6 +8,7 @@ import { PasswordDialogComponent } from '../../../layout/password-dialog/passwor
 import { MatSnackBar } from '@angular/material';
 import { showSnackbarError } from '../../../../utils/errors';
 import { TranslateService } from '@ngx-translate/core';
+import { NumberOfAddressesComponent } from '../number-of-addresses/number-of-addresses';
 
 @Component({
   selector: 'app-wallet-detail',
@@ -18,6 +19,7 @@ export class WalletDetailComponent implements OnInit, OnDestroy {
   @Input() wallet: Wallet;
 
   private encryptionWarning: string;
+  private HowManyAddresses: number;
 
   constructor(
     private dialog: MatDialog,
@@ -46,15 +48,15 @@ export class WalletDetailComponent implements OnInit, OnDestroy {
   newAddress() {
     this.snackbar.dismiss();
 
-    if (this.wallet.encrypted) {
-      this.dialog.open(PasswordDialogComponent).componentInstance.passwordSubmit
-        .subscribe(passwordDialog => {
-          this.walletService.addAddress(this.wallet, passwordDialog.password)
-            .subscribe(() => passwordDialog.close(), () => passwordDialog.error());
-        });
-    } else {
-      this.walletService.addAddress(this.wallet).subscribe(null, err => showSnackbarError(this.snackbar, err));
-    }
+    const config = new MatDialogConfig();
+    config.width = '566px';
+    this.dialog.open(NumberOfAddressesComponent, config).afterClosed()
+      .subscribe(response => {
+        if (response) {
+          this.HowManyAddresses = response;
+          this.continueNewAddress();
+        }
+      });
   }
 
   toggleEmpty() {
@@ -115,5 +117,17 @@ export class WalletDetailComponent implements OnInit, OnDestroy {
     const config = new MatDialogConfig();
     config.data = { address };
     this.dialog.open(QrCodeComponent, config);
+  }
+
+  private continueNewAddress() {
+    if (this.wallet.encrypted) {
+      this.dialog.open(PasswordDialogComponent).componentInstance.passwordSubmit
+        .subscribe(passwordDialog => {
+          this.walletService.addAddress(this.wallet, this.HowManyAddresses, passwordDialog.password)
+            .subscribe(() => passwordDialog.close(), () => passwordDialog.error());
+        });
+    } else {
+      this.walletService.addAddress(this.wallet, this.HowManyAddresses).subscribe(null, err => showSnackbarError(this.snackbar, err));
+    }
   }
 }

--- a/src/gui/static/src/app/services/api.service.ts
+++ b/src/gui/static/src/app/services/api.service.ts
@@ -92,15 +92,23 @@ export class ApiService {
         }));
   }
 
-  postWalletNewAddress(wallet: Wallet, password?: string): Observable<Address> {
+  postWalletNewAddress(wallet: Wallet, num: number, password?: string): Observable<Address[]> {
     const params = new Object();
     params['id'] = wallet.filename;
+    params['num'] = num;
     if (password) {
       params['password'] = password;
     }
 
     return this.post('wallet/newAddress', params)
-      .map((response: PostWalletNewAddressResponse) => ({ address: response.addresses[0], coins: null, hours: null }));
+      .map((response: PostWalletNewAddressResponse) => {
+        const result: Address[] = [];
+        response.addresses.forEach(value => {
+          result.push({ address: value, coins: null, hours: null });
+        });
+
+        return result;
+      });
   }
 
   postWalletToggleEncryption(wallet: Wallet, password: string) {

--- a/src/gui/static/src/app/services/purchase.service.ts
+++ b/src/gui/static/src/app/services/purchase.service.ts
@@ -38,13 +38,13 @@ export class PurchaseService {
   }
 
   generate(wallet: Wallet): Observable<PurchaseOrder> {
-    return this.walletService.addAddress(wallet).flatMap(address => {
-      return this.post('bind', { skyaddr: address.address, coin_type: 'BTC' })
+    return this.walletService.addAddress(wallet, 1).flatMap(address => {
+      return this.post('bind', { skyaddr: address[0].address, coin_type: 'BTC' })
         .map(response => ({
           coin_type: response.coin_type,
           deposit_address: response.deposit_address,
           filename: wallet.filename,
-          recipient_address: address.address,
+          recipient_address: address[0].address,
           status: 'waiting_deposit',
         }));
     });

--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -36,10 +36,10 @@ export class WalletService {
     return this.allAddresses().map(addrs => addrs.map(addr => addr.address)).map(addrs => addrs.join(','));
   }
 
-  addAddress(wallet: Wallet, password?: string) {
-    return this.apiService.postWalletNewAddress(wallet, password)
-      .do(address => {
-        wallet.addresses.push(address);
+  addAddress(wallet: Wallet, num: number, password?: string) {
+    return this.apiService.postWalletNewAddress(wallet, num, password)
+      .do(addresses => {
+        addresses.forEach(value => wallet.addresses.push(value));
         this.refreshBalances();
       });
   }

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -89,7 +89,7 @@
   },
 
   "wallet": {
-    "new-address": "New Address",
+    "new-address": "New Addresses",
     "show-empty": "Show Empty",
     "hide-empty": "Hide Empty",
     "encrypt": "Encrypt Wallet",
@@ -125,6 +125,13 @@
       "name-label": "Name",
       "cancel-button": "Cancel",
       "rename-button": "Rename"
+    },
+
+    "add-addresses": {
+      "title": "Select quantity",
+      "name-quantity": "How many addresses to create",
+      "cancel-button": "Cancel",
+      "create-button": "Create"
     },
 
     "address": {


### PR DESCRIPTION
Fixes #1792 

Changes:
- Now it is possible to add more than one address to a wallet in a single operation. The amount is selected in this dialog:
![quantity](https://user-images.githubusercontent.com/34079003/45368845-8e3d7a80-b5b2-11e8-9688-e8e91ca57633.png)

- The text of the "Add address" button was changed to "Add addresses"

Does this change need to mentioned in CHANGELOG.md?
No