### PR TITLE
Use a generic date format on the UI

### DIFF
--- a/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/transaction-info.component.html
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/transaction-info.component.html
@@ -14,7 +14,7 @@
         </ng-container>
         <ng-container *ngIf="!isPreview">
           <div class="-data">
-            <span>{{ 'tx.date' | translate }}:</span> <span>{{ transaction.timestamp * 1000 | date:'yyyy-MM-dd hh:mm a' }}</span>
+            <span>{{ 'tx.date' | translate }}:</span> <span>{{ transaction.timestamp | dateTime }}</span>
           </div>
           <div class="-data">
             <span>{{ 'tx.status' | translate }}:</span> <span>{{ (transaction.confirmed ? 'tx.confirmed' : 'tx.pending') | translate }}</span>

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/transaction-info.component.html
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/transaction-info.component.html
@@ -14,7 +14,7 @@
         </ng-container>
         <ng-container *ngIf="!isPreview">
           <div class="-data">
-            <span>{{ 'tx.date' | translate }}:</span> <span>{{ transaction.timestamp * 1000 | date:'short' }}</span>
+            <span>{{ 'tx.date' | translate }}:</span> <span>{{ transaction.timestamp * 1000 | date:'yyyy-MM-dd hh:mm a' }}</span>
           </div>
           <div class="-data">
             <span>{{ 'tx.status' | translate }}:</span> <span>{{ (transaction.confirmed ? 'tx.confirmed' : 'tx.pending') | translate }}</span>

--- a/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.html
+++ b/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.html
@@ -15,7 +15,7 @@
         <div class="-address">
           <h4 *ngIf="transaction.balance < 0 && transaction.confirmed">
             {{ 'history.sent' | translate }} {{ 'common.coin-id' | translate }}
-            <span class="-timestamp">{{ transaction.timestamp * 1000 | date:'yyyy-MM-dd hh:mm a' }}</span>
+            <span class="-timestamp">{{ transaction.timestamp | dateTime }}</span>
           </h4>
           <h4 *ngIf="transaction.balance < 0 && !transaction.confirmed">
             {{ 'history.sending' | translate }} {{ 'common.coin-id' | translate }}
@@ -23,7 +23,7 @@
           </h4>
           <h4 *ngIf="transaction.balance > 0 && transaction.confirmed">
             {{ 'history.received' | translate }} {{ 'common.coin-id' | translate }}
-            <span class="-timestamp">{{ transaction.timestamp * 1000 | date:'yyyy-MM-dd hh:mm a' }}</span>
+            <span class="-timestamp">{{ transaction.timestamp | dateTime }}</span>
           </h4>
           <h4 *ngIf="transaction.balance > 0 && !transaction.confirmed">
             {{ 'history.receiving' | translate }} {{ 'common.coin-id' | translate }}

--- a/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.html
+++ b/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.html
@@ -15,7 +15,7 @@
         <div class="-address">
           <h4 *ngIf="transaction.balance < 0 && transaction.confirmed">
             {{ 'history.sent' | translate }} {{ 'common.coin-id' | translate }}
-            <span class="-timestamp">{{ transaction.timestamp * 1000 | date:'short' }}</span>
+            <span class="-timestamp">{{ transaction.timestamp * 1000 | date:'yyyy-MM-dd hh:mm a' }}</span>
           </h4>
           <h4 *ngIf="transaction.balance < 0 && !transaction.confirmed">
             {{ 'history.sending' | translate }} {{ 'common.coin-id' | translate }}
@@ -23,7 +23,7 @@
           </h4>
           <h4 *ngIf="transaction.balance > 0 && transaction.confirmed">
             {{ 'history.received' | translate }} {{ 'common.coin-id' | translate }}
-            <span class="-timestamp">{{ transaction.timestamp * 1000 | date:'short' }}</span>
+            <span class="-timestamp">{{ transaction.timestamp * 1000 | date:'yyyy-MM-dd hh:mm a' }}</span>
           </h4>
           <h4 *ngIf="transaction.balance > 0 && !transaction.confirmed">
             {{ 'history.receiving' | translate }} {{ 'common.coin-id' | translate }}


### PR DESCRIPTION
Fixes #2107

Changes:
- The dates are now displayed with the `yyyy/MM/dd` format.

Does this change need to mentioned in CHANGELOG.md?
No