### PR TITLE
Use POST for long queries

### DIFF
--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -75,7 +75,7 @@ export class WalletService {
     return this.addressesAsString()
       .first()
       .filter(addresses => !!addresses)
-      .flatMap(addresses => this.apiService.get('outputs', {addrs: addresses}));
+      .flatMap(addresses => this.apiService.post('outputs', {addrs: addresses}));
   }
 
   outputsWithWallets(): Observable<any> {
@@ -198,17 +198,9 @@ export class WalletService {
     return this.allAddresses().first().flatMap(addresses => {
       this.addresses = addresses;
 
-      return Observable.forkJoin(addresses.map(address => this.apiService.getExplorerAddress(address)));
+      return this.apiService.getTransactions(addresses);
     }).map(transactions => {
-      return []
-        .concat.apply([], transactions)
-        .reduce((array, item) => {
-          if (!array.find(trans => trans.txid === item.txid)) {
-            array.push(item);
-          }
-
-          return array;
-        }, [])
+      return transactions
         .sort((a, b) =>  b.timestamp - a.timestamp)
         .map(transaction => {
           const outgoing = this.addresses.some(address => {


### PR DESCRIPTION
Changes:
- Stops using GET and start using POST for the calls made to the api with a lot of addresses.
- A mechanism was created to avoid racing conditions while getting csrf tokens, as the node invalidates them right after the first use and that cause big problems with racing conditions. If this is not done, a racing condition happens if the browser is refreshed on the history or the outputs page, as a csrf token is requested on `AppService` and then another one for getting the data for the page, and then the page remains loading indefinitely.

Does this change need to mentioned in CHANGELOG.md?
No