### PR TITLE
Add CLI `richList` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Make sure to upgrade to v0.25.0 so that your node will continue to connect once 
 - Complete support for `cipher` package in `libskycoin` C API.
 - Add `coin`, `wallet`, `util/droplet` and `util/fee` methods as part of `libskycoin` C API
 - Add `make update-golden-files` to `Makefile`
+- Add CLI `richList` command
 
 ### Fixed
 

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -30,6 +30,7 @@ The CLI command APIs can be used directly from a Go application, see [Skycoin CL
 	- [Last blocks](#last-blocks)
 	- [List wallet addresses](#list-wallet-addresses)
 	- [List wallets](#list-wallets)
+    - [Rich list](#rich-list)
 	- [Send](#send)
 	- [Show Config](#show-config)
 	- [Status](#status)
@@ -1489,6 +1490,54 @@ $ skycoin-cli listWallets
          "address_num": 6
      }
  ]
+}
+```
+</details>
+
+### Rich list
+Returns the top N address (default 20) balances (based on unspent outputs). Optionally include distribution addresses (exluded by default).
+
+```bash
+$ skycoin-cli richList [top N addresses] [include distribution addresses]
+```
+
+#### Example
+```bash
+$ skycoin-cli richList 5 false
+```
+
+<details>
+ <summary>View Output</summary>
+
+```json
+{
+    "richlist": [
+        {
+            "address": "2iNNt6fm9LszSWe51693BeyNUKX34pPaLx8",
+            "coins": "1072264.838000",
+            "locked": false
+        },
+        {
+            "address": "2fGi2jhvp6ppHg3DecguZgzqvpJj2Gd4KHW",
+            "coins": "500000.000000",
+            "locked": false
+        },
+        {
+            "address": "2jNwfvZNUoRLiFzJtmnevSF6TKPfSehvrc1",
+            "coins": "252297.068000",
+            "locked": false
+        },
+        {
+            "address": "2GgFvqoyk9RjwVzj8tqfcXVXB4orBwoc9qv",
+            "coins": "236884.364000",
+            "locked": false
+        },
+        {
+            "address": "2fR8BkeTRQC4R3ATNnujHsQQXcaB6m4Aqwo",
+            "coins": "173571.990000",
+            "locked": false
+        }
+    ]
 }
 ```
 </details>

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -264,6 +264,7 @@ func NewApp(cfg Config) (*App, error) {
 		walletDirCmd(),
 		walletHisCmd(),
 		walletOutputsCmd(cfg),
+		richListCmd(),
 	}
 
 	app.Name = fmt.Sprintf("%s-cli", cfg.Coin)

--- a/src/cli/richlist.go
+++ b/src/cli/richlist.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"github.com/skycoin/skycoin/src/api"
+	gcli "github.com/urfave/cli"
+)
+
+func richListCmd() gcli.Command {
+	name := "richList"
+	return gcli.Command{
+		Name:  name,
+		Usage: "Returns top 20 address balances (based on unspent outputs). Distribution wallets are not currently included.",
+		//ArgsUsage:    "[top N wallets (default 20)] [include distribution wallets (true / false) (defalut false)]",
+		OnUsageError: onCommandUsageError(name),
+		Action:       getRichList,
+	}
+}
+
+func getRichList(c *gcli.Context) error {
+	client := APIClientFromContext(c)
+
+	//num := c.Args().Get(0)
+	//if num == "" {
+	//	num = "10"
+	//}
+
+	//n, err := strconv.ParseInt(num, 10, 32)
+	//if err != nil {
+	//	return fmt.Errorf("invalid number or top wallets, %s", err)
+	//}
+
+	//incDist := c.Args().Get(1)
+	//incDistFlag, err2 := strconv.ParseBool(incDist)
+	//if err2 != nil {
+	//	return fmt.Errorf("invalid boolean value, %s", err2)
+	//}
+
+	params := &api.RichlistParams{
+		N:                   20,
+		IncludeDistribution: false,
+	}
+
+	richList, err3 := client.Richlist(params)
+	if err3 != nil {
+		return err3
+	}
+
+	return printJSON(richList)
+}


### PR DESCRIPTION
Fixes # None

Changes:
- Add CLI `richList` command. Supports parameters for top N addresses (default 20) and inclusion of distribution addresses (default false).

Does this change need to mentioned in CHANGELOG.md?
Yes, and update to CHANGELOG.md included in PR
