### PR TITLE
Allow to filter the transaction history

### DIFF
--- a/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.html
+++ b/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.html
@@ -1,7 +1,13 @@
 <app-header [headline]="'title.transactions' | translate"></app-header>
 <div class="container">
   <div [formGroup]="form" class="form-field" *ngIf="allTransactions">
-    <mat-select multiple formControlName="filter" [placeholder]="'history.no-filter' | translate" id="filter">
+    <mat-select
+      multiple
+      [ngClass]="{ 'bottom-line': !transactions || transactions.length === 0 }"
+      formControlName="filter"
+      [placeholder]="'history.no-filter' | translate"
+      id="filter"
+    >
       <mat-optgroup *ngFor="let wallet of wallets" label="
         {{ wallet.label }} - {{ wallet.coins | number:'1.0-6' }} {{ 'common.coin-id' | translate }}
         ({{ wallet.hours | number:'1.0-0' }} {{ 'common.coin-hours' | translate }})
@@ -15,7 +21,8 @@
         </mat-option>
       </mat-optgroup>
       <mat-select-trigger>
-        <span>{{ 'history.filter' | translate }}</span>
+        <span *ngIf="form.get('filter').value.length === 1">{{ 'history.filter' | translate }}</span>
+        <span *ngIf="form.get('filter').value.length > 1">{{ 'history.filters' | translate }}</span>
         <ng-container *ngFor="let filter of form.get('filter').value; let i = index">
           <div class="filter" *ngIf="filter.label || !filter.showingWholeWallet">
             <span *ngIf="filter.label">{{ filter.label }}</span>
@@ -26,6 +33,7 @@
         </ng-container>
       </mat-select-trigger>
     </mat-select>
+    <img class="x-button" src="assets/img/close-grey.png" (click)="removeFilters()" *ngIf="form.get('filter').value.length > 0">
   </div>
 
   <app-loading-content

--- a/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.html
+++ b/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.html
@@ -1,8 +1,36 @@
 <app-header [headline]="'title.transactions' | translate"></app-header>
 <div class="container">
+  <div [formGroup]="form" class="form-field" *ngIf="allTransactions">
+    <mat-select multiple formControlName="filter" [placeholder]="'history.no-filter' | translate" id="filter">
+      <mat-optgroup *ngFor="let wallet of wallets" label="
+        {{ wallet.label }} - {{ wallet.coins | number:'1.0-6' }} {{ 'common.coin-id' | translate }}
+        ({{ wallet.hours | number:'1.0-0' }} {{ 'common.coin-hours' | translate }})
+      ">
+        <mat-option *ngIf="wallet.addresses.length > 1" [value]="wallet">
+          {{ 'history.all-addresses' | translate }}
+        </mat-option>
+        <mat-option *ngFor="let address of wallet.addresses" [value]="address" [disabled]="wallet.allAddressesSelected">
+          {{ address.address }} - {{ address.coins | number:'1.0-6' }} {{ 'common.coin-id' | translate }}
+          ({{ address.hours | number:'1.0-0' }} {{ 'common.coin-hours' | translate }})
+        </mat-option>
+      </mat-optgroup>
+      <mat-select-trigger>
+        <span>{{ 'history.filter' | translate }}</span>
+        <ng-container *ngFor="let filter of form.get('filter').value; let i = index">
+          <div class="filter" *ngIf="filter.label || !filter.showingWholeWallet">
+            <span *ngIf="filter.label">{{ filter.label }}</span>
+            <span *ngIf="!filter.label">{{ filter.address }}</span>
+            - {{ filter.coins | number:'1.0-6' }} {{ 'common.coin-id' | translate }}
+            ({{ filter.hours | number:'1.0-0' }} {{ 'common.coin-hours' | translate }})
+          </div>
+        </ng-container>
+      </mat-select-trigger>
+    </mat-select>
+  </div>
+
   <app-loading-content
-    [isLoading]="!transactions"
-    noDataText="history.no-txs"
+    [isLoading]="!allTransactions"
+    [noDataText]="!allTransactions || allTransactions.length === 0 ? 'history.no-txs' : 'history.no-txs-filter'"
     *ngIf="!transactions || transactions.length === 0"
   ></app-loading-content>
 

