### PR TITLE
Check if peers would propagate a transaction when broadcasted

### DIFF
--- a/src/daemon/daemon_test.go
+++ b/src/daemon/daemon_test.go
@@ -2,10 +2,16 @@ package daemon
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/coin"
+	"github.com/skycoin/skycoin/src/params"
+	"github.com/skycoin/skycoin/src/util/fee"
+	"github.com/skycoin/skycoin/src/util/useragent"
+	"github.com/skycoin/skycoin/src/visor"
 )
 
 func TestDivideHashes(t *testing.T) {
@@ -100,6 +106,237 @@ func TestDivideHashes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			rlt := divideHashes(tc.init, tc.n)
 			require.Equal(t, tc.array, rlt)
+		})
+	}
+}
+
+func TestVerifyUserTxnAgainstPeer(t *testing.T) {
+	now := uint64(time.Now().UTC().Unix())
+
+	cases := []struct {
+		name         string
+		err          error
+		txn          coin.Transaction
+		head         *coin.SignedBlock
+		inputs       coin.UxArray
+		verifyParams params.VerifyTxn
+	}{
+		{
+			name: "invalid droplet precision",
+			err:  params.ErrInvalidDecimals,
+			txn: coin.Transaction{
+				Out: []coin.TransactionOutput{
+					{
+						Coins: 111100,
+					},
+				},
+			},
+			verifyParams: params.VerifyTxn{
+				MaxDropletPrecision: 3,
+			},
+		},
+
+		{
+			name: "invalid txn size",
+			err:  visor.ErrTxnExceedsMaxBlockSize,
+			txn: coin.Transaction{
+				Out: []coin.TransactionOutput{
+					{
+						Coins: 1e6,
+					},
+				},
+			},
+			verifyParams: params.VerifyTxn{
+				MaxDropletPrecision: 3,
+				MaxTransactionSize:  1,
+			},
+		},
+
+		{
+			name: "invalid burn fee",
+			err:  fee.ErrTxnInsufficientFee,
+			txn: coin.Transaction{
+				Out: []coin.TransactionOutput{
+					{
+						Coins: 1e6,
+						Hours: 100,
+					},
+				},
+			},
+			head: &coin.SignedBlock{
+				Block: coin.Block{
+					Head: coin.BlockHeader{
+						Time: now,
+					},
+				},
+			},
+			inputs: coin.UxArray{
+				{
+					Head: coin.UxHead{
+						Time: now,
+					},
+					Body: coin.UxBody{
+						Coins: 1e6,
+						Hours: 150,
+					},
+				},
+			},
+			verifyParams: params.VerifyTxn{
+				MaxDropletPrecision: 3,
+				MaxTransactionSize:  99999999,
+				BurnFactor:          2,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := verifyUserTxnAgainstPeer(tc.txn, tc.head, tc.inputs, tc.verifyParams)
+			require.Equal(t, tc.err, err)
+		})
+	}
+}
+
+func TestCheckBroadcastTxnRecipients(t *testing.T) {
+	// contains a connection not introduced and a connection without user agent
+	connections := NewConnections()
+
+	// one connection connected but not introduced
+	_, err := connections.connected("1.1.1.1:9999", 3)
+	require.NoError(t, err)
+
+	// one connection introduced without user agent
+	_, err = connections.connected("2.2.2.2:9999", 1)
+	require.NoError(t, err)
+	_, err = connections.introduced("2.2.2.2:9999", 1, &IntroductionMessage{
+		Mirror:          6666,
+		ListenPort:      9999,
+		ProtocolVersion: 2,
+	})
+	require.NoError(t, err)
+
+	// contains a connection not introduced, a connection without user agent
+	// and a connection with user agent
+	connections2 := NewConnections()
+
+	// one connection connected but not introduced
+	_, err = connections2.connected("1.1.1.1:9999", 3)
+	require.NoError(t, err)
+
+	// one connection introduced without user agent
+	_, err = connections2.connected("2.2.2.2:9999", 1)
+	require.NoError(t, err)
+	_, err = connections2.introduced("2.2.2.2:9999", 1, &IntroductionMessage{
+		Mirror:          6666,
+		ListenPort:      9999,
+		ProtocolVersion: 2,
+	})
+	require.NoError(t, err)
+
+	// one connection introduced with user agent
+	_, err = connections2.connected("3.3.3.3:9999", 2)
+	require.NoError(t, err)
+	_, err = connections2.introduced("3.3.3.3:9999", 2, &IntroductionMessage{
+		Mirror:          7777,
+		ListenPort:      9999,
+		ProtocolVersion: 2,
+		userAgent:       useragent.MustParse("skycoin:0.25.1"),
+		unconfirmedVerifyTxn: params.VerifyTxn{
+			MaxDropletPrecision: 4, // the default precision for unspecified peers is 3
+			MaxTransactionSize:  32768,
+			BurnFactor:          2,
+		},
+	})
+	require.NoError(t, err)
+
+	cases := []struct {
+		name        string
+		err         error
+		accepts     int
+		connections *Connections
+		ids         []uint64
+		txn         coin.Transaction
+		head        *coin.SignedBlock
+		inputs      coin.UxArray
+	}{
+		{
+			name:        "accepted by connection with no user agent",
+			err:         nil,
+			accepts:     1,
+			connections: connections,
+			ids:         []uint64{1, 2, 999}, // includes unknown gnet id to make sure it doesn't crash on bad input
+			txn: coin.Transaction{
+				Out: []coin.TransactionOutput{
+					{
+						Coins: 1e6,
+					},
+				},
+			},
+			head: &coin.SignedBlock{},
+			inputs: coin.UxArray{
+				{
+					Body: coin.UxBody{
+						Coins: 1e6,
+						Hours: 100,
+					},
+				},
+			},
+		},
+
+		{
+			name:        "not accepted by connection with no user agent",
+			err:         ErrNoPeerAcceptsTxn,
+			accepts:     0,
+			connections: connections,
+			ids:         []uint64{1, 2},
+			txn: coin.Transaction{
+				Out: []coin.TransactionOutput{
+					{
+						Coins: 1e2,
+					},
+				},
+			},
+			head: &coin.SignedBlock{},
+			inputs: coin.UxArray{
+				{
+					Body: coin.UxBody{
+						Coins: 1e2,
+						Hours: 100,
+					},
+				},
+			},
+		},
+
+		{
+			name:        "connections contains a connection that specifies user agent, which will propagate a txn even if soft-invalid",
+			err:         nil,
+			accepts:     1,
+			connections: connections2,
+			ids:         []uint64{1, 2, 3},
+			txn: coin.Transaction{
+				Out: []coin.TransactionOutput{
+					{
+						Coins: 1e1,
+					},
+				},
+			},
+			head: &coin.SignedBlock{},
+			inputs: coin.UxArray{
+				{
+					Body: coin.UxBody{
+						Coins: 1e1,
+						Hours: 100,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			accepts, err := checkBroadcastTxnRecipients(tc.connections, tc.ids, tc.txn, tc.head, tc.inputs)
+			require.Equal(t, tc.err, err)
+			require.Equal(t, tc.accepts, accepts)
 		})
 	}
 }

--- a/src/daemon/gateway.go
+++ b/src/daemon/gateway.go
@@ -498,8 +498,8 @@ func (gw *Gateway) InjectBroadcastTransaction(txn coin.Transaction) error {
 				return err
 			}
 
-			if err := gw.d.BroadcastTransaction(txn); err != nil {
-				logger.WithError(err).Error("BroadcastTransaction failed")
+			if err := gw.d.BroadcastUserTransaction(txn); err != nil {
+				logger.WithError(err).Error("BroadcastUserTransaction failed")
 				return err
 			}
 
@@ -623,7 +623,7 @@ func (gw *Gateway) Spend(wltID string, password []byte, coins uint64, dest ciphe
 			return
 		}
 
-		err = gw.d.BroadcastTransaction(*txn)
+		err = gw.d.BroadcastUserTransaction(*txn)
 		if err != nil {
 			logger.WithError(err).Error("BroadcastTransaction failed")
 			return

--- a/src/daemon/gnet/pool_test.go
+++ b/src/daemon/gnet/pool_test.go
@@ -1107,7 +1107,7 @@ func TestPoolBroadcastMessage(t *testing.T) {
 	m := NewByteMessage(88)
 	n, err := p.BroadcastMessage(m, addrs)
 	require.NoError(t, err)
-	require.Equal(t, 2, n)
+	require.Equal(t, 2, len(n))
 
 	_, err = p.BroadcastMessage(m, []string{})
 	require.Equal(t, ErrNoAddresses, err)

--- a/src/daemon/messages.go
+++ b/src/daemon/messages.go
@@ -365,8 +365,8 @@ func (intro *IntroductionMessage) process(d daemoner) {
 	}
 
 	// Announce unconfirmed txns
-	if err := d.announceAllTxns(); err != nil {
-		logger.WithError(err).Warning("announceAllTxns failed")
+	if err := d.announceAllValidTxns(); err != nil {
+		logger.WithError(err).Warning("announceAllValidTxns failed")
 	}
 }
 

--- a/src/daemon/messages_test.go
+++ b/src/daemon/messages_test.go
@@ -443,7 +443,7 @@ func TestIntroductionMessage(t *testing.T) {
 				return true
 			})).Return(tc.mockValue.connectionIntroduced, tc.mockValue.connectionIntroducedErr)
 			d.On("requestBlocksFromAddr", tc.addr).Return(tc.mockValue.requestBlocksFromAddrErr)
-			d.On("announceAllTxns").Return(tc.mockValue.announceAllTxnsErr)
+			d.On("announceAllValidTxns").Return(tc.mockValue.announceAllTxnsErr)
 			d.On("sendRandomPeers", tc.addr).Return(tc.mockValue.sendRandomPeersErr)
 
 			err := tc.intro.Handle(mc, d)

--- a/src/daemon/mock_daemoner_test.go
+++ b/src/daemon/mock_daemoner_test.go
@@ -28,8 +28,8 @@ func (_m *mockDaemoner) addPeers(addrs []string) int {
 	return r0
 }
 
-// announceAllTxns provides a mock function with given fields:
-func (_m *mockDaemoner) announceAllTxns() error {
+// announceAllValidTxns provides a mock function with given fields:
+func (_m *mockDaemoner) announceAllValidTxns() error {
 	ret := _m.Called()
 
 	var r0 error
@@ -43,14 +43,16 @@ func (_m *mockDaemoner) announceAllTxns() error {
 }
 
 // broadcastMessage provides a mock function with given fields: msg
-func (_m *mockDaemoner) broadcastMessage(msg gnet.Message) (int, error) {
+func (_m *mockDaemoner) broadcastMessage(msg gnet.Message) ([]uint64, error) {
 	ret := _m.Called(msg)
 
-	var r0 int
-	if rf, ok := ret.Get(0).(func(gnet.Message) int); ok {
+	var r0 []uint64
+	if rf, ok := ret.Get(0).(func(gnet.Message) []uint64); ok {
 		r0 = rf(msg)
 	} else {
-		r0 = ret.Get(0).(int)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]uint64)
+		}
 	}
 
 	var r1 error

--- a/src/visor/blockchain.go
+++ b/src/visor/blockchain.go
@@ -398,25 +398,29 @@ func (bc Blockchain) VerifySingleTxnHardConstraints(tx *dbutil.Tx, txn coin.Tran
 // VerifySingleTxnSoftHardConstraints checks that the transaction does not violate hard or soft constraints,
 // for transactions that are not included in a block.
 // Hard constraints are checked before soft constraints.
-func (bc Blockchain) VerifySingleTxnSoftHardConstraints(tx *dbutil.Tx, txn coin.Transaction, verifyParams params.VerifyTxn) error {
+func (bc Blockchain) VerifySingleTxnSoftHardConstraints(tx *dbutil.Tx, txn coin.Transaction, verifyParams params.VerifyTxn) (*coin.SignedBlock, coin.UxArray, error) {
 	// NOTE: Unspent().GetArray() returns an error if not all txn.In can be found
 	// This prevents double spends
 	uxIn, err := bc.Unspent().GetArray(tx, txn.In)
 	if err != nil {
-		return NewErrTxnViolatesHardConstraint(err)
+		return nil, nil, NewErrTxnViolatesHardConstraint(err)
 	}
 
 	head, err := bc.Head(tx)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	// Hard constraints must be checked before soft constraints
 	if err := bc.verifySingleTxnHardConstraints(tx, txn, head, uxIn); err != nil {
-		return err
+		return nil, nil, err
 	}
 
-	return VerifySingleTxnSoftConstraints(txn, head.Time(), uxIn, verifyParams)
+	if err := VerifySingleTxnSoftConstraints(txn, head.Time(), uxIn, verifyParams); err != nil {
+		return nil, nil, err
+	}
+
+	return head, uxIn, nil
 }
 
 func (bc Blockchain) verifySingleTxnHardConstraints(tx *dbutil.Tx, txn coin.Transaction, head *coin.SignedBlock, uxIn coin.UxArray) error {

--- a/src/visor/blockchain_verify_test.go
+++ b/src/visor/blockchain_verify_test.go
@@ -348,7 +348,8 @@ func TestVerifyTransactionSoftHardConstraints(t *testing.T) {
 
 	verifySingleTxnSoftHardConstraints := func(txn coin.Transaction, verifyParams params.VerifyTxn) error {
 		return db.View("", func(tx *dbutil.Tx) error {
-			return bc.VerifySingleTxnSoftHardConstraints(tx, txn, verifyParams)
+			_, _, err := bc.VerifySingleTxnSoftHardConstraints(tx, txn, verifyParams)
+			return err
 		})
 	}
 

--- a/src/visor/mock_blockchainer_test.go
+++ b/src/visor/mock_blockchainer_test.go
@@ -343,15 +343,33 @@ func (_m *MockBlockchainer) VerifySingleTxnHardConstraints(tx *dbutil.Tx, txn co
 }
 
 // VerifySingleTxnSoftHardConstraints provides a mock function with given fields: tx, txn, verifyParams
-func (_m *MockBlockchainer) VerifySingleTxnSoftHardConstraints(tx *dbutil.Tx, txn coin.Transaction, verifyParams params.VerifyTxn) error {
+func (_m *MockBlockchainer) VerifySingleTxnSoftHardConstraints(tx *dbutil.Tx, txn coin.Transaction, verifyParams params.VerifyTxn) (*coin.SignedBlock, coin.UxArray, error) {
 	ret := _m.Called(tx, txn, verifyParams)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*dbutil.Tx, coin.Transaction, params.VerifyTxn) error); ok {
+	var r0 *coin.SignedBlock
+	if rf, ok := ret.Get(0).(func(*dbutil.Tx, coin.Transaction, params.VerifyTxn) *coin.SignedBlock); ok {
 		r0 = rf(tx, txn, verifyParams)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*coin.SignedBlock)
+		}
 	}
 
-	return r0
+	var r1 coin.UxArray
+	if rf, ok := ret.Get(1).(func(*dbutil.Tx, coin.Transaction, params.VerifyTxn) coin.UxArray); ok {
+		r1 = rf(tx, txn, verifyParams)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(coin.UxArray)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(*dbutil.Tx, coin.Transaction, params.VerifyTxn) error); ok {
+		r2 = rf(tx, txn, verifyParams)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }

--- a/src/visor/unconfirmed.go
+++ b/src/visor/unconfirmed.go
@@ -203,7 +203,7 @@ func (utp *UnconfirmedTransactionPool) SetTransactionsAnnounced(tx *dbutil.Tx, h
 func (utp *UnconfirmedTransactionPool) InjectTransaction(tx *dbutil.Tx, bc Blockchainer, txn coin.Transaction, verifyParams params.VerifyTxn) (bool, *ErrTxnViolatesSoftConstraint, error) {
 	var isValid int8 = 1
 	var softErr *ErrTxnViolatesSoftConstraint
-	if err := bc.VerifySingleTxnSoftHardConstraints(tx, txn, verifyParams); err != nil {
+	if _, _, err := bc.VerifySingleTxnSoftHardConstraints(tx, txn, verifyParams); err != nil {
 		logger.Warningf("bc.VerifySingleTxnSoftHardConstraints failed for txn %s: %v", txn.TxIDHex(), err)
 		switch err.(type) {
 		case ErrTxnViolatesSoftConstraint:
@@ -314,7 +314,7 @@ func (utp *UnconfirmedTransactionPool) Refresh(tx *dbutil.Tx, bc Blockchainer, v
 	for _, utxn := range utxns {
 		utxn.Checked = now.UnixNano()
 
-		err := bc.VerifySingleTxnSoftHardConstraints(tx, utxn.Transaction, verifyParams)
+		_, _, err := bc.VerifySingleTxnSoftHardConstraints(tx, utxn.Transaction, verifyParams)
 
 		switch err.(type) {
 		case ErrTxnViolatesSoftConstraint, ErrTxnViolatesHardConstraint:

--- a/src/visor/verify.go
+++ b/src/visor/verify.go
@@ -68,8 +68,10 @@ since data from the blockchain and unspent output set are required to fully vali
 */
 
 var (
-	errTxnExceedsMaxBlockSize = errors.New("Transaction size bigger than max block size")
-	errTxnIsLocked            = errors.New("Transaction has locked address inputs")
+	// ErrTxnExceedsMaxBlockSize transaction size exceeds the max block size
+	ErrTxnExceedsMaxBlockSize = errors.New("Transaction size bigger than max block size")
+	// ErrTxnIsLocked transaction has locked address inputs
+	ErrTxnIsLocked = errors.New("Transaction has locked address inputs")
 )
 
 // ErrTxnViolatesHardConstraint is returned when a transaction violates hard constraints
@@ -150,11 +152,11 @@ func VerifySingleTxnSoftConstraints(txn coin.Transaction, headTime uint64, uxIn 
 func verifyTxnSoftConstraints(txn coin.Transaction, headTime uint64, uxIn coin.UxArray, verifyParams params.VerifyTxn) error {
 	txnSize, err := txn.Size()
 	if err != nil {
-		return errTxnExceedsMaxBlockSize
+		return ErrTxnExceedsMaxBlockSize
 	}
 
 	if txnSize > verifyParams.MaxTransactionSize {
-		return errTxnExceedsMaxBlockSize
+		return ErrTxnExceedsMaxBlockSize
 	}
 
 	f, err := fee.TransactionFee(&txn, headTime, uxIn)
@@ -167,7 +169,7 @@ func verifyTxnSoftConstraints(txn coin.Transaction, headTime uint64, uxIn coin.U
 	}
 
 	if TransactionIsLocked(uxIn) {
-		return errTxnIsLocked
+		return ErrTxnIsLocked
 	}
 
 	// Reject transactions that do not conform to decimal restrictions

--- a/src/visor/visor_test.go
+++ b/src/visor/visor_test.go
@@ -1998,7 +1998,7 @@ func TestRefreshUnconfirmed(t *testing.T) {
 	_, softErr, err = v.InjectForeignTransaction(sometimesInvalidTxn)
 	require.NoError(t, err)
 	require.NotNil(t, softErr)
-	testutil.RequireError(t, softErr.Err, errTxnExceedsMaxBlockSize.Error())
+	testutil.RequireError(t, softErr.Err, ErrTxnExceedsMaxBlockSize.Error())
 
 	err = db.View("", func(tx *dbutil.Tx) error {
 		length, err := unconfirmed.Len(tx)

--- a/src/visor/visor_test.go
+++ b/src/visor/visor_test.go
@@ -631,7 +631,7 @@ func TestVisorInjectTransaction(t *testing.T) {
 	uxs = coin.CreateUnspents(gb.Head, gb.Body.Transactions[0])
 	txn = makeSpendTx(t, uxs, []cipher.SecKey{genSecret}, genAddress, coins)
 	txn.Out[0].Address = cipher.Address{}
-	known, err = v.InjectUserTransaction(txn)
+	known, _, _, err = v.InjectUserTransaction(txn)
 	require.False(t, known)
 	require.IsType(t, ErrTxnViolatesUserConstraint{}, err)
 	testutil.RequireError(t, err, "Transaction violates user constraint: Transaction output is sent to the null address")

--- a/src/visor/visor_wallet.go
+++ b/src/visor/visor_wallet.go
@@ -145,7 +145,7 @@ func (vs *Visor) CreateTransaction(p wallet.CreateTransactionParams) (*coin.Tran
 				return err
 			}
 
-			if err := vs.Blockchain.VerifySingleTxnSoftHardConstraints(tx, *txn, params.UserVerifyTxn); err != nil {
+			if _, _, err := vs.Blockchain.VerifySingleTxnSoftHardConstraints(tx, *txn, params.UserVerifyTxn); err != nil {
 				logger.WithError(err).Error("Created transaction violates transaction constraints")
 				return err
 			}
@@ -202,7 +202,7 @@ func (vs *Visor) CreateTransactionDeprecated(wltID string, password []byte, coin
 				return err
 			}
 
-			if err := vs.Blockchain.VerifySingleTxnSoftHardConstraints(tx, *txn, params.UserVerifyTxn); err != nil {
+			if _, _, err := vs.Blockchain.VerifySingleTxnSoftHardConstraints(tx, *txn, params.UserVerifyTxn); err != nil {
 				logger.WithError(err).Error("Created transaction violates transaction constraints")
 				return err
 			}


### PR DESCRIPTION
Fixes #1970

Changes:
- Checks if peers who received a transaction will actually propagate it. v24 and older nodes will save but not propagate a txn that does not pass soft validation.  If none of the connected peers will propagate a transaction broadcast by the user, report an error.  This is needed for when we change droplet precision or burn rate, and the network is in a mixed validation state.

Does this change need to mentioned in CHANGELOG.md?
No