### PR TITLE
[docker] fixes #2071 fixes #2072 - Build info for skycoin binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Correct build info for `skycoin` binary compiled for `skycoin/skycoin` mainnet image 
+- `/api/v1/health` will return correct build info when running Docker containers based on `skycoin/skycoin` mainnet image.
 
 ### Changed
 - Switch `skycoin-cli` from `urfave/cli` to `spf13/cobra`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Correct build info for `skycoin` binary compiled for `skycoin/skycoin` mainnet image 
+
 ### Changed
 - Switch `skycoin-cli` from `urfave/cli` to `spf13/cobra`.
   Now all options of a cli command must only use `--` prefix instead of a mix of `--` and `-` prefixes.

--- a/docker/images/mainnet/Dockerfile
+++ b/docker/images/mainnet/Dockerfile
@@ -35,7 +35,7 @@ RUN sh -c \
      fi'
 
 RUN cd $GOPATH/src/github.com/skycoin/skycoin && \
-    COMMIT=$(git rev-parse HEAD) BRANCH=$(git rev-parse -—abbrev-ref HEAD) \
+    COMMIT=$SCOMMIT BRANCH=$(git rev-parse -—abbrev-ref HEAD) \
     GOARCH=$ARCH GOARM=$GOARM CGO_ENABLED=0 GOOS=linux \
     GOLDFLAGS="-X main.Commit=${COMMIT} -X main.Branch=${BRANCH}" \
     go install -ldflags "${GOLDFLAGS}" ./cmd/... && \

--- a/docker/images/mainnet/Dockerfile
+++ b/docker/images/mainnet/Dockerfile
@@ -7,6 +7,7 @@ ARG GOARM
 ARG SKYCOIN_VERSION
 ARG BDATE
 ARG SCOMMIT
+ARG SBRANCH
 
 # Image labels
 LABEL "org.label-schema.name"="Skycoin" \
@@ -35,7 +36,7 @@ RUN sh -c \
      fi'
 
 RUN cd $GOPATH/src/github.com/skycoin/skycoin && \
-    COMMIT=$SCOMMIT BRANCH=$(git rev-parse -—abbrev-ref HEAD) \
+    COMMIT=$SCOMMIT BRANCH=$SBRANCH \
     GOARCH=$ARCH GOARM=$GOARM CGO_ENABLED=0 GOOS=linux \
     GOLDFLAGS="-X main.Commit=${COMMIT} -X main.Branch=${BRANCH}" \
     go install -ldflags "${GOLDFLAGS}" ./cmd/... && \

--- a/docker/images/mainnet/Dockerfile
+++ b/docker/images/mainnet/Dockerfile
@@ -5,7 +5,6 @@ FROM golang:1.11-stretch AS build
 ARG ARCH=amd64
 ARG GOARM
 ARG SKYCOIN_VERSION
-ARG BDATE
 ARG SCOMMIT
 ARG SBRANCH
 ARG STAG
@@ -43,6 +42,10 @@ COPY docker_launcher.sh /tmp/files/usr/local/bin/docker_launcher.sh
 
 # skycoin image
 FROM $IMAGE_FROM
+ARG BDATE
+ARG SCOMMIT
+ARG SBRANCH
+ARG STAG
 
 # Image labels
 LABEL "org.label-schema.name"="Skycoin" \

--- a/docker/images/mainnet/Dockerfile
+++ b/docker/images/mainnet/Dockerfile
@@ -10,19 +10,6 @@ ARG SCOMMIT
 ARG SBRANCH
 ARG STAG
 
