### PR TITLE
Add deprecation warning for /explorer/address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ In the v0.26.0 these features and functions will be removed.  If you have a need
 - JSON-RPC 2.0 interface (this is no longer used by the CLI tool, and the REST API supports everything the JSON-RPC 2.0 API does). See https://github.com/skycoin/skycoin/blob/develop/src/api/README.md#migrating-from-the-jsonrpc-api
 - `/api/v1/wallet/spend` endpoint (use `POST /api/v1/wallet/transaction` followed by `POST /api/v1/injectTransaction` instead). See https://github.com/skycoin/skycoin/blob/develop/src/api/README.md#migrating-from--api-v1-spend
 - The unversioned REST API (the `-enable-unversioned-api` option will be removed, prefix your API requests with `/api/v1`). See https://github.com/skycoin/skycoin/blob/develop/src/api/README.md#migrating-from-the-unversioned-api
+- `/api/v1/explorer/address` endpoint (use `GET /api/v1/transactions?verbose=1` instead). See https://github.com/skycoin/skycoin/blob/develop/src/api/README.md#migrating-from--api-v1-explorer-address
 
 ### Notice
 
@@ -79,6 +80,7 @@ Make sure to upgrade to v0.25.0 so that your node will continue to connect once 
 - `cli generateWallet` renamed to `cli walletCreate`
 - `cli generateAddresses` renamed to `cli walletAddAddresses`
 - `run.sh` is now `run-client.sh` and a new `run-daemon.sh` script is added for running in server daemon mode.
