### PR TITLE
Encoder benchmarks

### DIFF
--- a/src/cipher/encoder/benchmark_test.go
+++ b/src/cipher/encoder/benchmark_test.go
@@ -9,14 +9,14 @@ type benchmarkExample struct {
 	Colors []string
 }
 
-func BenchmarkDeserializeRaw(b *testing.B) {
-	obj := benchmarkExample{
-		ID:     1,
-		Name:   "Reds",
-		Colors: []string{"Crimson", "Red", "Ruby", "Maroon"},
-	}
+var benchmarkExampleObj = benchmarkExample{
+	ID:     1,
+	Name:   "Reds",
+	Colors: []string{"Crimson", "Red", "Ruby", "Maroon"},
+}
 
-	byt := Serialize(obj)
+func BenchmarkDeserializeRaw(b *testing.B) {
+	byt := Serialize(benchmarkExampleObj)
 	result := &benchmarkExample{}
 
 	b.ResetTimer()
@@ -26,14 +26,8 @@ func BenchmarkDeserializeRaw(b *testing.B) {
 }
 
 func BenchmarkSerialize(b *testing.B) {
-	obj := benchmarkExample{
-		ID:     1,
-		Name:   "Reds",
-		Colors: []string{"Crimson", "Red", "Ruby", "Maroon"},
-	}
-
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		Serialize(&obj)
+		Serialize(&benchmarkExampleObj)
 	}
 }

--- a/src/cipher/encoder/benchmark_test.go
+++ b/src/cipher/encoder/benchmark_test.go
@@ -21,7 +21,7 @@ func BenchmarkDeserializeRaw(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		DeserializeRaw(byt, result)
+		DeserializeRaw(byt, result) // nolint: errcheck
 	}
 }
 

--- a/src/cipher/encoder/benchmark_test.go
+++ b/src/cipher/encoder/benchmark_test.go
@@ -1,0 +1,39 @@
+package encoder
+
+import "testing"
+
+// benchmarkExample is the same struct used in https://github.com/gz-c/gosercomp benchmarks
+type benchmarkExample struct {
+	ID     int32
+	Name   string
+	Colors []string
+}
+
+func BenchmarkDeserializeRaw(b *testing.B) {
+	obj := benchmarkExample{
+		ID:     1,
+		Name:   "Reds",
+		Colors: []string{"Crimson", "Red", "Ruby", "Maroon"},
+	}
+
+	byt := Serialize(obj)
+	result := &benchmarkExample{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		DeserializeRaw(byt, result)
+	}
+}
+
+func BenchmarkSerialize(b *testing.B) {
+	obj := benchmarkExample{
+		ID:     1,
+		Name:   "Reds",
+		Colors: []string{"Crimson", "Red", "Ruby", "Maroon"},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Serialize(&obj)
+	}
+}

--- a/src/cipher/go-bip39/bip39_test.go
+++ b/src/cipher/go-bip39/bip39_test.go
@@ -13,7 +13,7 @@ func TestIsMnemonicValid(t *testing.T) {
 	require.True(t, IsMnemonicValid(m))
 
 	// Truncated
-	m = m[:len(m)-2]
+	m = m[:len(m)-15]
 	require.False(t, IsMnemonicValid(m))
 
 	// Trailing whitespace

--- a/src/daemon/messages_benchmark_test.go
+++ b/src/daemon/messages_benchmark_test.go
@@ -16,7 +16,7 @@ func BenchmarkDeserializeRawGetPeersMessage(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		encoder.DeserializeRaw(byt, result)
+		encoder.DeserializeRaw(byt, result) // nolint: errcheck
 	}
 }
 
@@ -50,7 +50,7 @@ func BenchmarkDeserializeRawGivePeersMessage(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		encoder.DeserializeRaw(byt, result)
+		encoder.DeserializeRaw(byt, result) // nolint: errcheck
 	}
 }
 
@@ -74,7 +74,7 @@ func BenchmarkDeserializeRawIntroductionMessage(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		encoder.DeserializeRaw(byt, result)
+		encoder.DeserializeRaw(byt, result) // nolint: errcheck
 	}
 }
 
@@ -95,7 +95,7 @@ func BenchmarkDeserializeRawGiveBlocksMessage(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		encoder.DeserializeRaw(byt, result)
+		encoder.DeserializeRaw(byt, result) // nolint: errcheck
 	}
 }
 
