### PR TITLE
[skycoin] fixes #2052 - Accept all valid API set names

### DIFF
--- a/src/skycoin/config.go
+++ b/src/skycoin/config.go
@@ -563,7 +563,8 @@ func validateAPISets(opt string, apiSets []string) error {
 			api.EndpointsTransaction,
 			api.EndpointsWallet,
 			api.EndpointsInsecureWalletSeed,
-			api.EndpointsDeprecatedWalletSpend:
+			api.EndpointsDeprecatedWalletSpend,
+			api.EndpointsPrometheus:
 		case "":
 			continue
 		default:

--- a/src/skycoin/config.go
+++ b/src/skycoin/config.go
@@ -564,7 +564,8 @@ func validateAPISets(opt string, apiSets []string) error {
 			api.EndpointsWallet,
 			api.EndpointsInsecureWalletSeed,
 			api.EndpointsDeprecatedWalletSpend,
-			api.EndpointsPrometheus:
+			api.EndpointsPrometheus,
+			api.EndpointsNetCtrl:
 		case "":
 			continue
 		default:


### PR DESCRIPTION
Fixes #2052

Changes:
- `PROMETHEUS`, `NET_CTL` names added in `validateAPISets`

Does this change need to mentioned in CHANGELOG.md?
no