### PR TITLE
Maintain at least one trusted connection

### DIFF
--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -769,7 +769,7 @@ func (dm *Daemon) maybeConnectToTrustedPeer() error {
 	peers := dm.pex.TrustedPublic()
 	for _, p := range peers {
 		// Don't make a connection if we have a trusted peer connection
-		if dm.connections.get(p.Addr) != nil {
+		if len(dm.connections.getByListenAddr(p.Addr)) != 0 {
 			return nil
 		}
 	}

--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -566,8 +566,7 @@ loop:
 			elapser.Register("outgoingTrustedConnectionsTicker")
 			// If connecting to a trusted peer totally fails, make sure to wait longer between further attempts
 			if outgoingTrustedConnectionsTickerSkip {
-				delta := time.Now().Sub(outgoingTrustedConnectionsTickerSkipStart)
-				if delta < outgoingTrustedConnectionsTickerSkipDuration {
+				if time.Since(outgoingTrustedConnectionsTickerSkipStart) < outgoingTrustedConnectionsTickerSkipDuration {
 					continue
 				}
 			}

--- a/src/daemon/gnet/pool.go
+++ b/src/daemon/gnet/pool.go
@@ -61,8 +61,8 @@ var (
 	ErrPoolEmpty = errors.New("Connection pool is empty after filtering connections")
 	// ErrConnectionExists connection exists
 	ErrConnectionExists = errors.New("Connection exists")
-	// ErrMaxConnectionsReached max connection reached
-	ErrMaxConnectionsReached = errors.New("Max connections reached")
+	// ErrMaxIncomingConnectionsReached max incoming connections reached
+	ErrMaxIncomingConnectionsReached = errors.New("Max incoming connections reached")
 	// ErrMaxOutgoingConnectionsReached max outgoing connections reached
 	ErrMaxOutgoingConnectionsReached = errors.New("Max outgoing connections reached")
 	// ErrMaxOutgoingDefaultConnectionsReached max outgoing default connections reached
@@ -98,7 +98,7 @@ type Config struct {
 	Address string
 	// Port to listen on. Set to 0 for arbitrary assignment
 	Port uint16
-	// Maximum total connections
+	// Maximum total connections. Must be >= MaxOutgoingConnections + MaxDefaultPeerOutgoingConnections.
 	MaxConnections int
 	// Maximum outgoing connections
 	MaxOutgoingConnections int
@@ -252,12 +252,16 @@ type ConnectionPool struct {
 // NewConnectionPool creates a new ConnectionPool that will listen on
 // Config.Port upon StartListen. State is an application defined object that
 // will be passed to a Message's Handle().
-func NewConnectionPool(c Config, state interface{}) *ConnectionPool {
+func NewConnectionPool(c Config, state interface{}) (*ConnectionPool, error) {
 	for _, p := range c.DefaultConnections {
 		c.defaultConnections[p] = struct{}{}
 	}
 
-	pool := &ConnectionPool{
+	if c.MaxConnections < c.MaxOutgoingConnections+c.MaxDefaultPeerOutgoingConnections {
+		return nil, errors.New("MaxConnections must be >= MaxOutgoingConnections + MaxDefaultPeerOutgoingConnections")
+	}
+
+	return &ConnectionPool{
 		Config:                     c,
 		pool:                       make(map[uint64]*Connection),
 		addresses:                  make(map[string]*Connection),
@@ -269,9 +273,7 @@ func NewConnectionPool(c Config, state interface{}) *ConnectionPool {
 		done:                       make(chan struct{}),
 		strandDone:                 make(chan struct{}),
 		reqC:                       make(chan strand.Request),
-	}
-
-	return pool
+	}, nil
 }
 
 // Run starts the connection pool
@@ -395,15 +397,13 @@ func (pool *ConnectionPool) Shutdown() {
 	<-pool.done
 }
 
-// strand ensures all read and write action of pool's member variable are in one thread.
+// strand ensures all read and write action of pool's member variable are in one thread
 func (pool *ConnectionPool) strand(name string, f func() error) error {
 	name = fmt.Sprintf("daemon.gnet.ConnectionPool.%s", name)
 	return strand.Strand(logger, pool.reqC, name, f, pool.quit, ErrConnectionPoolClosed)
 }
 
-// ListeningAddress returns address, on which the ConnectionPool
-// listening on. It returns nil, and error if the ConnectionPool
-// is not listening
+// ListeningAddress returns the address on which the ConnectionPool listens on
 func (pool *ConnectionPool) ListeningAddress() (net.Addr, error) {
 	if pool.listener == nil {
 		return nil, errors.New("Not listening, call StartListen first")
@@ -416,20 +416,14 @@ func (pool *ConnectionPool) canConnect(a string, solicited bool) error {
 		return ErrConnectionExists
 	}
 
-	if pool.isMaxConnectionsReached() {
-		return ErrMaxConnectionsReached
-	}
-
 	if solicited {
-		if pool.isMaxOutgoingConnectionsReached() {
+		if _, ok := pool.Config.defaultConnections[a]; ok && pool.isMaxOutgoingDefaultConnectionsReached() {
+			return ErrMaxOutgoingDefaultConnectionsReached
+		} else if pool.isMaxOutgoingConnectionsReached() {
 			return ErrMaxOutgoingConnectionsReached
 		}
-
-		if _, ok := pool.Config.defaultConnections[a]; ok {
-			if pool.isMaxOutgoingDefaultConnectionsReached() {
-				return ErrMaxOutgoingDefaultConnectionsReached
-			}
-		}
+	} else if pool.isMaxIncomingConnectionsReached() {
+		return ErrMaxIncomingConnectionsReached
 	}
 
 	return nil
@@ -755,8 +749,8 @@ func (pool *ConnectionPool) isConnExist(addr string) bool {
 	return ok
 }
 
-func (pool *ConnectionPool) isMaxConnectionsReached() bool {
-	return len(pool.pool) >= pool.Config.MaxConnections
+func (pool *ConnectionPool) isMaxIncomingConnectionsReached() bool {
+	return len(pool.pool) >= (pool.Config.MaxConnections - pool.Config.MaxOutgoingConnections - pool.Config.MaxDefaultPeerOutgoingConnections)
 }
 
 func (pool *ConnectionPool) isMaxOutgoingConnectionsReached() bool {

--- a/src/daemon/pool.go
+++ b/src/daemon/pool.go
@@ -60,7 +60,7 @@ type Pool struct {
 }
 
 // NewPool creates pool
-func NewPool(cfg PoolConfig, d *Daemon) *Pool {
+func NewPool(cfg PoolConfig, d *Daemon) (*Pool, error) {
 	gnetCfg := gnet.NewConfig()
 	gnetCfg.DialTimeout = cfg.DialTimeout
 	gnetCfg.Port = uint16(cfg.port)
@@ -73,10 +73,15 @@ func NewPool(cfg PoolConfig, d *Daemon) *Pool {
 	gnetCfg.MaxDefaultPeerOutgoingConnections = cfg.MaxDefaultPeerOutgoingConnections
 	gnetCfg.DefaultConnections = cfg.DefaultConnections
 
+	pool, err := gnet.NewConnectionPool(gnetCfg, d)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Pool{
 		Config: cfg,
-		Pool:   gnet.NewConnectionPool(gnetCfg, d),
-	}
+		Pool:   pool,
+	}, nil
 }
 
 // Shutdown closes all connections and stops listening

--- a/src/skycoin/config.go
+++ b/src/skycoin/config.go
@@ -406,6 +406,10 @@ func (c *Config) postProcess() error {
 		return errors.New("Web interface auth enabled but HTTPS is not enabled. Use -web-interface-plaintext-auth=true if this is desired")
 	}
 
+	if c.Node.MaxConnections < c.Node.MaxOutgoingConnections+c.Node.MaxDefaultPeerOutgoingConnections {
+		return errors.New("-max-connections must be >= -max-outgoing-connections + -max-default-peer-outgoing-connections")
+	}
+
 	if c.Node.MaxOutgoingConnections > c.Node.MaxConnections {
 		return errors.New("-max-outgoing-connections cannot be higher than -max-connections")
 	}
@@ -514,7 +518,7 @@ func (c *NodeConfig) RegisterFlags() {
 	flag.BoolVar(&c.DownloadPeerList, "download-peerlist", c.DownloadPeerList, "download a peers.txt from -peerlist-url")
 	flag.StringVar(&c.PeerListURL, "peerlist-url", c.PeerListURL, "with -download-peerlist=true, download a peers.txt file from this url")
 	flag.BoolVar(&c.DisableOutgoingConnections, "disable-outgoing", c.DisableOutgoingConnections, "Don't make outgoing connections")
-	flag.BoolVar(&c.DisableIncomingConnections, "disable-incoming", c.DisableIncomingConnections, "Don't make incoming connections")
+	flag.BoolVar(&c.DisableIncomingConnections, "disable-incoming", c.DisableIncomingConnections, "Don't allow incoming connections")
 	flag.BoolVar(&c.DisableNetworking, "disable-networking", c.DisableNetworking, "Disable all network activity")
 	flag.BoolVar(&c.EnableGUI, "enable-gui", c.EnableGUI, "Enable GUI")
 	flag.BoolVar(&c.EnableUnversionedAPI, "enable-unversioned-api", c.EnableUnversionedAPI, "Enable the deprecated unversioned API endpoints without /api/v1 prefix")


### PR DESCRIPTION
Fixes #2002 

Changes:
- Max default outgoing, max outgoing and max incoming are treated separately.  For example, an outgoing connection to a default peer will not count against the max outgoing connections.
- Every 100ms, if there is no trusted connection, attempt to make one. Extra logic is added to change the attempt frequency to 5s in the event that no trusted peers are available.

Does this change need to mentioned in CHANGELOG.md?
No
