### PR TITLE
Hardcode the version in coin.template, not fiber.toml

### DIFF
--- a/cmd/newcoin/newcoin.go
+++ b/cmd/newcoin/newcoin.go
@@ -197,7 +197,6 @@ func createCoinCommand() cli.Command {
 			}
 
 			err = t.ExecuteTemplate(coinFile, coinTemplateFile, CoinTemplateParameters{
-				Version:             config.Build.Version,
 				PeerListURL:         config.Node.PeerListURL,
 				Port:                config.Node.Port,
 				WebInterfacePort:    config.Node.WebInterfacePort,

--- a/fiber.toml
+++ b/fiber.toml
@@ -22,11 +22,6 @@ peer_list_url = "https://downloads.skycoin.net/blockchain/peers.txt"
 #port = 6000
 #web_interface_port = 6420
 
-[build]
-version = "0.24.1"
-#build = ""
-#commit = ""
-
 [visor]
 #max_coin_supply = 1e8
 #distribution_addresses_total = 100

--- a/src/skycoin/parameters.go
+++ b/src/skycoin/parameters.go
@@ -10,7 +10,6 @@ import (
 // Parameters records fiber coin parameters
 type Parameters struct {
 	Node  NodeParameters  `mapstructure:"node"`
-	Build BuildParameters `mapstructure:"build"`
 	Visor VisorParameters `mapstructure:"visor"`
 }
 
@@ -60,13 +59,6 @@ type VisorParameters struct {
 	DefaultMaxBlockSize int `mapstructure:"default_max_block_size"`
 
 	DistributionAddresses []string `mapstructure:"distribution_addresses"`
-}
-
-// BuildParameters records build info
-type BuildParameters struct {
-	Version string `mapstructure:"version"` // node version
-	Commit  string `mapstructure:"commit"`  // git commit id
-	Branch  string `mapstructure:"branch"`  // git branch name
 }
 
 // NewParameters loads blockchain config parameters from a config file

--- a/src/skycoin/parameters_test.go
+++ b/src/skycoin/parameters_test.go
@@ -32,11 +32,6 @@ func TestNewParameters(t *testing.T) {
 			PeerListURL:      "https://downloads.skycoin.net/blockchain/peers.txt",
 			WebInterfacePort: 6420,
 		},
-		Build: BuildParameters{
-			Version: "0.23.1-rc2",
-			Commit:  "0aab9bf7730827d6fd11beb0d02096b40cea1872",
-			Branch:  "test-branch",
-		},
 		Visor: VisorParameters{
 			MaxCoinSupply:              1e8,
 			DistributionAddressesTotal: 100,

--- a/src/skycoin/testdata/test.fiber.toml
+++ b/src/skycoin/testdata/test.fiber.toml
@@ -19,9 +19,3 @@ default_connections = [
 ]
 launch_browser = true
 peer_list_url = "https://downloads.skycoin.net/blockchain/peers.txt"
-
-[build]
-version = "0.23.1-rc2"
-commit = "0aab9bf7730827d6fd11beb0d02096b40cea1872"
-branch = "test-branch"
-

--- a/template/coin.template
+++ b/template/coin.template
@@ -17,7 +17,7 @@ import (
 
 var (
 	// Version of the node. Can be set by -ldflags
-	Version = "{{.Version}}"
+	Version = "0.24.1"
 	// Commit ID. Can be set by -ldflags
 	Commit = ""
 	// Branch name. Can be set by -ldflags
@@ -77,14 +77,12 @@ func main() {
 	}
 
 	// create a new fiber coin instance
-	coin := skycoin.NewCoin(
-		skycoin.Config{
-			Node: nodeConfig,
-			Build: readable.BuildInfo{
-				Version: Version,
-				Commit:  Commit,
-				Branch:  Branch,
-			},
+	coin := skycoin.NewCoin(skycoin.Config{
+		Node: nodeConfig,
+		Build: readable.BuildInfo{
+			Version: Version,
+			Commit:  Commit,
+			Branch:  Branch,
 		},
 	}, logger)
 


### PR DESCRIPTION
Changes:
- Hardcode the version in `coin.template`, instead of getting it through `fiber.toml`.  It's not part of configuration, and leaving it in `fiber.toml` adds an extra step to fiber users for upgrading.

Does this change need to mentioned in CHANGELOG.md?
No