### PR TITLE
[docker] fixes #2055 - Fix failures building Docker in Docker image

### DIFF
--- a/docker/images/dev-docker/hooks/build
+++ b/docker/images/dev-docker/hooks/build
@@ -14,10 +14,8 @@
 
 echo "Build hook running"
 
-cd ../../../
-
 docker build --build-arg BDATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
              --build-arg SCOMMIT=$SOURCE_COMMIT \
              -f $DOCKERFILE_PATH \
-             -t "$DOCKER_REPO:dind" .
+             -t "$IMAGE_NAME" .
 


### PR DESCRIPTION

Fixes #2055 

Changes:
- Remove directory change from hooks/build
- Use of $IMAGE_NAME instead of a customized string

Does this change need to mentioned in CHANGELOG.md?
no
