### PR TITLE
Disable the github version check

### DIFF
--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -31,7 +31,7 @@ let splashLoaded = false
 let dev = process.argv.find(arg => arg === 'dev') ? true : false;
 
 // Force everything localhost, in case of a leak
-app.commandLine.appendSwitch('host-rules', 'MAP * 127.0.0.1, EXCLUDE api.coinmarketcap.com, EXCLUDE api.github.com');
+app.commandLine.appendSwitch('host-rules', 'MAP * 127.0.0.1, EXCLUDE api.coinmarketcap.com');
 app.commandLine.appendSwitch('ssl-version-fallback-min', 'tls1.2');
 app.commandLine.appendSwitch('--no-proxy-server');
 app.setAsDefaultProtocolClient('skycoin');


### PR DESCRIPTION
Since the version check wasn't working anyway, I'm keeping it disabled until we switch to storing the version in a file on our domain version.skycoin.net. 