### PR TITLE
Deactivate the hw wallet options on production builds

### DIFF
--- a/src/gui/static/.angular-cli.json
+++ b/src/gui/static/.angular-cli.json
@@ -31,7 +31,8 @@
       "environmentSource": "environments/environment.ts",
       "environments": {
         "dev": "environments/environment.ts",
-        "prod": "environments/environment.prod.ts"
+        "prod": "environments/environment.prod.ts",
+        "prod-hw": "environments/environment.ts"
       }
     }
   ],

--- a/src/gui/static/package.json
+++ b/src/gui/static/package.json
@@ -6,6 +6,7 @@
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.config.js --delete-output-path false",
     "build": "ng build --prod",
+    "build-prod-hw": "ng build --prod --environment prod-hw",
     "build-travis": "ng build --prod --output-path=$BUILD_UI_TRAVIS_DIR",
     "test": "ng test --watch=false",
     "lint": "ng lint",

--- a/src/gui/static/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.ts
+++ b/src/gui/static/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.ts
@@ -6,6 +6,7 @@ import { MatDialogRef } from '@angular/material';
 import { CreateWalletFormComponent } from '../../wallets/create-wallet/create-wallet-form/create-wallet-form.component';
 import { HwOptionsDialogComponent } from '../../../layout/hardware-wallet/hw-options-dialog/hw-options-dialog.component';
 import { Router } from '@angular/router';
+import { HwWalletService } from '../../../../services/hw-wallet.service';
 
 @Component({
   selector: 'app-onboarding-create-wallet',
@@ -24,10 +25,9 @@ export class OnboardingCreateWalletComponent implements OnInit {
   constructor(
     private dialog: MatDialog,
     private router: Router,
+    hwWalletService: HwWalletService,
   ) {
-    if (window['isElectron']) {
-      this.hwCompatibilityActivated = window['ipcRenderer'].sendSync('hwCompatibilityActivated');
-    }
+    this.hwCompatibilityActivated = hwWalletService.hwWalletCompatibilityActivated;
   }
 
   ngOnInit() {

--- a/src/gui/static/src/app/components/pages/wallets/wallets.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/wallets.component.ts
@@ -29,9 +29,7 @@ export class WalletsComponent implements OnInit, OnDestroy {
     private dialog: MatDialog,
     private router: Router,
   ) {
-    if (window['isElectron']) {
-      this.hwCompatibilityActivated = window['ipcRenderer'].sendSync('hwCompatibilityActivated');
-    }
+    this.hwCompatibilityActivated = this.hwWalletService.hwWalletCompatibilityActivated;
 
     this.subscription = this.walletService.all().subscribe(wallets => {
       this.wallets = [];

--- a/src/gui/static/src/app/services/hw-wallet.service.ts
+++ b/src/gui/static/src/app/services/hw-wallet.service.ts
@@ -6,6 +6,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { AppConfig } from '../app.config';
 import { MatDialog, MatDialogConfig } from '@angular/material';
 import { HwPinDialogParams } from '../components/layout/hardware-wallet/hw-pin-dialog/hw-pin-dialog.component';
+import { environment } from '../../environments/environment';
 
 export enum ChangePinStates {
   RequestingCurrentPin,
@@ -64,7 +65,7 @@ export class HwWalletService {
   }
 
   constructor(private translate: TranslateService, dialog: MatDialog) {
-    if (window['isElectron'] && window['ipcRenderer'].sendSync('hwCompatibilityActivated')) {
+    if (this.hwWalletCompatibilityActivated) {
       window['ipcRenderer'].on('hwConnectionEvent', (event, connected) => {
         if (!connected) {
           this.eventsObservers.forEach((value, key) => {
@@ -133,6 +134,10 @@ export class HwWalletService {
         });
       });
     }
+  }
+
+  get hwWalletCompatibilityActivated(): boolean {
+    return !environment.production && window['isElectron'] && window['ipcRenderer'].sendSync('hwCompatibilityActivated');
   }
 
   get walletConnectedAsyncEvent(): Observable<boolean> {

--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -538,7 +538,7 @@ export class WalletService {
     this.apiService.getWallets().first().subscribe(
       recoveredWallets => {
         let wallets: Wallet[] = [];
-        if (window['isElectron'] && window['ipcRenderer'].sendSync('hwCompatibilityActivated')) {
+        if (this.hwWalletService.hwWalletCompatibilityActivated) {
           this.loadHardwareWallets(wallets);
         }
         wallets = wallets.concat(recoveredWallets);


### PR DESCRIPTION
Changes:
- Disable the hardware wallet options in production builds. However, if you want to activate the options in a production build for testing during development, you can do it compiling the front-end with `npm run build-prod-hw`

Does this change need to mentioned in CHANGELOG.md?
No