### PR TITLE
Fix Electron menu

### DIFF
--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -232,13 +232,13 @@ function createWindow(url) {
   }, {
     label: 'Edit',
     submenu: [
-      { label: 'Undo', accelerator: 'CmdOrCtrl+Z', selector: 'undo:' },
-      { label: 'Redo', accelerator: 'Shift+CmdOrCtrl+Z', selector: 'redo:' },
+      { label: 'Undo', accelerator: 'CmdOrCtrl+Z', role: 'undo' },
+      { label: 'Redo', accelerator: 'Shift+CmdOrCtrl+Z', role: 'redo' },
       { type: 'separator' },
-      { label: 'Cut', accelerator: 'CmdOrCtrl+X', selector: 'cut:' },
-      { label: 'Copy', accelerator: 'CmdOrCtrl+C', selector: 'copy:' },
-      { label: 'Paste', accelerator: 'CmdOrCtrl+V', selector: 'paste:' },
-      { label: 'Select All', accelerator: 'CmdOrCtrl+A', selector: 'selectAll:' }
+      { label: 'Cut', accelerator: 'CmdOrCtrl+X', role: 'cut' },
+      { label: 'Copy', accelerator: 'CmdOrCtrl+C', role: 'copy' },
+      { label: 'Paste', accelerator: 'CmdOrCtrl+V', role: 'paste' },
+      { label: 'Select All', accelerator: 'CmdOrCtrl+A', role: 'selectall' }
     ]
   }, {
     label: 'Show',


### PR DESCRIPTION
Changes:
- The options inside the Edit menu of the Electron app were not working correctly in Windows. This PR modifies the menu so that it uses the `role` attribute instead of the `selector` attribute , as recommended in the documentation (https://electronjs.org/docs/api/menu-item#roles), so that the options work correctly.

Does this change need to mentioned in CHANGELOG.md?
No