### PR TITLE
Increase VERSION_UPGRADE_TEST_WAIT_TIMEOUT for osx builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       # Do not start osx build for PR
       if: type != pull_request
       osx_image: xcode8
-      env: VERSION_UPGRADE_TEST_WAIT_TIMEOUT=30s
+      env: VERSION_UPGRADE_TEST_WAIT_TIMEOUT=60s
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt-get update -qq; fi


### PR DESCRIPTION

Changes:
- Increase VERSION_UPGRADE_TEST_WAIT_TIMEOUT for osx builds on travis

Does this change need to mentioned in CHANGELOG.md?
No