### PR TITLE
Add run-daemon.sh, update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ In the v0.26.0 these features and functions will be removed.  If you have a need
 - `cli addressGen` arguments have changed
 - `cli generateWallet` renamed to `cli walletCreate`
 - `cli generateAddresses` renamed to `cli walletAddAddresses`
+- `run.sh` is now `run-client.sh` and a new `run-daemon.sh` script is added for running in server daemon mode.
 
 ### Removed
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -53,8 +53,8 @@ In China, use `--source=https://github.com/golang/go` to bypass firewall when fe
 gvm install go1.4 --source=https://github.com/golang/go
 gvm use go1.4
 
-gvm install go1.10.2
-gvm use go1.10.2 --default
+gvm install go1.11.1
+gvm use go1.11.1 --default
 ```
 
 #### Installation issues
@@ -62,7 +62,7 @@ If you open up new a terminal and the `go` command is not found then add this to
 
 ```sh
 [[ -s "$HOME/.gvm/scripts/gvm" ]] && source "$HOME/.gvm/scripts/gvm"
-gvm use go1.10.2 >/dev/null
+gvm use go1.11.1 >/dev/null
 ```
 
 ## Install Go manually
@@ -72,7 +72,7 @@ Let's go to home directory and declare `go`'s version that you want to download.
 
 ```sh
 cd ~
-export GOV=1.10.2 # golang version
+export GOV=1.11.1 # golang version
 ```
 
 After that, let's download and uncompress golang source.

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -32,6 +32,7 @@ and to use the CLI tool for wallet operations (seed and address generation, tran
 
 <!-- MarkdownTOC autolink="true" bracket="round" levels="1,2,3,4,5,6" -->
 
+- [Running the skycoin node](#running-the-skycoin-node)
 - [API Documentation](#api-documentation)
 	- [Wallet REST API](#wallet-rest-api)
 	- [Skycoin command line interface](#skycoin-command-line-interface)
@@ -67,6 +68,9 @@ and to use the CLI tool for wallet operations (seed and address generation, tran
 
 <!-- /MarkdownTOC -->
 
+## Running the skycoin node
+
+For integrations, the skycoin node should be run from source with `./run-daemon.sh`. This requires go1.10+ to be installed.
 
 ## API Documentation
 

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,11 @@ else
   LDFLAGS=$(LIBC_FLAGS)
 endif
 
-run:  ## Run the skycoin node. To add arguments, do 'make ARGS="--foo" run'.
-	./run.sh ${ARGS}
+run-client:  ## Run skycoin with desktop client configuration. To add arguments, do 'make ARGS="--foo" run'.
+	./run-client.sh ${ARGS}
+
+run-daemon:  ## Run skycoin with server daemon configuration. To add arguments, do 'make ARGS="--foo" run'.
+	./run-daemon.sh ${ARGS}
 
 run-help: ## Show skycoin node help
 	@go run cmd/$(COIN)/$(COIN).go --help

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ scratch, to remedy the rough edges in the Bitcoin design.
 		- [Rules](#rules)
 		- [Management](#management)
 	- [Configuration Modes](#configuration-modes)
-		- [Development Desktop Daemon Mode](#development-desktop-daemon-mode)
+		- [Development Desktop Client Mode](#development-desktop-client-mode)
 		- [Server Daemon Mode](#server-daemon-mode)
 		- [Electron Desktop Client Mode](#electron-desktop-client-mode)
 		- [Standalone Desktop Client Mode](#standalone-desktop-client-mode)
@@ -297,7 +297,7 @@ The live integration tests run against a live runnning skycoin node, so before r
 need to start a skycoin node:
 
 ```sh
-./run.sh -launch-browser=false
+./run-daemon.sh
 ```
 
 After the skycoin node is up, run the following command to start the live tests:
@@ -507,17 +507,24 @@ There are 4 configuration modes in which you can run a skycoin node:
 - Electron Desktop Client
 - Standalone Desktop Client
 
-#### Development Desktop Daemon Mode
-This mode is configured via `run.sh`
+#### Development Desktop Client Mode
+This mode is configured via `run-client.sh`
 ```bash
