### PR TITLE
Add a test env for Electron

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -65,6 +65,7 @@
         }
     },
     "scripts": {
+        "start": "electron ./src/electron-main.js dev",
         "dist-win32": "build -w --ia32 -p=never",
         "dist-win64": "build -w --x64 -p=never",
         "dist-win": "build -w --x64 --ia32 -p=never",

--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -22,6 +22,13 @@ global.eval = function() { throw new Error('bad!!'); }
 let currentURL;
 let showErrorCalled = false;
 
+// Detect if the code is running with the "dev" arg. The "dev" arg is added when running npm
+// start. If this is true, a local node will not be started, but one is expected to be running,
+// the contents served in http://localhost:4200 will be displayed and it will be allowed to
+// reload the URLs using the Electron window, so that it is easier to test the changes made to
+// the UI using npm start.
+let dev = process.argv.find(arg => arg === 'dev') ? true : false;
+
 // Force everything localhost, in case of a leak
 app.commandLine.appendSwitch('host-rules', 'MAP * 127.0.0.1, EXCLUDE api.coinmarketcap.com, api.github.com');
 app.commandLine.appendSwitch('ssl-version-fallback-min', 'tls1.2');
@@ -37,94 +44,101 @@ let win;
 var skycoin = null;
 
 function startSkycoin() {
-  console.log('Starting skycoin from electron');
+  if (!dev) {
+    console.log('Starting skycoin from electron');
 
-  if (skycoin) {
-    console.log('Skycoin already running');
-    app.emit('skycoin-ready');
-    return
-  }
-
-  var reset = () => {
-    skycoin = null;
-  }
-
-  // Resolve skycoin binary location
-  var appPath = app.getPath('exe');
-  var exe = (() => {
-    switch (process.platform) {
-      case 'darwin':
-        return path.join(appPath, '../../Resources/app/skycoin');
-      case 'win32':
-        // Use only the relative path on windows due to short path length
-        // limits
-        return './resources/app/skycoin.exe';
-      case 'linux':
-        return path.join(path.dirname(appPath), './resources/app/skycoin');
-      default:
-        return './resources/app/skycoin';
-    }
-  })()
-
-  var args = [
-    '-launch-browser=false',
-    '-gui-dir=' + path.dirname(exe),
-    '-color-log=false', // must be disabled for web interface detection
-    '-logtofile=true',
-    '-download-peerlist=true',
-    '-enable-all-api-sets=true',
-    '-enable-api-sets=INSECURE_WALLET_SEED',
-    '-rpc-interface=false',
-    '-disable-csrf=false',
-    '-reset-corrupt-db=true',
-    '-enable-gui=true',
-    '-web-interface-port=0' // random port assignment
-    // will break
-    // broken (automatically generated certs do not work):
-    // '-web-interface-https=true',
-  ]
-  skycoin = childProcess.spawn(exe, args);
-
-  createWindow();
-
-  skycoin.on('error', (e) => {
-    showError();
-    app.quit();
-  });
-
-  skycoin.stdout.on('data', (data) => {
-    console.log(data.toString());
-    if (currentURL) {
+    if (skycoin) {
+      console.log('Skycoin already running');
+      app.emit('skycoin-ready');
       return
     }
 
-    const marker = 'Starting web interface on ';
+    var reset = () => {
+      skycoin = null;
+    }
 
-    data.toString().split('\n').forEach(line => {
-      if (line.indexOf(marker) !== -1) {
-        currentURL = 'http://' + line.split(marker)[1].trim();
-        app.emit('skycoin-ready', { url: currentURL });
+    // Resolve skycoin binary location
+    var appPath = app.getPath('exe');
+    var exe = (() => {
+      switch (process.platform) {
+        case 'darwin':
+          return path.join(appPath, '../../Resources/app/skycoin');
+        case 'win32':
+          // Use only the relative path on windows due to short path length
+          // limits
+          return './resources/app/skycoin.exe';
+        case 'linux':
+          return path.join(path.dirname(appPath), './resources/app/skycoin');
+        default:
+          return './resources/app/skycoin';
       }
+    })()
+
+    var args = [
+      '-launch-browser=false',
+      '-gui-dir=' + path.dirname(exe),
+      '-color-log=false', // must be disabled for web interface detection
+      '-logtofile=true',
+      '-download-peerlist=true',
+      '-enable-all-api-sets=true',
+      '-enable-api-sets=INSECURE_WALLET_SEED',
+      '-rpc-interface=false',
+      '-disable-csrf=false',
+      '-reset-corrupt-db=true',
+      '-enable-gui=true',
+      '-web-interface-port=0' // random port assignment
+      // will break
+      // broken (automatically generated certs do not work):
+      // '-web-interface-https=true',
+    ]
+    skycoin = childProcess.spawn(exe, args);
+
+    createWindow();
+
+    skycoin.on('error', (e) => {
+      showError();
+      app.quit();
     });
-  });
 
-  skycoin.stderr.on('data', (data) => {
-    console.log(data.toString());
-  });
+    skycoin.stdout.on('data', (data) => {
+      console.log(data.toString());
+      if (currentURL) {
+        return
+      }
 
-  skycoin.on('close', (code) => {
-    // log.info('Skycoin closed');
-    console.log('Skycoin closed');
-    showError();
-    reset();
-  });
+      const marker = 'Starting web interface on ';
 
-  skycoin.on('exit', (code) => {
-    // log.info('Skycoin exited');
-    console.log('Skycoin exited');
-    showError();
-    reset();
-  });
+      data.toString().split('\n').forEach(line => {
+        if (line.indexOf(marker) !== -1) {
+          currentURL = 'http://' + line.split(marker)[1].trim();
+          app.emit('skycoin-ready', { url: currentURL });
+        }
+      });
+    });
+
+    skycoin.stderr.on('data', (data) => {
+      console.log(data.toString());
+    });
+
+    skycoin.on('close', (code) => {
+      // log.info('Skycoin closed');
+      console.log('Skycoin closed');
+      showError();
+      reset();
+    });
+
+    skycoin.on('exit', (code) => {
+      // log.info('Skycoin exited');
+      console.log('Skycoin exited');
+      showError();
+      reset();
+    });
+
+  } else {
+    // If in dev mode, simply open the dev server URL.
+    currentURL = 'http://localhost:4200/';
+    app.emit('skycoin-ready', { url: currentURL });
+  }
 }
 
 function showError() {
@@ -201,10 +215,13 @@ function createWindow(url) {
     win = null;
   });
 
-  win.webContents.on('will-navigate', function(e, url) {
-    e.preventDefault();
-    require('electron').shell.openExternal(url);
-  });
+  // If in dev mode, allow to open URLs.
+  if (!dev) {
+    win.webContents.on('will-navigate', function(e, url) {
+      e.preventDefault();
+      require('electron').shell.openExternal(url);
+    });
+  }
 
   // create application's main menu
   var template = [{


### PR DESCRIPTION
Changes:
- Because the hardware wallets needs integration with Node, they only works on Electron. In order to make development easier, this commit adds the command `npm start` inside the `electron` folder, to open a development Electron window that instead of starting a Skycoin node and then showing the contents of the `dist` folder, it simply shows the contents of http://localhost:4200. In this way it is possible to simply modify the UI while running the test server and see the changes directly in the Electron window, without needing to recompile.
- Most of the changes were limited to placing pre-existing code inside `if (!dev)`, but because of the tabulation changes Github shows changes in a large number of lines.

Does this change need to mentioned in CHANGELOG.md?
No