### PR TITLE
Update Electron

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -37,9 +37,9 @@
             "optional": true
         },
         "@types/node": {
-            "version": "8.10.21",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.21.tgz",
-            "integrity": "sha512-87XkD9qDXm8fIax+5y7drx84cXsu34ZZqfB7Cial3Q/2lxSoJ/+DRaWckkCbxP41wFSIrrb939VhzaNxj4eY1w==",
+            "version": "8.10.29",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.29.tgz",
+            "integrity": "sha512-zbteaWZ2mdduacm0byELwtRyhYE40aK+pAanQk415gr1eRuu67x7QGOLmn8jz5zI8LDK7d0WI/oT6r5Trz4rzQ==",
             "dev": true
         },
         "ajv": {
@@ -538,7 +538,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -713,12 +713,12 @@
             "dev": true
         },
         "electron": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.0.tgz",
-            "integrity": "sha512-FCcVzHgoBmNTPUEhKN7yUxjluCRNAQsHNOfdtFEWKL3DPYEdLdyQW8CpmJEMqIXha5qZ+qdKVAtwvvuJs+b/PQ==",
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.9.tgz",
+            "integrity": "sha512-xRefYuz6C65ahX8vDwIJxr1Y5ffFa106dugZEbl23yLKfrAG01lh5csBJ9hJwCBPLHp2zj/9PGoJ8dt5zlzOvQ==",
             "dev": true,
             "requires": {
-                "@types/node": "8.10.21",
+                "@types/node": "8.10.29",
                 "electron-download": "3.3.0",
                 "extract-zip": "1.6.7"
             }
@@ -937,9 +937,9 @@
             }
         },
         "es6-promise": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-            "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+            "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
             "dev": true
         },
         "escape-string-regexp": {
@@ -1120,9 +1120,9 @@
             }
         },
         "glob": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
             "dev": true,
             "requires": {
                 "fs.realpath": "1.0.0",
@@ -1443,7 +1443,7 @@
         },
         "jsonfile": {
             "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+            "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
             "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
             "dev": true,
             "requires": {
@@ -1646,7 +1646,7 @@
         },
         "mkdirp": {
             "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "dev": true,
             "requires": {
@@ -1655,7 +1655,7 @@
             "dependencies": {
                 "minimist": {
                     "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                     "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                     "dev": true
                 }
@@ -2133,7 +2133,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "7.1.3"
             }
         },
         "safe-buffer": {
@@ -2360,7 +2360,7 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "es6-promise": "4.2.4"
+                "es6-promise": "4.2.5"
             }
         },
         "supports-color": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -74,7 +74,7 @@
         "postinstall": "electron-builder install-app-deps"
     },
     "devDependencies": {
-        "electron": "2.0.0",
+        "electron": "^2.0.9",
         "electron-builder": "20.13.3"
     },
     "dependencies": {}


### PR DESCRIPTION
Changes:
- Updates Electron from v2.0.0 to 2.0.9 and up. This pr does not update Electron Builder, since new versions of Electron Builder are the ones that gave problems when recompiling the app.

Does this change need to mentioned in CHANGELOG.md?
No