### PR TITLE
Add Encoder.CopyBytes method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 .PHONY: integration-test-db-no-unconfirmed integration-test-auth
 .PHONY: install-linters format release clean-release clean-coverage
 .PHONY: install-deps-ui build-ui help newcoins merge-coverage
-.PHONY: generate-mocks update-golden-files
+.PHONY: generate update-golden-files
 .PHONY: fuzz-base58 fuzz-encoder
 
 COIN ?= skycoin
@@ -159,7 +159,7 @@ clean-coverage: ## Remove coverage output files
 newcoin: ## Rebuild cmd/$COIN/$COIN.go file from the template. Call like "make newcoin COIN=foo".
 	go run cmd/newcoin/newcoin.go createcoin --coin $(COIN)
 
-generate-mocks: ## Regenerate test interface mocks
+generate: ## Generate test interface mocks and struct encoders
 	go generate ./src/...
 	# mockery can't generate the UnspentPooler mock in package visor, patch it
 	mv ./src/visor/blockdb/mock_unspent_pooler_test.go ./src/visor/mock_unspent_pooler_test.go

--- a/src/cipher/encoder/encoder.go
+++ b/src/cipher/encoder/encoder.go
@@ -586,9 +586,14 @@ func (e *Encoder) Uint64(x uint64) {
 	e.Buffer = e.Buffer[8:]
 }
 
-// Bytes encodes []byte
-func (e *Encoder) Bytes(x []byte) {
+// ByteSlice encodes []byte
+func (e *Encoder) ByteSlice(x []byte) {
 	e.Uint32(uint32(len(x)))
+	e.CopyBytes(x)
+}
+
+// CopyBytes copies bytes to the buffer, without a length prefix
+func (e *Encoder) CopyBytes(x []byte) {
 	copy(e.Buffer, x)
 	e.Buffer = e.Buffer[len(x):]
 }
@@ -916,7 +921,7 @@ func (e *Encoder) value(v reflect.Value) {
 		elem := t.Elem()
 		switch elem.Kind() {
 		case reflect.Uint8:
-			e.Bytes(v.Bytes())
+			e.ByteSlice(v.Bytes())
 		default:
 			e.Uint32(uint32(v.Len()))
 			for i := 0; i < v.Len(); i++ {
@@ -963,7 +968,7 @@ func (e *Encoder) value(v reflect.Value) {
 		e.Bool(v.Bool())
 
 	case reflect.String:
-		e.Bytes([]byte(v.String()))
+		e.ByteSlice([]byte(v.String()))
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		switch v.Type().Kind() {


### PR DESCRIPTION
Changes:
- Rename `make generate-mocks` to `make generate` (will be adding other `go:generate` directives besides `mockery`)
- Rename `encoder.Encoder.Bytes` to `encoder.Encoder.ByteSlice`
- Add `encoder.Encoder.CopyBytes` method

Does this change need to mentioned in CHANGELOG.md?
No