### PR TITLE
Send GIVP before disconnecting due to peer list full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ Make sure to upgrade to v0.25.0 so that your node will continue to connect once 
 - `/api/v1/network/connection*` field `"connected_at"` added to connection object
 - `/api/v1/network/connections` now includes incoming connections. Filters are added to query connections by state and direction
 - `/api/v1/resendUnconfirmedTxns` is now a `POST` method, previously was a `GET` method
+- Node will send more peers before disconnecting due to a full peer list
 
 ### Removed
 

--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -232,12 +232,8 @@ type daemoner interface {
 	Disconnect(addr string, r gnet.DisconnectReason) error
 	DisconnectNow(addr string, r gnet.DisconnectReason) error
 	PexConfig() pex.Config
-	RandomExchangeable(n int) pex.Peers
-	AddPeer(addr string) error
 	AddPeers(addrs []string) int
-	SetHasIncomingPort(addr string) error
 	IncreaseRetryTimes(addr string)
-	ResetRetryTimes(addr string)
 	RecordPeerHeight(addr string, gnetID, height uint64)
 	GetSignedBlocksSince(seq, count uint64) ([]coin.SignedBlock, error)
 	HeadBkSeq() (uint64, bool, error)
@@ -250,10 +246,10 @@ type daemoner interface {
 	BlockchainPubkey() cipher.PubKey
 	RequestBlocksFromAddr(addr string) error
 	AnnounceAllTxns() error
-	RecordUserAgent(addr string, userAgent useragent.Data) error
 
 	recordMessageEvent(m asyncMessage, c *gnet.MessageContext) error
 	connectionIntroduced(addr string, gnetID uint64, m *IntroductionMessage, userAgent *useragent.Data) (*connection, error)
+	sendRandomPeers(addr string) error
 }
 
 // Daemon stateful properties of the daemon
@@ -829,15 +825,15 @@ func (dm *Daemon) onMessageEvent(e messageEvent) {
 		return
 	}
 
-	// The first message received must be an IntroductionMessage
+	// The first message received must be INTR, DISC or GIVP
 	if !c.HasIntroduced() {
 		switch e.Message.(type) {
-		case *IntroductionMessage, *DisconnectMessage:
+		case *IntroductionMessage, *DisconnectMessage, *GivePeersMessage:
 		default:
 			logger.WithFields(logrus.Fields{
 				"addr":        e.Context.Addr,
 				"messageType": fmt.Sprintf("%T", e.Message),
-			}).Info("needsIntro but first message is not INTR or DISC")
+			}).Info("needsIntro but first message is not INTR, DISC or GIVP")
 			if err := dm.Disconnect(e.Context.Addr, ErrDisconnectNoIntroduction); err != nil {
 				logger.WithError(err).WithField("addr", e.Context.Addr).Error("Disconnect")
 			}
@@ -1232,8 +1228,58 @@ func (dm *Daemon) BlockchainPubkey() cipher.PubKey {
 }
 
 // connectionIntroduced transfers a connection to the "introduced" state in the connections state machine
+// and updates other state
 func (dm *Daemon) connectionIntroduced(addr string, gnetID uint64, m *IntroductionMessage, userAgent *useragent.Data) (*connection, error) {
-	return dm.connections.introduced(addr, gnetID, m, userAgent)
+	c, err := dm.connections.introduced(addr, gnetID, m, userAgent)
+	if err != nil {
+		return nil, err
+	}
+
+	listenAddr := c.ListenAddr()
+
+	fields := logrus.Fields{
+		"addr":       addr,
+		"gnetID":     m.c.ConnID,
+		"connGnetID": c.gnetID,
+		"listenPort": m.ListenPort,
+		"listenAddr": listenAddr,
+	}
+
+	if c.Outgoing {
+		// For successful outgoing connections, mark the peer as having an incoming port in the pex peerlist
+		// The peer should already be in the peerlist, since we use the peerlist to choose an outgoing connection to make
+		if err := dm.pex.SetHasIncomingPort(listenAddr, true); err != nil {
+			logger.Critical().WithError(err).WithFields(fields).Error("pex.SetHasIncomingPort failed")
+			return nil, err
+		}
+	} else {
+		// For successful incoming connections, add the peer to the peer list, with their self-reported listen port
+		if err := dm.pex.AddPeer(listenAddr); err != nil {
+			logger.Critical().WithError(err).WithFields(fields).Error("pex.AddPeer failed")
+			return nil, err
+		}
+	}
+
+	dm.pex.ResetRetryTimes(listenAddr)
+
+	if err := dm.pex.SetUserAgent(listenAddr, c.UserAgent); err != nil {
+		logger.Critical().WithError(err).WithFields(fields).Error("pex.SetUserAgent failed")
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// sendRandomPeers sends a random sample of peers to another peer
+func (dm *Daemon) sendRandomPeers(addr string) error {
+	peers := dm.pex.RandomExchangeable(dm.pex.Config.ReplyCount)
+	if len(peers) == 0 {
+		logger.Debug("sendRandomPeers: no peers to send in reply")
+		return errors.New("No peers available")
+	}
+
+	m := NewGivePeersMessage(peers)
+	return dm.SendMessage(addr, m)
 }
 
 // Implements pooler interface
@@ -1279,34 +1325,14 @@ func (dm *Daemon) DisconnectNow(addr string, r gnet.DisconnectReason) error {
 
 // Implements pexer interface
 
-// RandomExchangeable returns N random exchangeable peers
-func (dm *Daemon) RandomExchangeable(n int) pex.Peers {
-	return dm.pex.RandomExchangeable(n)
-}
-
 // PexConfig returns the pex config
 func (dm *Daemon) PexConfig() pex.Config {
 	return dm.pex.Config
 }
 
-// AddPeer adds peer to the pex
-func (dm *Daemon) AddPeer(addr string) error {
-	return dm.pex.AddPeer(addr)
-}
-
 // AddPeers adds peers to the pex
 func (dm *Daemon) AddPeers(addrs []string) int {
 	return dm.pex.AddPeers(addrs)
-}
-
-// SetHasIncomingPort sets the peer public peer
-func (dm *Daemon) SetHasIncomingPort(addr string) error {
-	return dm.pex.SetHasIncomingPort(addr, true)
-}
-
-// RecordUserAgent sets the peer's user agent
-func (dm *Daemon) RecordUserAgent(addr string, userAgent useragent.Data) error {
-	return dm.pex.SetUserAgent(addr, userAgent)
 }
 
 // IncreaseRetryTimes increases the retry times of given peer

--- a/src/daemon/errors.go
+++ b/src/daemon/errors.go
@@ -37,6 +37,8 @@ var (
 	ErrDisconnectInvalidUserAgent gnet.DisconnectReason = errors.New("Invalid user agent")
 	// ErrDisconnectRequestedByOperator the operator of the node requested a disconnect
 	ErrDisconnectRequestedByOperator gnet.DisconnectReason = errors.New("Disconnect requested by the node operator")
+	// ErrDisconnectPeerlistFull the peerlist is full
+	ErrDisconnectPeerlistFull gnet.DisconnectReason = errors.New("Peerlist is full")
 
 	// ErrDisconnectUnknownReason used when mapping an unknown reason code to an error. Is not sent over the network.
 	ErrDisconnectUnknownReason gnet.DisconnectReason = errors.New("Unknown DisconnectReason")
@@ -59,6 +61,7 @@ var (
 		ErrDisconnectReceivedDisconnect:            13,
 		ErrDisconnectInvalidUserAgent:              14,
 		ErrDisconnectRequestedByOperator:           15,
+		ErrDisconnectPeerlistFull:                  16,
 
 		// gnet codes are registered here, but they are not sent in a DISC
 		// message by gnet. Only daemon sends a DISC packet.

--- a/src/daemon/messages.go
+++ b/src/daemon/messages.go
@@ -218,8 +218,8 @@ func (gpm *GivePeersMessage) process(d daemoner) {
 
 	// Cap the number of peers printed in the log to prevent log spam abuse
 	peersToFmt := peers
-	if len(peersToFmt) > 1 {
-		peersToFmt = peersToFmt[:1]
+	if len(peersToFmt) > 30 {
+		peersToFmt = peersToFmt[:30]
 	}
 	peersStr := strings.Join(peersToFmt, ", ")
 	if len(peers) != len(peersToFmt) {

--- a/src/daemon/messages.go
+++ b/src/daemon/messages.go
@@ -391,7 +391,7 @@ func (intro *IntroductionMessage) verify(d daemoner) (*useragent.Data, error) {
 	if len(intro.Extra) > 0 {
 		var bcPubKey cipher.PubKey
 		if len(intro.Extra) < len(bcPubKey) {
-			logger.WithFields(fields).Info("Extra data length does not meet the minimum requirement")
+			logger.WithFields(fields).Warning("Extra data length does not meet the minimum requirement")
 			return nil, ErrDisconnectInvalidExtraData
 		}
 		copy(bcPubKey[:], intro.Extra[:len(bcPubKey)])
@@ -400,20 +400,20 @@ func (intro *IntroductionMessage) verify(d daemoner) (*useragent.Data, error) {
 			logger.WithFields(fields).WithFields(logrus.Fields{
 				"pubkey":       bcPubKey.Hex(),
 				"daemonPubkey": d.BlockchainPubkey().Hex(),
-			}).Info("Blockchain pubkey does not match")
+			}).Warning("Blockchain pubkey does not match")
 			return nil, ErrDisconnectBlockchainPubkeyNotMatched
 		}
 
 		userAgentSerialized := intro.Extra[len(bcPubKey):]
 		userAgent, _, err := encoder.DeserializeString(userAgentSerialized, useragent.MaxLen)
 		if err != nil {
-			logger.WithError(err).WithFields(fields).Info("Extra data user agent string could not be deserialized")
+			logger.WithError(err).WithFields(fields).Warning("Extra data user agent string could not be deserialized")
 			return nil, ErrDisconnectInvalidExtraData
 		}
 
 		userAgentData, err = useragent.Parse(useragent.Sanitize(userAgent))
 		if err != nil {
-			logger.WithError(err).WithFields(fields).WithField("userAgent", userAgent).Info("User agent is invalid")
+			logger.WithError(err).WithFields(fields).WithField("userAgent", userAgent).Warning("User agent is invalid")
 			return nil, ErrDisconnectInvalidUserAgent
 		}
 	}

--- a/src/daemon/messages_test.go
+++ b/src/daemon/messages_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/skycoin/skycoin/src/cipher/encoder"
 	"github.com/skycoin/skycoin/src/coin"
 	"github.com/skycoin/skycoin/src/daemon/gnet"
+	"github.com/skycoin/skycoin/src/daemon/pex"
 	"github.com/skycoin/skycoin/src/util/useragent"
 )
 
@@ -39,6 +40,7 @@ func TestIntroductionMessage(t *testing.T) {
 		requestBlocksFromAddrErr error
 		announceAllTxnsErr       error
 		recordUserAgentErr       error
+		sendRandomPeersErr       error
 	}
 
 	tt := []struct {
@@ -257,6 +259,34 @@ func TestIntroductionMessage(t *testing.T) {
 			},
 		},
 		{
+			name: "incoming connection peer list full",
+			addr: "121.121.121.121:12345",
+			mockValue: daemonMockValue{
+				mirror:           10000,
+				protocolVersion:  1,
+				pubkey:           pubkey,
+				addPeerArg:       "121.121.121.121:6000",
+				addPeerErr:       pex.ErrPeerlistFull,
+				disconnectReason: ErrDisconnectPeerlistFull,
+				connectionIntroduced: &connection{
+					Addr: "121.121.121.121:12345",
+					ConnectionDetails: ConnectionDetails{
+						ListenPort: 6000,
+						UserAgent: useragent.Data{
+							Coin:    "skycoin",
+							Version: "0.24.1",
+							Remark:  "foo",
+						},
+					},
+				},
+			},
+			intro: &IntroductionMessage{
+				Mirror:          10001,
+				ProtocolVersion: 1,
+				ListenPort:      6000,
+			},
+		},
+		{
 			name:      "Connect twice",
 			addr:      "121.121.121.121:6000",
 			gnetID:    2,
@@ -297,7 +327,7 @@ func TestIntroductionMessage(t *testing.T) {
 			d.On("Mirror").Return(tc.mockValue.mirror)
 			d.On("SetHasIncomingPort", tc.addr).Return(tc.mockValue.setHasIncomingPortErr)
 			d.On("recordMessageEvent", tc.intro, mc).Return(tc.mockValue.recordMessageEventErr)
-			d.On("ResetRetryTimes", tc.addr)
+			d.On("ResetRetryTimes", tc.mockValue.addPeerArg)
 			d.On("BlockchainPubkey").Return(tc.mockValue.pubkey)
 			d.On("Disconnect", tc.addr, tc.mockValue.disconnectReason).Return(tc.mockValue.disconnectErr)
 			d.On("IncreaseRetryTimes", tc.addr)
@@ -306,6 +336,7 @@ func TestIntroductionMessage(t *testing.T) {
 			d.On("connectionIntroduced", tc.addr, tc.gnetID, tc.intro, mock.Anything).Return(tc.mockValue.connectionIntroduced, tc.mockValue.connectionIntroducedErr)
 			d.On("RequestBlocksFromAddr", tc.addr).Return(tc.mockValue.requestBlocksFromAddrErr)
 			d.On("AnnounceAllTxns").Return(tc.mockValue.announceAllTxnsErr)
+			d.On("SendRandomPeers", tc.addr).Return(tc.mockValue.sendRandomPeersErr)
 
 			var userAgent useragent.Data
 			if tc.mockValue.connectionIntroduced != nil {

--- a/src/daemon/mock_daemoner_test.go
+++ b/src/daemon/mock_daemoner_test.go
@@ -52,8 +52,8 @@ func (_m *mockDaemoner) recordMessageEvent(m asyncMessage, c *gnet.MessageContex
 	return r0
 }
 
-// AddPeer provides a mock function with given fields: addr
-func (_m *mockDaemoner) AddPeer(addr string) error {
+// sendRandomPeers provides a mock function with given fields: addr
+func (_m *mockDaemoner) sendRandomPeers(addr string) error {
 	ret := _m.Called(addr)
 
 	var r0 error
@@ -340,39 +340,9 @@ func (_m *mockDaemoner) PexConfig() pex.Config {
 	return r0
 }
 
-// RandomExchangeable provides a mock function with given fields: n
-func (_m *mockDaemoner) RandomExchangeable(n int) pex.Peers {
-	ret := _m.Called(n)
-
-	var r0 pex.Peers
-	if rf, ok := ret.Get(0).(func(int) pex.Peers); ok {
-		r0 = rf(n)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(pex.Peers)
-		}
-	}
-
-	return r0
-}
-
 // RecordPeerHeight provides a mock function with given fields: addr, gnetID, height
 func (_m *mockDaemoner) RecordPeerHeight(addr string, gnetID uint64, height uint64) {
 	_m.Called(addr, gnetID, height)
-}
-
-// RecordUserAgent provides a mock function with given fields: addr, userAgent
-func (_m *mockDaemoner) RecordUserAgent(addr string, userAgent useragent.Data) error {
-	ret := _m.Called(addr, userAgent)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string, useragent.Data) error); ok {
-		r0 = rf(addr, userAgent)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
 }
 
 // RequestBlocksFromAddr provides a mock function with given fields: addr
@@ -389,11 +359,6 @@ func (_m *mockDaemoner) RequestBlocksFromAddr(addr string) error {
 	return r0
 }
 
-// ResetRetryTimes provides a mock function with given fields: addr
-func (_m *mockDaemoner) ResetRetryTimes(addr string) {
-	_m.Called(addr)
-}
-
 // SendMessage provides a mock function with given fields: addr, msg
 func (_m *mockDaemoner) SendMessage(addr string, msg gnet.Message) error {
 	ret := _m.Called(addr, msg)
@@ -401,20 +366,6 @@ func (_m *mockDaemoner) SendMessage(addr string, msg gnet.Message) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, gnet.Message) error); ok {
 		r0 = rf(addr, msg)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// SetHasIncomingPort provides a mock function with given fields: addr
-func (_m *mockDaemoner) SetHasIncomingPort(addr string) error {
-	ret := _m.Called(addr)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(addr)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/src/daemon/mock_daemoner_test.go
+++ b/src/daemon/mock_daemoner_test.go
@@ -277,11 +277,6 @@ func (_m *mockDaemoner) HeadBkSeq() (uint64, bool, error) {
 	return r0, r1, r2
 }
 
-// IncreaseRetryTimes provides a mock function with given fields: addr
-func (_m *mockDaemoner) IncreaseRetryTimes(addr string) {
-	_m.Called(addr)
-}
-
 // InjectTransaction provides a mock function with given fields: txn
 func (_m *mockDaemoner) InjectTransaction(txn coin.Transaction) (bool, *visor.ErrTxnViolatesSoftConstraint, error) {
 	ret := _m.Called(txn)

--- a/src/daemon/pex/peerlist.go
+++ b/src/daemon/pex/peerlist.go
@@ -181,10 +181,6 @@ func canTry(p Peer) bool {
 	return p.CanTry()
 }
 
-func zeroRetryTimes(p Peer) bool {
-	return p.RetryTimes == 0
-}
-
 // isExchangeable filters exchangeable peers
 var isExchangeable = []Filter{hasIncomingPort, isPublic}
 

--- a/src/daemon/pex/peerlist.go
+++ b/src/daemon/pex/peerlist.go
@@ -121,7 +121,6 @@ func (pl *peerlist) addPeers(addrs []string) {
 func (pl *peerlist) seen(addr string) {
 	if p, ok := pl.peers[addr]; ok && p != nil {
 		p.Seen()
-		p.ResetRetryTimes()
 	}
 }
 

--- a/src/daemon/pex/pex.go
+++ b/src/daemon/pex/pex.go
@@ -440,12 +440,12 @@ func (px *Pex) AddPeer(addr string) error {
 	}
 
 	if px.isFull() {
-		worstPeer := px.peerlist.findWorstPeer()
-		if worstPeer == nil {
+		oldestPeer := px.peerlist.findOldestUntrustedPeer()
+		if oldestPeer == nil || time.Now().UTC().Unix()-oldestPeer.LastSeen < 60*60*24 {
 			return ErrPeerlistFull
 		}
 
-		px.peerlist.removePeer(worstPeer.Addr)
+		px.peerlist.removePeer(oldestPeer.Addr)
 
 		if px.isFull() {
 			// This should never happen, but if it does, don't return an error

--- a/src/daemon/pex/pex_test.go
+++ b/src/daemon/pex/pex_test.go
@@ -423,9 +423,8 @@ func TestPexAddPeer(t *testing.T) {
 					LastSeen: now,
 				},
 				{
-					Addr:       testPeers[1],
-					LastSeen:   now - 60,
-					RetryTimes: 1,
+					Addr:     testPeers[1],
+					LastSeen: now - 60,
 				},
 			},
 			max:      2,
@@ -435,7 +434,7 @@ func TestPexAddPeer(t *testing.T) {
 			check: func(px *Pex) {
 				p := px.peerlist.peers[testPeers[1]]
 				require.NotNil(t, p)
-				require.Equal(t, 0, p.RetryTimes)
+				// Peer should have been marked as seen
 				require.True(t, p.LastSeen > now-60)
 			},
 		},

--- a/src/daemon/pex/pex_test.go
+++ b/src/daemon/pex/pex_test.go
@@ -424,7 +424,7 @@ func TestPexAddPeer(t *testing.T) {
 				},
 				{
 					Addr:       testPeers[1],
-					LastSeen:   now,
+					LastSeen:   now - 60,
 					RetryTimes: 1,
 				},
 			},
@@ -436,7 +436,7 @@ func TestPexAddPeer(t *testing.T) {
 				p := px.peerlist.peers[testPeers[1]]
 				require.NotNil(t, p)
 				require.Equal(t, 0, p.RetryTimes)
-				require.True(t, p.LastSeen >= now)
+				require.True(t, p.LastSeen > now-60)
 			},
 		},
 		{
@@ -680,92 +680,79 @@ func TestPexRandomExchangeable(t *testing.T) {
 		expectPeers []Peer
 	}{
 		{
-			"n=0 exchangeable=0",
-			[]Peer{
+			name: "n=0 exchangeable=0",
+			peers: []Peer{
 				Peer{Addr: testPeers[0], Private: true, HasIncomingPort: true},
 				Peer{Addr: testPeers[1], Private: true, HasIncomingPort: true},
 				Peer{Addr: testPeers[2], Private: true, HasIncomingPort: true},
 			},
-			0,
-			0,
-			[]Peer{},
+			n:           0,
+			expectN:     0,
+			expectPeers: []Peer{},
 		},
 		{
-			"n=0 exchangeable=1",
-			[]Peer{
+			name: "n=0 exchangeable=1",
+			peers: []Peer{
 				Peer{Addr: testPeers[0], Private: false, HasIncomingPort: true},
 				Peer{Addr: testPeers[1], Private: true, HasIncomingPort: true},
 				Peer{Addr: testPeers[2], Private: true, HasIncomingPort: true},
 			},
-			0,
-			1,
-			[]Peer{
+			n:       0,
+			expectN: 1,
+			expectPeers: []Peer{
 				Peer{Addr: testPeers[0], Private: false, HasIncomingPort: true},
 			},
 		},
 		{
-			"n=0 exchangeable=2",
-			[]Peer{
+			name: "n=0 exchangeable=2",
+			peers: []Peer{
 				Peer{Addr: testPeers[0], Private: false, HasIncomingPort: true},
 				Peer{Addr: testPeers[1], Private: false, HasIncomingPort: true},
 				Peer{Addr: testPeers[2], Private: true, HasIncomingPort: true},
 			},
-			0,
-			2,
-			[]Peer{
+			n:       0,
+			expectN: 2,
+			expectPeers: []Peer{
 				Peer{Addr: testPeers[0], Private: false, HasIncomingPort: true},
 				Peer{Addr: testPeers[1], Private: false, HasIncomingPort: true},
 			},
 		},
 		{
-			"n=1 exchangeable=0",
-			[]Peer{
+			name: "n=1 exchangeable=0",
+			peers: []Peer{
 				Peer{Addr: testPeers[0], Private: true, HasIncomingPort: true},
 				Peer{Addr: testPeers[1], Private: true, HasIncomingPort: true},
 				Peer{Addr: testPeers[2], Private: true, HasIncomingPort: true},
 			},
-			1,
-			0,
-			[]Peer{},
+			n:           1,
+			expectN:     0,
+			expectPeers: []Peer{},
 		},
 		{
-			"n=1 exchangeable=1",
-			[]Peer{
+			name: "n=1 exchangeable=1",
+			peers: []Peer{
 				Peer{Addr: testPeers[0], Private: false, HasIncomingPort: true},
 				Peer{Addr: testPeers[1], Private: false, HasIncomingPort: false},
 				Peer{Addr: testPeers[2], Private: true, HasIncomingPort: true},
 			},
-			1,
-			1,
-			[]Peer{
+			n:       1,
+			expectN: 1,
+			expectPeers: []Peer{
 				Peer{Addr: testPeers[0], Private: false, HasIncomingPort: true},
 			},
 		},
 		{
-			"n=1 exchangeable=2",
-			[]Peer{
+			name: "n=1 exchangeable=2",
+			peers: []Peer{
 				Peer{Addr: testPeers[0], Private: false, HasIncomingPort: true},
 				Peer{Addr: testPeers[1], Private: false, HasIncomingPort: true},
 				Peer{Addr: testPeers[2], Private: true, HasIncomingPort: true},
 			},
-			1,
-			1,
-			[]Peer{
+			n:       1,
+			expectN: 1,
+			expectPeers: []Peer{
 				Peer{Addr: testPeers[0], Private: false, HasIncomingPort: true},
 				Peer{Addr: testPeers[1], Private: false, HasIncomingPort: true},
-			},
-		},
-		{
-			"n=2 exchangeable=1",
-			[]Peer{
-				Peer{Addr: testPeers[0], Private: false, HasIncomingPort: true},
-				Peer{Addr: testPeers[1], Private: false, HasIncomingPort: true, RetryTimes: 1},
-				Peer{Addr: testPeers[2], Private: true, HasIncomingPort: true},
-			},
-			2,
-			1,
-			[]Peer{
-				Peer{Addr: testPeers[0], Private: false, HasIncomingPort: true},
 			},
 		},
 	}

--- a/src/skycoin/config.go
+++ b/src/skycoin/config.go
@@ -545,7 +545,7 @@ func (c *NodeConfig) RegisterFlags() {
 	flag.IntVar(&c.MaxConnections, "max-connections", c.MaxConnections, "Maximum number of total connections allowed")
 	flag.IntVar(&c.MaxOutgoingConnections, "max-outgoing-connections", c.MaxOutgoingConnections, "Maximum number of outgoing connections allowed")
 	flag.IntVar(&c.MaxDefaultPeerOutgoingConnections, "max-default-peer-outgoing-connections", c.MaxDefaultPeerOutgoingConnections, "The maximum default peer outgoing connections allowed")
-	flag.IntVar(&c.PeerlistSize, "peerlist-size", c.PeerlistSize, "The peer list size")
+	flag.IntVar(&c.PeerlistSize, "peerlist-size", c.PeerlistSize, "Max number of peers to track in peerlist")
 	flag.DurationVar(&c.OutgoingConnectionsRate, "connection-rate", c.OutgoingConnectionsRate, "How often to make an outgoing connection")
 	flag.BoolVar(&c.LocalhostOnly, "localhost-only", c.LocalhostOnly, "Run on localhost and only connect to localhost peers")
 	flag.BoolVar(&c.Arbitrating, "arbitrating", c.Arbitrating, "Run node in arbitrating mode")


### PR DESCRIPTION
Fixes #735 

Changes:
- Sends a GIVP message before disconnecting due to full peers
- When adding an incoming peer, if the peerlist is full, kick out the oldest peer if the oldest peer was last seen in over 24 hours

This GIVP is unlikely to be sent since the default peerlist size is 65535 and the oldest peer would be kicked out.  However, there are still certain DoS scenarios that could flood peerlists and cause problems. The peerlist data will need to track the idea of "Seen" as in received via PEX versus "Seen" as in successfully established a connection to resolve part of that problem.

Does this change need to mentioned in CHANGELOG.md?
Yes