### PR TITLE
Add BigNumber where missing

### DIFF
--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -358,7 +358,7 @@ export class WalletService {
         convertedOutputs = txOutputs.map(output => {
           return {
             ...output,
-            coins: parseInt((output.coins * 1000000) + '', 10),
+            coins: parseInt(new BigNumber(output.coins).multipliedBy(1000000).toFixed(0), 10),
           };
         });
 


### PR DESCRIPTION
Fixes #2108

Changes:
- Adds Bignumber where missing in `WalletService.createHwTransaction`

Does this change need to mentioned in CHANGELOG.md?
No