### PR TITLE
Stop showing multiple warnings in the same banner

### DIFF
--- a/src/gui/static/src/app/components/layout/header/header.component.html
+++ b/src/gui/static/src/app/components/layout/header/header.component.html
@@ -48,7 +48,7 @@
     <div *ngIf="appService.error === 3">{{ 'header.errors.csrf' | translate }}</div>
   </mat-toolbar>
   <mat-toolbar class="notification-bar" *ngIf="hasPendingTxs || !synchronized">
-    <div *ngIf="hasPendingTxs">
+    <div *ngIf="hasPendingTxs && synchronized">
       {{ 'header.pending-txs1' | translate }}
       <a routerLink='/settings/pending-transactions'>{{ 'header.pending-txs2' | translate }}</a>
       {{ 'header.pending-txs3' | translate }}


### PR DESCRIPTION
Fixes #2142 

Changes:
- Now when the wallet is both syncing and there are pending transactions, only the syncing warning is shown.

Does this change need to mentioned in CHANGELOG.md?
No
