### PR TITLE
Bip39 verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Make sure to upgrade to v0.25.0 so that your node will continue to connect once 
 - `/api/v1/network/disconnect` to disconnect a peer
 - Complete support for `cipher` package in `libskycoin` C API.
 - Add `coin`, `wallet`, `util/droplet` and `util/fee` methods as part of `libskycoin` C API
+- Add `/api/v2/wallet/seed/verify` to verify if seed is a valid bip39 mnemonic seed
 
 ### Fixed
 

--- a/lib/cgo/libsky_handle.go
+++ b/lib/cgo/libsky_handle.go
@@ -13,13 +13,14 @@ import "C"
 import (
 	"hash"
 
+	gcli "github.com/urfave/cli"
+
 	api "github.com/skycoin/skycoin/src/api"
 	webrpc "github.com/skycoin/skycoin/src/api/webrpc"
 	cli "github.com/skycoin/skycoin/src/cli"
 	"github.com/skycoin/skycoin/src/coin"
 	"github.com/skycoin/skycoin/src/readable"
 	wallet "github.com/skycoin/skycoin/src/wallet"
-	gcli "github.com/urfave/cli"
 )
 
 type Handle uint64

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -33,6 +33,7 @@ and the `/api/v1` prefix will be required for previously unversioned endpoints.
 	- [Get wallets](#get-wallets)
 	- [Get wallet folder name](#get-wallet-folder-name)
 	- [Generate wallet seed](#generate-wallet-seed)
+	- [Verify Wallet Seed](#verify-wallet-seed)
 	- [Create a wallet from seed](#create-a-wallet-from-seed)
 	- [Generate new address in wallet](#generate-new-address-in-wallet)
 	- [Updates wallet label](#updates-wallet-label)
@@ -852,6 +853,52 @@ Result:
 ```json
 {
     "seed": "helmet van actor peanut differ icon trial glare member cancel marble rack"
+}
+```
+
+### Verify wallet Seed
+
+API sets: `WALLET`
+
+```
+URI: /api/v2/wallet/seed/verify
+Method: POST
+Args:
+    seed: seed to be verified
+```
+
+Example:
+
+```sh
+curl -X POST http://127.0.0.1:6420/api/v2/wallet/seed/verify \
+ -H 'Content-type: application/json' \
+ -d '{ "seed": "nut wife logic sample addict shop before tobacco crisp bleak lawsuit affair" }'
+```
+
+Result:
+
+```json
+{
+    "data": {}
+}
+```
+
+Example (wrong bip39 seed):
+
+```sh
+curl -X POST http://127.0.0.1:6420/api/v2/wallet/seed/verify \
+ -H 'Content-type: application/json' \
+ -d '{ "seed": "wrong seed" }'
+```
+
+Result:
+
+```json
+{
+    "error": {
+        "message": "seed is not a valid bip39 seed",
+        "code": 422
+    }
 }
 ```
 

--- a/src/api/client.go
+++ b/src/api/client.go
@@ -272,11 +272,13 @@ func (c *Client) PostJSONV2(endpoint string, reqObj, respObj interface{}) (bool,
 		return false, rspErr
 	}
 
-	decoder = json.NewDecoder(bytes.NewReader(wrapObj.Data))
-	decoder.DisallowUnknownFields()
+	if respObj != struct{}{} {
+		decoder = json.NewDecoder(bytes.NewReader(wrapObj.Data))
+		decoder.DisallowUnknownFields()
 
-	if err := decoder.Decode(respObj); err != nil {
-		return false, err
+		if err := decoder.Decode(respObj); err != nil {
+			return false, err
+		}
 	}
 
 	return true, rspErr
@@ -795,6 +797,15 @@ func (c *Client) NewSeed(entropy int) (string, error) {
 		return "", err
 	}
 	return r.Seed, nil
+}
+
+// VerifySeed verifies whether the given seed is a valid bip39 mnemonic or not
+func (c *Client) VerifySeed(seed VerifySeedRequest) (bool, error) {
+	ok, err := c.PostJSONV2("/api/v2/wallet/seed/verify", seed, struct{}{})
+	if err != nil {
+		return false, err
+	}
+	return ok, nil
 }
 
 // WalletSeed makes a request to POST /api/v1/wallet/seed

--- a/src/api/http.go
+++ b/src/api/http.go
@@ -454,6 +454,7 @@ func newServerMux(c muxConfig, gateway Gatewayer, csrfStore *CSRFStore, rpc *web
 	webHandlerV1("/wallets/folderName", forAPISet(walletFolderHandler(gateway), []string{EndpointsWallet}))
 	webHandlerV1("/wallet/newSeed", forAPISet(newSeedHandler(), []string{EndpointsWallet}))
 	webHandlerV1("/wallet/seed", forAPISet(walletSeedHandler(gateway), []string{EndpointsInsecureWalletSeed}))
+	webHandlerV2("/wallet/seed/verify", forAPISet(walletVerifySeedHandler, []string{EndpointsWallet}))
 
 	webHandlerV1("/wallet/unload", forAPISet(walletUnloadHandler(gateway), []string{EndpointsWallet}))
 	webHandlerV1("/wallet/encrypt", forAPISet(walletEncryptHandler(gateway), []string{EndpointsWallet}))

--- a/src/api/integration/integration_test.go
+++ b/src/api/integration/integration_test.go
@@ -5392,6 +5392,25 @@ func TestRecoverWallet(t *testing.T) {
 	require.Equal(t, w, w4)
 }
 
+func TestVerifyWallet(t *testing.T) {
+	if !doLiveOrStable(t) {
+		return
+	}
+	c := newClient()
+
+	// check with correct seed
+	seedReq := api.VerifySeedRequest{Seed: "nut wife logic sample addict shop before tobacco crisp bleak lawsuit affair"}
+	isBip, err := c.VerifySeed(seedReq)
+	require.NoError(t, err)
+	require.True(t, isBip)
+
+	// check with incorrect seed
+	seedReq = api.VerifySeedRequest{Seed: "nut "}
+	isBip, err = c.VerifySeed(seedReq)
+	testutil.RequireError(t, err, "seed is not a valid bip39 seed")
+	require.False(t, isBip)
+}
+
 func TestGetWalletSeedDisabledAPI(t *testing.T) {
 	if !doLiveOrStable(t) {
 		return

--- a/src/api/wallet.go
+++ b/src/api/wallet.go
@@ -793,6 +793,50 @@ func walletSeedHandler(gateway Gatewayer) http.HandlerFunc {
 	}
 }
 
+// VerifySeedRequest is the request data for POST /api/v2/wallet/seed/verify
+type VerifySeedRequest struct {
+	Seed string `json:"seed"`
+}
+
+// walletVerifySeedHandler verifies a wallet seed
+// Method: POST
+// URI: /api/v2/wallet/seed/verify
+func walletVerifySeedHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		resp := NewHTTPErrorResponse(http.StatusMethodNotAllowed, "")
+		writeHTTPResponse(w, resp)
+		return
+	}
+
+	if r.Header.Get("Content-Type") != ContentTypeJSON {
+		resp := NewHTTPErrorResponse(http.StatusUnsupportedMediaType, "")
+		writeHTTPResponse(w, resp)
+		return
+	}
+
+	var req VerifySeedRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		resp := NewHTTPErrorResponse(http.StatusBadRequest, err.Error())
+		writeHTTPResponse(w, resp)
+		return
+	}
+
+	if req.Seed == "" {
+		resp := NewHTTPErrorResponse(http.StatusBadRequest, "seed is required")
+		writeHTTPResponse(w, resp)
+		return
+	}
+
+	mnemonicValid := bip39.IsMnemonicValid(req.Seed)
+	if !mnemonicValid {
+		resp := NewHTTPErrorResponse(http.StatusUnprocessableEntity, "seed is not a valid bip39 seed")
+		writeHTTPResponse(w, resp)
+		return
+	}
+
+	writeHTTPResponse(w, HTTPResponse{Data: struct{}{}})
+}
+
 // Unloads wallet from the wallet service
 // URI: /api/v1/wallet/unload
 // Method: POST

--- a/src/api/wallet_test.go
+++ b/src/api/wallet_test.go
@@ -1720,6 +1720,130 @@ func TestWalletNewSeed(t *testing.T) {
 	}
 }
 
+func TestVerifySeed(t *testing.T) {
+	cases := []struct {
+		name         string
+		method       string
+		status       int
+		contentType  string
+		csrfDisabled bool
+		httpBody     string
+		httpResponse HTTPResponse
+	}{
+		{
+			name:         "405",
+			method:       http.MethodGet,
+			status:       http.StatusMethodNotAllowed,
+			httpResponse: NewHTTPErrorResponse(http.StatusMethodNotAllowed, ""),
+		},
+
+		{
+			name:         "415 - Unsupported Media Type",
+			method:       http.MethodPost,
+			contentType:  ContentTypeForm,
+			status:       http.StatusUnsupportedMediaType,
+			httpResponse: NewHTTPErrorResponse(http.StatusUnsupportedMediaType, ""),
+		},
+
+		{
+			name:         "400 - EOF",
+			method:       http.MethodPost,
+			contentType:  ContentTypeJSON,
+			status:       http.StatusBadRequest,
+			httpResponse: NewHTTPErrorResponse(http.StatusBadRequest, "EOF"),
+		},
+		{
+			name:         "400 - Missing Seed",
+			method:       http.MethodPost,
+			contentType:  ContentTypeJSON,
+			status:       http.StatusBadRequest,
+			httpBody:     "{}",
+			httpResponse: NewHTTPErrorResponse(http.StatusBadRequest, "seed is required"),
+		},
+		{
+			name:        "400 - Invalid seed",
+			method:      http.MethodPost,
+			contentType: ContentTypeJSON,
+			status:      http.StatusUnprocessableEntity,
+			httpBody: toJSON(t, VerifySeedRequest{
+				Seed: "bag attitude butter flock slab desk ship brain famous scheme clerk",
+			}),
+			httpResponse: NewHTTPErrorResponse(http.StatusUnprocessableEntity, "seed is not a valid bip39 seed"),
+		},
+		{
+			name:   "200",
+			method: http.MethodPost,
+			status: http.StatusOK,
+			httpBody: toJSON(t, VerifySeedRequest{
+				Seed: "chief stadium sniff exhibit ostrich exit fruit noodle good lava coin supply",
+			}),
+			httpResponse: HTTPResponse{Data: struct{}{}},
+		},
+		{
+			name:   "200 - csrf disabled",
+			method: http.MethodPost,
+			status: http.StatusOK,
+			httpBody: toJSON(t, VerifySeedRequest{
+				Seed: "chief stadium sniff exhibit ostrich exit fruit noodle good lava coin supply",
+			}),
+			httpResponse: HTTPResponse{Data: struct{}{}},
+			csrfDisabled: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			endpoint := "/api/v2/wallet/seed/verify"
+			gateway := &MockGatewayer{}
+
+			req, err := http.NewRequest(tc.method, endpoint, strings.NewReader(tc.httpBody))
+			require.NoError(t, err)
+
+			contentType := tc.contentType
+			if contentType == "" {
+				contentType = ContentTypeJSON
+			}
+
+			req.Header.Set("Content-Type", contentType)
+
+			csrfStore := &CSRFStore{
+				Enabled: !tc.csrfDisabled,
+			}
+			if csrfStore.Enabled {
+				setCSRFParameters(csrfStore, tokenValid, req)
+			} else {
+				setCSRFParameters(csrfStore, tokenInvalid, req)
+			}
+
+			rr := httptest.NewRecorder()
+			handler := newServerMux(defaultMuxConfig(), gateway, csrfStore, nil)
+			handler.ServeHTTP(rr, req)
+
+			status := rr.Code
+			require.Equal(t, tc.status, status, "got `%v` want `%v`", status, tc.status)
+
+			var rsp ReceivedHTTPResponse
+			err = json.NewDecoder(rr.Body).Decode(&rsp)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.httpResponse.Error, rsp.Error)
+
+			if rsp.Data == nil {
+				require.Nil(t, tc.httpResponse.Data)
+			} else {
+				require.NotNil(t, tc.httpResponse.Data)
+
+				var addrRsp struct{}
+				err := json.Unmarshal(rsp.Data, &addrRsp)
+				require.NoError(t, err)
+
+				require.Equal(t, tc.httpResponse.Data, addrRsp)
+			}
+
+		})
+	}
+}
+
 func TestGetWalletSeed(t *testing.T) {
 
 	tt := []struct {


### PR DESCRIPTION
Fixes #1929 

Changes:
-  Add `/api/v2/wallet/seed/verify` to verify if seed is a valid bip39 mnemonic seed

Does this change need to mentioned in CHANGELOG.md?
yes