### PR TITLE
Accept POST for endpoints with potentially long query strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Make sure to upgrade to v0.25.0 so that your node will continue to connect once 
 - `cli generateWallet` renamed to `cli walletCreate`
 - `cli generateAddresses` renamed to `cli walletAddAddresses`
 - `run.sh` is now `run-client.sh` and a new `run-daemon.sh` script is added for running in server daemon mode.
+- `/api/v1/balance`, `/api/v1/transactions`, `/api/v1/outputs` and `/api/v1/blocks` accept the `POST` method so that large request bodies can be sent to the server, which would not fit in a `GET` query string
 
 ### Removed
 

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -386,10 +386,13 @@ API sets: `READ`
 
 ```
 URI: /api/v1/balance
-Method: GET
+Method: GET, POST
 Args:
     addrs: comma-separated list of addresses. must contain at least one address
 ```
+
+Returns the cumulative and individual balances of one or more addresses.
+The `POST` method can be used if many addresses need to be queried.
 
 Example:
 
@@ -450,7 +453,7 @@ API sets: `READ`
 
 ```
 URI: /api/v1/outputs
-Method: GET
+Method: GET, POST
 Args:
     addrs: address list, joined with ","
     hashes: hash list, joined with ","
@@ -463,6 +466,8 @@ In the response, `"head_outputs"` are outputs in the current unspent output set,
 and `"incoming_outputs"` are outputs that will be created by an unconfirmed transaction.
 
 The current head block header is returned as `"head"`.
+
+The `POST` method can be used if many addresses or hashes need to be queried.
 
 Example:
 
@@ -1895,7 +1900,7 @@ API sets: `READ`
 
 ```
 URI: /api/v1/transactions
-Method: GET
+Method: GET, POST
 Args:
     addrs: Comma seperated addresses [optional, returns all transactions if no address is provided]
     confirmed: Whether the transactions should be confirmed [optional, must be 0 or 1; if not provided, returns all]
@@ -1907,6 +1912,8 @@ The hours are the original hours the output was created with.
 If the transaction is confirmed, the calculated hours are the hours the transaction had in the block in which it was executed.
 If the transaction is unconfirmed, the calculated hours are based upon the current system time, and are approximately
 equal to the hours the output would have if it become confirmed immediately.
+
+The `POST` method can be used if many addresses need to be queried.
 
 To get address related confirmed transactions:
 

