### PR TITLE
Support v2 style error responses in middleware

### DIFF
--- a/src/api/README.md
+++ b/src/api/README.md
@@ -54,6 +54,9 @@ All responses will set an appropriate HTTP status code indicating an error, and 
 Since `/api/v2` is still under development, there are no guarantees for backwards compatibility.
 However, any changes to the API will be recorded in the [changelog](../../CHANGELOG.md).
 
+Under some circumstances an error response body may not be valid JSON.
+Any client consuming the API should accomodate this and conditionally parse JSON for non-`200` responses.
+
 ## API Sets
 
 API endpoints are grouped into "sets" which can be toggled with the command line parameters

--- a/src/api/csrf.go
+++ b/src/api/csrf.go
@@ -123,7 +123,7 @@ func getCSRFToken(store *CSRFStore) http.HandlerFunc {
 }
 
 // CSRFCheck verifies X-CSRF-Token header value
-func CSRFCheck(store *CSRFStore, handler http.Handler) http.Handler {
+func CSRFCheck(apiVersion string, store *CSRFStore, handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if store.Enabled {
 			switch r.Method {
@@ -131,7 +131,7 @@ func CSRFCheck(store *CSRFStore, handler http.Handler) http.Handler {
 				token := r.Header.Get(CSRFHeaderName)
 				if err := store.verifyToken(token); err != nil {
 					logger.Errorf("CSRF token invalid: %v", err)
-					wh.Error403(w, "invalid CSRF token")
+					writeError(w, apiVersion, http.StatusForbidden, "invalid CSRF token")
 					return
 				}
 			}

--- a/src/api/csrf_test.go
+++ b/src/api/csrf_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -81,7 +82,12 @@ func TestCSRFWrapper(t *testing.T) {
 
 					status := rr.Code
 					require.Equal(t, http.StatusForbidden, status, "wrong status code: got `%v` want `%v`", status, http.StatusForbidden)
-					require.Equal(t, "403 Forbidden - invalid CSRF token\n", rr.Body.String())
+
+					if strings.HasPrefix(endpoint, "/api/v2") {
+						require.Equal(t, "{\n    \"error\": {\n        \"message\": \"invalid CSRF token\",\n        \"code\": 403\n    }\n}", rr.Body.String())
+					} else {
+						require.Equal(t, "403 Forbidden - invalid CSRF token\n", rr.Body.String())
+					}
 				})
 			}
 		}

--- a/src/api/http.go
+++ b/src/api/http.go
@@ -4,8 +4,8 @@ Package api implements the REST API interface
 package api
 
 import (
-	"crypto/subtle"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -20,7 +20,6 @@ import (
 	"github.com/rs/cors"
 
 	"github.com/skycoin/skycoin/src/api/webrpc"
-	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/daemon"
 	"github.com/skycoin/skycoin/src/readable"
 	"github.com/skycoin/skycoin/src/util/file"
@@ -36,6 +35,9 @@ const (
 	resourceDir = "dist/"
 	devDir      = "dev/"
 	indexPage   = "index.html"
+
+	apiVersion1 = "v1"
+	apiVersion2 = "v2"
 
 	defaultReadTimeout  = time.Second * 10
 	defaultWriteTimeout = time.Second * 60
@@ -119,6 +121,31 @@ func NewHTTPErrorResponse(code int, msg string) HTTPResponse {
 			Code:    code,
 			Message: msg,
 		},
+	}
+}
+
+func writeHTTPResponse(w http.ResponseWriter, resp HTTPResponse) {
+	out, err := json.MarshalIndent(resp, "", "    ")
+	if err != nil {
+		wh.Error500(w, "json.MarshalIndent failed")
+		return
+	}
+
+	w.Header().Add("Content-Type", "application/json")
+
+	if resp.Error == nil {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		if resp.Error.Code < 400 || resp.Error.Code >= 600 {
+			logger.Critical().Errorf("writeHTTPResponse invalid error status code: %d", resp.Error.Code)
+			w.WriteHeader(http.StatusInternalServerError)
+		} else {
+			w.WriteHeader(resp.Error.Code)
+		}
+	}
+
+	if _, err := w.Write(out); err != nil {
+		logger.WithError(err).Error("http Write failed")
 	}
 }
 
@@ -303,9 +330,9 @@ func newServerMux(c muxConfig, gateway Gatewayer, csrfStore *CSRFStore, rpc *web
 		OptionsPassthrough: false,
 	})
 
-	headerCheck := func(host string, hostWhitelist []string, handler http.Handler) http.Handler {
-		handler = OriginRefererCheck(host, hostWhitelist, handler)
-		handler = HostCheck(host, hostWhitelist, handler)
+	headerCheck := func(apiVersion, host string, hostWhitelist []string, handler http.Handler) http.Handler {
+		handler = originRefererCheck(apiVersion, host, hostWhitelist, handler)
+		handler = hostCheck(apiVersion, host, hostWhitelist, handler)
 		return handler
 	}
 
@@ -332,38 +359,38 @@ func newServerMux(c muxConfig, gateway Gatewayer, csrfStore *CSRFStore, rpc *web
 		}
 	}
 
-	webHandlerCSRFOptional := func(endpoint string, handler http.Handler, checkCSRF bool) {
+	webHandlerCSRFOptional := func(apiVersion, endpoint string, handler http.Handler, checkCSRF bool) {
 		handler = wh.ElapsedHandler(logger, handler)
 		handler = corsHandler.Handler(handler)
 		if checkCSRF {
-			handler = CSRFCheck(csrfStore, handler)
+			handler = CSRFCheck(apiVersion, csrfStore, handler)
 		}
-		handler = headerCheck(c.host, c.hostWhitelist, handler)
-		handler = basicAuth(c.username, c.password, "skycoin daemon", handler)
+		handler = headerCheck(apiVersion, c.host, c.hostWhitelist, handler)
+		handler = basicAuth(apiVersion, c.username, c.password, "skycoin daemon", handler)
 		handler = gziphandler.GzipHandler(handler)
 		mux.Handle(endpoint, handler)
 	}
 
-	webHandler := func(endpoint string, handler http.Handler) {
-		webHandlerCSRFOptional(endpoint, handler, true)
+	webHandler := func(apiVersion, endpoint string, handler http.Handler) {
+		webHandlerCSRFOptional(apiVersion, endpoint, handler, true)
 	}
 
 	webHandlerV1 := func(endpoint string, handler http.Handler) {
 		if c.enableUnversionedAPI {
-			webHandler(endpoint, handler)
+			webHandler(apiVersion1, endpoint, handler)
 		}
-		webHandler("/api/v1"+endpoint, handler)
+		webHandler(apiVersion1, "/api/v1"+endpoint, handler)
 	}
 
 	webHandlerV2 := func(endpoint string, handler http.Handler) {
-		webHandler("/api/v2"+endpoint, handler)
+		webHandler(apiVersion2, "/api/v2"+endpoint, handler)
 	}
 
 	indexHandler := newIndexHandler(c.appLoc, c.enableGUI)
 	if !c.disableCSP {
 		indexHandler = CSPHandler(indexHandler)
 	}
-	webHandler("/", indexHandler)
+	webHandler(apiVersion1, "/", indexHandler)
 
 	if c.enableGUI {
 		fileInfos, err := ioutil.ReadDir(c.appLoc)
@@ -382,7 +409,7 @@ func newServerMux(c muxConfig, gateway Gatewayer, csrfStore *CSRFStore, rpc *web
 				route = route + "/"
 			}
 
-			webHandler(route, fs)
+			webHandler(apiVersion1, route, fs)
 		}
 	}
 
@@ -393,9 +420,9 @@ func newServerMux(c muxConfig, gateway Gatewayer, csrfStore *CSRFStore, rpc *web
 	// get the current CSRF token
 	csrfHandlerV1 := func(endpoint string, handler http.Handler) {
 		if c.enableUnversionedAPI {
-			webHandlerCSRFOptional(endpoint, handler, false)
+			webHandlerCSRFOptional(apiVersion1, endpoint, handler, false)
 		}
-		webHandlerCSRFOptional("/api/v1"+endpoint, handler, false)
+		webHandlerCSRFOptional(apiVersion1, "/api/v1"+endpoint, handler, false)
 	}
 	csrfHandlerV1("/csrf", getCSRFToken(csrfStore)) // csrf is always available, regardless of the API set
 
@@ -464,41 +491,6 @@ func newServerMux(c muxConfig, gateway Gatewayer, csrfStore *CSRFStore, rpc *web
 	webHandlerV1("/addresscount", forAPISet(addressCountHandler(gateway), []string{EndpointsRead}))
 
 	return mux
-}
-
-func basicAuth(username, password, realm string, f http.Handler) http.HandlerFunc {
-	needsAuth := username != "" || password != ""
-	usernamePasswordHash := cipher.SumSHA256(append([]byte(username), []byte(password)...))
-	authHeader := fmt.Sprintf("Basic realm=%q", realm)
-
-	return func(w http.ResponseWriter, r *http.Request) {
-		user, pass, ok := r.BasicAuth()
-
-		if needsAuth {
-			if !ok {
-				wh.Error401(w, authHeader, "")
-				return
-			}
-
-			userPassHash := cipher.SumSHA256(append([]byte(user), []byte(pass)...))
-
-			if subtle.ConstantTimeCompare(userPassHash[:], usernamePasswordHash[:]) != 1 {
-				wh.Error401(w, authHeader, "")
-				return
-			}
-		} else {
-			// If auth is not configured but the request provides auth, reject
-			// This will avoid a mistake where the daemon is not configured with auth,
-			// but the client is, and does not realize the daemon is not configured with auth
-			// because all requests are accepted
-			if user != "" || pass != "" {
-				wh.Error401(w, authHeader, "")
-				return
-			}
-		}
-
-		f.ServeHTTP(w, r)
-	}
 }
 
 // newIndexHandler returns a http.HandlerFunc for index.html, where index.html is in appLoc

--- a/src/api/http_test.go
+++ b/src/api/http_test.go
@@ -445,7 +445,11 @@ func TestHTTPBasicAuthInvalid(t *testing.T) {
 
 				if !tc.authorized {
 					require.Equal(t, http.StatusUnauthorized, rr.Code)
-					require.Equal(t, "401 Unauthorized", strings.TrimSpace(rr.Body.String()))
+					if strings.HasPrefix(e, "/api/v2") {
+						require.Equal(t, "{\n    \"error\": {\n        \"message\": \"Unauthorized\",\n        \"code\": 401\n    }\n}", rr.Body.String())
+					} else {
+						require.Equal(t, "401 Unauthorized", strings.TrimSpace(rr.Body.String()))
+					}
 				} else {
 					require.NotEqual(t, http.StatusUnauthorized, rr.Code)
 				}

--- a/src/api/transaction.go
+++ b/src/api/transaction.go
@@ -480,31 +480,6 @@ type VerifyTxnResponse struct {
 	Transaction CreatedTransaction `json:"transaction"`
 }
 
-func writeHTTPResponse(w http.ResponseWriter, resp HTTPResponse) {
-	out, err := json.MarshalIndent(resp, "", "    ")
-	if err != nil {
-		wh.Error500(w, "json.MarshalIndent failed")
-		return
-	}
-
-	w.Header().Add("Content-Type", "application/json")
-
-	if resp.Error == nil {
-		w.WriteHeader(http.StatusOK)
-	} else {
-		if resp.Error.Code < 400 || resp.Error.Code >= 600 {
-			logger.Critical().Errorf("writeHTTPResponse invalid error status code: %d", resp.Error.Code)
-			w.WriteHeader(http.StatusInternalServerError)
-		} else {
-			w.WriteHeader(resp.Error.Code)
-		}
-	}
-
-	if _, err := w.Write(out); err != nil {
-		logger.WithError(err).Error("http Write failed")
-	}
-}
-
 // Decode and verify an encoded transaction
 // Method: POST
 // URI: /api/v2/transaction/verify

--- a/src/util/http/error.go
+++ b/src/util/http/error.go
@@ -2,106 +2,67 @@
 package httphelper
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
-
-	"github.com/skycoin/skycoin/src/util/logging"
 )
 
-// HTTPError wraps http.Error
-func HTTPError(w http.ResponseWriter, status int, httpMsg string) {
-	msg := fmt.Sprintf("%d %s", status, httpMsg)
-	http.Error(w, msg, status)
-}
-
-func httpError(w http.ResponseWriter, status int) {
-	HTTPError(w, status, http.StatusText(status))
-}
-
-func errorXXXMsg(w http.ResponseWriter, status int, msg string) {
-	httpMsg := http.StatusText(status)
+// ErrorXXX writes an error message with status code
+func ErrorXXX(w http.ResponseWriter, status int, msg string) {
+	httpMsg := fmt.Sprintf("%d %s", status, http.StatusText(status))
 	if msg != "" {
 		httpMsg = fmt.Sprintf("%s - %s", httpMsg, msg)
 	}
-	HTTPError(w, status, httpMsg)
-}
 
-func errorXXXJSONOr500(log *logging.Logger, w http.ResponseWriter, status int, m interface{}) {
-	out, err := json.MarshalIndent(m, "", "    ")
-	if err != nil {
-		Error500(w, "json.MarshalIndent failed")
-		return
-	}
-
-	w.Header().Add("Content-Type", "application/json")
-	w.WriteHeader(status)
-	if _, err := w.Write(out); err != nil {
-		log.WithError(err).Error("http write failed")
-	}
+	http.Error(w, httpMsg, status)
 }
 
 // Error400 respond with a 400 error and include a message
 func Error400(w http.ResponseWriter, msg string) {
-	errorXXXMsg(w, http.StatusBadRequest, msg)
-}
-
-// Error400JSONOr500 returns a 400 error with an object as JSON, writing a 500 error if it fails
-func Error400JSONOr500(log *logging.Logger, w http.ResponseWriter, m interface{}) {
-	errorXXXJSONOr500(log, w, http.StatusBadRequest, m)
+	ErrorXXX(w, http.StatusBadRequest, msg)
 }
 
 // Error401 respond with a 401 error
 func Error401(w http.ResponseWriter, auth, msg string) {
 	w.Header().Set("WWW-Authenticate", auth)
-	httpMsg := http.StatusText(http.StatusUnauthorized)
-	if msg != "" {
-		httpMsg = fmt.Sprintf("%s - %s", httpMsg, msg)
-	}
-	HTTPError(w, http.StatusUnauthorized, httpMsg)
+	ErrorXXX(w, http.StatusUnauthorized, msg)
 }
 
 // Error403 respond with a 403 error and include a message
 func Error403(w http.ResponseWriter, msg string) {
-	errorXXXMsg(w, http.StatusForbidden, msg)
+	ErrorXXX(w, http.StatusForbidden, msg)
 }
 
 // Error404 respond with a 404 error and include a message
 func Error404(w http.ResponseWriter, msg string) {
-	errorXXXMsg(w, http.StatusNotFound, msg)
+	ErrorXXX(w, http.StatusNotFound, msg)
 }
 
 // Error405 respond with a 405 error
 func Error405(w http.ResponseWriter) {
-	httpError(w, http.StatusMethodNotAllowed)
+	ErrorXXX(w, http.StatusMethodNotAllowed, "")
 }
 
 // Error415 respond with a 415 error
 func Error415(w http.ResponseWriter) {
-	httpError(w, http.StatusUnsupportedMediaType)
+	ErrorXXX(w, http.StatusUnsupportedMediaType, "")
 }
 
 // Error422 response with a 422 error and include a message
 func Error422(w http.ResponseWriter, msg string) {
-	errorXXXMsg(w, http.StatusUnprocessableEntity, msg)
-}
-
-// Error422JSONOr500 returns a 422 error with an object as JSON, writing a 500 error if it fails
-func Error422JSONOr500(log *logging.Logger, w http.ResponseWriter, m interface{}) {
-	errorXXXJSONOr500(log, w, http.StatusUnprocessableEntity, m)
-}
-
-// Error501 respond with a 501 error
-func Error501(w http.ResponseWriter) {
-	httpError(w, http.StatusNotImplemented)
+	ErrorXXX(w, http.StatusUnprocessableEntity, msg)
 }
 
 // Error500 respond with a 500 error and include a message
 func Error500(w http.ResponseWriter, msg string) {
-	errorXXXMsg(w, http.StatusInternalServerError, msg)
+	ErrorXXX(w, http.StatusInternalServerError, msg)
+}
+
+// Error501 respond with a 501 error
+func Error501(w http.ResponseWriter) {
+	ErrorXXX(w, http.StatusNotImplemented, "")
 }
 
 // Error503 respond with a 503 error and include a message
 func Error503(w http.ResponseWriter, msg string) {
-	errorXXXMsg(w, http.StatusServiceUnavailable, msg)
+	ErrorXXX(w, http.StatusServiceUnavailable, msg)
 }


### PR DESCRIPTION
Fixes #1923 

Changes:
- v2 endpoints will return JSON errors for middleware problems (invalid auth, invalid csrf, etc)

Does this change need to mentioned in CHANGELOG.md?
No