### PR TITLE
Continually rescan wallets until a sequence of empty addresses is found

### DIFF
--- a/src/wallet/service_test.go
+++ b/src/wallet/service_test.go
@@ -2416,8 +2416,86 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			expect: exp{
 				err:              nil,
 				seed:             seed,
-				lastSeed:         childSeeds[4],
-				entryNum:         4 + 1,
+				lastSeed:         childSeeds[6],
+				entryNum:         6 + 1,
+				confirmedBalance: 20,
+				predictedBalance: 0,
+			},
+		},
+		{
+			name: "scan 5 get 2 have 7, unencrypted",
+			opts: Options{
+				Seed:  seed,
+				ScanN: 5,
+			},
+			balGetter: mockBalanceGetter{
+				addrs[2]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+				addrs[7]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+			},
+			expect: exp{
+				err:              nil,
+				seed:             seed,
+				lastSeed:         childSeeds[7],
+				entryNum:         7 + 1,
+				confirmedBalance: 20,
+				predictedBalance: 0,
+			},
+		},
+		{
+			name: "scan 5 get 2 get 7 have 12, unencrypted",
+			opts: Options{
+				Seed:  seed,
+				ScanN: 5,
+			},
+			balGetter: mockBalanceGetter{
+				addrs[2]:  BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+				addrs[7]:  BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+				addrs[12]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+			},
+			expect: exp{
+				err:              nil,
+				seed:             seed,
+				lastSeed:         childSeeds[12],
+				entryNum:         12 + 1,
+				confirmedBalance: 20,
+				predictedBalance: 0,
+			},
+		},
+		{
+			name: "scan 5 get 2 get 7 have 13, unencrypted",
+			opts: Options{
+				Seed:  seed,
+				ScanN: 5,
+			},
+			balGetter: mockBalanceGetter{
+				addrs[2]:  BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+				addrs[7]:  BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+				addrs[13]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+			},
+			expect: exp{
+				err:              nil,
+				seed:             seed,
+				lastSeed:         childSeeds[7],
+				entryNum:         7 + 1,
+				confirmedBalance: 20,
+				predictedBalance: 0,
+			},
+		},
+		{
+			name: "scan 5 get 2 have 8, unencrypted",
+			opts: Options{
+				Seed:  seed,
+				ScanN: 5,
+			},
+			balGetter: mockBalanceGetter{
+				addrs[2]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+				addrs[8]: BalancePair{Confirmed: Balance{Coins: 10, Hours: 100}},
+			},
+			expect: exp{
+				err:              nil,
+				seed:             seed,
+				lastSeed:         childSeeds[2],
+				entryNum:         2 + 1,
 				confirmedBalance: 20,
 				predictedBalance: 0,
 			},

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -897,8 +897,8 @@ func (w *Wallet) GenerateAddresses(num uint64) ([]cipher.Address, error) {
 }
 
 // ScanAddresses scans ahead N addresses, truncating up to the highest address with a non-zero balance.
-// If the highest address with a non-zero balance is the Nth address, it scans ahead another N addresses,
-// until the last address has no balance. Returns the number of addresses added.
+// If any address has a nonzero balance, it rescans N more addresses from that point, until a entire
+// sequence of N addresses has no balance.
 func (w *Wallet) ScanAddresses(scanN uint64, bg BalanceGetter) (uint64, error) {
 	if w.IsEncrypted() {
 		return 0, ErrWalletEncrypted
@@ -933,11 +933,11 @@ func (w *Wallet) ScanAddresses(scanN uint64, bg BalanceGetter) (uint64, error) {
 			}
 		}
 
-		nAddAddrs += keepNum
-
-		if keepNum != uint64(len(bals)) {
+		if keepNum == 0 {
 			break
 		}
+
+		nAddAddrs += keepNum
 	}
 
 	// Regenerate addresses up to nExistingAddrs + nAddAddrss.

--- a/src/wallet/wallet_test.go
+++ b/src/wallet/wallet_test.go
@@ -104,43 +104,6 @@ func (mb mockBalanceGetter) GetBalanceOfAddrs(addrs []cipher.Address) ([]Balance
 	return bals, nil
 }
 
-// 10 addresses of seed1
-var addrsOfSeed1 = []string{
-	"2GBifzJEehbDX7Mkk63Prfa4MQQQyRzBLfe",
-	"q2kU13X8XsAg8cS8BuSeSVzjPF9AT9ghAa",
-	"2WXvTagXtrc1Qq71yjNXw86TC6SRgfVRH1B",
-	"2NUNw748b9mT2FHRxgJL5KjBHasLfdP32Sh",
-	"2V1CnVzWoXDaCX6wHU4tLJkWaFmLcQBb2q4",
-	"wBkMr936thcr57wxyrH6ffvA99JN2Q1MN1",
-	"2f92Wht7VQefAyoJUz3SEnfwT6wTdeAcq3L",
-	"27UM5jPFYVuve3ceEHAYGaJSmkynQYmwPcH",
-	"xjWbVN7ihReasVFwXJSSYYWF7rgQa22auC",
-	"2LyanokLYFeBfBsNkRYHp2qtN8naGFJqeUw",
-}
-
-var childSeedsOfSeed1 = []string{
-	"22b826c586039f8078433be26618ca1024e883d97de2267313bb78068f634c5a",
-	"68efbbdf8aa06368cfc55e252d1e782bbd7651e590ee59e94ab579d2e44c20ad",
-	"8894c818732375680284be4509d153272726f42296b85ecac1fb66b9dc7484b9",
-	"6603375ee19c1e9fffe369e3f62e9deaa6931c1183d7da7f24ecbbd591061502",
-	"91a63f939149d423ea39701d8ed16cfb16a3554c184d214d2289018ddb9e73de",
-	"f0f4f008aa3e7cd32ee953507856fb46e37b734fd289dc01449133d7e37a1f07",
-	"6b194da58a5ba5660cf2b00076cf6a2962fe8fe0523abca5647c87df3352866a",
-	"b47a2678f7e797d3ada86e7e36855f572a18ab78dcbe54ed0613bba69fd76f8d",
-	"fe064533108dadbef13be3a95f547ba03423aa6a701c40aaaed775cb783b12b3",
-	"d554da211321a437e4d08f2a57e3ef255cffa89dd182e0fd52a4fd5bdfcab1ae",
-}
-
-func fromAddrString(t *testing.T, addrStrs []string) []cipher.Address {
-	addrs := make([]cipher.Address, 0, len(addrStrs))
-	for _, addr := range addrStrs {
-		a, err := cipher.DecodeBase58Address(addr)
-		require.NoError(t, err)
-		addrs = append(addrs, a)
-	}
-	return addrs
-}
-
 func TestNewWallet(t *testing.T) {
 	type expect struct {
 		meta map[string]string


### PR DESCRIPTION
Fixes #1864

Changes:
- wallet.ScanAddresses will keep scanning until a sequence of N addresses all have zero balance.  For example, if we scan ahead 100 addresses and find a nonzero balance in address 40, it will rescan to address 140.  If we find another balance at address 110, it will rescan to address 210 and so on.
- When creating a wallet, scanning starts after generating initial addresses (which is defaulted to 1, but can be set with `wallet.Options.GenerateN`).  Previously, scanning started at 0, regardless of the pregenerated addresses. 
- Fixes a bug where if `GetBalanceOfAddrs` failed, the wallet would have generated an additional `ScanN` addresses

Does this change need to mentioned in CHANGELOG.md?
No