### PR TITLE
Fix the initial state of the Selects on Safari

### DIFF
--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.html
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.html
@@ -3,6 +3,7 @@
     <label for="wallets">{{ 'send.wallet-label' | translate }}</label>
     <div class="-select">
       <select formControlName="wallet" id="wallets">
+        <option disabled hidden [ngValue]="''">{{ 'send.select-wallet' | translate }}</option>
         <option *ngFor="let wallet of walletService.all() | async" [disabled]="!wallet.coins || wallet.coins.isLessThanOrEqualTo(0)" [ngValue]="wallet">
           {{ wallet.label }} - {{ (wallet.coins ? wallet.coins.decimalPlaces(6).toString() : 0) | number:'1.0-6' }} {{ 'common.coin-id' | translate }}
           ({{ wallet.hours.decimalPlaces(0).toString() | number:'1.0-0' }} {{ 'common.coin-hours' | translate }})

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.html
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.html
@@ -3,6 +3,7 @@
     <label for="wallet">{{ 'send.from-label' | translate }}</label>
     <div class="-select">
       <select formControlName="wallet" id="wallet">
+        <option disabled hidden [ngValue]="''">{{ 'send.select-wallet' | translate }}</option>
         <option *ngFor="let wallet of walletService.all() | async" [disabled]="!wallet.coins || wallet.coins.isLessThanOrEqualTo(0)" [ngValue]="wallet">
           {{ wallet.label }} - {{ (wallet.coins ? wallet.coins.decimalPlaces(6).toString() : 0) | number:'1.0-6' }} {{ 'common.coin-id' | translate }}
         </option>

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -169,7 +169,8 @@
     "send-button": "Send",
     "back-button": "Back",
     "simple": "Simple",
-    "advanced": "Advanced"
+    "advanced": "Advanced",
+    "select-wallet": "Select Wallet"
   },
 
   "reset": {


### PR DESCRIPTION
Fixes #1899 

Changes:
- I could not reproduce the exact error, but the problem seems to be that, unlike other browsers, Safari always shows a selected item in the Select controls and the code expects the Select to be empty until the user makes a selection manually. This PR adds a first generic element to the Select, to force the user to choose the wallet, so the behavior should be the same in all browsers:
![select](https://user-images.githubusercontent.com/34079003/46919907-4b593300-cfb4-11e8-9b13-3b7e1f7516a3.png)
Please test in several web browsers.

Does this change need to mentioned in CHANGELOG.md?
No