### PR TITLE
Migrate from CMC to Coin Paprika

### DIFF
--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -31,7 +31,7 @@ let splashLoaded = false
 let dev = process.argv.find(arg => arg === 'dev') ? true : false;
 
 // Force everything localhost, in case of a leak
-app.commandLine.appendSwitch('host-rules', 'MAP * 127.0.0.1, EXCLUDE api.coinmarketcap.com');
+app.commandLine.appendSwitch('host-rules', 'MAP * 127.0.0.1, EXCLUDE api.coinpaprika.com');
 app.commandLine.appendSwitch('ssl-version-fallback-min', 'tls1.2');
 app.commandLine.appendSwitch('--no-proxy-server');
 app.setAsDefaultProtocolClient('skycoin');

--- a/src/gui/static/src/app/services/price.service.ts
+++ b/src/gui/static/src/app/services/price.service.ts
@@ -6,7 +6,7 @@ import { Observable } from 'rxjs/Observable';
 
 @Injectable()
 export class PriceService {
-  readonly CMC_TICKER_ID = 1619;
+  readonly PRICE_API_ID = 'sky-skycoin';
 
   price: Subject<number> = new BehaviorSubject<number>(null);
 
@@ -16,10 +16,10 @@ export class PriceService {
   ) {
     this.ngZone.runOutsideAngular(() => {
       Observable.timer(0, 10 * 60 * 1000).subscribe(() => {
-        this.http.get(`https://api.coinmarketcap.com/v2/ticker/${this.CMC_TICKER_ID}/`)
+        this.http.get(`https://api.coinpaprika.com/v1/tickers/${this.PRICE_API_ID}?quotes=USD`)
           .map(response => response.json())
           .subscribe(response => this.ngZone.run(() => {
-            this.price.next(response.data.quotes.USD.price);
+            this.price.next(response.quotes.USD.price);
           }));
       });
     });


### PR DESCRIPTION
Fixes #2136

Changes:
- Now the UI gets the price in USD from the Coin Paprika API, instead of the CMC API.

Does this change need to mentioned in CHANGELOG.md?
No