### PR TITLE
Stop sending the post requests sequentially

### DIFF
--- a/src/gui/static/src/app/services/api.service.ts
+++ b/src/gui/static/src/app/services/api.service.ts
@@ -7,7 +7,6 @@ import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/map';
 import { TranslateService } from '@ngx-translate/core';
 import { BigNumber } from 'bignumber.js';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import {
   Address, GetWalletsResponseEntry, GetWalletsResponseWallet, NormalTransaction,
@@ -17,7 +16,6 @@ import {
 @Injectable()
 export class ApiService {
   private url = environment.nodeUrl;
-  private gettingCsrf: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
   constructor(
     private http: Http,
@@ -127,21 +125,7 @@ export class ApiService {
   }
 
   getCsrf() {
-    return this.gettingCsrf.filter(response => !response).first().flatMap(() => {
-      this.gettingCsrf.next(true);
-
-      return this.get('csrf')
-        .map(response => {
-          setTimeout(() => this.gettingCsrf.next(false));
-
-          return response.csrf_token;
-        })
-        .catch((error: any) => {
-          setTimeout(() => this.gettingCsrf.next(false));
-
-          return error;
-        });
-    });
+    return this.get('csrf').map(response => response.csrf_token);
   }
 
   post(url, params = {}, options: any = {}, useV2 = false) {


### PR DESCRIPTION
Changes:
Until recently, when requesting a csrf token to make a post request any csrf token previously requested was invalidated. Due to this, in https://github.com/skycoin/skycoin/pull/1988 a procedure was created to force the post requests to be made sequentially.

However, thanks to https://github.com/skycoin/skycoin/pull/2018 the csrf tokens are no longer invalidated just after requesting a new token. That means that the procedure added in https://github.com/skycoin/skycoin/pull/1988 is no longer necessary, so it is deleted in this PR.

This should solve https://github.com/skycoin/skycoin/issues/2013


Does this change need to mentioned in CHANGELOG.md?
No