+- `/api/v1/explorer/address` is deprecated in favor of `/api/v1/transactions?verbose=1`
 
 ### Removed
 

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -49,7 +49,7 @@ and the `/api/v1` prefix will be required for previously unversioned endpoints.
 	- [Get transaction info by id](#get-transaction-info-by-id)
 	- [Get raw transaction by id](#get-raw-transaction-by-id)
 	- [Inject raw transaction](#inject-raw-transaction)
-	- [Get transactions that are addresses related](#get-transactions-that-are-addresses-related)
+	- [Get transactions for addresses](#get-transactions-for-addresses)
 	- [Resend unconfirmed transactions](#resend-unconfirmed-transactions)
 	- [Verify encoded transaction](#verify-encoded-transaction)
 - [Block APIs](#block-apis)
@@ -76,6 +76,7 @@ and the `/api/v1` prefix will be required for previously unversioned endpoints.
 - [Migrating from the unversioned API](#migrating-from-the-unversioned-api)
 - [Migrating from the JSONRPC API](#migrating-from-the-jsonrpc-api)
 - [Migrating from /api/v1/spend](#migrating-from-apiv1spend)
+- [Migration from /api/v1/explorer/address](#migration-from-apiv1exploreraddress)
 
 <!-- /MarkdownTOC -->
 
@@ -1889,7 +1890,7 @@ Result:
 "3615fc23cc12a5cb9190878a2151d1cf54129ff0cd90e5fc4f4e7debebad6868"
 ```
 
-### Get transactions that are addresses related
+### Get transactions for addresses
 
 API sets: `READ`
 
@@ -1908,18 +1909,22 @@ If the transaction is confirmed, the calculated hours are the hours the transact
 If the transaction is unconfirmed, the calculated hours are based upon the current system time, and are approximately
 equal to the hours the output would have if it become confirmed immediately.
 
-To get address related confirmed transactions:
+The `"time"` field at the top level of each object in the response array indicates either the confirmed timestamp of a confirmed
+transaction or the last received timestamp of an unconfirmed transaction.
+
+To get confirmed transactions for one or more addresses:
 
 ```sh
 curl http://127.0.0.1:6420/api/v1/transactions?addrs=7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD,6dkVxyKFbFKg9Vdg6HPg1UANLByYRqkrdY&confirmed=1
 ```
 
-To get address related unconfirmed transactions:
+To unconfirmed transactions for one or more addresses:
+
 ```sh
 curl http://127.0.0.1:6420/api/v1/transactions?addrs=7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD,6dkVxyKFbFKg9Vdg6HPg1UANLByYRqkrdY&confirmed=0
 ```
 
-To get all addresses related transactions:
+To both confirmed and unconfirmed transactions for one or more addresses:
 
 ```sh
 curl http://127.0.0.1:6420/api/v1/transactions?addrs=7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD,6dkVxyKFbFKg9Vdg6HPg1UANLByYRqkrdY
@@ -3220,6 +3225,8 @@ Args:
     address
 ```
 
+**Deprecated** Use `/api/v1/transactions?verbose=1&addrs=` instead.
+
 Example:
 
 ```sh
@@ -3811,3 +3818,108 @@ The request header `Content-Type` must be `application/json`.
 The response to `POST /api/v1/wallet/transaction` will include a verbose decoded transaction with details
 and the hex-encoded binary transaction in the `"encoded_transaction"` field.
 Use the value of `"encoded_transaction"` as the `"rawtx"` value in the request to `/api/v1/injectTransaction`.
+
+## Migration from /api/v1/explorer/address
+
+The `GET /api/v1/explorer/address` endpoint is deprecated and will be removed in v0.26.0.
+
+To migrate from it, use [`GET /api/v1/transactions?verbose=1`](#get-transactions-for-addresses).
+
+`/api/v1/explorer/address` accepted a single `address` query parameter. `/api/v1/transactions` uses an `addrs` query parameter and
+accepts multiple addresses at once.
+
+The response data is the same but the structure is slightly different. Compare the follow two example responses:
+
+`/api/v1/explorer/address?address=WzPDgdfL1NzSbX96tscUNXUqtCRLjaBugC`:
+
+```json
+[
+    {
+        "status": {
+            "confirmed": true,
+            "unconfirmed": false,
+            "height": 38076,
+            "block_seq": 15493
+        },
+        "timestamp": 1518878675,
+        "length": 183,
+        "type": 0,
+        "txid": "6d8e2f8b436a2f38d604b3aa1196ef2176779c5e11e33fbdd09f993fe659c39f",
+        "inner_hash": "8da7c64dcedeeb6aa1e0d21fb84a0028dcd68e6801f1a3cc0224fdd50682046f",
+        "fee": 126249,
+        "sigs": [
+            "c60e43980497daad59b4c72a2eac053b1584f960c57a5e6ac8337118dccfcee4045da3f60d9be674867862a13fdd87af90f4b85cbf39913bde13674e0a039b7800"
+        ],
+        "inputs": [
+            {
+                "uxid": "349b06e5707f633fd2d8f048b687b40462d875d968b246831434fb5ab5dcac38",
+                "owner": "WzPDgdfL1NzSbX96tscUNXUqtCRLjaBugC",
+                "coins": "125.000000",
+                "hours": 34596,
+                "calculated_hours": 178174
+            }
+        ],
+        "outputs": [
+            {
+                "uxid": "5b4a79c7de2e9099e083bbc8096619ae76ba6fbe34875c61bbe2d3bfa6b18b99",
+                "dst": "2NfNKsaGJEndpSajJ6TsKJfsdDjW2gFsjXg",
+                "coins": "125.000000",
+                "hours": 51925
+            }
+        ]
+    }
+]
+```
+
+`/api/v1/transactions?verbose=1&addrs=WzPDgdfL1NzSbX96tscUNXUqtCRLjaBugC`:
+
+```json
+[
+    {
+        "status": {
+            "confirmed": true,
+            "unconfirmed": false,
+            "height": 57564,
+            "block_seq": 7498
+        },
+        "time": 1514743602,
+        "txn": {
+            "timestamp": 1514743602,
+            "length": 220,
+            "type": 0,
+            "txid": "df5bcef198fe6e96d496c30482730f895cabc1d55b338afe5633b0c2889d02f9",
+            "inner_hash": "4677ff9b9b56485495a45693cc09f8496199929fccb52091d32f2d3cf2ee8a41",
+            "fee": 69193,
+            "sigs": [
+                "8e1f6f621a11f737ac2031be975d4b2fc17bf9f17a0da0a2fe219ee018011ab506e2ad0367be302a8d859cc355c552313389cd0aa9fa98dc7d2085a52f11ef5a00"
+            ],
+            "inputs": [
+                {
+                    "uxid": "2374201ff29f1c024ccfc6c53160e741d06720562853ad3613c121acd8389031",
+                    "owner": "2GgFvqoyk9RjwVzj8tqfcXVXB4orBwoc9qv",
+                    "coins": "162768.000000",
+                    "hours": 485,
+                    "calculated_hours": 138385
+                }
+            ],
+            "outputs": [
+                {
+                    "uxid": "63f299fc85fe6fc34d392718eee55909837c7231b6ffd93e5a9a844c4375b313",
+                    "dst": "2GgFvqoyk9RjwVzj8tqfcXVXB4orBwoc9qv",
+                    "coins": "162643.000000",
+                    "hours": 34596
+                },
+                {
+                    "uxid": "349b06e5707f633fd2d8f048b687b40462d875d968b246831434fb5ab5dcac38",
+                    "dst": "WzPDgdfL1NzSbX96tscUNXUqtCRLjaBugC",
+                    "coins": "125.000000",
+                    "hours": 34596
+                }
+            ]
+        }
+    }
+]
+```
+
+The transaction data is wrapped in a `"txn"` field.  A `"time"` field is present at the top level. This `"time"` field
+is either the confirmation timestamp of a confirmed transaction or the last received time of an unconfirmed transaction.

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1918,13 +1918,13 @@ To get confirmed transactions for one or more addresses:
 curl http://127.0.0.1:6420/api/v1/transactions?addrs=7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD,6dkVxyKFbFKg9Vdg6HPg1UANLByYRqkrdY&confirmed=1
 ```
 
-To unconfirmed transactions for one or more addresses:
+To get unconfirmed transactions for one or more addresses:
 
 ```sh
 curl http://127.0.0.1:6420/api/v1/transactions?addrs=7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD,6dkVxyKFbFKg9Vdg6HPg1UANLByYRqkrdY&confirmed=0
 ```
 
-To both confirmed and unconfirmed transactions for one or more addresses:
+To get both confirmed and unconfirmed transactions for one or more addresses:
 
 ```sh
 curl http://127.0.0.1:6420/api/v1/transactions?addrs=7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD,6dkVxyKFbFKg9Vdg6HPg1UANLByYRqkrdY

--- a/src/api/explorer.go
+++ b/src/api/explorer.go
@@ -163,6 +163,8 @@ func coinSupplyHandler(gateway Gatewayer) http.HandlerFunc {
 //	address [string]
 func transactionsForAddressHandler(gateway Gatewayer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		logger.Critical().Warning("Call to deprecated /api/v1/explorer/address endpoint")
+
 		if r.Method != http.MethodGet {
 			wh.Error405(w)
 			return


### PR DESCRIPTION
Fixes #1963

Changes:
- Add deprecation warning and migration guide for `/explorer/address` to `/transactions?verbose=1`

Does this change need to mentioned in CHANGELOG.md?
Yes