### PR TITLE
Improve validation of bip39 seeds

### DIFF
--- a/cmd/address_gen/address_gen.go
+++ b/cmd/address_gen/address_gen.go
@@ -30,6 +30,7 @@ func main() {
 	seed := flag.String("seed", "", "Seed for deterministic key generation. Will use bip39 as the seed if not provided")
 	secKeysList := flag.Bool("sec-keys-list", false, "only print a list of secret keys")
 	addrsList := flag.Bool("addrs-list", false, "only print a list of addresses")
+	strict := flag.Bool("strict", true, "Checks if input is space separated list of words.")
 	flag.Parse()
 
 	var coinType wallet.CoinType
@@ -51,6 +52,13 @@ func main() {
 			}
 
 			*seed = mnemonic
+		}
+	}
+
+	if !*hexSeed && *strict {
+		if !bip39.IsMnemonicValid(*seed) {
+			fmt.Println("your seed isn't valid")
+			os.Exit(1)
 		}
 	}
 

--- a/cmd/address_gen/address_gen.go
+++ b/cmd/address_gen/address_gen.go
@@ -30,7 +30,7 @@ func main() {
 	seed := flag.String("seed", "", "Seed for deterministic key generation. Will use bip39 as the seed if not provided")
 	secKeysList := flag.Bool("sec-keys-list", false, "only print a list of secret keys")
 	addrsList := flag.Bool("addrs-list", false, "only print a list of addresses")
-	strict := flag.Bool("strict", true, "Checks if input is space separated list of words.")
+	strict := flag.Bool("strict", true, "Checks if seed is a valid bip39 mnemonic seed")
 	flag.Parse()
 
 	var coinType wallet.CoinType

--- a/src/cipher/go-bip39/bip39.go
+++ b/src/cipher/go-bip39/bip39.go
@@ -249,10 +249,21 @@ func validateEntropyWithChecksumBitSize(bitSize int) error {
 // Validity is determined by both the number of words being appropriate,
 // and that all the words in the mnemonic are present in the word list.
 func IsMnemonicValid(mnemonic string) bool {
-	// Create a list of all the words in the mnemonic sentence
-	words := strings.Fields(mnemonic)
+	// Make sure no leading/trailing whitespace
+	if mnemonic != strings.TrimSpace(mnemonic) {
+		return false
+	}
 
-	//Get num of words
+	// Create a list of all the words in the mnemonic sentence
+	words := strings.Split(mnemonic, " ")
+
+	// Detect duplicate whitespace
+	for _, w := range words {
+		if w == "" {
+			return false
+		}
+	}
+
 	numOfWords := len(words)
 
 	// The number of words should be 12, 15, 18, 21 or 24

--- a/src/cipher/go-bip39/bip39_test.go
+++ b/src/cipher/go-bip39/bip39_test.go
@@ -1,0 +1,62 @@
+package bip39
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsMnemonicValid(t *testing.T) {
+	m, err := NewDefaultMnemonic()
+	require.NoError(t, err)
+	require.True(t, IsMnemonicValid(m))
+
+	// Truncated
+	m = m[:len(m)-2]
+	require.False(t, IsMnemonicValid(m))
+
+	// Trailing whitespace
+	m, err = NewDefaultMnemonic()
+	require.NoError(t, err)
+	m += " "
+	require.False(t, IsMnemonicValid(m))
+
+	m, err = NewDefaultMnemonic()
+	require.NoError(t, err)
+	m += "\n"
+	require.False(t, IsMnemonicValid(m))
+
+	// Preceding whitespace
+	m, err = NewDefaultMnemonic()
+	require.NoError(t, err)
+	m = " " + m
+	require.False(t, IsMnemonicValid(m))
+
+	m, err = NewDefaultMnemonic()
+	require.NoError(t, err)
+	m = "\n" + m
+	require.False(t, IsMnemonicValid(m))
+
+	// Extra whitespace between words
+	m, err = NewDefaultMnemonic()
+	require.NoError(t, err)
+	ms := strings.Split(m, " ")
+	m = strings.Join(ms, "  ")
+	require.False(t, IsMnemonicValid(m))
+
+	// Contains invalid word
+	m, err = NewDefaultMnemonic()
+	require.NoError(t, err)
+	ms = strings.Split(m, " ")
+	ms[2] = "foo"
+	m = strings.Join(ms, " ")
+	require.False(t, IsMnemonicValid(m))
+
+	// Invalid number of words
+	m, err = NewDefaultMnemonic()
+	require.NoError(t, err)
+	ms = strings.Split(m, " ")
+	m = strings.Join(ms[:len(ms)-1], " ")
+	require.False(t, IsMnemonicValid(m))
+}


### PR DESCRIPTION
Fixes #1910

Changes:
- Improve `bip39.IsValidMnemonic` by checking for leading and trailing whitespace and for extra whitespace in between words.  It already checked words against the wordlist

Does this change need to mentioned in CHANGELOG.md?
No