--- a/src/api/address.go
+++ b/src/api/address.go
@@ -27,7 +27,7 @@ func addressVerifyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.Header.Get("Content-Type") != "application/json" {
+	if r.Header.Get("Content-Type") != ContentTypeJSON {
 		resp := NewHTTPErrorResponse(http.StatusUnsupportedMediaType, "")
 		writeHTTPResponse(w, resp)
 		return

--- a/src/api/address_test.go
+++ b/src/api/address_test.go
@@ -36,7 +36,7 @@ func TestVerifyAddress(t *testing.T) {
 		{
 			name:         "415 - Unsupported Media Type",
 			method:       http.MethodPost,
-			contentType:  "application/x-www-form-urlencoded",
+			contentType:  ContentTypeForm,
 			status:       http.StatusUnsupportedMediaType,
 			httpResponse: NewHTTPErrorResponse(http.StatusUnsupportedMediaType, ""),
 		},
@@ -44,7 +44,7 @@ func TestVerifyAddress(t *testing.T) {
 		{
 			name:         "400 - EOF",
 			method:       http.MethodPost,
-			contentType:  "application/json",
+			contentType:  ContentTypeJSON,
 			status:       http.StatusBadRequest,
 			httpResponse: NewHTTPErrorResponse(http.StatusBadRequest, "EOF"),
 		},
@@ -52,7 +52,7 @@ func TestVerifyAddress(t *testing.T) {
 		{
 			name:         "400 - Missing address",
 			method:       http.MethodPost,
-			contentType:  "application/json",
+			contentType:  ContentTypeJSON,
 			status:       http.StatusBadRequest,
 			httpBody:     "{}",
 			httpResponse: NewHTTPErrorResponse(http.StatusBadRequest, "address is required"),
@@ -106,7 +106,7 @@ func TestVerifyAddress(t *testing.T) {
 
 			contentType := tc.contentType
 			if contentType == "" {
-				contentType = "application/json"
+				contentType = ContentTypeJSON
 			}
 
 			req.Header.Set("Content-Type", contentType)

--- a/src/api/blockchain.go
+++ b/src/api/blockchain.go
@@ -197,7 +197,7 @@ func blockHandler(gateway Gatewayer) http.HandlerFunc {
 // or an explicit list of sequences.
 // If using start and end, the block sequences include both the start and end point.
 // Explicit sequences cannot be combined with start and end.
-// Method: GET
+// Method: GET, POST
 // URI: /api/v1/blocks
 // Args:
 //	start [int]

--- a/src/api/blockchain.go
+++ b/src/api/blockchain.go
@@ -206,7 +206,7 @@ func blockHandler(gateway Gatewayer) http.HandlerFunc {
 //  verbose [bool]
 func blocksHandler(gateway Gatewayer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
+		if r.Method != http.MethodGet && r.Method != http.MethodPost {
 			wh.Error405(w)
 			return
 		}

--- a/src/api/client.go
+++ b/src/api/client.go
@@ -338,7 +338,7 @@ func (c *Client) Outputs() (*readable.UnspentOutputsSummary, error) {
 	return &o, nil
 }
 
-// OutputsForAddresses makes a request to GET /api/v1/outputs?addrs=xxx
+// OutputsForAddresses makes a request to POST /api/v1/outputs?addrs=xxx
 func (c *Client) OutputsForAddresses(addrs []string) (*readable.UnspentOutputsSummary, error) {
 	v := url.Values{}
 	v.Add("addrs", strings.Join(addrs, ","))
@@ -352,7 +352,7 @@ func (c *Client) OutputsForAddresses(addrs []string) (*readable.UnspentOutputsSu
 	return &o, nil
 }
 
-// OutputsForHashes makes a request to GET /api/v1/outputs?hashes=zzz
+// OutputsForHashes makes a request to POST /api/v1/outputs?hashes=zzz
 func (c *Client) OutputsForHashes(hashes []string) (*readable.UnspentOutputsSummary, error) {
 	v := url.Values{}
 	v.Add("hashes", strings.Join(hashes, ","))
@@ -428,7 +428,7 @@ func (c *Client) BlockBySeqVerbose(seq uint64) (*readable.BlockVerbose, error) {
 	return &b, nil
 }
 
-// Blocks makes a request to GET /api/v1/blocks?seqs=
+// Blocks makes a request to POST /api/v1/blocks?seqs=
 func (c *Client) Blocks(seqs []uint64) (*readable.Blocks, error) {
 	sSeqs := make([]string, len(seqs))
 	for i, x := range seqs {
@@ -446,7 +446,7 @@ func (c *Client) Blocks(seqs []uint64) (*readable.Blocks, error) {
 	return &b, nil
 }
 
-// BlocksVerbose makes a request to GET /api/v1/blocks?verbose=1&start=&end=
+// BlocksVerbose makes a request to POST /api/v1/blocks?verbose=1&seqs=
 func (c *Client) BlocksVerbose(seqs []uint64) (*readable.BlocksVerbose, error) {
 	sSeqs := make([]string, len(seqs))
 	for i, x := range seqs {
@@ -539,7 +539,7 @@ func (c *Client) BlockchainProgress() (*readable.BlockchainProgress, error) {
 	return &b, nil
 }
 
-// Balance makes a request to GET /api/v1/balance?addrs=xxx
+// Balance makes a request to POST /api/v1/balance?addrs=xxx
 func (c *Client) Balance(addrs []string) (*BalanceResponse, error) {
 	v := url.Values{}
 	v.Add("addrs", strings.Join(addrs, ","))
@@ -920,7 +920,7 @@ func (c *Client) TransactionEncoded(txid string) (*TransactionEncodedResponse, e
 	return &r, nil
 }
 
-// Transactions makes a request to GET /api/v1/transactions
+// Transactions makes a request to POST /api/v1/transactions
 func (c *Client) Transactions(addrs []string) ([]readable.TransactionWithStatus, error) {
 	v := url.Values{}
 	v.Add("addrs", strings.Join(addrs, ","))
@@ -933,7 +933,7 @@ func (c *Client) Transactions(addrs []string) ([]readable.TransactionWithStatus,
 	return r, nil
 }
 
-// ConfirmedTransactions makes a request to GET /api/v1/transactions?confirmed=true
+// ConfirmedTransactions makes a request to POST /api/v1/transactions?confirmed=true
 func (c *Client) ConfirmedTransactions(addrs []string) ([]readable.TransactionWithStatus, error) {
 	v := url.Values{}
 	v.Add("addrs", strings.Join(addrs, ","))
@@ -947,7 +947,7 @@ func (c *Client) ConfirmedTransactions(addrs []string) ([]readable.TransactionWi
 	return r, nil
 }
 
-// UnconfirmedTransactions makes a request to GET /api/v1/transactions?confirmed=false
+// UnconfirmedTransactions makes a request to POST /api/v1/transactions?confirmed=false
 func (c *Client) UnconfirmedTransactions(addrs []string) ([]readable.TransactionWithStatus, error) {
 	v := url.Values{}
 	v.Add("addrs", strings.Join(addrs, ","))
@@ -961,7 +961,7 @@ func (c *Client) UnconfirmedTransactions(addrs []string) ([]readable.Transaction
 	return r, nil
 }
 
-// TransactionsVerbose makes a request to GET /api/v1/transactions?verbose=1
+// TransactionsVerbose makes a request to POST /api/v1/transactions?verbose=1
 func (c *Client) TransactionsVerbose(addrs []string) ([]readable.TransactionWithStatusVerbose, error) {
 	v := url.Values{}
 	v.Add("addrs", strings.Join(addrs, ","))
@@ -975,7 +975,7 @@ func (c *Client) TransactionsVerbose(addrs []string) ([]readable.TransactionWith
 	return r, nil
 }
 
-// ConfirmedTransactionsVerbose makes a request to GET /api/v1/transactions?confirmed=true&verbose=1
+// ConfirmedTransactionsVerbose makes a request to POST /api/v1/transactions?confirmed=true&verbose=1
 func (c *Client) ConfirmedTransactionsVerbose(addrs []string) ([]readable.TransactionWithStatusVerbose, error) {
 	v := url.Values{}
 	v.Add("addrs", strings.Join(addrs, ","))
@@ -990,7 +990,7 @@ func (c *Client) ConfirmedTransactionsVerbose(addrs []string) ([]readable.Transa
 	return r, nil
 }
 
-// UnconfirmedTransactionsVerbose makes a request to GET /api/v1/transactions?confirmed=false&verbose=1
+// UnconfirmedTransactionsVerbose makes a request to POST /api/v1/transactions?confirmed=false&verbose=1
 func (c *Client) UnconfirmedTransactionsVerbose(addrs []string) ([]readable.TransactionWithStatusVerbose, error) {
 	v := url.Values{}
 	v.Add("addrs", strings.Join(addrs, ","))

--- a/src/api/csrf_test.go
+++ b/src/api/csrf_test.go
@@ -111,7 +111,7 @@ func TestCSRF(t *testing.T) {
 
 		req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBufferString(v.Encode()))
 		require.NoError(t, err)
-		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Add("Content-Type", ContentTypeForm)
 
 		if csrfToken != "" {
 			req.Header.Set("X-CSRF-Token", csrfToken)

--- a/src/api/http.go
+++ b/src/api/http.go
@@ -131,7 +131,7 @@ func writeHTTPResponse(w http.ResponseWriter, resp HTTPResponse) {
 		return
 	}
 
-	w.Header().Add("Content-Type", "application/json")
+	w.Header().Add("Content-Type", ContentTypeJSON)
 
 	if resp.Error == nil {
 		w.WriteHeader(http.StatusOK)
@@ -208,6 +208,7 @@ func create(host string, c Config, gateway Gatewayer) (*Server, error) {
 		ReadTimeout:  c.ReadTimeout,
 		WriteTimeout: c.WriteTimeout,
 		IdleTimeout:  c.IdleTimeout,
+		// MaxHeaderBytes: http.DefaultMaxHeaderBytes, // adjust this to allow longer GET queries
 	}
 
 	return &Server{

--- a/src/api/integration/integration_test.go
+++ b/src/api/integration/integration_test.go
@@ -5719,7 +5719,7 @@ func TestDisableWalletAPI(t *testing.T) {
 			name:        "create transaction",
 			method:      http.MethodPost,
 			endpoint:    "/api/v1/wallet/transaction",
-			contentType: "application/json",
+			contentType: api.ContentTypeJSON,
 			json: func() interface{} {
 				return api.CreateTransactionRequest{
 					HoursSelection: api.HoursSelection{
@@ -5753,7 +5753,7 @@ func TestDisableWalletAPI(t *testing.T) {
 					err = c.Get(tc.endpoint, nil)
 				case http.MethodPost:
 					switch tc.contentType {
-					case "application/json":
+					case api.ContentTypeJSON:
 						err = c.PostJSON(tc.endpoint, tc.json(), nil)
 					default:
 						err = c.PostForm(tc.endpoint, tc.body(), nil)

--- a/src/api/outputs.go
+++ b/src/api/outputs.go
@@ -12,7 +12,7 @@ import (
 
 // outputsHandler returns UxOuts filtered by a set of addresses or a set of hashes
 // URI: /api/v1/outputs
-// Method: GET
+// Method: GET, POST
 // Args:
 //    addrs: comma-separated list of addresses
 //    hashes: comma-separated list of uxout hashes

--- a/src/api/outputs.go
+++ b/src/api/outputs.go
@@ -21,7 +21,7 @@ import (
 // Both filters cannot be specified.
 func outputsHandler(gateway Gatewayer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
+		if r.Method != http.MethodGet && r.Method != http.MethodPost {
 			wh.Error405(w)
 			return
 		}

--- a/src/api/outputs_test.go
+++ b/src/api/outputs_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -38,7 +39,7 @@ func TestGetOutputsHandler(t *testing.T) {
 	}{
 		{
 			name:   "405",
-			method: http.MethodPost,
+			method: http.MethodDelete,
 			status: http.StatusMethodNotAllowed,
 			err:    "405 Method Not Allowed",
 		},
@@ -88,6 +89,25 @@ func TestGetOutputsHandler(t *testing.T) {
 				IncomingOutputs: readable.UnspentOutputs{},
 			},
 		},
+		{
+			name:   "200 - OK POST",
+			method: http.MethodPost,
+			status: http.StatusOK,
+			getUnspentOutputsResponse: &visor.UnspentOutputsSummary{
+				HeadBlock: &coin.SignedBlock{},
+			},
+			httpResponse: &readable.UnspentOutputsSummary{
+				Head: readable.BlockHeader{
+					Hash:         "7b8ec8dd836b564f0c85ad088fc744de820345204e154bc1503e04e9d6fdd9f1",
+					PreviousHash: "0000000000000000000000000000000000000000000000000000000000000000",
+					BodyHash:     "0000000000000000000000000000000000000000000000000000000000000000",
+					UxHash:       "0000000000000000000000000000000000000000000000000000000000000000",
+				},
+				HeadOutputs:     readable.UnspentOutputs{},
+				OutgoingOutputs: readable.UnspentOutputs{},
+				IncomingOutputs: readable.UnspentOutputs{},
+			},
+		},
 	}
 
 	for _, tc := range tt {
@@ -106,12 +126,21 @@ func TestGetOutputsHandler(t *testing.T) {
 				}
 			}
 
+			var reqBody io.Reader
 			if len(v) > 0 {
-				endpoint += "?" + v.Encode()
+				if tc.method == http.MethodPost {
+					reqBody = strings.NewReader(v.Encode())
+				} else {
+					endpoint += "?" + v.Encode()
+				}
 			}
 
-			req, err := http.NewRequest(tc.method, endpoint, nil)
+			req, err := http.NewRequest(tc.method, endpoint, reqBody)
 			require.NoError(t, err)
+
+			if tc.method == http.MethodPost {
+				req.Header.Set("Content-Type", ContentTypeForm)
+			}
 
 			rr := httptest.NewRecorder()
 			handler := newServerMux(defaultMuxConfig(), gateway, &CSRFStore{}, nil)

--- a/src/api/spend.go
+++ b/src/api/spend.go
@@ -476,7 +476,7 @@ func createTransactionHandler(gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 
-		if r.Header.Get("Content-Type") != "application/json" {
+		if r.Header.Get("Content-Type") != ContentTypeJSON {
 			wh.Error415(w)
 			return
 		}

--- a/src/api/spend_test.go
+++ b/src/api/spend_test.go
@@ -131,7 +131,7 @@ func TestCreateTransaction(t *testing.T) {
 			name:        "415",
 			method:      http.MethodPost,
 			status:      http.StatusUnsupportedMediaType,
-			contentType: "application/x-www-form-urlencoded",
+			contentType: ContentTypeForm,
 			err:         "415 Unsupported Media Type",
 		},
 
@@ -862,7 +862,7 @@ func TestCreateTransaction(t *testing.T) {
 
 			contentType := tc.contentType
 			if contentType == "" {
-				contentType = "application/json"
+				contentType = ContentTypeJSON
 			}
 
 			req.Header.Add("Content-Type", contentType)

--- a/src/api/transaction.go
+++ b/src/api/transaction.go
@@ -247,7 +247,7 @@ func NewTransactionsWithStatusVerbose(txns []visor.Transaction, inputs [][]visor
 }
 
 // Returns transactions that match the filters.
-// Method: GET
+// Method: GET, POST
 // URI: /api/v1/transactions
 // Args:
 //     addrs: Comma separated addresses [optional, returns all transactions if no address provided]

--- a/src/api/transaction.go
+++ b/src/api/transaction.go
@@ -255,7 +255,7 @@ func NewTransactionsWithStatusVerbose(txns []visor.Transaction, inputs [][]visor
 //	   verbose: [bool] include verbose transaction input data
 func transactionsHandler(gateway Gatewayer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
+		if r.Method != http.MethodGet && r.Method != http.MethodPost {
 			wh.Error405(w)
 			return
 		}
@@ -491,7 +491,7 @@ func verifyTxnHandler(gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 
-		if r.Header.Get("Content-Type") != "application/json" {
+		if r.Header.Get("Content-Type") != ContentTypeJSON {
 			resp := NewHTTPErrorResponse(http.StatusUnsupportedMediaType, "")
 			writeHTTPResponse(w, resp)
 			return

--- a/src/api/transaction_test.go
+++ b/src/api/transaction_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"io"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -1019,7 +1020,7 @@ func TestGetTransactions(t *testing.T) {
 	}{
 		{
 			name:   "405",
-			method: http.MethodPost,
+			method: http.MethodDelete,
 			status: http.StatusMethodNotAllowed,
 			err:    "405 Method Not Allowed",
 		},
@@ -1135,11 +1136,27 @@ func TestGetTransactions(t *testing.T) {
 			},
 			httpResponse: []readable.TransactionWithStatusVerbose{},
 		},
+
+		{
+			name:   "200 POST",
+			method: http.MethodPost,
+			status: http.StatusOK,
+			httpBody: &httpBody{
+				addrs:     addrsStr,
+				confirmed: "true",
+			},
+			getTransactionsArg: []visor.TxFilter{
+				visor.NewAddrsFilter(addrs),
+				visor.NewConfirmedTxFilter(true),
+			},
+			getTransactionsResponse: []visor.Transaction{},
+			httpResponse:            []readable.TransactionWithStatus{},
+		},
 	}
 
 	for _, tc := range tt {
-		endpoint := "/api/v1/transactions"
 		t.Run(tc.name, func(t *testing.T) {
+			endpoint := "/api/v1/transactions"
 			gateway := &MockGatewayer{}
 
 			// Custom argument matching function for matching TxFilter args
@@ -1209,12 +1226,22 @@ func TestGetTransactions(t *testing.T) {
 					v.Add("verbose", tc.httpBody.verbose)
 				}
 			}
+
+			var reqBody io.Reader
 			if len(v) > 0 {
-				endpoint += "?" + v.Encode()
+				if tc.method == http.MethodPost {
+					reqBody = strings.NewReader(v.Encode())
+				} else {
+					endpoint += "?" + v.Encode()
+				}
 			}
 
-			req, err := http.NewRequest(tc.method, endpoint, nil)
+			req, err := http.NewRequest(tc.method, endpoint, reqBody)
 			require.NoError(t, err)
+
+			if tc.method == http.MethodPost {
+				req.Header.Set("Content-Type", ContentTypeForm)
+			}
 
 			csrfStore := &CSRFStore{
 				Enabled: true,
@@ -1343,7 +1370,7 @@ func TestVerifyTransaction(t *testing.T) {
 		{
 			name:         "400 - EOF",
 			method:       http.MethodPost,
-			contentType:  "application/json",
+			contentType:  ContentTypeJSON,
 			status:       http.StatusBadRequest,
 			httpResponse: NewHTTPErrorResponse(http.StatusBadRequest, "EOF"),
 		},
@@ -1357,7 +1384,7 @@ func TestVerifyTransaction(t *testing.T) {
 		{
 			name:         "400 - Invalid transaction: Not enough buffer data to deserialize",
 			method:       http.MethodPost,
-			contentType:  "application/json",
+			contentType:  ContentTypeJSON,
 			status:       http.StatusBadRequest,
 			httpBody:     `{"wrongKey":"wrongValue"}`,
 			httpResponse: NewHTTPErrorResponse(http.StatusBadRequest, "decode transaction failed: Invalid transaction: Not enough buffer data to deserialize"),
@@ -1365,7 +1392,7 @@ func TestVerifyTransaction(t *testing.T) {
 		{
 			name:         "400 - encoding/hex: odd length hex string",
 			method:       http.MethodPost,
-			contentType:  "application/json",
+			contentType:  ContentTypeJSON,
 			status:       http.StatusBadRequest,
 			httpBody:     `{"encoded_transaction":"aab"}`,
 			httpResponse: NewHTTPErrorResponse(http.StatusBadRequest, "decode transaction failed: encoding/hex: odd length hex string"),
@@ -1373,7 +1400,7 @@ func TestVerifyTransaction(t *testing.T) {
 		{
 			name:         "400 - deserialization error",
 			method:       http.MethodPost,
-			contentType:  "application/json",
+			contentType:  ContentTypeJSON,
 			status:       http.StatusBadRequest,
 			httpBody:     string(invalidTxnBodyJSON),
 			httpResponse: NewHTTPErrorResponse(http.StatusBadRequest, "decode transaction failed: Invalid transaction: Not enough buffer data to deserialize"),
@@ -1381,7 +1408,7 @@ func TestVerifyTransaction(t *testing.T) {
 		{
 			name:                       "422 - txn sends to empty address",
 			method:                     http.MethodPost,
-			contentType:                "application/json",
+			contentType:                ContentTypeJSON,
 			status:                     http.StatusUnprocessableEntity,
 			httpBody:                   string(invalidTxnEmptyAddressBodyJSON),
 			gatewayVerifyTxnVerboseArg: invalidTxnEmptyAddress.txn,
@@ -1400,7 +1427,7 @@ func TestVerifyTransaction(t *testing.T) {
 		{
 			name:                       "500 - internal server error",
 			method:                     http.MethodPost,
-			contentType:                "application/json",
+			contentType:                ContentTypeJSON,
 			status:                     http.StatusInternalServerError,
 			httpBody:                   string(validTxnBodyJSON),
 			gatewayVerifyTxnVerboseArg: txnAndInputs.txn,
@@ -1412,7 +1439,7 @@ func TestVerifyTransaction(t *testing.T) {
 		{
 			name:                       "422 - txn is confirmed",
 			method:                     http.MethodPost,
-			contentType:                "application/json",
+			contentType:                ContentTypeJSON,
 			status:                     http.StatusUnprocessableEntity,
 			httpBody:                   string(validTxnBodyJSON),
 			gatewayVerifyTxnVerboseArg: txnAndInputs.txn,
@@ -1431,7 +1458,7 @@ func TestVerifyTransaction(t *testing.T) {
 		{
 			name:                       "200",
 			method:                     http.MethodPost,
-			contentType:                "application/json",
+			contentType:                ContentTypeJSON,
 			status:                     http.StatusOK,
 			httpBody:                   string(validTxnBodyJSON),
 			gatewayVerifyTxnVerboseArg: txnAndInputs.txn,

--- a/src/api/wallet.go
+++ b/src/api/wallet.go
@@ -128,12 +128,12 @@ func walletBalanceHandler(gateway Gatewayer) http.HandlerFunc {
 // Returns the balance of one or more addresses, both confirmed and predicted.  The predicted
 // balance is the confirmed balance minus the pending spends.
 // URI: /api/v1/balance
-// Method: GET
+// Method: GET, POST
 // Args:
 //     addrs: command separated list of addresses [required]
 func balanceHandler(gateway Gatewayer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
+		if r.Method != http.MethodGet && r.Method != http.MethodPost {
 			wh.Error405(w)
 			return
 		}
@@ -949,7 +949,7 @@ func walletRecoverHandler(gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 
-		if r.Header.Get("Content-Type") != "application/json" {
+		if r.Header.Get("Content-Type") != ContentTypeJSON {
 			resp := NewHTTPErrorResponse(http.StatusUnsupportedMediaType, "")
 			writeHTTPResponse(w, resp)
 			return


### PR DESCRIPTION
Fixes #1971

Changes:
- `/api/v1/balance`, `/api/v1/transactions`, `/api/v1/outputs` and `/api/v1/blocks` accept the `POST` method so that large request bodies can be sent to the server, which would not fit in a `GET` query string

The URL max is about 4000 characters. This is indirectly controlled by [`http.Server.MaxHeaderBytes`](https://golang.org/pkg/net/http/#Server).

Does this change need to mentioned in CHANGELOG.md?
Yes