### PR TITLE
[docker] fixes #1930 - Image files copied at correct locations

### DIFF
--- a/docker/images/mainnet/Dockerfile
+++ b/docker/images/mainnet/Dockerfile
@@ -55,4 +55,4 @@ VOLUME $DATA_DIR
 
 EXPOSE 6000 6420
 
-ENTRYPOINT ["docker_launcher.sh", "--web-interface-addr=0.0.0.0", "--gui-dir=/usr/local/skycoin/src/gui/static"]
+#ENTRYPOINT ["docker_launcher.sh", "--web-interface-addr=0.0.0.0", "--gui-dir=/usr/local/skycoin/src/gui/static"]

--- a/docker/images/mainnet/Dockerfile
+++ b/docker/images/mainnet/Dockerfile
@@ -47,7 +47,7 @@ ENV RPC_ADDR="http://0.0.0.0:6420" \
     WALLET_NAME="$COIN_cli.wlt"
 
 # copy all the binaries
-COPY --from=build /tmp/files/* /
+COPY --from=build /tmp/files /
 
 # volumes
 VOLUME $WALLET_DIR

--- a/docker/images/mainnet/Dockerfile
+++ b/docker/images/mainnet/Dockerfile
@@ -55,4 +55,4 @@ VOLUME $DATA_DIR
 
 EXPOSE 6000 6420
 
-#ENTRYPOINT ["docker_launcher.sh", "--web-interface-addr=0.0.0.0", "--gui-dir=/usr/local/skycoin/src/gui/static"]
+ENTRYPOINT ["docker_launcher.sh", "--web-interface-addr=0.0.0.0", "--gui-dir=/usr/local/skycoin/src/gui/static"]


### PR DESCRIPTION
Fixes #1930 after #1903 

Changes:
- Copy `build` image files at `/tmp/files` (rather than `/tmp/files/*`) so that they be copied onto production image at the right location.

Does this change need to mentioned in CHANGELOG.md?
no
