### PR TITLE
Improve error message for /injectTransaction /transaction/verify

### DIFF
--- a/src/api/transaction.go
+++ b/src/api/transaction.go
@@ -348,6 +348,11 @@ func injectTransactionHandler(gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 
+		if v.Rawtx == "" {
+			wh.Error400(w, "rawtx is required")
+			return
+		}
+
 		b, err := hex.DecodeString(v.Rawtx)
 		if err != nil {
 			wh.Error400(w, err.Error())
@@ -490,6 +495,12 @@ func verifyTxnHandler(gateway Gatewayer) http.HandlerFunc {
 		var req VerifyTxnRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			resp := NewHTTPErrorResponse(http.StatusBadRequest, err.Error())
+			writeHTTPResponse(w, resp)
+			return
+		}
+
+		if req.EncodedTransaction == "" {
+			resp := NewHTTPErrorResponse(http.StatusBadRequest, "encoded_transaction is required")
 			writeHTTPResponse(w, resp)
 			return
 		}

--- a/src/api/transaction_test.go
+++ b/src/api/transaction_test.go
@@ -662,10 +662,10 @@ func TestInjectTransaction(t *testing.T) {
 			err:    "400 Bad Request - EOF",
 		},
 		{
-			name:     "400 - Invalid transaction: Not enough buffer data to deserialize",
+			name:     "400 - rawtx required",
 			method:   http.MethodPost,
 			status:   http.StatusBadRequest,
-			err:      "400 Bad Request - Invalid transaction: Not enough buffer data to deserialize",
+			err:      "400 Bad Request - rawtx is required",
 			httpBody: `{"wrongKey":"wrongValue"}`,
 		},
 		{
@@ -1405,12 +1405,12 @@ func TestVerifyTransaction(t *testing.T) {
 			httpResponse: NewHTTPErrorResponse(http.StatusUnsupportedMediaType, ""),
 		},
 		{
-			name:         "400 - Invalid transaction: Not enough buffer data to deserialize",
+			name:         "400 - encoded_transaction is required",
 			method:       http.MethodPost,
 			contentType:  ContentTypeJSON,
 			status:       http.StatusBadRequest,
 			httpBody:     `{"wrongKey":"wrongValue"}`,
-			httpResponse: NewHTTPErrorResponse(http.StatusBadRequest, "decode transaction failed: Invalid transaction: Not enough buffer data to deserialize"),
+			httpResponse: NewHTTPErrorResponse(http.StatusBadRequest, "encoded_transaction is required"),
 		},
 		{
 			name:         "400 - encoding/hex: odd length hex string",


### PR DESCRIPTION
Changes:
- If `rawtx` or `encoded_transaction` is missing, display a better error message than "could not decode buffer"

Does this change need to mentioned in CHANGELOG.md?
No