### PR TITLE
Add the reset password page

### DIFF
--- a/src/gui/static/src/app/app.module.ts
+++ b/src/gui/static/src/app/app.module.ts
@@ -74,6 +74,7 @@ import { LoadingContentComponent } from './components/layout/loading-content/loa
 import { NumberOfAddressesComponent } from './components/pages/wallets/number-of-addresses/number-of-addresses';
 import { SelectAddressComponent } from './components/pages/send-skycoin/send-form-advanced/select-address/select-address';
 import { CreateWalletFormComponent } from './components/pages/wallets/create-wallet/create-wallet-form/create-wallet-form.component';
+import { ResetPasswordComponent } from './components/pages/reset-password/reset-password.component';
 
 
 const ROUTES = [
@@ -132,6 +133,10 @@ const ROUTES = [
     path: 'wizard',
     component: OnboardingComponent,
   },
+  {
+    path: 'reset/:id',
+    component: ResetPasswordComponent,
+  },
 ];
 
 @NgModule({
@@ -176,6 +181,7 @@ const ROUTES = [
     NumberOfAddressesComponent,
     SelectAddressComponent,
     CreateWalletFormComponent,
+    ResetPasswordComponent,
   ],
   entryComponents: [
     AddDepositAddressComponent,

--- a/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.html
@@ -10,6 +10,7 @@
       <input formControlName="confirm_password" id="confirm_password" type="password" appDontSavePassword (keydown.enter)="proceed()">
     </div>
   </div>
+  <a *ngIf="data.wallet" [href]="'#/reset/' + data.wallet.filename" class="link">{{ 'password.reset-link' | translate }}</a>
   <div class="-buttons">
     <app-button #button (action)="proceed()" class="primary" [disabled]="!form.valid">
       {{ 'password.button' | translate }}

--- a/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.scss
+++ b/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.scss
@@ -10,3 +10,12 @@
   font-size: 12px;
   line-height: 1.5;
 }
+
+.link {
+  font-size: 13px;
+  width: 100%;
+  display: inline-block;
+  text-align: center;
+  text-decoration: none;
+  color: $gradient-blue-dark;
+}

--- a/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.ts
@@ -32,6 +32,7 @@ export class PasswordDialogComponent implements OnInit, OnDestroy {
       confirm: false,
       description: null,
       title: null,
+      wallet: null,
     }, data || {});
 
     this.translateService.get(['errors.incorrect-password', 'errors.api-disabled', 'errors.no-wallet']).subscribe(res => {

--- a/src/gui/static/src/app/components/pages/reset-password/reset-password.component.html
+++ b/src/gui/static/src/app/components/pages/reset-password/reset-password.component.html
@@ -1,0 +1,28 @@
+<app-header [headline]="'title.reset' | translate"></app-header>
+<div class="container">
+  <div class="-paper">
+    <div [formGroup]="form">
+      <div class="form-field">
+        <label for="wallet">{{ 'reset.wallet-label' | translate }}</label>
+        <input formControlName="wallet" id="wallet" readonly class="-disabled">
+      </div>
+      <div class="form-field">
+        <label for="seed">{{ 'reset.seed-label' | translate }}</label>
+        <textarea formControlName="seed" id="seed" row="2"></textarea>
+      </div>
+      <div class="form-field">
+        <label for="password">{{ 'reset.password-label' | translate }}</label>
+        <input formControlName="password" id="password" type="password">
+      </div>
+      <div class="form-field">
+        <label for="confirm">{{ 'reset.confirm-label' | translate }}</label>
+        <input formControlName="confirm" id="confirm" type="password" (keydown.enter)="reset()">
+      </div>
+      <div class="-buttons">
+        <app-button #resetButton (action)="reset()" class="primary" [disabled]="!form.valid">
+          {{ 'reset.reset-button' | translate }}
+        </app-button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/gui/static/src/app/components/pages/reset-password/reset-password.component.scss
+++ b/src/gui/static/src/app/components/pages/reset-password/reset-password.component.scss
@@ -1,0 +1,15 @@
+.-buttons {
+  text-align: center;
+}
+
+.-paper {
+  background-color: #fbfbfb;
+  border-radius: 10px;
+  box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.01), 1px 1px 2px 2px rgba(0, 0, 0, 0.01);
+  padding: 30px;
+  margin: 30px;
+}
+
+.-disabled {
+  opacity: 0.5;
+}

--- a/src/gui/static/src/app/components/pages/reset-password/reset-password.component.spec.ts
+++ b/src/gui/static/src/app/components/pages/reset-password/reset-password.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ResetPasswordComponent } from './reset-password.component';
+
+describe('ResetPasswordComponent', () => {
+  let component: ResetPasswordComponent;
+  let fixture: ComponentFixture<ResetPasswordComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ResetPasswordComponent ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ResetPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/gui/static/src/app/components/pages/reset-password/reset-password.component.ts
+++ b/src/gui/static/src/app/components/pages/reset-password/reset-password.component.ts
@@ -1,0 +1,93 @@
+import { Component, OnDestroy, ViewChild } from '@angular/core';
+import { ISubscription } from 'rxjs/Subscription';
+import { ButtonComponent } from '../../layout/button/button.component';
+import { FormGroup, FormBuilder, FormControl, Validators } from '@angular/forms';
+import { Params, ActivatedRoute, Router } from '@angular/router';
+import { Observable } from 'rxjs/Observable';
+import { WalletService } from '../../../services/wallet.service';
+import { Wallet } from '../../../app.datatypes';
+import { MatSnackBar } from '@angular/material';
+import { showSnackbarError } from '../../../utils/errors';
+
+@Component({
+  selector: 'app-reset-password',
+  templateUrl: './reset-password.component.html',
+  styleUrls: ['./reset-password.component.scss'],
+})
+export class ResetPasswordComponent implements OnDestroy {
+  @ViewChild('resetButton') resetButton: ButtonComponent;
+
+  form: FormGroup;
+
+  private subscription: ISubscription;
+  private wallet: Wallet;
+  private done = false;
+
+  constructor(
+    public formBuilder: FormBuilder,
+    private route: ActivatedRoute,
+    private router: Router,
+    private walletService: WalletService,
+    private snackbar: MatSnackBar,
+  ) {
+    this.initForm('');
+    this.subscription = Observable.zip(this.route.params, this.walletService.all(), (params: Params, wallets: Wallet[]) => {
+      const wallet = wallets.find(w => w.filename === params['id']);
+      if (!wallet) {
+        setTimeout(() => this.router.navigate([''], {skipLocationChange: true}));
+
+        return;
+      }
+
+      this.wallet = wallet;
+      this.initForm(wallet.label);
+    }).subscribe();
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+    this.snackbar.dismiss();
+  }
+
+  initForm(walletName: string) {
+    const validators = [];
+    validators.push(this.passwordMatchValidator.bind(this));
+
+    this.form = new FormGroup({}, validators);
+    this.form.addControl('wallet', new FormControl(walletName));
+    this.form.addControl('seed', new FormControl('', [Validators.required]));
+    this.form.addControl('password', new FormControl());
+    this.form.addControl('confirm', new FormControl());
+  }
+
+  reset() {
+    if (!this.form.valid || this.resetButton.isLoading() || this.done) {
+      return;
+    }
+
+    this.snackbar.dismiss();
+    this.resetButton.setLoading();
+
+    this.walletService.resetPassword(this.wallet, this.form.value.seed, this.form.value.password !== '' ? this.form.value.password : null)
+      .subscribe(() => {
+        this.resetButton.setSuccess();
+        this.resetButton.setDisabled();
+        this.done = true;
+
+        setTimeout(() => {
+          this.router.navigate(['']);
+        }, 2000);
+      }, error => {
+        this.resetButton.setError(error);
+        showSnackbarError(this.snackbar, error);
+      });
+  }
+
+  private passwordMatchValidator() {
+    if (this.form && this.form.get('password') && this.form.get('confirm')) {
+      return this.form.get('password').value === this.form.get('confirm').value ? null : { NotEqual: true };
+    } else {
+      return { NotEqual: true };
+    }
+  }
+}

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.ts
@@ -92,7 +92,12 @@ export class SendFormAdvancedComponent implements OnInit, OnDestroy {
     this.sendButton.resetState();
 
     if (this.form.get('wallet').value.encrypted) {
-      this.dialog.open(PasswordDialogComponent).componentInstance.passwordSubmit
+      const config = new MatDialogConfig();
+      config.data = {
+        wallet: this.form.get('wallet').value,
+      };
+
+      this.dialog.open(PasswordDialogComponent, config).componentInstance.passwordSubmit
         .subscribe(passwordDialog => {
           this.createTransaction(passwordDialog);
         });

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
@@ -5,7 +5,7 @@ import 'rxjs/add/operator/delay';
 import 'rxjs/add/operator/filter';
 import { ButtonComponent } from '../../../layout/button/button.component';
 import { PasswordDialogComponent } from '../../../layout/password-dialog/password-dialog.component';
-import { MatDialog, MatSnackBar } from '@angular/material';
+import { MatDialog, MatSnackBar, MatDialogConfig } from '@angular/material';
 import { showSnackbarError } from '../../../../utils/errors';
 import { ISubscription } from 'rxjs/Subscription';
 import { NavBarService } from '../../../../services/nav-bar.service';
@@ -67,7 +67,12 @@ export class SendFormComponent implements OnInit, OnDestroy {
     this.sendButton.resetState();
 
     if (this.form.value.wallet.encrypted) {
-      this.dialog.open(PasswordDialogComponent).componentInstance.passwordSubmit
+      const config = new MatDialogConfig();
+      config.data = {
+        wallet: this.form.value.wallet,
+      };
+
+      this.dialog.open(PasswordDialogComponent, config).componentInstance.passwordSubmit
         .subscribe(passwordDialog => {
           this.createTransaction(passwordDialog);
         });

--- a/src/gui/static/src/app/components/pages/settings/backup/backup.component.ts
+++ b/src/gui/static/src/app/components/pages/settings/backup/backup.component.ts
@@ -38,7 +38,12 @@ export class BackupComponent implements OnInit, OnDestroy {
   }
 
   showSeed(wallet: Wallet) {
-    this.dialog.open(PasswordDialogComponent).componentInstance.passwordSubmit
+    const initialConfig = new MatDialogConfig();
+    initialConfig.data = {
+      wallet: wallet,
+    };
+
+    this.dialog.open(PasswordDialogComponent, initialConfig).componentInstance.passwordSubmit
       .subscribe(passwordDialog => {
         this.walletService.getWalletSeed(wallet, passwordDialog.password).subscribe(seed => {
           passwordDialog.close();

--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
@@ -72,6 +72,8 @@ export class WalletDetailComponent implements OnInit, OnDestroy {
 
     if (!this.wallet.encrypted) {
       config.data['description'] = this.encryptionWarning;
+    } else {
+      config.data['wallet'] = this.wallet;
     }
 
     this.dialog.open(PasswordDialogComponent, config).componentInstance.passwordSubmit
@@ -121,7 +123,12 @@ export class WalletDetailComponent implements OnInit, OnDestroy {
 
   private continueNewAddress() {
     if (this.wallet.encrypted) {
-      this.dialog.open(PasswordDialogComponent).componentInstance.passwordSubmit
+      const config = new MatDialogConfig();
+      config.data = {
+        wallet: this.wallet,
+      };
+
+      this.dialog.open(PasswordDialogComponent, config).componentInstance.passwordSubmit
         .subscribe(passwordDialog => {
           this.walletService.addAddress(this.wallet, this.HowManyAddresses, passwordDialog.password)
             .subscribe(() => passwordDialog.close(), () => passwordDialog.error());

--- a/src/gui/static/src/app/services/api.service.ts
+++ b/src/gui/static/src/app/services/api.service.ts
@@ -126,13 +126,17 @@ export class ApiService {
     return this.get('csrf').map(response => response.csrf_token);
   }
 
-  post(url, params = {}, options: any = {}) {
+  post(url, params = {}, options: any = {}, useV2 = false) {
     return this.getCsrf().first().flatMap(csrf => {
       options.csrf = csrf;
 
+      if (useV2) {
+        options.json = true;
+      }
+
       return this.http.post(
-        this.getUrl(url),
-        options.json ? JSON.stringify(params) : this.getQueryString(params),
+        this.getUrl(url, null, useV2),
+        options.json || useV2 ? JSON.stringify(params) : this.getQueryString(params),
         this.returnRequestOptions(options),
       )
         .map((res: any) => res.json())
@@ -171,8 +175,8 @@ export class ApiService {
     }, []).join('&');
   }
 
-  private getUrl(url, options = null) {
-    return this.url + url + '?' + this.getQueryString(options);
+  private getUrl(url, options = null, useV2 = false) {
+    return this.url + (useV2 ? 'v2/' : 'v1/') + url + '?' + this.getQueryString(options);
   }
 
   private processConnectionError(error: any): Observable<void> {

--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -131,6 +131,20 @@ export class WalletService {
       });
   }
 
+  resetPassword(wallet: Wallet, seed: string, password: string): Observable<Wallet> {
+    const params = new Object();
+    params['id'] = wallet.filename;
+    params['seed'] = seed;
+    if (password) {
+      params['password'] = password;
+    }
+
+    return this.apiService.post('wallet/recover', params, {}, true).do(w => {
+      wallet.encrypted = w.data.meta.encrypted;
+      this.updateWallet(w.data);
+    });
+  }
+
   getWalletSeed(wallet: Wallet, password: string): Observable<string> {
     return this.apiService.getWalletSeed(wallet, password);
   }

--- a/src/gui/static/src/app/utils/errors.ts
+++ b/src/gui/static/src/app/utils/errors.ts
@@ -5,6 +5,10 @@ export function parseResponseMessage(body: string): string {
     body = body['_body'];
   }
 
+  if (body.indexOf('"error":') !== -1) {
+    body = JSON.parse(body).error.message;
+  }
+
   if (body.startsWith('400') || body.startsWith('403')) {
     const parts = body.split(' - ', 2);
 

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -29,7 +29,8 @@
     "backup": "Backup Wallet",
     "explorer": "Skycoin Explorer",
     "seed": "Wallet Seed",
-    "qrcode": "QR Code"
+    "qrcode": "QR Code",
+    "reset": "Reset Password"
   },
 
   "header": {
@@ -53,7 +54,8 @@
     "title": "Enter Password",
     "label": "Password",
     "confirm-label": "Confirm password",
-    "button": "Proceed"
+    "button": "Proceed",
+    "reset-link": "I forgot my password"
   },
 
   "buy": {
@@ -168,6 +170,14 @@
     "back-button": "Back",
     "simple": "Simple",
     "advanced": "Advanced"
+  },
+
+  "reset": {
+    "wallet-label": "Wallet",
+    "seed-label": "Wallet seed",
+    "password-label": "New password (leave empty if you want the wallet not to be encrypted)",
+    "confirm-label": "Confirm new password",
+    "reset-button": "Reset"
   },
 
   "tx": {

--- a/src/gui/static/src/environments/environment.prod.ts
+++ b/src/gui/static/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
-  nodeUrl: '/api/v1/',
+  nodeUrl: '/api/',
   production: true,
   tellerUrl: 'https://event.skycoin.net/api/',
 };

--- a/src/gui/static/src/environments/environment.ts
+++ b/src/gui/static/src/environments/environment.ts
@@ -4,7 +4,7 @@
 // The list of which env maps to which file can be found in `.angular-cli.json`.
 
 export const environment = {
-  nodeUrl: '/api/v1/',
+  nodeUrl: '/api/',
   production: false,
   tellerUrl: '/teller/',
 };


### PR DESCRIPTION
Fixes #1574

Changes:
- Changes needed for using version 2 of the api
- Now the modal window in which the user must enter the password shows an "I forgot my password" link:
![modal](https://user-images.githubusercontent.com/34079003/46118799-58b1a780-c1d6-11e8-9a14-f8cab0aef6fc.png)
- A page for reseting the password was added. The form was created in a page instead of a modal window to avoid possible complications in the code when having to update the status of the wallet after resetting the password.

Does this change need to mentioned in CHANGELOG.md?
No