### PR TITLE
Daemon builds

### DIFF
--- a/.Doxyfile
+++ b/.Doxyfile
@@ -5,7 +5,7 @@
 #---------------------------------------------------------------------------
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = libskycoin
-PROJECT_NUMBER         = 0.24.1-develop
+PROJECT_NUMBER         = 0.25.0-rc1-develop
 PROJECT_BRIEF          = "Skycoin C client library"
 PROJECT_LOGO           = ./docs/assets/sky.libc.jpg
 OUTPUT_DIRECTORY       = ./docs/libc

--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ electron/node_modules
 electron/.gox_output
 electron/.electron_output
 electron/.standalone_output
+electron/.daemon_output
 # Do not ignore the icons folder
 !electron/build
 !electron/build/icons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ In the v0.26.0 these features and functions will be removed.  If you have a need
 - Add `/api/v2/wallet/recover` to recover an encrypted wallet by providing the seed
 - Add `fiberAddressGen` CLI command to generate distribution addresses for fiber coins
 - Coinhour burn factor can be configured at runtime with `COINHOUR_BURN_FACTOR` envvar
+- Daemon configured builds will be available on the [releases](https://github.com/skycoin/skycoin/releases) page. The builds available for previous versions are configured for desktop client use.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ In the v0.26.0 these features and functions will be removed.  If you have a need
 
 - Remove `USE_CSRF` envvar from the CLI tool. It uses the REST API client now, which will automatically detect CSRF as needed, so no additional configuration is necessary.  Operators may still wish to disable CSRF on their remote node to reduce request overhead.
 - Remove `-enable-wallet-api` and `-enable-seed-api` in place of including `WALLET` and `INSECURE_WALLET_SEED` in `-enable-api-sets`.
+- Copies of the source code removed from release builds due to build artifact size
 
 ## [0.24.1] - 2018-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ In the v0.26.0 these features and functions will be removed.  If you have a need
 - `cli addressGen` arguments have changed
 - `cli generateWallet` renamed to `cli walletCreate`
 - `cli generateAddresses` renamed to `cli walletAddAddresses`
+- `run.sh` is now `run-client.sh` and a new `run-daemon.sh` script is added for running in server daemon mode.
 
 ### Removed
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -53,8 +53,8 @@ In China, use `--source=https://github.com/golang/go` to bypass firewall when fe
 gvm install go1.4 --source=https://github.com/golang/go
 gvm use go1.4
 
-gvm install go1.10.2
-gvm use go1.10.2 --default
+gvm install go1.11.1
+gvm use go1.11.1 --default
 ```
 
 #### Installation issues
@@ -62,7 +62,7 @@ If you open up new a terminal and the `go` command is not found then add this to
 
 ```sh
 [[ -s "$HOME/.gvm/scripts/gvm" ]] && source "$HOME/.gvm/scripts/gvm"
-gvm use go1.10.2 >/dev/null
+gvm use go1.11.1 >/dev/null
 ```
 
 ## Install Go manually
@@ -72,7 +72,7 @@ Let's go to home directory and declare `go`'s version that you want to download.
 
 ```sh
 cd ~
-export GOV=1.10.2 # golang version
+export GOV=1.11.1 # golang version
 ```
 
 After that, let's download and uncompress golang source.

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -32,6 +32,7 @@ and to use the CLI tool for wallet operations (seed and address generation, tran
 
 <!-- MarkdownTOC autolink="true" bracket="round" levels="1,2,3,4,5,6" -->
 
+- [Running the skycoin node](#running-the-skycoin-node)
 - [API Documentation](#api-documentation)
 	- [Wallet REST API](#wallet-rest-api)
 	- [Skycoin command line interface](#skycoin-command-line-interface)
@@ -67,6 +68,9 @@ and to use the CLI tool for wallet operations (seed and address generation, tran
 
 <!-- /MarkdownTOC -->
 
+## Running the skycoin node
+
+For integrations, the skycoin node should be run from source with `./run-daemon.sh`. This requires go1.10+ to be installed.
 
 ## API Documentation
 

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ release-daemon: ## Build daemon apps. Use osarch=${osarch} to specify the platfo
 	@echo release files are in the folder of electron/release
 
 clean-release: ## Clean dist files and delete all builds in electron/release
-	rm $(ELECTRON_DIR)/release/*
+	rm -r $(ELECTRON_DIR)/release
 
 clean-coverage: ## Remove coverage output files
 	rm -rf ./coverage/

--- a/Makefile
+++ b/Makefile
@@ -212,16 +212,20 @@ build-ui:  ## Builds the UI
 build-ui-travis:  ## Builds the UI for travis
 	cd $(GUI_STATIC_DIR) && npm run build-travis
 
-release: ## Build electron and standalone apps. Use osarch=${osarch} to specify the platform. Example: 'make release osarch=darwin/amd64', multiple platform can be supported in this way: 'make release osarch="darwin/amd64 windows/amd64"'. Supported architectures are: darwin/amd64 windows/amd64 windows/386 linux/amd64 linux/arm, the builds are located in electron/release folder.
+release: ## Build electron, standalone and daemon apps. Use osarch=${osarch} to specify the platform. Example: 'make release osarch=darwin/amd64', multiple platform can be supported in this way: 'make release osarch="darwin/amd64 windows/amd64"'. Supported architectures are: darwin/amd64 windows/amd64 windows/386 linux/amd64 linux/arm, the builds are located in electron/release folder.
 	cd $(ELECTRON_DIR) && ./build.sh ${osarch}
 	@echo release files are in the folder of electron/release
 
-release-bin: ## Build standalone apps. Use osarch=${osarch} to specify the platform. Example: 'make release-bin osarch=darwin/amd64' Supported architectures are the same as 'release' command.
+release-standalone: ## Build standalone apps. Use osarch=${osarch} to specify the platform. Example: 'make release-standalone osarch=darwin/amd64' Supported architectures are the same as 'release' command.
 	cd $(ELECTRON_DIR) && ./build-standalone-release.sh ${osarch}
 	@echo release files are in the folder of electron/release
 
-release-gui: ## Build electron apps. Use osarch=${osarch} to specify the platform. Example: 'make release-gui osarch=darwin/amd64' Supported architectures are the same as 'release' command.
+release-electron: ## Build electron apps. Use osarch=${osarch} to specify the platform. Example: 'make release-electron osarch=darwin/amd64' Supported architectures are the same as 'release' command.
 	cd $(ELECTRON_DIR) && ./build-electron-release.sh ${osarch}
+	@echo release files are in the folder of electron/release
+
+release-daemon: ## Build daemon apps. Use osarch=${osarch} to specify the platform. Example: 'make release-daemon osarch=darwin/amd64' Supported architectures are the same as 'release' command.
+	cd $(ELECTRON_DIR) && ./build-daemon-release.sh ${osarch}
 	@echo release files are in the folder of electron/release
 
 clean-release: ## Clean dist files and delete all builds in electron/release

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,11 @@ else
   LDFLAGS=$(LIBC_FLAGS)
 endif
 
-run:  ## Run the skycoin node. To add arguments, do 'make ARGS="--foo" run'.
-	./run.sh ${ARGS}
+run-client:  ## Run skycoin with desktop client configuration. To add arguments, do 'make ARGS="--foo" run'.
+	./run-client.sh ${ARGS}
+
+run-daemon:  ## Run skycoin with server daemon configuration. To add arguments, do 'make ARGS="--foo" run'.
+	./run-daemon.sh ${ARGS}
 
 run-help: ## Show skycoin node help
 	@go run cmd/$(COIN)/$(COIN).go --help

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ scratch, to remedy the rough edges in the Bitcoin design.
 		- [Rules](#rules)
 		- [Management](#management)
 	- [Configuration Modes](#configuration-modes)
-		- [Development Desktop Daemon Mode](#development-desktop-daemon-mode)
+		- [Development Desktop Client Mode](#development-desktop-client-mode)
 		- [Server Daemon Mode](#server-daemon-mode)
 		- [Electron Desktop Client Mode](#electron-desktop-client-mode)
 		- [Standalone Desktop Client Mode](#standalone-desktop-client-mode)
@@ -297,7 +297,7 @@ The live integration tests run against a live runnning skycoin node, so before r
 need to start a skycoin node:
 
 ```sh
-./run.sh -launch-browser=false
+./run-daemon.sh
 ```
 
 After the skycoin node is up, run the following command to start the live tests:
@@ -507,17 +507,24 @@ There are 4 configuration modes in which you can run a skycoin node:
 - Electron Desktop Client
 - Standalone Desktop Client
 
-#### Development Desktop Daemon Mode
-This mode is configured via `run.sh`
+#### Development Desktop Client Mode
+This mode is configured via `run-client.sh`
 ```bash
-$ ./run.sh
+$ ./run-client.sh
 ```
 
 #### Server Daemon Mode
 The default settings for a skycoin node are chosen for `Server Daemon`, which is typically run from source.
 This mode is usually preferred to be run with security options, though `-disable-csrf` is normal for server daemon mode, it is left enabled by default.
+
 ```bash
-$ go run cmd/skycoin/skycoin.go
+$ ./run-daemon.sh
+```
+
+To disable CSRF:
+
+```bash
+$ ./run-daemon.sh -disable-csrf
 ```
 
 #### Electron Desktop Client Mode
@@ -565,7 +572,7 @@ Performs these actions before releasing:
 * `make check`
 * `make integration-test-live` (see [live integration tests](#live-integration-tests)) both with an unencrypted and encrypted wallet, and once with `-networking-disabled`
 * `go run cmd/cli/cli.go checkdb` against a synced node
-* On all OSes, make sure that the client runs properly from the command line (`./run.sh`)
+* On all OSes, make sure that the client runs properly from the command line (`./run-client.sh` and `./run-daemon.sh`)
 * Build the releases and make sure that the Electron client runs properly on Windows, Linux and macOS.
     * Use a clean data directory with no wallets or database to sync from scratch and verify the wallet setup wizard.
     * Load a test wallet with nonzero balance from seed to confirm wallet loading works

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -129,7 +129,7 @@ USAGE:
    skycoin-cli [global options] command [command options] [arguments...]
 
 VERSION:
-   0.24.1
+   0.25.0-rc1
 
 COMMANDS:
      addPrivateKey         Add a private key to specific wallet

--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	// Version of the node. Can be set by -ldflags
-	Version = "0.24.1"
+	Version = "0.25.0-rc1"
 	// Commit ID. Can be set by -ldflags
 	Commit = ""
 	// Branch name. Can be set by -ldflags

--- a/electron/build-conf.sh
+++ b/electron/build-conf.sh
@@ -25,8 +25,12 @@ else
 fi
 
 GOX_OUTPUT=".gox_output"
+GOX_GUI_OUTPUT="${GOX_OUTPUT}/gui"
+GOX_DMN_OUTPUT="${GOX_OUTPUT}/daemon"
 
 STL_OUTPUT=".standalone_output"
+
+DMN_OUTPUT=".daemon_output"
 
 FINAL_OUTPUT="release"
 
@@ -35,50 +39,60 @@ GUI_DIST_DIR="../src/gui/static/dist"  # Do not append "/" to this path
 # Variable suffix guide:
 # _APP -- name of the OS X app
 # _ELN_PLT -- directory name created by electron for its build of this platform
-# _ELN -- our name for electron/gui releases
-# _ELN_ZIP -- our compressed name for electron/gui releases
-# _STL -- our name for standalone/non-gui releases
-# _STL_ZIP -- our compressed name for standalone/non-gui releases
+# _ELN -- our name for electron gui releases
+# _ELN_ZIP -- our compressed name for electron gui releases
+# _STL -- our name for standalone gui releases
+# _STL_ZIP -- our compressed name for standalone gui releases
+# _DMN -- our name for daemon releases
+# _DMN_ZIP -- our compressed name for daemon releases
 
 if [[ $GOX_OSARCH == *"darwin/amd64"* ]]; then
     OSX64_APP="${PDT_NAME}.app"
     OSX64_ELN_PLT="darwin-x64"
-    OSX64_ELN="${PKG_NAME}-${APP_VERSION}-gui-osx-darwin-x64"
+    OSX64_ELN="${PKG_NAME}-${APP_VERSION}-gui-electron-osx-darwin-x64"
     OSX64_ELN_ZIP="${OSX64_ELN}.zip"
-    OSX64_STL="${PKG_NAME}-${APP_VERSION}-bin-osx-darwin-x64"
+    OSX64_STL="${PKG_NAME}-${APP_VERSION}-gui-standalone-osx-darwin-x64"
     OSX64_STL_ZIP="${OSX64_STL}.zip"
+    OSX64_DMN="${PKG_NAME}-${APP_VERSION}-daemon-osx-darwin-x64"
+    OSX64_DMN_ZIP="${OSX64_DMN}.zip"
     OSX64_OUT="mac_x64"
 fi
 
 if [[ $GOX_OSARCH == *"linux/amd64"* ]]; then
-    LNX64_ELN="${PKG_NAME}-${APP_VERSION}-gui-linux-x64"
+    LNX64_ELN="${PKG_NAME}-${APP_VERSION}-gui-electron-linux-x64"
     LNX64_ELN_PLT="linux-x64"
     LNX64_ELN_ZIP="${LNX64_ELN}.tar.gz"
-    LNX64_STL="${PKG_NAME}-${APP_VERSION}-bin-linux-x64"
+    LNX64_STL="${PKG_NAME}-${APP_VERSION}-gui-standalone-linux-x64"
     LNX64_STL_ZIP="${LNX64_STL}.tar.gz"
+    LNX64_DMN="${PKG_NAME}-${APP_VERSION}-daemon-linux-x64"
+    LNX64_DMN_ZIP="${LNX64_DMN}.tar.gz"
     LNX64_OUT="linux_x64"
 fi
 
 if [[ $GOX_OSARCH == *"windows/amd64"* ]]; then
-    WIN64_ELN="${PKG_NAME}-${APP_VERSION}-gui-win-x64"
+    WIN64_ELN="${PKG_NAME}-${APP_VERSION}-gui-electron-win-x64"
     WIN64_ELN_PLT="win32-x64"
     WIN64_ELN_ZIP="${WIN64_ELN}.zip"
-    WIN64_STL="${PKG_NAME}-${APP_VERSION}-bin-win-x64"
+    WIN64_STL="${PKG_NAME}-${APP_VERSION}-gui-standalone-win-x64"
     WIN64_STL_ZIP="${WIN64_STL}.zip"
     WIN64_OUT="win_x64"
 fi
 
 if [[ $GOX_OSARCH == *"windows/386"* ]]; then
-    WIN32_ELN="${PKG_NAME}-${APP_VERSION}-gui-win-x86"
+    WIN32_ELN="${PKG_NAME}-${APP_VERSION}-gui-electron-win-x86"
     WIN32_ELN_PLT="win32-ia32"
     WIN32_ELN_ZIP="${WIN32_ELN}.zip"
-    WIN32_STL="${PKG_NAME}-${APP_VERSION}-bin-win-x86"
+    WIN32_STL="${PKG_NAME}-${APP_VERSION}-gui-standalone-win-x86"
     WIN32_STL_ZIP="${WIN32_STL}.zip"
+    WIN32_DMN="${PKG_NAME}-${APP_VERSION}-daemon-win-x86"
+    WIN32_DMN_ZIP="${WIN32_DMN}.zip"
     WIN32_OUT="win_ia32"
 fi
 
 if [[ $GOX_OSARCH == *"linux/arm"* ]]; then
-    LNX_ARM_STL="${PKG_NAME}-${APP_VERSION}-bin-linux-arm"
+    LNX_ARM_STL="${PKG_NAME}-${APP_VERSION}-gui-standalone-linux-arm"
     LNX_ARM_STL_ZIP="${LNX_ARM_STL}.tar.gz"
+    LNX_ARM_DMN="${PKG_NAME}-${APP_VERSION}-daemon-linux-arm"
+    LNX_ARM_DMN_ZIP="${LNX_ARM_DMN}.tar.gz"
     LNX_ARM_OUT="linux_arm"
 fi

--- a/electron/build-daemon-release.sh
+++ b/electron/build-daemon-release.sh
@@ -12,16 +12,16 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd "$SCRIPTDIR" >/dev/null
 
 if [ $SKIP_COMPILATION -ne 1 ]; then
-    CONFIG_MODE=STANDALONE_CLIENT ./gox.sh "$GOX_OSARCH" "$GOX_GUI_OUTPUT"
+    CONFIG_MODE= ./gox.sh "$GOX_OSARCH" "$GOX_DMN_OUTPUT"
 fi
 
 echo
 echo "==========================="
-echo "Packaging standalone release"
-./package-standalone-release.sh "$GOX_OSARCH"
+echo "Packaging daemon release"
+./package-daemon-release.sh "$GOX_OSARCH"
 
 echo "------------------------------"
-echo "Compressing standalone release"
-./compress-standalone-release.sh "$GOX_OSARCH"
+echo "Compressing daemon release"
+./compress-daemon-release.sh "$GOX_OSARCH"
 
 popd >/dev/null

--- a/electron/build-electron-release.sh
+++ b/electron/build-electron-release.sh
@@ -23,7 +23,7 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd "$SCRIPTDIR" >/dev/null
 
 if [ $SKIP_COMPILATION -ne 1 ]; then
-    ./gox.sh "$GOX_OSARCH" "$GOX_OUTPUT"
+    CONFIG_MODE=STANDALONE_CLIENT ./gox.sh "$GOX_OSARCH" "$GOX_GUI_OUTPUT"
 fi
 
 if [ -e "$ELN_OUTPUT" ]; then

--- a/electron/build-electron-release.sh
+++ b/electron/build-electron-release.sh
@@ -57,12 +57,12 @@ pushd "$FINAL_OUTPUT" >/dev/null
 if [ -e "mac" ]; then
     pushd "mac" >/dev/null
     if [ -e "${PDT_NAME}-${APP_VERSION}.dmg" ]; then
-        mv "${PDT_NAME}-${APP_VERSION}.dmg" "../${PKG_NAME}-${APP_VERSION}-gui-osx-x64.dmg"
+        mv "${PDT_NAME}-${APP_VERSION}.dmg" "../${PKG_NAME}-${APP_VERSION}-gui-electron-osx-x64.dmg"
     elif [ -e "${PDT_NAME}.app" ]; then
         if [[ "$OSTYPE" == "darwin"* ]]; then
-            tar czf "../${PKG_NAME}-${APP_VERSION}-gui-osx-x64.zip" "${PDT_NAME}.app"
+            tar czf "../${PKG_NAME}-${APP_VERSION}-gui-electron-osx-x64.zip" "${PDT_NAME}.app"
         elif [[ "$OSTYPE" == "linux"* ]]; then
-            tar czf "../${PKG_NAME}-${APP_VERSION}-gui-osx-x64.zip" --owner=0 --group=0 "${PDT_NAME}.app"
+            tar czf "../${PKG_NAME}-${APP_VERSION}-gui-electron-osx-x64.zip" --owner=0 --group=0 "${PDT_NAME}.app"
         fi
     fi
     popd >/dev/null
@@ -70,7 +70,7 @@ if [ -e "mac" ]; then
 fi
 
 IMG="${PKG_NAME}-${APP_VERSION}-x86_64.AppImage"
-DEST_IMG="${PKG_NAME}-${APP_VERSION}-gui-linux-x64.AppImage"
+DEST_IMG="${PKG_NAME}-${APP_VERSION}-gui-electron-linux-x64.AppImage"
 if [ -e $IMG ]; then
     mv "$IMG" "$DEST_IMG"
     chmod +x "$DEST_IMG"
@@ -79,7 +79,7 @@ fi
 EXE="${PDT_NAME} Setup ${APP_VERSION}.exe"
 if [ -e "$EXE" ]; then
     if [ ! -z $WIN32_ELN ] && [ ! -z $WIN64_ELN ]; then
-        mv "$EXE" "${PKG_NAME}-${APP_VERSION}-gui-win-setup.exe"
+        mv "$EXE" "${PKG_NAME}-${APP_VERSION}-gui-electron-win-setup.exe"
     elif [ ! -z $WIN32_ELN ]; then
         mv "$EXE" "${WIN32_ELN}.exe"
     elif [ ! -z $WIN64_ELN ]; then
@@ -90,7 +90,7 @@ fi
 # rename dmg file name
 DMG="${PKG_NAME}-${APP_VERSION}.dmg"
 if [ -e "$DMG" ]; then
-    mv "$DMG" "${PKG_NAME}-${APP_VERSION}-gui-osx.dmg"
+    mv "$DMG" "${PKG_NAME}-${APP_VERSION}-gui-electron-osx.dmg"
 fi
 
 # delete app zip file

--- a/electron/build.sh
+++ b/electron/build.sh
@@ -13,8 +13,8 @@ pushd "$SCRIPTDIR" >/dev/null
 
 echo "Compiling with gox"
 pwd
-# Build with gox here and make the other scripts skip it
-./gox.sh "$GOX_OSARCH" "$GOX_OUTPUT"
+# Build the client mode with gox here so that the standalone and electron releases don't need to compile twice
+CONFIG_MODE=STANDALONE_CLIENT ./gox.sh "$GOX_OSARCH" "$GOX_GUI_OUTPUT"
 
 echo "Installing node modules"
 ./install-node-modules.sh
@@ -30,5 +30,11 @@ echo "==========================="
 echo "Building electron release"
 
 SKIP_COMPILATION=1 ./build-electron-release.sh "$GOX_OSARCH"
+
+echo
+echo "==========================="
+echo "Building daemon release"
+
+./build-daemon-release.sh "$GOX_OSARCH"
 
 popd >/dev/null

--- a/electron/compress-daemon-release.sh
+++ b/electron/compress-daemon-release.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+
+# Compresses packaged daemon release after
+# ./package-daemon-release.sh is done
+
+GOX_OSARCH="$@"
+
+. build-conf.sh "$GOX_OSARCH"
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+pushd "$SCRIPTDIR" >/dev/null
+
+# Compress archives
+pushd "$DMN_OUTPUT" >/dev/null
+
+FINALS=()
+
+# OS X
+if [ -e "$OSX64_DMN" ]; then
+    if [ -e "$OSX64_DMN_ZIP" ]; then
+        echo "Removing old $OSX64_DMN_ZIP"
+        rm "$OSX64_DMN_ZIP"
+    fi
+    echo "Zipping $OSX64_DMN_ZIP"
+    # -y preserves symlinks,
+    # so that the massive .framework library isn't duplicated
+    zip -r -y --quiet "$OSX64_DMN_ZIP" "$OSX64_DMN"
+    FINALS+=("$OSX64_DMN_ZIP")
+fi
+
+# Windows 64bit
+if [ -e "$WIN64_DMN" ]; then
+    if [ -e "$WIN64_DMN_ZIP" ]; then
+        echo "Removing old $WIN64_DMN_ZIP"
+        rm "$WIN64_DMN_ZIP"
+    fi
+    echo "Zipping $WIN64_DMN_ZIP"
+    if [[ "$OSTYPE" == "linux"* ]]; then
+        zip -r --quiet -X "$WIN64_DMN_ZIP"  "$WIN64_DMN"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        zip -r --quiet "$WIN64_DMN_ZIP" "$WIN64_DMN"
+    elif [[ "$OSTYPE" == "msys"* ]]; then
+        7z a "$WIN64_DMN_ZIP" "$WIN64_DMN"
+    fi
+    FINALS+=("$WIN64_DMN_ZIP")
+fi
+
+# Windows 32bit
+if [ -e "$WIN32_DMN" ]; then
+    if [ -e "$WIN32_DMN_ZIP" ]; then
+        echo "Removing old $WIN32_DMN_ZIP"
+        rm "$WIN32_DMN_ZIP"
+    fi
+    echo "Zipping $WIN32_DMN_ZIP"
+    if [[ "$OSTYPE" == "linux"* ]]; then
+        zip -r --quiet -X "$WIN32_DMN_ZIP"  "$WIN32_DMN"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        zip -r --quiet "$WIN32_DMN_ZIP" "$WIN32_DMN"
+    elif [[ "$OSTYPE" == "msys"* ]]; then
+        7z a "$WIN32_DMN_ZIP" "$WIN32_DMN"
+    fi
+    FINALS+=("$WIN32_DMN_ZIP")
+fi
+
+# Linux
+if [ -e "$LNX64_DMN" ]; then
+    if [ -e "$LNX64_DMN_ZIP" ]; then
+        echo "Removing old $LNX64_DMN_ZIP"
+        rm "$LNX64_DMN_ZIP"
+    fi
+    echo "Zipping $LNX64_DMN_ZIP"
+    if [[ "$OSTYPE" == "linux"* ]]; then
+        tar czf "$LNX64_DMN_ZIP" --owner=0 --group=0 "$LNX64_DMN"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        tar czf "$LNX64_DMN_ZIP"  "$LNX64_DMN"
+    fi
+    FINALS+=("$LNX64_DMN_ZIP")
+fi
+
+# Linux arm
+if [ -e "$LNX_ARM_DMN" ]; then
+    if [ -e "$LNX_ARM_DMN_ZIP" ]; then
+        echo "Removing old $LNX_ARM_DMN_ZIP"
+        rm "$LNX_ARM_DMN_ZIP"
+    fi
+    echo "Zipping $LNX_ARM_DMN_ZIP"
+    if [[ "$OSTYPE" == "linux"* ]]; then
+        tar czf "$LNX_ARM_DMN_ZIP" --owner=0 --group=0 "$LNX_ARM_DMN"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        tar czf "$LNX_ARM_DMN_ZIP"  "$LNX_ARM_DMN"
+    fi
+    FINALS+=("$LNX_ARM_DMN_ZIP")
+fi
+
+popd >/dev/null
+
+# Move to final release dir
+mkdir -p "$FINAL_OUTPUT"
+for var in "${FINALS[@]}"; do
+    mv "${DMN_OUTPUT}/${var}" "$FINAL_OUTPUT"
+done
+
+popd >/dev/null

--- a/electron/gox.sh
+++ b/electron/gox.sh
@@ -20,6 +20,8 @@ CMD="${PKG_NAME}"
 OSARCH="$1"
 OUTPUT="$2"
 
+CONFIG_MODE=${CONFIG_MODE:-}
+
 if [ -z "$OSARCH" ]; then
     echo "$USAGE"
     exit 1
@@ -46,7 +48,7 @@ COMMIT=`git rev-parse HEAD`
 gox -osarch="$OSARCH" \
     -gcflags="-trimpath=${HOME}" \
     -asmflags="-trimpath=${HOME}" \
-    -ldflags="-X main.Version=${APP_VERSION} -X main.Commit=${COMMIT} -X main.ConfigMode=STANDALONE_CLIENT" \
+    -ldflags="-X main.Version=${APP_VERSION} -X main.Commit=${COMMIT} -X main.ConfigMode=${CONFIG_MODE}" \
     -output="${OUTPUT}{{.Dir}}_{{.OS}}_{{.Arch}}" \
     "${CMDDIR}/${CMD}"
 

--- a/electron/package-daemon-release.sh
+++ b/electron/package-daemon-release.sh
@@ -31,14 +31,13 @@ function copy_if_exists {
         fi
         mkdir -p "$DESTDIR"
 
-        # Copy binary to electron app
+        # Copy binary to app
         echo "Copying $BIN to $DESTDIR"
         cp "$BIN" "$DESTDIR"
 
-        # Copy static resources to electron app
-        echo "Copying $GUI_DIST_DIR to ${DESTDIR}/src/gui/static"
-        mkdir -p "${DESTDIR}/src/gui/static"
-        cp -R "$GUI_DIST_DIR" "${DESTDIR}/src/gui/static"
+        # Copy changelog to app
+        echo "Copying CHANGELOG.md to $DESTDIR"
+        cp ../CHANGELOG.md "$DESTDIR"
 
         echo "Adding $DESTSRC to package-source.sh list"
         DESTSRCS+=("$DESTSRC")
@@ -84,8 +83,8 @@ if [ ! -z "$WIN32_DMN" ]; then
     copy_if_exists "${WIN32_OUT}/${PKG_NAME}.exe" "$WIN32" "$WIN32_SRC"
 fi
 
-# Copy the source for reference
-# tar it with filters, move it, then untar in order to do this
-echo "Copying source snapshot"
+# # Copy the source for reference
+# # tar it with filters, move it, then untar in order to do this
+# echo "Copying source snapshot"
 
-./package-source.sh "${DESTSRCS[@]}"
+# ./package-source.sh "${DESTSRCS[@]}"

--- a/electron/package-daemon-release.sh
+++ b/electron/package-daemon-release.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -e -o pipefail
 
-# Builds the release without electron
+# Builds the daemon release
 
 GOX_OSARCH="$@"
 
-echo "In package standalone release: $GOX_OSARCH"
+echo "In package daemon release: $GOX_OSARCH"
 
 . build-conf.sh "$GOX_OSARCH"
 
@@ -21,7 +21,7 @@ function copy_if_exists {
         exit 1
     fi
 
-    BIN="${GOX_GUI_OUTPUT}/${1}"
+    BIN="${GOX_DMN_OUTPUT}/${1}"
     DESTDIR="$2"
     DESTSRC="$3"
 
@@ -50,36 +50,36 @@ function copy_if_exists {
 echo "Copying ${PKG_NAME} binaries"
 
 # OS X
-if [ ! -z "$OSX64_STL" ]; then
-    OSX64="${STL_OUTPUT}/${OSX64_STL}"
+if [ ! -z "$OSX64_DMN" ]; then
+    OSX64="${DMN_OUTPUT}/${OSX64_DMN}"
     OSX64_SRC="${OSX64}/src"
     copy_if_exists "${OSX64_OUT}/${PKG_NAME}" "$OSX64" "$OSX64_SRC"
 fi
 
 # Linux amd64
-if [ ! -z "$LNX64_STL" ]; then
-    LNX64="${STL_OUTPUT}/${LNX64_STL}"
+if [ ! -z "$LNX64_DMN" ]; then
+    LNX64="${DMN_OUTPUT}/${LNX64_DMN}"
     LNX64_SRC="${LNX64}/src"
     copy_if_exists "${LNX64_OUT}/${PKG_NAME}" "$LNX64" "$LNX64_SRC"
 fi
 
 # Linux arm
-if [ ! -z "$LNX_ARM_STL" ]; then
-    LNX_ARM="${STL_OUTPUT}/${LNX_ARM_STL}"
+if [ ! -z "$LNX_ARM_DMN" ]; then
+    LNX_ARM="${DMN_OUTPUT}/${LNX_ARM_DMN}"
     LNX_ARM_SRC="${LNX_ARM}/src"
     copy_if_exists "${LNX_ARM_OUT}/${PKG_NAME}" "$LNX_ARM" "$LNX_ARM_SRC"
 fi
 
 # Windows amd64
-if [ ! -z "$WIN64_STL" ]; then
-    WIN64="${STL_OUTPUT}/${WIN64_STL}"
+if [ ! -z "$WIN64_DMN" ]; then
+    WIN64="${DMN_OUTPUT}/${WIN64_DMN}"
     WIN64_SRC="${WIN64}/src"
     copy_if_exists "${WIN64_OUT}/${PKG_NAME}.exe" "$WIN64" "$WIN64_SRC"
 fi
 
 # Windows 386
-if [ ! -z "$WIN32_STL" ]; then
-    WIN32="${STL_OUTPUT}/${WIN32_STL}"
+if [ ! -z "$WIN32_DMN" ]; then
+    WIN32="${DMN_OUTPUT}/${WIN32_DMN}"
     WIN32_SRC="${WIN32}/src"
     copy_if_exists "${WIN32_OUT}/${PKG_NAME}.exe" "$WIN32" "$WIN32_SRC"
 fi

--- a/electron/package-electron-release.sh
+++ b/electron/package-electron-release.sh
@@ -40,7 +40,7 @@ function copy_if_exists {
         exit 1
     fi
 
-    BIN="${GOX_OUTPUT}/${1}"
+    BIN="${GOX_GUI_OUTPUT}/${1}"
     DESTDIR="$2"
     DESTBIN="${DESTDIR}/${3}"
     DESTSRC="$4"

--- a/electron/package-electron-release.sh
+++ b/electron/package-electron-release.sh
@@ -55,6 +55,10 @@ function copy_if_exists {
         echo "Copying $GUI_DIST_DIR to $DESTDIR"
         cp -R "$GUI_DIST_DIR" "$DESTDIR"
 
+        # Copy changelog to app
+        echo "Copying CHANGELOG.md to $DESTDIR"
+        cp ../CHANGELOG.md "$DESTDIR"
+
         DESTSRCS+=("$DESTSRC")
     else
         echo "$BIN does not exist"
@@ -68,8 +72,8 @@ copy_if_exists "${PKG_NAME}_windows_amd64.exe" "$WIN64_RES" "${PKG_NAME}.exe" "$
 copy_if_exists "${PKG_NAME}_windows_386.exe" "$WIN32_RES" "${PKG_NAME}.exe" "$WIN32_SRC"
 copy_if_exists "${PKG_NAME}_linux_amd64" "$LNX64_RES" "${PKG_NAME}" "$LNX64_SRC"
 
-# Copy the source for reference
-# tar it with filters, move it, then untar in order to do this
-echo "Copying source snapshot"
+# # Copy the source for reference
+# # tar it with filters, move it, then untar in order to do this
+# echo "Copying source snapshot"
 
-./package-source.sh "${DESTSRCS[@]}"
+# ./package-source.sh "${DESTSRCS[@]}"

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "skycoin",
-    "version": "0.24.1",
+    "version": "0.25.0-rc1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/electron/package-source.sh
+++ b/electron/package-source.sh
@@ -10,17 +10,17 @@ pushd "${SCRIPTDIR}"
 if [[ "$OSTYPE" == "linux"* ]]; then
     tar -C .. -cvPf "${SRC_TAR}" --owner=0 --group=0 --exclude=electron \
         --exclude=node_modules --exclude=_deprecated --exclude='.*' \
-        src cmd run.sh README.md INSTALLATION.md CHANGELOG.md INTEGRATION.md \
+        src cmd run-client.sh run-daemon.sh README.md INSTALLATION.md CHANGELOG.md INTEGRATION.md \
         >/dev/null
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     tar -C .. -cvf "${SRC_TAR}" --exclude=electron \
         --exclude=node_modules --exclude=_deprecated --exclude='.*' \
-        src cmd run.sh README.md INSTALLATION.md CHANGELOG.md INTEGRATION.md \
+        src cmd run-client.sh run-daemon.sh README.md INSTALLATION.md CHANGELOG.md INTEGRATION.md \
         >/dev/null
 elif [[ "$OSTYPE" == "msys"* ]]; then
     tar -C .. -cvPf "${SRC_TAR}" --owner=0 --group=0 --exclude=electron \
         --exclude=node_modules --exclude=_deprecated --exclude='.*' \
-        src cmd run.sh README.md INSTALLATION.md CHANGELOG.md INTEGRATION.md \
+        src cmd run-client.sh run-daemon.sh README.md INSTALLATION.md CHANGELOG.md INTEGRATION.md \
         >/dev/null
 fi
 

--- a/electron/package-standalone-release.sh
+++ b/electron/package-standalone-release.sh
@@ -40,6 +40,10 @@ function copy_if_exists {
         mkdir -p "${DESTDIR}/src/gui/static"
         cp -R "$GUI_DIST_DIR" "${DESTDIR}/src/gui/static"
 
+        # Copy changelog to app
+        echo "Copying CHANGELOG.md to $DESTDIR"
+        cp ../CHANGELOG.md "$DESTDIR"
+
         echo "Adding $DESTSRC to package-source.sh list"
         DESTSRCS+=("$DESTSRC")
     else
@@ -84,8 +88,8 @@ if [ ! -z "$WIN32_STL" ]; then
     copy_if_exists "${WIN32_OUT}/${PKG_NAME}.exe" "$WIN32" "$WIN32_SRC"
 fi
 
-# Copy the source for reference
-# tar it with filters, move it, then untar in order to do this
-echo "Copying source snapshot"
+# # Copy the source for reference
+# # tar it with filters, move it, then untar in order to do this
+# echo "Copying source snapshot"
 
-./package-source.sh "${DESTSRCS[@]}"
+# ./package-source.sh "${DESTSRCS[@]}"

--- a/electron/package.json
+++ b/electron/package.json
@@ -3,7 +3,7 @@
     "productName": "Skycoin",
     "author": "skycoin",
     "main": "src/electron-main.js",
-    "version": "0.24.1",
+    "version": "0.25.0-rc1",
     "description": "skycoin wallet",
     "license": "MIT",
     "build": {

--- a/electron/skycoin/current-skycoin.json
+++ b/electron/skycoin/current-skycoin.json
@@ -1,1 +1,1 @@
-versionData='{     "version": "0.24.1" }';
+versionData='{     "version": "0.25.0-rc1" }';

--- a/run-client.sh
+++ b/run-client.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Runs skycoin in desktop client configuration
+
 set -x
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/run-daemon.sh
+++ b/run-daemon.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Runs skycoin in daemon mode configuration
+
+set -x
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+echo "skycoin binary dir:" "$DIR"
+pushd "$DIR" >/dev/null
+
+COMMIT=$(git rev-parse HEAD)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+GOLDFLAGS="-X main.Commit=${COMMIT} -X main.Branch=${BRANCH}"
+
+GORUNFLAGS=${GORUNFLAGS:-}
+
+go run -ldflags "${GOLDFLAGS}" $GORUNFLAGS cmd/skycoin/skycoin.go \
+    -enable-gui=false \
+    -launch-browser=false \
+    -rpc-interface=false \
+    -log-level=debug \
+    $@
+
+popd >/dev/null

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// Version is the CLI Version
-	Version           = "0.24.1"
+	Version           = "0.25.0-rc1"
 	walletExt         = ".wlt"
 	defaultCoin       = "skycoin"
 	defaultWalletName = "$COIN_cli" + walletExt

--- a/src/gui/static/src/current-skycoin.json
+++ b/src/gui/static/src/current-skycoin.json
@@ -1,1 +1,1 @@
-versionData='{     "version": "0.24.1" }';
+versionData='{     "version": "0.25.0-rc1" }';

--- a/template/coin.template
+++ b/template/coin.template
@@ -20,7 +20,7 @@ import (
 
 var (
 	// Version of the node. Can be set by -ldflags
-	Version = "0.24.1"
+	Version = "0.25.0-rc1"
 	// Commit ID. Can be set by -ldflags
 	Commit = ""
 	// Branch name. Can be set by -ldflags


### PR DESCRIPTION
Fixes #1950 

Changes:
- Bump version to 0.25.0-rc1
- Add a `daemon` release build, this is compiled with the default CLI options
- For build names, rename `gui` to `gui-electron` and rename `bin` to `gui-standalone`

Does this change need to mentioned in CHANGELOG.md?
Yes