### PR TITLE
Implement common encoding interfaces for PubKey and SecKey

### DIFF
--- a/src/cipher/crypto.go
+++ b/src/cipher/crypto.go
@@ -191,6 +191,39 @@ func (pk PubKey) Null() bool {
 	return pk == PubKey{}
 }
 
+// String implements fmt.Stringer for PubKey. Returns Hex representation.
+func (pk PubKey) String() string {
+	return pk.Hex()
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (pk PubKey) MarshalText() ([]byte, error) {
+	return []byte(pk.Hex()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (pk *PubKey) UnmarshalText(data []byte) error {
+	dPK, err := PubKeyFromHex(string(data))
+	if err == nil {
+		*pk = dPK
+	}
+	return err
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (pk PubKey) MarshalBinary() ([]byte, error) {
+	return pk[:], nil
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (pk *PubKey) UnmarshalBinary(data []byte) error {
+	dPK, err := NewPubKey(data)
+	if err == nil {
+		*pk = dPK
+	}
+	return err
+}
+
 // SecKey secret key
 type SecKey [32]byte
 
@@ -266,6 +299,39 @@ func (sk SecKey) Hex() string {
 // Null returns true if SecKey is the null SecKey
 func (sk SecKey) Null() bool {
 	return sk == SecKey{}
+}
+
+// String implements fmt.Stringer for SecKey. Returns Hex representation.
+func (sk SecKey) String() string {
+	return sk.Hex()
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (sk SecKey) MarshalText() ([]byte, error) {
+	return []byte(sk.Hex()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (sk *SecKey) UnmarshalText(data []byte) error {
+	dSK, err := SecKeyFromHex(string(data))
+	if err == nil {
+		*sk = dSK
+	}
+	return err
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (sk SecKey) MarshalBinary() ([]byte, error) {
+	return sk[:], nil
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (sk *SecKey) UnmarshalBinary(data []byte) error {
+	dSK, err := NewSecKey(data)
+	if err == nil {
+		*sk = dSK
+	}
+	return err
 }
 
 //ECDH generates a shared secret

--- a/src/cipher/crypto_test.go
+++ b/src/cipher/crypto_test.go
@@ -103,6 +103,33 @@ func TestPubKeyHex(t *testing.T) {
 	require.Equal(t, p2.Hex(), h)
 }
 
+func TestPubKeyString(t *testing.T) {
+	p, _ := GenerateKeyPair()
+	require.Equal(t, p.Hex(), p.String())
+}
+
+func TestPubKeyTextMarshaller(t *testing.T) {
+	p, _ := GenerateKeyPair()
+	h, err := p.MarshalText()
+	require.NoError(t, err)
+
+	var p2 PubKey
+	err = p2.UnmarshalText(h)
+	require.NoError(t, err)
+	require.Equal(t, p, p2)
+}
+
+func TestPubKeyBinaryMarshaller(t *testing.T) {
+	p, _ := GenerateKeyPair()
+	b, err := p.MarshalBinary()
+	require.NoError(t, err)
+
+	var p2 PubKey
+	err = p2.UnmarshalBinary(b)
+	require.NoError(t, err)
+	require.Equal(t, p, p2)
+}
+
 func TestNewPubKeyRandom(t *testing.T) {
 	// Random bytes should not be valid, most of the time
 	failed := false
@@ -261,6 +288,33 @@ func TestSecKeyHex(t *testing.T) {
 	p2 := MustSecKeyFromHex(h)
 	require.Equal(t, p2, p)
 	require.Equal(t, p2.Hex(), h)
+}
+
+func TestSecKeyString(t *testing.T) {
+	_, s := GenerateKeyPair()
+	require.Equal(t, s.Hex(), s.String())
+}
+
+func TestSecKeyTextMarshaller(t *testing.T) {
+	_, s := GenerateKeyPair()
+	h, err := s.MarshalText()
+	require.NoError(t, err)
+
+	var s2 SecKey
+	err = s2.UnmarshalText(h)
+	require.NoError(t, err)
+	require.Equal(t, s, s2)
+}
+
+func TestSecKeyBinaryMarshaller(t *testing.T) {
+	_, s := GenerateKeyPair()
+	b, err := s.MarshalBinary()
+	require.NoError(t, err)
+
+	var s2 SecKey
+	err = s2.UnmarshalBinary(b)
+	require.NoError(t, err)
+	require.Equal(t, s, s2)
 }
 
 func TestSecKeyVerify(t *testing.T) {


### PR DESCRIPTION
Fixes -

Changes:
- Implements `fmt.Stringer`, `encoding.Text/BinaryMarshaller` and `encoding.Text/BinaryUnmarshaller` for `cipher.PubKey` and `cipher.SecKey`.

Does this change need to mentioned in CHANGELOG.md?
I don't see similar changes in changelog.
