### PR TITLE
Fix the wallet upgrade detection

### DIFF
--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -30,7 +30,7 @@ let showErrorCalled = false;
 let dev = process.argv.find(arg => arg === 'dev') ? true : false;
 
 // Force everything localhost, in case of a leak
-app.commandLine.appendSwitch('host-rules', 'MAP * 127.0.0.1, EXCLUDE api.coinmarketcap.com, api.github.com');
+app.commandLine.appendSwitch('host-rules', 'MAP * 127.0.0.1, EXCLUDE api.coinmarketcap.com, EXCLUDE api.github.com');
 app.commandLine.appendSwitch('ssl-version-fallback-min', 'tls1.2');
 app.commandLine.appendSwitch('--no-proxy-server');
 app.setAsDefaultProtocolClient('skycoin');


### PR DESCRIPTION
Fixes #1384 

Changes:
- Electron was blocking the connection to `api.coinmarketcap.com` because the whitelisting code had an error, so the version check was not working. This PR solves that.

Additional changes will be nedded when solving https://github.com/skycoin/skycoin/issues/2043

Does this change need to mentioned in CHANGELOG.md?
No