### PR TITLE
refs #2061 - Fix typo in README release steps list

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,10 +630,7 @@ Instructions for doing this:
 0. Run `make newcoin`. Compare `git diff cmd/skycoin/skycoin.go`. The only change should be the version number in the file.
 0. If changes require a new database verification on the next upgrade, update `src/skycoin/skycoin.go`'s `DBVerifyCheckpointVersion` value
 0. Update `CHANGELOG.md`: move the "unreleased" changes to the version and add the date
-0. Update files in https://github.com/skycoin/repo-info/tree/master/repos/skycoin/remote, adding a new file for the new version and adjusting any configuration text that may have changed
-  * `skycoin/skycoin`
-  * `skycoin/skycoindev-cli`
-  * `skycoin/skycoindev-vscode`
+0. Update files in https://github.com/skycoin/repo-info/tree/master/repos/skycoin/remote for images `skycoin/skycoin`, `skycoin/skycoindev-cli`, and `skycoin/skycoindev-vscode`, adding a new file for the new version and adjusting any configuration text that may have changed
 0. Merge these changes to `develop`
 0. Follow the steps in [pre-release testing](#pre-release-testing)
 0. Make a PR merging `develop` into `master`

--- a/README.md
+++ b/README.md
@@ -630,7 +630,7 @@ Instructions for doing this:
 0. Run `make newcoin`. Compare `git diff cmd/skycoin/skycoin.go`. The only change should be the version number in the file.
 0. If changes require a new database verification on the next upgrade, update `src/skycoin/skycoin.go`'s `DBVerifyCheckpointVersion` value
 0. Update `CHANGELOG.md`: move the "unreleased" changes to the version and add the date
-q0. Update files in https://github.com/skycoin/repo-info/tree/master/repos/skycoin/remote, adding a new file for the new version and adjusting any configuration text that may have changed
+0. Update files in https://github.com/skycoin/repo-info/tree/master/repos/skycoin/remote, adding a new file for the new version and adjusting any configuration text that may have changed
   * `skycoin/skycoin`
   * `skycoin/skycoindev-cli`
   * `skycoin/skycoindev-vscode`


### PR DESCRIPTION
Fixes #2061

Changes:
- Fix minor typo in README.md

Does this change need to mentioned in CHANGELOG.md?
no