-$ ./run.sh
+$ ./run-client.sh
 ```
 
 #### Server Daemon Mode
 The default settings for a skycoin node are chosen for `Server Daemon`, which is typically run from source.
 This mode is usually preferred to be run with security options, though `-disable-csrf` is normal for server daemon mode, it is left enabled by default.
+
 ```bash
-$ go run cmd/skycoin/skycoin.go
+$ ./run-daemon.sh
+```
+
+To disable CSRF:
+
+```bash
+$ ./run-daemon.sh -disable-csrf
 ```
 
 #### Electron Desktop Client Mode
@@ -565,7 +572,7 @@ Performs these actions before releasing:
 * `make check`
 * `make integration-test-live` (see [live integration tests](#live-integration-tests)) both with an unencrypted and encrypted wallet, and once with `-networking-disabled`
 * `go run cmd/cli/cli.go checkdb` against a synced node
-* On all OSes, make sure that the client runs properly from the command line (`./run.sh`)
+* On all OSes, make sure that the client runs properly from the command line (`./run-client.sh` and `./run-daemon.sh`)
 * Build the releases and make sure that the Electron client runs properly on Windows, Linux and macOS.
     * Use a clean data directory with no wallets or database to sync from scratch and verify the wallet setup wizard.
     * Load a test wallet with nonzero balance from seed to confirm wallet loading works

--- a/electron/package-source.sh
+++ b/electron/package-source.sh
@@ -10,17 +10,17 @@ pushd "${SCRIPTDIR}"
 if [[ "$OSTYPE" == "linux"* ]]; then
     tar -C .. -cvPf "${SRC_TAR}" --owner=0 --group=0 --exclude=electron \
         --exclude=node_modules --exclude=_deprecated --exclude='.*' \
-        src cmd run.sh README.md INSTALLATION.md CHANGELOG.md INTEGRATION.md \
+        src cmd run-client.sh run-daemon.sh README.md INSTALLATION.md CHANGELOG.md INTEGRATION.md \
         >/dev/null
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     tar -C .. -cvf "${SRC_TAR}" --exclude=electron \
         --exclude=node_modules --exclude=_deprecated --exclude='.*' \
-        src cmd run.sh README.md INSTALLATION.md CHANGELOG.md INTEGRATION.md \
+        src cmd run-client.sh run-daemon.sh README.md INSTALLATION.md CHANGELOG.md INTEGRATION.md \
         >/dev/null
 elif [[ "$OSTYPE" == "msys"* ]]; then
     tar -C .. -cvPf "${SRC_TAR}" --owner=0 --group=0 --exclude=electron \
         --exclude=node_modules --exclude=_deprecated --exclude='.*' \
-        src cmd run.sh README.md INSTALLATION.md CHANGELOG.md INTEGRATION.md \
+        src cmd run-client.sh run-daemon.sh README.md INSTALLATION.md CHANGELOG.md INTEGRATION.md \
         >/dev/null
 fi
 

--- a/run-client.sh
+++ b/run-client.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Runs skycoin in desktop client configuration
+
 set -x
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/run-daemon.sh
+++ b/run-daemon.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Runs skycoin in daemon mode configuration
+
+set -x
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+echo "skycoin binary dir:" "$DIR"
+pushd "$DIR" >/dev/null
+
+COMMIT=$(git rev-parse HEAD)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+GOLDFLAGS="-X main.Commit=${COMMIT} -X main.Branch=${BRANCH}"
+
+GORUNFLAGS=${GORUNFLAGS:-}
+
+go run -ldflags "${GOLDFLAGS}" $GORUNFLAGS cmd/skycoin/skycoin.go \
+    -enable-gui=false \
+    -launch-browser=false \
+    -rpc-interface=false \
+    -log-level=debug \
+    $@
+
+popd >/dev/null


### PR DESCRIPTION
Changes:
- Move `run.sh` to `run-client.sh` and create `run-daemon.sh`
- Update documentation on running the node
- Update go version in docs to go1.11.1

Does this change need to mentioned in CHANGELOG.md?
Yes