-# Image labels
-LABEL "org.label-schema.name"="Skycoin" \
-      "org.label-schema.description"="Skycoin core docker image" \
-      "org.label-schema.vcs-url"="https://github.com/skycoin/skycoin/tree/develop/docker/images/mainnet" \
-      "org.label-schema.vendor"="Skycoin project" \
-      "org.label-schema.url"="skycoin.net" \
-      "org.label-schema.schema-version"="1.0" \
-      "org.label-schema.build-date"=$BDATE \
-      "org.label-schema.vcs-ref"=$SCOMMIT \
-      "org.label-schema.version"=$STAG \
-      "org.label-schema.usage"="https://github.com/skycoin/skycoin/blob/"$SCOMMIT"/docker/images/mainnet/README.md" \
-      "org.label-schema.docker.cmd"="docker volume create skycoin-data; docker volume create skycoin-wallet; docker run -d -v skycoin-data:/data/.skycoin -v skycoin-wallet:/wallet -p 6000:6000 -p 6420:6420 --name skycoin-node-stable skycoin/skycoin"
-
 COPY . $GOPATH/src/github.com/skycoin/skycoin
 
 # This code checks if SKYCOIN_VERSION is set and checkouts to that version if
@@ -56,6 +43,19 @@ COPY docker_launcher.sh /tmp/files/usr/local/bin/docker_launcher.sh
 
 # skycoin image
 FROM $IMAGE_FROM
+
+# Image labels
+LABEL "org.label-schema.name"="Skycoin" \
+      "org.label-schema.description"="Skycoin core docker image" \
+      "org.label-schema.vcs-url"="https://github.com/skycoin/skycoin/tree/develop/docker/images/mainnet" \
+      "org.label-schema.vendor"="Skycoin project" \
+      "org.label-schema.url"="skycoin.net" \
+      "org.label-schema.schema-version"="1.0" \
+      "org.label-schema.build-date"=$BDATE \
+      "org.label-schema.vcs-ref"=$SCOMMIT \
+      "org.label-schema.version"=$STAG \
+      "org.label-schema.usage"="https://github.com/skycoin/skycoin/blob/"$SCOMMIT"/docker/images/mainnet/README.md" \
+      "org.label-schema.docker.cmd"="docker volume create skycoin-data; docker volume create skycoin-wallet; docker run -d -v skycoin-data:/data/.skycoin -v skycoin-wallet:/wallet -p 6000:6000 -p 6420:6420 --name skycoin-node-stable skycoin/skycoin"
 
 ENV COIN="skycoin"
 ENV RPC_ADDR="http://0.0.0.0:6420" \

--- a/docker/images/mainnet/Dockerfile
+++ b/docker/images/mainnet/Dockerfile
@@ -8,6 +8,7 @@ ARG SKYCOIN_VERSION
 ARG BDATE
 ARG SCOMMIT
 ARG SBRANCH
+ARG STAG
 
 # Image labels
 LABEL "org.label-schema.name"="Skycoin" \
@@ -18,7 +19,7 @@ LABEL "org.label-schema.name"="Skycoin" \
       "org.label-schema.schema-version"="1.0" \
       "org.label-schema.build-date"=$BDATE \
       "org.label-schema.vcs-ref"=$SCOMMIT \
-      "org.label-schema.version"="1.0.0-rc.1" \
+      "org.label-schema.version"=$STAG \
       "org.label-schema.usage"="https://github.com/skycoin/skycoin/blob/"$SCOMMIT"/docker/images/mainnet/README.md" \
       "org.label-schema.docker.cmd"="docker volume create skycoin-data; docker volume create skycoin-wallet; docker run -d -v skycoin-data:/data/.skycoin -v skycoin-wallet:/wallet -p 6000:6000 -p 6420:6420 --name skycoin-node-stable skycoin/skycoin"
 

--- a/docker/images/mainnet/hooks/build
+++ b/docker/images/mainnet/hooks/build
@@ -17,6 +17,7 @@ cd ../../../
 # Build skycoin/skycoin:latest
 docker build --build-arg BDATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
              --build-arg SCOMMIT=$SOURCE_COMMIT \
+             --build-arg SBRANCH=$SOURCE_BRANCH \
              -f $DOCKERFILE_PATH \
              -t $IMAGE_NAME .
 
@@ -26,6 +27,7 @@ docker build --build-arg=ARCH=arm \
              --build-arg=IMAGE_FROM="arm32v5/busybox" \
              --build-arg BDATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
              --build-arg SCOMMIT=$SOURCE_COMMIT \
+             --build-arg SBRANCH=$SOURCE_BRANCH \
              -f $DOCKERFILE_PATH \
              -t $IMAGE_NAME-arm32v5 .
 