--- a/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.scss
+++ b/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.scss
@@ -1,13 +1,22 @@
 @import '../../../../theme/variables';
 
 .form-field {
-  margin: 20px 40px;
-  margin-bottom: -10px;
+  margin: 10px 40px;
+  margin-bottom: -20px;
+  display: flex;
+
+  .x-button {
+    width: 42px;
+    height: 42px;
+    cursor: pointer;
+  }
+}
+
+.bottom-line {
+  border-bottom: 2px solid rgba(0, 0, 0, 0.02);
 }
 
 mat-select {
-  border-bottom: 2px solid rgba(0, 0, 0, 0.02);
-
   ::ng-deep .mat-select-trigger {
     padding: 10px 30px 10px 10px;
     display: block;
@@ -17,7 +26,7 @@ mat-select {
   }
 
   ::ng-deep .mat-select-value {
-    font-size: 16px;
+    font-size: 13px;
     line-height: 22px;
   }
 
@@ -27,6 +36,7 @@ mat-select {
 
   ::ng-deep .mat-select-placeholder {
     transition: unset !important;
+    color: $grey;
 
     &::before {
       content: 'filter_list';
@@ -53,6 +63,7 @@ mat-select {
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+    color: $grey;
   }
 }
 

--- a/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.scss
+++ b/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.scss
@@ -6,8 +6,9 @@
   display: flex;
 
   .x-button {
-    width: 42px;
-    height: 42px;
+    width: 24px;
+    height: 24px;
+    margin-top: 10px;
     cursor: pointer;
   }
 }

--- a/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.scss
+++ b/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.scss
@@ -1,5 +1,71 @@
 @import '../../../../theme/variables';
 
+.form-field {
+  margin: 20px 40px;
+  margin-bottom: -10px;
+}
+
+mat-select {
+  border-bottom: 2px solid rgba(0, 0, 0, 0.02);
+
+  ::ng-deep .mat-select-trigger {
+    padding: 10px 30px 10px 10px;
+    display: block;
+    font-size: 11px;
+    height: 100%;
+    line-height: 20px;
+  }
+
+  ::ng-deep .mat-select-value {
+    font-size: 16px;
+    line-height: 22px;
+  }
+
+  ::ng-deep .mat-select-arrow {
+    border: none;
+  }
+
+  ::ng-deep .mat-select-placeholder {
+    transition: unset !important;
+
+    &::before {
+      content: 'filter_list';
+      font-family: 'Material Icons';
+      font-weight: normal;
+      font-style: normal;
+      font-size: 13px;
+      margin-right: 10px;
+    }
+  }
+
+  mat-select-trigger::before {
+    content: 'filter_list';
+    font-family: 'Material Icons';
+    font-weight: normal;
+    font-style: normal;
+    font-size: 13px;
+    margin-right: 10px;
+  }
+
+  .filter {
+    font-size: 13px;
+    margin-left: 28px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+}
+
+mat-option ::ng-deep .mat-pseudo-checkbox-checked {
+  background: $gradient-blue-dark;
+}
+
+.mat-option-disabled {
+  ::ng-deep .mat-pseudo-checkbox-disabled {
+    opacity: 0.5;
+  }
+}
+
 .-paper {
   background-color: #fbfbfb;
   border-radius: 10px;

--- a/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.ts
+++ b/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.ts
@@ -6,6 +6,22 @@ import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { TransactionDetailComponent } from './transaction-detail/transaction-detail.component';
 import { NormalTransaction } from '../../../app.datatypes';
 import { QrCodeComponent } from '../../layout/qr-code/qr-code.component';
+import { FormGroup, FormBuilder } from '@angular/forms';
+
+export class Wallet {
+  label: string;
+  coins: string;
+  hours: string;
+  addresses: Address[];
+  allAddressesSelected: boolean;
+}
+
+export class Address {
+  address: string;
+  coins: string;
+  hours: string;
+  showingWholeWallet: boolean;
+}
 
 @Component({
   selector: 'app-transaction-list',
@@ -13,24 +29,111 @@ import { QrCodeComponent } from '../../layout/qr-code/qr-code.component';
   styleUrls: ['./transaction-list.component.scss'],
 })
 export class TransactionListComponent implements OnInit, OnDestroy {
+  allTransactions: NormalTransaction[];
   transactions: NormalTransaction[];
+  wallets: Wallet[];
+  form: FormGroup;
 
   private price: number;
   private priceSubscription: ISubscription;
+  private filterSubscription: ISubscription;
+  private walletsSubscription: ISubscription;
 
   constructor(
     private dialog: MatDialog,
     private priceService: PriceService,
     private walletService: WalletService,
-  ) { }
+    private formBuilder: FormBuilder,
+  ) {
+    this.walletsSubscription = walletService.all().delay(1).subscribe(wallets => {
+      this.wallets = [];
+      let incompleteData = false;
+
+      // A local copy of the data is created to avoid problems when updating the
+      // wallet addresses when updating the balance.
+      wallets.forEach(wallet => {
+        if (!wallet.coins || !wallet.hours || incompleteData) {
+          incompleteData = true;
+
+          return;
+        }
+
+        this.wallets.push({
+          label: wallet.label,
+          coins: wallet.coins.decimalPlaces(6).toString(),
+          hours: wallet.hours.decimalPlaces(0).toString(),
+          addresses: [],
+          allAddressesSelected: false,
+        });
+
+        wallet.addresses.forEach(address => {
+          if (!address.coins || !address.hours || incompleteData) {
+            incompleteData = true;
+
+            return;
+          }
+
+          this.wallets[this.wallets.length - 1].addresses.push({
+            address: address.address,
+            coins: address.coins.decimalPlaces(6).toString(),
+            hours: address.hours.decimalPlaces(0).toString(),
+            showingWholeWallet: false,
+          });
+        });
+      });
+
+      if (incompleteData) {
+        this.wallets = [];
+      } else {
+        this.walletsSubscription.unsubscribe();
+      }
+    });
+
+    this.form = this.formBuilder.group({
+      filter: [[]],
+    });
+  }
 
   ngOnInit() {
     this.priceSubscription = this.priceService.price.subscribe(price => this.price = price);
-    this.walletService.transactions().first().subscribe(transactions => this.transactions = transactions);
+
+    this.walletService.transactions().first().subscribe(transactions => {
+      this.allTransactions = transactions;
+      this.transactions = transactions;
+    });
+
+    this.filterSubscription = this.form.get('filter').valueChanges.subscribe(() => {
+      const selectedfilters: (Wallet|Address)[] = this.form.get('filter').value;
+      this.wallets.forEach(wallet => {
+        wallet.allAddressesSelected = false;
+        wallet.addresses.forEach(address => address.showingWholeWallet = false);
+      });
+
+      if (selectedfilters.length === 0) {
+        this.transactions = this.allTransactions;
+      } else {
+        const selectedAddresses: Map<string, boolean> = new Map<string, boolean>();
+        selectedfilters.forEach(filter => {
+          if ((filter as Wallet).addresses) {
+            (filter as Wallet).addresses.forEach(address => selectedAddresses.set(address.address, true));
+            (filter as Wallet).allAddressesSelected = true;
+            (filter as Wallet).addresses.forEach(address => address.showingWholeWallet = true);
+          } else {
+            selectedAddresses.set((filter as Address).address, true);
+          }
+        });
+
+        this.transactions = this.allTransactions.filter(tx =>
+          tx.inputs.some(input => selectedAddresses.has(input.owner)) || tx.outputs.some(output => selectedAddresses.has(output.dst)),
+        );
+      }
+    });
   }
 
   ngOnDestroy() {
     this.priceSubscription.unsubscribe();
+    this.filterSubscription.unsubscribe();
+    this.walletsSubscription.unsubscribe();
   }
 
   showTransaction(transaction: NormalTransaction) {

--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.html
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.html
@@ -48,6 +48,9 @@
           <button mat-menu-item routerLink="/settings/outputs" [queryParams]="{ addr: address.address }">
             {{ 'wallet.address.outputs' | translate }}
           </button>
+          <button mat-menu-item routerLink="/transactions" [queryParams]="{ addr: address.address }">
+            {{ 'wallet.address.history' | translate }}
+          </button>
         </mat-menu>
       </div>
     </div>

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -266,7 +266,11 @@
     "received": "Received",
     "receiving": "Receiving",
     "pending": "Pending",
-    "no-txs": "You have no transaction history"
+    "no-txs": "You have no transaction history",
+    "no-txs-filter": "There are no transactions matching the current filter criteria",
+    "no-filter": "Showing for all the wallets and addresses",
+    "filter": "Showing only for: ",
+    "all-addresses": "All addresses"
   },
 
   "teller": {

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -153,7 +153,8 @@
       "copy": "Copy",
       "copy-address": "Copy address",
       "copied": "Copied!",
-      "outputs": "Unspent Outputs"
+      "outputs": "Unspent Outputs",
+      "history": "History"
     }
   },
 
@@ -268,8 +269,9 @@
     "pending": "Pending",
     "no-txs": "You have no transaction history",
     "no-txs-filter": "There are no transactions matching the current filter criteria",
-    "no-filter": "Showing for all the wallets and addresses",
-    "filter": "Showing only for: ",
+    "no-filter": "No filter active (press to select wallets/addresses)",
+    "filter": "Active filter: ",
+    "filters": "Active filters: ",
     "all-addresses": "All addresses"
   },
 


### PR DESCRIPTION
Fixes #2104

Changes:
- Now it is possible to limit the history page to certain addresses or wallets.
![filter](https://user-images.githubusercontent.com/34079003/51643932-ad76ec00-1f44-11e9-908f-389d102b5841.png)
![filter2](https://user-images.githubusercontent.com/34079003/51643946-b5cf2700-1f44-11e9-93b6-b499f5756673.png)

Does this change need to mentioned in CHANGELOG.md?
No