### PR TITLE
Fix flaky e2e tests

### DIFF
--- a/src/gui/static/e2e/onboarding.e2e-spec.ts
+++ b/src/gui/static/e2e/onboarding.e2e-spec.ts
@@ -1,10 +1,12 @@
 import { OnboardingCreatePage } from './onboarding.po';
+import { browser } from 'protractor';
 
 describe('Onboarding', () => {
   const page = new OnboardingCreatePage();
 
   it('should display title', () => {
     page.navigateTo();
+    browser.sleep(1000);
     expect<any>(page.getHeaderText()).toEqual('Create Wallet');
   });
 

--- a/src/gui/static/e2e/send.e2e-spec.ts
+++ b/src/gui/static/e2e/send.e2e-spec.ts
@@ -1,10 +1,12 @@
 import { SendPage } from './send.po';
+import { browser } from 'protractor';
 
 describe('Send', () => {
   const page = new SendPage();
 
   it('should display title', () => {
     page.navigateTo();
+    browser.sleep(1000);
     expect<any>(page.getHeaderText()).toEqual('Wallets');
   });
 

--- a/src/gui/static/e2e/transactions.e2e-spec.ts
+++ b/src/gui/static/e2e/transactions.e2e-spec.ts
@@ -1,10 +1,12 @@
 import { TransactionsPage } from './transactions.po';
+import { browser } from 'protractor';
 
 describe('Transactions', () => {
   const page = new TransactionsPage();
 
   it('should display title', () => {
     page.navigateTo();
+    browser.sleep(1000);
     expect<any>(page.getHeaderText()).toEqual('Transactions');
   });
 

--- a/src/gui/static/e2e/wallets.e2e-spec.ts
+++ b/src/gui/static/e2e/wallets.e2e-spec.ts
@@ -1,10 +1,12 @@
 import { WalletsPage } from './wallets.po';
+import { browser } from 'protractor';
 
 describe('Wallets', () => {
   const page = new WalletsPage();
 
   it('should display title', () => {
     page.navigateTo();
+    browser.sleep(1000);
     expect<any>(page.getHeaderText()).toEqual('Wallets');
   });
 


### PR DESCRIPTION
Probably fixes #2013 

Changes:
- When navigating to a page, in the e2e tests, Protractor waits a small amount of time before running the tests, to avoid problems with the post requests. This could solve what was discussed in https://github.com/skycoin/skycoin/issues/2013#issuecomment-437207828

Does this change need to mentioned in CHANGELOG.md?
No