### PR TITLE
Show the Coin Hours in the simple form

### DIFF
--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.html
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.html
@@ -6,6 +6,7 @@
         <option disabled hidden [ngValue]="''">{{ 'send.select-wallet' | translate }}</option>
         <option *ngFor="let wallet of walletService.all() | async" [disabled]="!wallet.coins || wallet.coins.isLessThanOrEqualTo(0)" [ngValue]="wallet">
           {{ wallet.label }} - {{ (wallet.coins ? wallet.coins.decimalPlaces(6).toString() : 0) | number:'1.0-6' }} {{ 'common.coin-id' | translate }}
+          ({{ wallet.hours.decimalPlaces(0).toString() | number:'1.0-0' }} {{ 'common.coin-hours' | translate }})
         </option>
       </select>
     </div>


### PR DESCRIPTION
Changes:
- With this PR now the Select that allows to select the wallet in the simple form for sending coins also shows the Coin Hours balance, as it happens in the advanced form.

Does this change need to mentioned in CHANGELOG.md?
No