@@ -35,6 +37,7 @@ docker build --build-arg=ARCH=arm \
              --build-arg=IMAGE_FROM="arm32v6/busybox" \
              --build-arg BDATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
              --build-arg SCOMMIT=$SOURCE_COMMIT \
+             --build-arg SBRANCH=$SOURCE_BRANCH \
              -f $DOCKERFILE_PATH \
              -t $IMAGE_NAME-arm32v6 .
 
@@ -44,6 +47,7 @@ docker build --build-arg=ARCH=arm \
              --build-arg=IMAGE_FROM="arm32v7/busybox" \
              --build-arg BDATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
              --build-arg SCOMMIT=$SOURCE_COMMIT \
+             --build-arg SBRANCH=$SOURCE_BRANCH \
              -f $DOCKERFILE_PATH \
              -t $IMAGE_NAME-arm32v7 .
 
@@ -52,5 +56,6 @@ docker build --build-arg=ARCH=arm64 \
              --build-arg=IMAGE_FROM="arm64v8/busybox" \
              --build-arg BDATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
              --build-arg SCOMMIT=$SOURCE_COMMIT \
+             --build-arg SBRANCH=$SOURCE_BRANCH \
              -f $DOCKERFILE_PATH \
              -t $IMAGE_NAME-arm64v8 .

--- a/docker/images/mainnet/hooks/build
+++ b/docker/images/mainnet/hooks/build
@@ -14,10 +14,15 @@
 
 cd ../../../
 
+if ["${CACHE_TAG#release-v}" != "$CACHE_TAG"] ; then
+  SOURCE_TAG="${CACHE_TAG#release-v}"
+fi
+
 # Build skycoin/skycoin:latest
 docker build --build-arg BDATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
              --build-arg SCOMMIT=$SOURCE_COMMIT \
              --build-arg SBRANCH=$SOURCE_BRANCH \
+             --build-arg STAG=$SOURCE_TAG \
              -f $DOCKERFILE_PATH \
              -t $IMAGE_NAME .
 
@@ -28,6 +33,7 @@ docker build --build-arg=ARCH=arm \
              --build-arg BDATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
              --build-arg SCOMMIT=$SOURCE_COMMIT \
              --build-arg SBRANCH=$SOURCE_BRANCH \
+             --build-arg STAG=$SOURCE_TAG \
              -f $DOCKERFILE_PATH \
              -t $IMAGE_NAME-arm32v5 .
 
@@ -38,6 +44,7 @@ docker build --build-arg=ARCH=arm \
              --build-arg BDATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
              --build-arg SCOMMIT=$SOURCE_COMMIT \
              --build-arg SBRANCH=$SOURCE_BRANCH \
+             --build-arg STAG=$SOURCE_TAG \
              -f $DOCKERFILE_PATH \
              -t $IMAGE_NAME-arm32v6 .
 
@@ -48,6 +55,7 @@ docker build --build-arg=ARCH=arm \
              --build-arg BDATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
              --build-arg SCOMMIT=$SOURCE_COMMIT \
              --build-arg SBRANCH=$SOURCE_BRANCH \
+             --build-arg STAG=$SOURCE_TAG \
              -f $DOCKERFILE_PATH \
              -t $IMAGE_NAME-arm32v7 .
 
@@ -57,5 +65,6 @@ docker build --build-arg=ARCH=arm64 \
              --build-arg BDATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
              --build-arg SCOMMIT=$SOURCE_COMMIT \
              --build-arg SBRANCH=$SOURCE_BRANCH \
+             --build-arg STAG=$SOURCE_TAG \
              -f $DOCKERFILE_PATH \
              -t $IMAGE_NAME-arm64v8 .


### PR DESCRIPTION
Fixes #2071 
Fixes #2072 

Changes:
- Hook `SOURCE_COMMIT` used in `Dockerfile` for build info
- Hook `SOURCE_BRANCH` used in `Dockerfile` for build info
- Correct version (from `CACHE_TAG`) for software version distributed in `skycoin/skycoin` Docker image

Does this change need to mentioned in CHANGELOG.md?
yes