### PR TITLE
Optimize /outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,8 @@ docs/libc/xml
 
 *.prof
 *.profile
+*.cpuprofile
+*.memprofile
 
 # cli fiberAddressGen default output
 addresses.txt

--- a/src/api/explorer_test.go
+++ b/src/api/explorer_test.go
@@ -257,7 +257,7 @@ func TestCoinSupply(t *testing.T) {
 		testutil.MakeAddress(),
 	}
 
-	unlockedAddrs := params.GetUnlockedDistributionAddresses()
+	unlockedAddrs := params.GetUnlockedDistributionAddressesDecoded()
 	successGatewayGetUnspentOutputsResult := readable.UnspentOutputsSummary{
 		HeadOutputs: readable.UnspentOutputs{
 			readable.UnspentOutput{
@@ -269,13 +269,6 @@ func TestCoinSupply(t *testing.T) {
 				Coins:   "0",
 			},
 		},
-	}
-
-	unlockedAddrsRaw := make([]cipher.Address, len(unlockedAddrs))
-	for i, addr := range unlockedAddrs {
-		a, err := cipher.DecodeBase58Address(addr)
-		require.NoError(t, err)
-		unlockedAddrsRaw[i] = a
 	}
 
 	var filterInUnlocked []visor.OutputsFilter
@@ -325,7 +318,7 @@ func TestCoinSupply(t *testing.T) {
 						UxOut: coin.UxOut{
 							Body: coin.UxBody{
 								Coins:   9223372036854775807,
-								Address: unlockedAddrsRaw[0],
+								Address: unlockedAddrs[0],
 							},
 						},
 					},
@@ -333,7 +326,7 @@ func TestCoinSupply(t *testing.T) {
 						UxOut: coin.UxOut{
 							Body: coin.UxBody{
 								Coins:   1000000,
-								Address: unlockedAddrsRaw[0],
+								Address: unlockedAddrs[0],
 							},
 						},
 					},

--- a/src/api/http.go
+++ b/src/api/http.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rs/cors"
 
 	"github.com/skycoin/skycoin/src/api/webrpc"
+	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/daemon"
 	"github.com/skycoin/skycoin/src/readable"
 	"github.com/skycoin/skycoin/src/util/file"
@@ -547,4 +548,38 @@ func splitCommaString(s string) []string {
 	}
 
 	return dedupWords
+}
+
+// parseAddressesFromStr parses comma-separated addresses string into []cipher.Address
+func parseAddressesFromStr(s string) ([]cipher.Address, error) {
+	addrsStr := splitCommaString(s)
+
+	addrs := make([]cipher.Address, len(addrsStr))
+	for i, s := range addrsStr {
+		a, err := cipher.DecodeBase58Address(s)
+		if err != nil {
+			return nil, fmt.Errorf("address %q is invalid: %v", s, err)
+		}
+
+		addrs[i] = a
+	}
+
+	return addrs, nil
+}
+
+// parseAddressesFromStr parses comma-separated hashes string into []cipher.SHA256
+func parseHashesFromStr(s string) ([]cipher.SHA256, error) {
+	hashesStr := splitCommaString(s)
+
+	hashes := make([]cipher.SHA256, len(hashesStr))
+	for i, s := range hashesStr {
+		h, err := cipher.SHA256FromHex(s)
+		if err != nil {
+			return nil, fmt.Errorf("SHA256 hash %q is invalid: %v", s, err)
+		}
+
+		hashes[i] = h
+	}
+
+	return hashes, nil
 }

