### PR TITLE
Improved transactions processing in the history

### DIFF
--- a/src/gui/static/src/app/app.datatypes.ts
+++ b/src/gui/static/src/app/app.datatypes.ts
@@ -31,6 +31,7 @@ export class Transaction {
   txid: string;
   hoursSent?: BigNumber;
   hoursBurned?: BigNumber;
+  coinsMovedInternally?: boolean;
 }
 
 export class PreviewTransaction extends Transaction {

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/transaction-info.component.html
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/transaction-info.component.html
@@ -23,7 +23,7 @@
         <div class="-data">
           <span>{{ 'tx.hours' | translate }}:</span>
           <span>
-            {{ transaction.hoursSent.decimalPlaces(0).toString() | number:'1.0-0' }} {{ !isPreview && transaction.balance.isGreaterThan(0) ? ('tx.hours-received' | translate) : ('tx.hours-sent' | translate) }}
+            {{ transaction.hoursSent.decimalPlaces(0).toString() | number:'1.0-0' }} {{ hoursText | translate }}
             |
             {{ transaction.hoursBurned.decimalPlaces(0).toString() | number:'1.0-0' }} {{ 'tx.hours-burned' | translate }}
           </span>
@@ -34,7 +34,7 @@
       </div>
 
       <div class="col-md-3 -tx-price">
-        <div class="-icon" [ngClass]="{ '-incoming': !isPreview && transaction.balance.isGreaterThan(0) }">
+        <div class="-icon" [ngClass]="{ '-incoming': !isPreview && transaction.balance.isGreaterThan(0) && !transaction.coinsMovedInternally }">
           <img src="/assets/img/send-blue.png">
         </div>
         <h4>{{ transaction.balance.decimalPlaces(6).toString() | number:'1.0-6' }} {{ 'common.coin-id' | translate }}</h4>

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/transaction-info.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/transaction-info.component.ts
@@ -21,6 +21,22 @@ export class TransactionInfoComponent implements OnInit, OnDestroy {
     this.subscription = this.priceService.price.subscribe(price => this.price = price);
   }
 
+  get hoursText(): string {
+    if (!this.transaction) {
+      return '';
+    }
+
+    if (!this.isPreview) {
+      if ((this.transaction as any).coinsMovedInternally) {
+        return 'tx.hours-moved';
+      } else if (this.transaction.balance.isGreaterThan(0)) {
+        return 'tx.hours-received';
+      }
+    }
+
+    return 'tx.hours-sent';
+  }
+
   ngOnInit() {
     if (this.isPreview) {
       this.transaction.hoursSent = new BigNumber('0');

--- a/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.html
+++ b/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.html
@@ -44,7 +44,7 @@
 
   <div class="-paper" *ngIf="transactions && transactions.length > 0">
     <ng-container *ngFor="let transaction of transactions">
-      <div class="-transaction" *ngIf="transaction.balance !== 0" (click)="showTransaction(transaction)">
+      <div class="-transaction" (click)="showTransaction(transaction)">
         <div class="-icon" [ngClass]="{ '-incoming': transaction.balance > 0 && !transaction.coinsMovedInternally, '-pending': !transaction.confirmed }">
           <img src="/assets/img/send-blue.png">
         </div>

--- a/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.html
+++ b/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.html
@@ -45,7 +45,7 @@
   <div class="-paper" *ngIf="transactions && transactions.length > 0">
     <ng-container *ngFor="let transaction of transactions">
       <div class="-transaction" (click)="showTransaction(transaction)">
-        <div class="-icon" [ngClass]="{ '-incoming': transaction.balance > 0 && !transaction.coinsMovedInternally, '-pending': !transaction.confirmed }">
+        <div class="-icon" [ngClass]="{ '-incoming': transaction.balance.isGreaterThan(0) && !transaction.coinsMovedInternally, '-pending': !transaction.confirmed }">
           <img src="/assets/img/send-blue.png">
         </div>
         <div class="-address">

--- a/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.html
+++ b/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.html
@@ -45,26 +45,38 @@
   <div class="-paper" *ngIf="transactions && transactions.length > 0">
     <ng-container *ngFor="let transaction of transactions">
       <div class="-transaction" *ngIf="transaction.balance !== 0" (click)="showTransaction(transaction)">
-        <div class="-icon" [ngClass]="{ '-incoming': transaction.balance > 0, '-pending': !transaction.confirmed }">
+        <div class="-icon" [ngClass]="{ '-incoming': transaction.balance > 0 && !transaction.coinsMovedInternally, '-pending': !transaction.confirmed }">
           <img src="/assets/img/send-blue.png">
         </div>
         <div class="-address">
-          <h4 *ngIf="transaction.balance < 0 && transaction.confirmed">
-            {{ 'history.sent' | translate }} {{ 'common.coin-id' | translate }}
-            <span class="-timestamp">{{ transaction.timestamp | dateTime }}</span>
-          </h4>
-          <h4 *ngIf="transaction.balance < 0 && !transaction.confirmed">
-            {{ 'history.sending' | translate }} {{ 'common.coin-id' | translate }}
-            <span class="-pending">{{ 'history.pending' | translate }}</span>
-          </h4>
-          <h4 *ngIf="transaction.balance > 0 && transaction.confirmed">
-            {{ 'history.received' | translate }} {{ 'common.coin-id' | translate }}
-            <span class="-timestamp">{{ transaction.timestamp | dateTime }}</span>
-          </h4>
-          <h4 *ngIf="transaction.balance > 0 && !transaction.confirmed">
-            {{ 'history.receiving' | translate }} {{ 'common.coin-id' | translate }}
-            <span class="-pending">{{ 'history.pending' | translate }}</span>
-          </h4>
+          <ng-container *ngIf="!transaction.coinsMovedInternally">
+            <h4 *ngIf="transaction.balance.isLessThan(0) && transaction.confirmed">
+              {{ 'history.sent' | translate }} {{ 'common.coin-id' | translate }}
+              <span class="-timestamp">{{ transaction.timestamp | dateTime }}</span>
+            </h4>
+            <h4 *ngIf="transaction.balance.isLessThan(0) && !transaction.confirmed">
+              {{ 'history.sending' | translate }} {{ 'common.coin-id' | translate }}
+              <span class="-pending">{{ 'history.pending' | translate }}</span>
+            </h4>
+            <h4 *ngIf="transaction.balance.isGreaterThan(0) && transaction.confirmed">
+              {{ 'history.received' | translate }} {{ 'common.coin-id' | translate }}
+              <span class="-timestamp">{{ transaction.timestamp | dateTime }}</span>
+            </h4>
+            <h4 *ngIf="transaction.balance.isGreaterThan(0) && !transaction.confirmed">
+              {{ 'history.receiving' | translate }} {{ 'common.coin-id' | translate }}
+              <span class="-pending">{{ 'history.pending' | translate }}</span>
+            </h4>
+          </ng-container>
+          <ng-container *ngIf="transaction.coinsMovedInternally">
+            <h4 *ngIf="transaction.confirmed">
+              {{ 'history.moved' | translate }} {{ 'common.coin-id' | translate }}
+              <span class="-timestamp">{{ transaction.timestamp | dateTime }}</span>
+            </h4>
+            <h4 *ngIf="!transaction.confirmed">
+              {{ 'history.moving' | translate }} {{ 'common.coin-id' | translate }}
+              <span class="-pending">{{ 'history.pending' | translate }}</span>
+            </h4>
+          </ng-container>
           <div class="-item" *ngFor="let address of transaction.addresses">
             <img src="../../../../assets/img/qr-code-black.png" (click)="showQrCode($event, address)" class="qr-code-button">
             <span>{{ address }}</span>

--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -409,44 +409,78 @@ export class WalletService {
   }
 
   transactions(): Observable<NormalTransaction[]> {
-    return this.allAddresses().first().flatMap(addresses => {
+    let wallets: Wallet[];
+    const addressesMap: Map<string, boolean> = new Map<string, boolean>();
+
+
+    return this.wallets.first().flatMap(w => {
+      wallets = w;
+
+      return this.allAddresses().first();
+    }).flatMap(addresses => {
       this.addresses = addresses;
+      addresses.map(add => addressesMap.set(add.address, true));
 
       return this.apiService.getTransactions(addresses);
     }).map(transactions => {
       return transactions
         .sort((a, b) =>  b.timestamp - a.timestamp)
         .map(transaction => {
-          const outgoing = this.addresses.some(address => {
-            return transaction.inputs.some(input => input.owner === address.address);
-          });
+          const outgoing = transaction.inputs.some(input => addressesMap.has(input.owner));
 
-          const relevantOutputs = transaction.outputs.reduce((array, output) => {
-            const isMyOutput = this.addresses.some(address => address.address === output.dst);
-
-            if ((outgoing && !isMyOutput) || (!outgoing && isMyOutput)) {
-              array.push(output);
-            }
-
-            return array;
-          }, []);
-
-          const calculatedOutputs = (outgoing && relevantOutputs.length === 0)
-          || (!outgoing && relevantOutputs.length === transaction.outputs.length)
-            ? transaction.outputs
-            : relevantOutputs;
-
-          transaction.addresses.push(
-            ...calculatedOutputs
-              .map(output => output.dst)
-              .filter((dst, i, self) => self.indexOf(dst) === i),
-          );
-
-          calculatedOutputs.map (output => transaction.balance = transaction.balance.plus(output.coins));
-          transaction.balance = (outgoing ? transaction.balance.negated() : transaction.balance);
-
+          const relevantAddresses: Map<string, boolean> = new Map<string, boolean>();
+          transaction.balance = new BigNumber('0');
           transaction.hoursSent = new BigNumber('0');
-          calculatedOutputs.map(output => transaction.hoursSent = transaction.hoursSent.plus(new BigNumber(output.hours)));
+
+          if (!outgoing) {
+            transaction.outputs.map(output => {
+              if (addressesMap.has(output.dst)) {
+                relevantAddresses.set(output.dst, true);
+                transaction.balance = transaction.balance.plus(output.coins);
+                transaction.hoursSent = transaction.hoursSent.plus(output.hours);
+              }
+            });
+          } else {
+            const possibleReturnAddressesMap: Map<string, boolean> = new Map<string, boolean>();
+            transaction.inputs.map(input => {
+              if (addressesMap.has(input.owner)) {
+                relevantAddresses.set(input.owner, true);
+                wallets.map(wallet => {
+                  if (wallet.addresses.some(add => add.address === input.owner)) {
+                    wallet.addresses.map(add => possibleReturnAddressesMap.set(add.address, true));
+                  }
+                });
+              }
+            });
+
+            transaction.outputs.map(output => {
+              if (!possibleReturnAddressesMap.has(output.dst)) {
+                transaction.balance = transaction.balance.minus(output.coins);
+                transaction.hoursSent = transaction.hoursSent.plus(output.hours);
+              }
+            });
+
+            if (transaction.balance.isEqualTo(0)) {
+              transaction.coinsMovedInternally = true;
+              const inputAddressesMap: Map<string, boolean> = new Map<string, boolean>();
+
+              transaction.inputs.map(input => {
+                inputAddressesMap.set(input.owner, true);
+              });
+
+              transaction.outputs.map(output => {
+                if (!inputAddressesMap.has(output.dst)) {
+                  relevantAddresses.set(output.dst, true);
+                  transaction.balance = transaction.balance.plus(output.coins);
+                  transaction.hoursSent = transaction.hoursSent.plus(output.hours);
+                }
+              });
+            }
+          }
+
+          relevantAddresses.forEach((value, key) => {
+            transaction.addresses.push(key);
+          });
 
           let inputsHours = new BigNumber('0');
           transaction.inputs.map(input => inputsHours = inputsHours.plus(new BigNumber(input.calculated_hours)));

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -205,6 +205,7 @@
     "hours": "Hours",
     "id": "Tx ID",
     "show-more": "Show more",
+    "hours-moved": "moved",
     "hours-sent": "sent",
     "hours-received": "received",
     "hours-burned": "burned",
@@ -264,6 +265,8 @@
 
   "history": {
     "tx-detail": "Transaction Detail",
+    "moving": "Internally moving",
+    "moved": "Internally moved",
     "sending": "Sending",
     "sent": "Sent",
     "received": "Received",


### PR DESCRIPTION
Fixes #2128 

Changes:
- When coins were moved between wallet addresses, the history showed that the user sended as many coins as there were in the inputs. Now that case is treated differently, and the UI shows `Internally moved`, instead of `Sent` or `Received`.

Does this change need to mentioned in CHANGELOG.md?
No