@@ -116,7 +116,7 @@ func BenchmarkDeserializeRawAnnounceTxnsMessage(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		encoder.DeserializeRaw(byt, result)
+		encoder.DeserializeRaw(byt, result) // nolint: errcheck
 	}
 }
 
@@ -137,7 +137,7 @@ func BenchmarkDeserializeRawGiveTxnsMessage(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		encoder.DeserializeRaw(byt, result)
+		encoder.DeserializeRaw(byt, result) // nolint: errcheck
 	}
 }
 

--- a/src/daemon/messages_benchmark_test.go
+++ b/src/daemon/messages_benchmark_test.go
@@ -1,0 +1,149 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/cipher/encoder"
+	"github.com/skycoin/skycoin/src/coin"
+)
+
+var getPeersMessageObj = GetPeersMessage{}
+
+func BenchmarkDeserializeRawGetPeersMessage(b *testing.B) {
+	byt := encoder.Serialize(getPeersMessageObj)
+	result := &GetPeersMessage{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encoder.DeserializeRaw(byt, result)
+	}
+}
+
+func BenchmarkSerializeGetPeersMessage(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encoder.Serialize(&getPeersMessageObj)
+	}
+}
+
+var givePeersMessageObj = GivePeersMessage{
+	Peers: []IPAddr{
+		{
+			IP:   1234,
+			Port: 1234,
+		},
+		{
+			IP:   5678,
+			Port: 5678,
+		},
+		{
+			IP:   9876,
+			Port: 9876,
+		},
+	},
+}
+
+func BenchmarkDeserializeRawGivePeersMessage(b *testing.B) {
+	byt := encoder.Serialize(givePeersMessageObj)
+	result := &GivePeersMessage{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encoder.DeserializeRaw(byt, result)
+	}
+}
+
+func BenchmarkSerializeGivePeersMessage(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encoder.Serialize(&givePeersMessageObj)
+	}
+}
+
+var introMessageObj = IntroductionMessage{
+	Mirror:  1234,
+	Port:    5678,
+	Version: 1,
+	Extra:   []byte("abcdefghijklmnoqrstuvwxyz1234567890"),
+}
+
+func BenchmarkDeserializeRawIntroductionMessage(b *testing.B) {
+	byt := encoder.Serialize(introMessageObj)
+	result := &IntroductionMessage{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encoder.DeserializeRaw(byt, result)
+	}
+}
+
+func BenchmarkSerializeIntroductionMessage(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encoder.Serialize(&introMessageObj)
+	}
+}
+
+var giveBlocksMessageObj = GiveBlocksMessage{
+	Blocks: make([]coin.SignedBlock, 3),
+}
+
+func BenchmarkDeserializeRawGiveBlocksMessage(b *testing.B) {
+	byt := encoder.Serialize(giveBlocksMessageObj)
+	result := &GiveBlocksMessage{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encoder.DeserializeRaw(byt, result)
+	}
+}
+
+func BenchmarkSerializeGiveBlocksMessage(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encoder.Serialize(&giveBlocksMessageObj)
+	}
+}
+
+var announceTxnsMessageObj = AnnounceTxnsMessage{
+	Transactions: make([]cipher.SHA256, 3),
+}
+
+func BenchmarkDeserializeRawAnnounceTxnsMessage(b *testing.B) {
+	byt := encoder.Serialize(announceTxnsMessageObj)
+	result := &AnnounceTxnsMessage{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encoder.DeserializeRaw(byt, result)
+	}
+}
+
+func BenchmarkSerializeAnnounceTxnsMessage(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encoder.Serialize(&announceTxnsMessageObj)
+	}
+}
+
+var giveTxnsMessageObj = GiveTxnsMessage{
+	Transactions: make(coin.Transactions, 3),
+}
+
+func BenchmarkDeserializeRawGiveTxnsMessage(b *testing.B) {
+	byt := encoder.Serialize(giveTxnsMessageObj)
+	result := &GiveTxnsMessage{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encoder.DeserializeRaw(byt, result)
+	}
+}
+
+func BenchmarkSerializeGiveTxnsMessage(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encoder.Serialize(&giveTxnsMessageObj)
+	}
+}


### PR DESCRIPTION
Fixes #1872 

Changes:
- Add basic benchmark in cipher/encoder, of the same struct used in https://github.com/gz-c/gosercomp
- Add benchmarks for daemon message encoding (which gives a decent representation of the kinds of data we encode). Not all messages are benchmarked, if the struct field types are similar to another struct already benchmarked.

Does this change need to mentioned in CHANGELOG.md?
No