### PR TITLE
Add a warning when decrypting a wallet

### DIFF
--- a/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.html
@@ -1,5 +1,5 @@
 <app-modal [headline]="data.title ? (data.title | translate) : ('password.title' | translate)" [dialog]="dialogRef" [disableDismiss]="disableDismiss">
-  <p class="-info" *ngIf="data.description">{{ data.description }}</p>
+  <p class="-info" [ngClass]="{'-warning' : data.warning}" *ngIf="data.description">{{ data.description | translate }}</p>
   <div [formGroup]="form">
     <div class="form-field">
       <label for="password">{{ 'password.label' | translate }}</label>

--- a/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.scss
+++ b/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.scss
@@ -11,6 +11,10 @@
   line-height: 1.5;
 }
 
+.-warning {
+  color: $red;
+}
+
 .link {
   font-size: 13px;
   width: 100%;

--- a/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.ts
@@ -31,6 +31,7 @@ export class PasswordDialogComponent implements OnInit, OnDestroy {
     this.data = Object.assign({
       confirm: false,
       description: null,
+      warning: false,
       title: null,
       wallet: null,
     }, data || {});

--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
@@ -22,7 +22,7 @@ export class WalletDetailComponent implements OnDestroy {
   constructor(
     private dialog: MatDialog,
     private walletService: WalletService,
-    private snackbar: MatSnackBar
+    private snackbar: MatSnackBar,
   ) { }
 
   ngOnDestroy() {

--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
@@ -7,7 +7,6 @@ import { QrCodeComponent } from '../../../layout/qr-code/qr-code.component';
 import { PasswordDialogComponent } from '../../../layout/password-dialog/password-dialog.component';
 import { MatSnackBar } from '@angular/material';
 import { showSnackbarError } from '../../../../utils/errors';
-import { TranslateService } from '@ngx-translate/core';
 import { NumberOfAddressesComponent } from '../number-of-addresses/number-of-addresses';
 
 @Component({
@@ -15,24 +14,16 @@ import { NumberOfAddressesComponent } from '../number-of-addresses/number-of-add
   templateUrl: './wallet-detail.component.html',
   styleUrls: ['./wallet-detail.component.scss'],
 })
-export class WalletDetailComponent implements OnInit, OnDestroy {
+export class WalletDetailComponent implements OnDestroy {
   @Input() wallet: Wallet;
 
-  private encryptionWarning: string;
   private HowManyAddresses: number;
 
   constructor(
     private dialog: MatDialog,
     private walletService: WalletService,
-    private snackbar: MatSnackBar,
-    private translateService: TranslateService,
+    private snackbar: MatSnackBar
   ) { }
-
-  ngOnInit() {
-    this.translateService.get('wallet.new.encrypt-warning').subscribe(msg => {
-      this.encryptionWarning = msg;
-    });
-  }
 
   ngOnDestroy() {
     this.snackbar.dismiss();
@@ -71,8 +62,10 @@ export class WalletDetailComponent implements OnInit, OnDestroy {
     };
 
     if (!this.wallet.encrypted) {
-      config.data['description'] = this.encryptionWarning;
+      config.data['description'] = 'wallet.new.encrypt-warning';
     } else {
+      config.data['description'] = 'wallet.decrypt-warning';
+      config.data['warning'] = true;
       config.data['wallet'] = this.wallet;
     }
 

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -96,6 +96,7 @@
     "hide-empty": "Hide Empty",
     "encrypt": "Encrypt Wallet",
     "decrypt": "Decrypt Wallet",
+    "decrypt-warning": "Warning: for security reasons, it is not recommended to keep the wallets unencrypted. Caution is advised.",
     "edit": "Edit Wallet",
     "add": "Add Wallet",
     "load": "Load Wallet",


### PR DESCRIPTION
Changes:
- When the option for encrypting a wallet is selected, a message is displayed indicating that it is recommended to encrypt all wallets. With this pr when selecting the option to decrypt a wallet a warning is shown indicating to the user that it is not recommended to do so:
![warning](https://user-images.githubusercontent.com/34079003/47463980-d9ec6200-d7b5-11e8-96e8-f1dafe05daf7.png)

- The message that appears in the upper part of the password dialog, when encrypting or decrypting a wallet, is now translated inside the HTML file, which is more convenient to keep the code clean and future functionality.

Does this change need to mentioned in CHANGELOG.md?
No