--- a/src/api/integration/integration_test.go
+++ b/src/api/integration/integration_test.go
@@ -2406,7 +2406,7 @@ func TestStableTransactions(t *testing.T) {
 			err: api.ClientError{
 				Status:     "400 Bad Request",
 				StatusCode: http.StatusBadRequest,
-				Message:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid address length",
+				Message:    "400 Bad Request - parse parameter: 'addrs' failed: address \"abcd\" is invalid: Invalid address length",
 			},
 		},
 		{
@@ -2415,7 +2415,7 @@ func TestStableTransactions(t *testing.T) {
 			err: api.ClientError{
 				Status:     "400 Bad Request",
 				StatusCode: http.StatusBadRequest,
-				Message:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid base58 character",
+				Message:    "400 Bad Request - parse parameter: 'addrs' failed: address \"701d23fd513bad325938ba56869f9faba19384a8ec3dd41833aff147eac53947\" is invalid: Invalid base58 character",
 			},
 		},
 		{
@@ -2424,7 +2424,7 @@ func TestStableTransactions(t *testing.T) {
 			err: api.ClientError{
 				Status:     "400 Bad Request",
 				StatusCode: http.StatusBadRequest,
-				Message:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid checksum",
+				Message:    "400 Bad Request - parse parameter: 'addrs' failed: address \"2kvLEyXwAYvHfJuFCkjnYNRTUfHPyWgVwKk\" is invalid: Invalid checksum",
 			},
 		},
 		{
@@ -2510,7 +2510,7 @@ func TestStableConfirmedTransactions(t *testing.T) {
 			err: api.ClientError{
 				Status:     "400 Bad Request",
 				StatusCode: http.StatusBadRequest,
-				Message:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid address length",
+				Message:    "400 Bad Request - parse parameter: 'addrs' failed: address \"abcd\" is invalid: Invalid address length",
 			},
 		},
 		{
@@ -2519,7 +2519,7 @@ func TestStableConfirmedTransactions(t *testing.T) {
 			err: api.ClientError{
 				Status:     "400 Bad Request",
 				StatusCode: http.StatusBadRequest,
-				Message:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid base58 character",
+				Message:    "400 Bad Request - parse parameter: 'addrs' failed: address \"701d23fd513bad325938ba56869f9faba19384a8ec3dd41833aff147eac53947\" is invalid: Invalid base58 character",
 			},
 		},
 		{
@@ -2528,7 +2528,7 @@ func TestStableConfirmedTransactions(t *testing.T) {
 			err: api.ClientError{
 				Status:     "400 Bad Request",
 				StatusCode: http.StatusBadRequest,
-				Message:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid checksum",
+				Message:    "400 Bad Request - parse parameter: 'addrs' failed: address \"2kvLEyXwAYvHfJuFCkjnYNRTUfHPyWgVwKk\" is invalid: Invalid checksum",
 			},
 		},
 		{
@@ -2587,7 +2587,7 @@ func TestStableUnconfirmedTransactions(t *testing.T) {
 			err: api.ClientError{
 				Status:     "400 Bad Request",
 				StatusCode: http.StatusBadRequest,
-				Message:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid address length",
+				Message:    "400 Bad Request - parse parameter: 'addrs' failed: address \"abcd\" is invalid: Invalid address length",
 			},
 		},
 		{
@@ -2596,7 +2596,7 @@ func TestStableUnconfirmedTransactions(t *testing.T) {
 			err: api.ClientError{
 				Status:     "400 Bad Request",
 				StatusCode: http.StatusBadRequest,
-				Message:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid base58 character",
+				Message:    "400 Bad Request - parse parameter: 'addrs' failed: address \"701d23fd513bad325938ba56869f9faba19384a8ec3dd41833aff147eac53947\" is invalid: Invalid base58 character",
 			},
 		},
 		{
@@ -2605,7 +2605,7 @@ func TestStableUnconfirmedTransactions(t *testing.T) {
 			err: api.ClientError{
 				Status:     "400 Bad Request",
 				StatusCode: http.StatusBadRequest,
-				Message:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid checksum",
+				Message:    "400 Bad Request - parse parameter: 'addrs' failed: address \"2kvLEyXwAYvHfJuFCkjnYNRTUfHPyWgVwKk\" is invalid: Invalid checksum",
 			},
 		},
 	}
@@ -2697,7 +2697,7 @@ func TestStableTransactionsVerbose(t *testing.T) {
 			err: api.ClientError{
 				Status:     "400 Bad Request",
 				StatusCode: http.StatusBadRequest,
-				Message:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid address length",
+				Message:    "400 Bad Request - parse parameter: 'addrs' failed: address \"abcd\" is invalid: Invalid address length",
 			},
 		},
 		{
@@ -2706,7 +2706,7 @@ func TestStableTransactionsVerbose(t *testing.T) {
 			err: api.ClientError{
 				Status:     "400 Bad Request",
 				StatusCode: http.StatusBadRequest,
-				Message:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid base58 character",
+				Message:    "400 Bad Request - parse parameter: 'addrs' failed: address \"701d23fd513bad325938ba56869f9faba19384a8ec3dd41833aff147eac53947\" is invalid: Invalid base58 character",
 			},
 		},
 		{
@@ -2715,7 +2715,7 @@ func TestStableTransactionsVerbose(t *testing.T) {
 			err: api.ClientError{
 				Status:     "400 Bad Request",
 				StatusCode: http.StatusBadRequest,
-				Message:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid checksum",
+				Message:    "400 Bad Request - parse parameter: 'addrs' failed: address \"2kvLEyXwAYvHfJuFCkjnYNRTUfHPyWgVwKk\" is invalid: Invalid checksum",
 			},
 		},
 		{
@@ -2796,7 +2796,7 @@ func TestStableConfirmedTransactionsVerbose(t *testing.T) {
 			err: api.ClientError{
 				Status:     "400 Bad Request",
 				StatusCode: http.StatusBadRequest,
-				Message:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid address length",
+				Message:    "400 Bad Request - parse parameter: 'addrs' failed: address \"abcd\" is invalid: Invalid address length",
 			},
 		},
 		{
@@ -2805,7 +2805,7 @@ func TestStableConfirmedTransactionsVerbose(t *testing.T) {
 			err: api.ClientError{
 				Status:     "400 Bad Request",
 				StatusCode: http.StatusBadRequest,
-				Message:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid base58 character",
+				Message:    "400 Bad Request - parse parameter: 'addrs' failed: address \"701d23fd513bad325938ba56869f9faba19384a8ec3dd41833aff147eac53947\" is invalid: Invalid base58 character",
 			},
 		},
 		{
@@ -2814,7 +2814,7 @@ func TestStableConfirmedTransactionsVerbose(t *testing.T) {
 			err: api.ClientError{
 				Status:     "400 Bad Request",
 				StatusCode: http.StatusBadRequest,
-				Message:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid checksum",
+				Message:    "400 Bad Request - parse parameter: 'addrs' failed: address \"2kvLEyXwAYvHfJuFCkjnYNRTUfHPyWgVwKk\" is invalid: Invalid checksum",
 			},
 		},
 		{
@@ -2873,7 +2873,7 @@ func TestStableUnconfirmedTransactionsVerbose(t *testing.T) {
 			err: api.ClientError{
 				Status:     "400 Bad Request",
 				StatusCode: http.StatusBadRequest,
-				Message:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid address length",
+				Message:    "400 Bad Request - parse parameter: 'addrs' failed: address \"abcd\" is invalid: Invalid address length",
 			},
 		},
 		{
@@ -2882,7 +2882,7 @@ func TestStableUnconfirmedTransactionsVerbose(t *testing.T) {
 			err: api.ClientError{
 				Status:     "400 Bad Request",
 				StatusCode: http.StatusBadRequest,
-				Message:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid base58 character",
+				Message:    "400 Bad Request - parse parameter: 'addrs' failed: address \"701d23fd513bad325938ba56869f9faba19384a8ec3dd41833aff147eac53947\" is invalid: Invalid base58 character",
 			},
 		},
 		{
@@ -2891,7 +2891,7 @@ func TestStableUnconfirmedTransactionsVerbose(t *testing.T) {
 			err: api.ClientError{
 				Status:     "400 Bad Request",
 				StatusCode: http.StatusBadRequest,
-				Message:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid checksum",
+				Message:    "400 Bad Request - parse parameter: 'addrs' failed: address \"2kvLEyXwAYvHfJuFCkjnYNRTUfHPyWgVwKk\" is invalid: Invalid checksum",
 			},
 		},
 	}

--- a/src/api/outputs.go
+++ b/src/api/outputs.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/readable"
 	wh "github.com/skycoin/skycoin/src/util/http"
 	"github.com/skycoin/skycoin/src/visor"
@@ -26,9 +25,6 @@ func outputsHandler(gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 
-		var addrs []string
-		var hashes []string
-
 		addrStr := r.FormValue("addrs")
 		hashStr := r.FormValue("hashes")
 
@@ -37,16 +33,13 @@ func outputsHandler(gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 
-		filters := []visor.OutputsFilter{}
+		var filters []visor.OutputsFilter
 
 		if addrStr != "" {
-			addrs = splitCommaString(addrStr)
-
-			for _, a := range addrs {
-				if _, err := cipher.DecodeBase58Address(a); err != nil {
-					wh.Error400(w, "addrs contains invalid address")
-					return
-				}
+			addrs, err := parseAddressesFromStr(addrStr)
+			if err != nil {
+				wh.Error400(w, err.Error())
+				return
 			}
 
 			if len(addrs) > 0 {
@@ -55,7 +48,12 @@ func outputsHandler(gateway Gatewayer) http.HandlerFunc {
 		}
 
 		if hashStr != "" {
-			hashes = splitCommaString(hashStr)
+			hashes, err := parseHashesFromStr(hashStr)
+			if err != nil {
+				wh.Error400(w, err.Error())
+				return
+			}
+
 			if len(hashes) > 0 {
 				filters = append(filters, visor.FbyHashes(hashes))
 			}

--- a/src/api/outputs_test.go
+++ b/src/api/outputs_test.go
@@ -57,7 +57,7 @@ func TestGetOutputsHandler(t *testing.T) {
 			name:   "400 - invalid address",
 			method: http.MethodGet,
 			status: http.StatusBadRequest,
-			err:    "400 Bad Request - addrs contains invalid address",
+			err:    "400 Bad Request - address \"invalidAddr\" is invalid: Invalid base58 character",
 			httpBody: &httpBody{
 				addrs: invalidAddr,
 			},
@@ -150,8 +150,7 @@ func TestGetOutputsHandler(t *testing.T) {
 			require.Equal(t, tc.status, status, "got `%v` want `%v`", status, tc.status)
 
 			if status != http.StatusOK {
-				require.Equal(t, tc.err, strings.TrimSpace(rr.Body.String()), "got `%v`| %d, want `%v`",
-					strings.TrimSpace(rr.Body.String()), status, tc.err)
+				require.Equal(t, tc.err, strings.TrimSpace(rr.Body.String()))
 			} else {
 				var msg *readable.UnspentOutputsSummary
 				err = json.Unmarshal(rr.Body.Bytes(), &msg)

--- a/src/api/transaction.go
+++ b/src/api/transaction.go
@@ -323,23 +323,6 @@ func transactionsHandler(gateway Gatewayer) http.HandlerFunc {
 	}
 }
 
-// parseAddressesFromStr parses comma separated addresses string into []cipher.Address
-func parseAddressesFromStr(s string) ([]cipher.Address, error) {
-	addrsStr := splitCommaString(s)
-
-	var addrs []cipher.Address
-	for _, s := range addrsStr {
-		a, err := cipher.DecodeBase58Address(s)
-		if err != nil {
-			return nil, err
-		}
-
-		addrs = append(addrs, a)
-	}
-
-	return addrs, nil
-}
-
 // URI: /api/v1/injectTransaction
 // Method: POST
 // Content-Type: application/json

--- a/src/api/transaction_test.go
+++ b/src/api/transaction_test.go
@@ -1044,7 +1044,7 @@ func TestGetTransactions(t *testing.T) {
 			name:   "400 - invalid `addrs` param",
 			method: http.MethodGet,
 			status: http.StatusBadRequest,
-			err:    "400 Bad Request - parse parameter: 'addrs' failed: Invalid base58 character",
+			err:    "400 Bad Request - parse parameter: 'addrs' failed: address \"invalid\" is invalid: Invalid base58 character",
 			httpBody: &httpBody{
 				addrs: invalidAddrsStr,
 			},

--- a/src/api/wallet.go
+++ b/src/api/wallet.go
@@ -139,16 +139,10 @@ func balanceHandler(gateway Gatewayer) http.HandlerFunc {
 		}
 
 		addrsParam := r.FormValue("addrs")
-		addrsStr := splitCommaString(addrsParam)
-
-		addrs := make([]cipher.Address, 0, len(addrsStr))
-		for _, addr := range addrsStr {
-			a, err := cipher.DecodeBase58Address(addr)
-			if err != nil {
-				wh.Error400(w, fmt.Sprintf("address %s is invalid: %v", addr, err))
-				return
-			}
-			addrs = append(addrs, a)
+		addrs, err := parseAddressesFromStr(addrsParam)
+		if err != nil {
+			wh.Error400(w, err.Error())
+			return
 		}
 
 		if len(addrs) == 0 {

--- a/src/api/wallet_test.go
+++ b/src/api/wallet_test.go
@@ -53,7 +53,7 @@ func TestGetBalanceHandler(t *testing.T) {
 			name:   "400 - invalid address",
 			method: http.MethodGet,
 			status: http.StatusBadRequest,
-			err:    "400 Bad Request - address invalidAddr is invalid: Invalid base58 character",
+			err:    "400 Bad Request - address \"invalidAddr\" is invalid: Invalid base58 character",
 			httpBody: &httpBody{
 				addrs: invalidAddr,
 			},
@@ -198,8 +198,7 @@ func TestGetBalanceHandler(t *testing.T) {
 			require.Equal(t, tc.status, status, "got `%v` want `%v`", status, tc.status)
 
 			if status != http.StatusOK {
-				require.Equal(t, tc.err, strings.TrimSpace(rr.Body.String()), "got `%v`| %d, want `%v`",
-					strings.TrimSpace(rr.Body.String()), status, tc.err)
+				require.Equal(t, tc.err, strings.TrimSpace(rr.Body.String()))
 			} else {
 				var msg readable.BalancePair
 				err = json.Unmarshal(rr.Body.Bytes(), &msg)

--- a/src/api/webrpc/outputs.go
+++ b/src/api/webrpc/outputs.go
@@ -29,13 +29,16 @@ func getOutputsHandler(req Request, gateway Gatewayer) Response {
 	}
 
 	// validate those addresses
-	for _, a := range addrs {
-		if _, err := cipher.DecodeBase58Address(a); err != nil {
+	realAddrs := make([]cipher.Address, len(addrs))
+	for i, a := range addrs {
+		addr, err := cipher.DecodeBase58Address(a)
+		if err != nil {
 			return MakeErrorResponse(ErrCodeInvalidParams, fmt.Sprintf("invalid address: %v", a))
 		}
+		realAddrs[i] = addr
 	}
 
-	summary, err := gateway.GetUnspentOutputsSummary([]visor.OutputsFilter{visor.FbyAddresses(addrs)})
+	summary, err := gateway.GetUnspentOutputsSummary([]visor.OutputsFilter{visor.FbyAddresses(realAddrs)})
 	if err != nil {
 		logger.Errorf("get unspent outputs failed: %v", err)
 		return MakeErrorResponse(ErrCodeInternalError, fmt.Sprintf("gateway.GetUnspentOutputsSummary failed: %v", err))

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -2467,13 +2467,13 @@ func (vs *Visor) GetVerboseTransactionsForAddress(a cipher.Address) ([]Transacti
 type OutputsFilter func(outputs coin.UxArray) coin.UxArray
 
 // FbyAddressesNotIncluded filters the unspent outputs that are not owned by the addresses
-func FbyAddressesNotIncluded(addrs []string) OutputsFilter {
+func FbyAddressesNotIncluded(addrs []cipher.Address) OutputsFilter {
 	return func(outputs coin.UxArray) coin.UxArray {
 		addrMatch := coin.UxArray{}
-		addrMap := newStringSet(addrs)
+		addrMap := newAddrSet(addrs)
 
 		for _, u := range outputs {
-			if _, ok := addrMap[u.Body.Address.String()]; !ok {
+			if _, ok := addrMap[u.Body.Address]; !ok {
 				addrMatch = append(addrMatch, u)
 			}
 		}
@@ -2482,13 +2482,13 @@ func FbyAddressesNotIncluded(addrs []string) OutputsFilter {
 }
 
 // FbyAddresses filters the unspent outputs that owned by the addresses
-func FbyAddresses(addrs []string) OutputsFilter {
+func FbyAddresses(addrs []cipher.Address) OutputsFilter {
 	return func(outputs coin.UxArray) coin.UxArray {
 		addrMatch := coin.UxArray{}
-		addrMap := newStringSet(addrs)
+		addrMap := newAddrSet(addrs)
 
 		for _, u := range outputs {
-			if _, ok := addrMap[u.Body.Address.String()]; ok {
+			if _, ok := addrMap[u.Body.Address]; ok {
 				addrMatch = append(addrMatch, u)
 			}
 		}
@@ -2497,13 +2497,13 @@ func FbyAddresses(addrs []string) OutputsFilter {
 }
 
 // FbyHashes filters the unspent outputs that have hashes matched.
-func FbyHashes(hashes []string) OutputsFilter {
+func FbyHashes(hashes []cipher.SHA256) OutputsFilter {
 	return func(outputs coin.UxArray) coin.UxArray {
 		hsMatch := coin.UxArray{}
-		hsMap := newStringSet(hashes)
+		hsMap := newSHA256Set(hashes)
 
 		for _, u := range outputs {
-			if _, ok := hsMap[u.Hash().Hex()]; ok {
+			if _, ok := hsMap[u.Hash()]; ok {
 				hsMatch = append(hsMatch, u)
 			}
 		}
@@ -2511,9 +2511,17 @@ func FbyHashes(hashes []string) OutputsFilter {
 	}
 }
 
-// newStringSet returns a map-based set for string lookup
-func newStringSet(keys []string) map[string]struct{} {
-	s := make(map[string]struct{}, len(keys))
+func newAddrSet(keys []cipher.Address) map[cipher.Address]struct{} {
+	s := make(map[cipher.Address]struct{}, len(keys))
+	for _, k := range keys {
+		s[k] = struct{}{}
+	}
+	return s
+}
+
+// newSHA256Set returns a map-based set for string lookup
+func newSHA256Set(keys []cipher.SHA256) map[cipher.SHA256]struct{} {
+	s := make(map[cipher.SHA256]struct{}, len(keys))
 	for _, k := range keys {
 		s[k] = struct{}{}
 	}

--- a/src/visor/visor_test.go
+++ b/src/visor/visor_test.go
@@ -3121,26 +3121,24 @@ func TestFbyAddresses(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		addrs   []string
+		addrs   []cipher.Address
 		outputs []coin.UxOut
 		want    []coin.UxOut
 	}{
-		// TODO: Add test cases.
 		{
 			"filter with one address",
-			[]string{addrs[0].String()},
+			[]cipher.Address{addrs[0]},
 			uxs[:2],
 			uxs[:1],
 		},
 		{
 			"filter with multiple addresses",
-			[]string{addrs[0].String(), addrs[1].String()},
+			[]cipher.Address{addrs[0], addrs[1]},
 			uxs[:3],
 			uxs[:2],
 		},
 	}
 	for _, tt := range tests {
-		// fmt.Printf("want:%+v\n", tt.want)
 		outs := FbyAddresses(tt.addrs)(tt.outputs)
 		require.Equal(t, outs, coin.UxArray(tt.want))
 	}
@@ -3160,20 +3158,19 @@ func TestFbyHashes(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		hashes  []string
+		hashes  []cipher.SHA256
 		outputs coin.UxArray
 		want    coin.UxArray
 	}{
-		// TODO: Add test cases.
 		{
 			"filter with one hash",
-			[]string{uxs[0].Hash().Hex()},
+			[]cipher.SHA256{uxs[0].Hash()},
 			uxs[:2],
 			uxs[:1],
 		},
 		{
 			"filter with multiple hash",
-			[]string{uxs[0].Hash().Hex(), uxs[1].Hash().Hex()},
+			[]cipher.SHA256{uxs[0].Hash(), uxs[1].Hash()},
 			uxs[:3],
 			uxs[:2],
 		},


### PR DESCRIPTION
Changes:
- Removes `cipher.Address.String` and `cipher.SHA256.Hex` operations from uxto query filtering, using the raw cipher objects instead

Speed when from ~2s to ~300ms on my sample query.