### PR TITLE
Create unsigned transaction from wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add `unsigned` option to `POST /api/v2/wallet/transaction` to create unsigned transactions from a wallet
+
 ### Fixed
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add `unsigned` option to `POST /api/v2/wallet/transaction` to create unsigned transactions from a wallet
+- Add `unsigned` option to `POST /api/v1/wallet/transaction` to create unsigned transactions from a wallet
 
 ### Fixed
 

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1111,7 +1111,6 @@ Example request body with manual hours selection type, unencrypted wallet and al
 
 ```json
 {
-    "ignore_unconfirmed": false,
     "hours_selection": {
         "type": "manual"
     },
@@ -1127,7 +1126,9 @@ Example request body with manual hours selection type, unencrypted wallet and al
         "address": "7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD",
         "coins": "99.2",
         "hours": "0"
-    }]
+    }],
+	"unsigned": false,
+    "ignore_unconfirmed": false
 }
 ```
 
@@ -1152,7 +1153,9 @@ Example request body with auto hours selection type, encrypted wallet, specified
     }, {
         "address": "7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD",
         "coins": "99.2"
-    }]
+    }],
+	"unsigned": false,
+    "ignore_unconfirmed": false
 }
 ```
 
@@ -1176,7 +1179,9 @@ Example request body with manual hours selection type, unencrypted wallet and sp
         "address": "7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD",
         "coins": "99.2",
         "hours": "0"
-    }]
+    }],
+	"unsigned": false,
+    "ignore_unconfirmed": false
 }
 ```
 
@@ -1275,6 +1280,12 @@ a transaction in the unconfirmed transaction pool.
 When `true`, the API will ignore unspent outputs that appear as spent in
 a transaction in the unconfirmed transaction pool when building the transaction,
 but not return an error.
+
+`unsigned` is optional and defaults to `false`.
+When `true`, the transaction will not be signed by the wallet.
+An unsigned transaction will be returned.
+The `"length"` and `"txid"` values of the `"transaction"` object will need to be updated
+after signing the transaction, which can be performed offline.
 
 Example:
 

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1284,8 +1284,8 @@ but not return an error.
 `unsigned` is optional and defaults to `false`.
 When `true`, the transaction will not be signed by the wallet.
 An unsigned transaction will be returned.
-The `"length"` and `"txid"` values of the `"transaction"` object will need to be updated
-after signing the transaction, which can be performed offline.
+The `"txid"` value of the `"transaction"` object will need to be updated
+after signing the transaction.
 
 Example:
 

--- a/src/api/client.go
+++ b/src/api/client.go
@@ -679,6 +679,7 @@ func (c *Client) WalletBalance(id string) (*BalanceResponse, error) {
 
 // CreateTransactionRequest is sent to /api/v1/wallet/transaction
 type CreateTransactionRequest struct {
+	Unsigned          bool                           `json:"unsigned"`
 	IgnoreUnconfirmed bool                           `json:"ignore_unconfirmed"`
 	HoursSelection    HoursSelection                 `json:"hours_selection"`
 	Wallet            CreateTransactionRequestWallet `json:"wallet"`

--- a/src/api/integration/integration_test.go
+++ b/src/api/integration/integration_test.go
@@ -4812,10 +4812,12 @@ func assertCreatedTransactionValid(t *testing.T, r api.CreatedTransaction, unsig
 	require.NotEmpty(t, r.In)
 	require.NotEmpty(t, r.Out)
 
+	require.Equal(t, len(r.In), len(r.Sigs))
 	if unsigned {
-		require.Empty(t, r.Sigs)
-	} else {
-		require.Equal(t, len(r.In), len(r.Sigs))
+		for _, s := range r.Sigs {
+			ss := cipher.MustSigFromHex(s)
+			require.True(t, ss.Null())
+		}
 	}
 
 	fee, err := strconv.ParseUint(r.Fee, 10, 64)

--- a/src/api/integration/integration_test.go
+++ b/src/api/integration/integration_test.go
@@ -3739,7 +3739,15 @@ func toDropletString(t *testing.T, i uint64) string {
 	return x
 }
 
-func TestLiveWalletCreateTransactionSpecific(t *testing.T) {
+func TestLiveWalletCreateTransactionSpecificUnsigned(t *testing.T) {
+	testLiveWalletCreateTransactionSpecific(t, true)
+}
+
+func TestLiveWalletCreateTransactionSpecificSigned(t *testing.T) {
+	testLiveWalletCreateTransactionSpecific(t, false)
+}
+
+func testLiveWalletCreateTransactionSpecific(t *testing.T, unsigned bool) {
 	if !doLive(t) {
 		return
 	}
@@ -4483,16 +4491,19 @@ func TestLiveWalletCreateTransactionSpecific(t *testing.T) {
 	}
 }
 
-func TestLiveWalletCreateTransactionRandom(t *testing.T) {
+func TestLiveWalletCreateTransactionRandomUnsigned(t *testing.T) {
+	testLiveWalletCreateTransactionRandom(t, true)
+}
+
+func TestLiveWalletCreateTransactionRandomSigned(t *testing.T) {
+	testLiveWalletCreateTransactionRandom(t, false)
+}
+
+func testLiveWalletCreateTransactionRandom(t *testing.T, unsigned bool) {
 	if !doLive(t) {
 		return
 	}
 
-	testLiveWalletCreateTransactionRandom(t, false)
-	testLiveWalletCreateTransactionRandom(t, true)
-}
-
-func testLiveWalletCreateTransactionRandom(t *testing.T, unsigned bool) {
 	debug := false
 	tLog := func(t *testing.T, args ...interface{}) {
 		if debug {

--- a/src/api/spend.go
+++ b/src/api/spend.go
@@ -254,6 +254,7 @@ func NewCreatedTransactionInput(out wallet.UxBalance) (*CreatedTransactionInput,
 
 // createTransactionRequest is sent to /wallet/transaction
 type createTransactionRequest struct {
+	Unsigned          bool                           `json:"unsigned"`
 	IgnoreUnconfirmed bool                           `json:"ignore_unconfirmed"`
 	HoursSelection    hoursSelection                 `json:"hours_selection"`
 	Wallet            createTransactionRequestWallet `json:"wallet"`
@@ -453,6 +454,7 @@ func (r createTransactionRequest) ToWalletParams() wallet.CreateTransactionParam
 	}
 
 	return wallet.CreateTransactionParams{
+		Unsigned:          r.Unsigned,
 		IgnoreUnconfirmed: r.IgnoreUnconfirmed,
 		HoursSelection: wallet.HoursSelection{
 			Type:        r.HoursSelection.Type,

--- a/src/cipher/crypto.go
+++ b/src/cipher/crypto.go
@@ -343,6 +343,11 @@ func MustSigFromHex(s string) Sig {
 	return sig
 }
 
+// Null returns true if the Sig is a null Sig
+func (s Sig) Null() bool {
+	return s == Sig{}
+}
+
 // Hex converts signature to hex string
 func (s Sig) Hex() string {
 	return hex.EncodeToString(s[:])

--- a/src/cli/create_rawtx.go
+++ b/src/cli/create_rawtx.go
@@ -536,7 +536,7 @@ func CreateRawTx(c GetOutputser, wlt *wallet.Wallet, inAddrs []string, chgAddr s
 		return nil, err
 	}
 
-	if err := visor.VerifySingleTxnSoftConstraints(*txn, head.Time, inUxsFiltered, params.UserVerifyTxn); err != nil {
+	if err := visor.VerifySingleTxnSoftConstraints(*txn, head.Time, inUxsFiltered, params.UserVerifyTxn, visor.TxnSigned); err != nil {
 		return nil, err
 	}
 	if err := visor.VerifySingleTxnHardConstraints(*txn, head, inUxsFiltered, visor.TxnSigned); err != nil {

--- a/src/cli/create_rawtx.go
+++ b/src/cli/create_rawtx.go
@@ -539,7 +539,7 @@ func CreateRawTx(c GetOutputser, wlt *wallet.Wallet, inAddrs []string, chgAddr s
 	if err := visor.VerifySingleTxnSoftConstraints(*txn, head.Time, inUxsFiltered, params.UserVerifyTxn); err != nil {
 		return nil, err
 	}
-	if err := visor.VerifySingleTxnHardConstraints(*txn, head, inUxsFiltered); err != nil {
+	if err := visor.VerifySingleTxnHardConstraints(*txn, head, inUxsFiltered, visor.TxnSigned); err != nil {
 		return nil, err
 	}
 	if err := visor.VerifySingleTxnUserConstraints(*txn); err != nil {

--- a/src/cli/create_rawtx.go
+++ b/src/cli/create_rawtx.go
@@ -536,7 +536,7 @@ func CreateRawTx(c GetOutputser, wlt *wallet.Wallet, inAddrs []string, chgAddr s
 		return nil, err
 	}
 
-	if err := visor.VerifySingleTxnSoftConstraints(*txn, head.Time, inUxsFiltered, params.UserVerifyTxn, visor.TxnSigned); err != nil {
+	if err := visor.VerifySingleTxnSoftConstraints(*txn, head.Time, inUxsFiltered, params.UserVerifyTxn); err != nil {
 		return nil, err
 	}
 	if err := visor.VerifySingleTxnHardConstraints(*txn, head, inUxsFiltered, visor.TxnSigned); err != nil {

--- a/src/coin/transactions.go
+++ b/src/coin/transactions.go
@@ -17,6 +17,9 @@ var (
 	DebugLevel1 = true
 	// DebugLevel2 enable checks for impossible conditions
 	DebugLevel2 = true
+
+	// ErrTransactionSigned is returned if a method for unsigned transactions is called on a signed transaction
+	ErrTransactionSigned = errors.New("Transaction is signed")
 )
 
 /*
@@ -270,7 +273,7 @@ func (txn *Transaction) Size() (uint32, error) {
 // plus the expected size of the signatures that are absent in an unsigned transaction
 func (txn *Transaction) UnsignedEstimatedSize() (uint32, error) {
 	if !txn.IsUnsigned() {
-		return 0, errors.New("Transaction is signed")
+		return 0, ErrTransactionSigned
 	}
 
 	s, err := txn.Size()
@@ -284,7 +287,7 @@ func (txn *Transaction) UnsignedEstimatedSize() (uint32, error) {
 	}
 
 	if n > math.MaxUint32 {
-		return 0, errors.New("Estimate byte size of pending signatures exceeds math.MaxUint32")
+		return 0, errors.New("Estimated byte size of pending signatures exceeds math.MaxUint32")
 	}
 
 	return AddUint32(s, uint32(n))

--- a/src/coin/transactions_test.go
+++ b/src/coin/transactions_test.go
@@ -164,13 +164,13 @@ func TestTransactionVerifyInput(t *testing.T) {
 	// Invalid uxIn args
 	txn := makeTransaction(t)
 	_require.PanicsWithLogMessage(t, "txn.In != uxIn", func() {
-		_ = txn.VerifyInput(nil) // nolint: errcheck
+		_ = txn.VerifyInputSignatures(nil) // nolint: errcheck
 	})
 	_require.PanicsWithLogMessage(t, "txn.In != uxIn", func() {
-		_ = txn.VerifyInput(UxArray{}) // nolint: errcheck
+		_ = txn.VerifyInputSignatures(UxArray{}) // nolint: errcheck
 	})
 	_require.PanicsWithLogMessage(t, "txn.In != uxIn", func() {
-		_ = txn.VerifyInput(make(UxArray, 3)) // nolint: errcheck
+		_ = txn.VerifyInputSignatures(make(UxArray, 3)) // nolint: errcheck
 	})
 
 	// txn.In != txn.Sigs
@@ -178,14 +178,14 @@ func TestTransactionVerifyInput(t *testing.T) {
 	txn = makeTransactionFromUxOut(t, ux, s)
 	txn.Sigs = []cipher.Sig{}
 	_require.PanicsWithLogMessage(t, "txn.In != txn.Sigs", func() {
-		_ = txn.VerifyInput(UxArray{ux}) // nolint: errcheck
+		_ = txn.VerifyInputSignatures(UxArray{ux}) // nolint: errcheck
 	})
 
 	ux, s = makeUxOutWithSecret(t)
 	txn = makeTransactionFromUxOut(t, ux, s)
 	txn.Sigs = append(txn.Sigs, cipher.Sig{})
 	_require.PanicsWithLogMessage(t, "txn.In != txn.Sigs", func() {
-		_ = txn.VerifyInput(UxArray{ux}) // nolint: errcheck
+		_ = txn.VerifyInputSignatures(UxArray{ux}) // nolint: errcheck
 	})
 
 	// txn.InnerHash != txn.HashInner()
@@ -193,27 +193,27 @@ func TestTransactionVerifyInput(t *testing.T) {
 	txn = makeTransactionFromUxOut(t, ux, s)
 	txn.InnerHash = cipher.SHA256{}
 	_require.PanicsWithLogMessage(t, "Invalid Tx Inner Hash", func() {
-		_ = txn.VerifyInput(UxArray{ux}) // nolint: errcheck
+		_ = txn.VerifyInputSignatures(UxArray{ux}) // nolint: errcheck
 	})
 
 	// txn.In does not match uxIn hashes
 	ux, s = makeUxOutWithSecret(t)
 	txn = makeTransactionFromUxOut(t, ux, s)
 	_require.PanicsWithLogMessage(t, "Ux hash mismatch", func() {
-		_ = txn.VerifyInput(UxArray{UxOut{}}) // nolint: errcheck
+		_ = txn.VerifyInputSignatures(UxArray{UxOut{}}) // nolint: errcheck
 	})
 
 	// Invalid signature
 	ux, s = makeUxOutWithSecret(t)
 	txn = makeTransactionFromUxOut(t, ux, s)
 	txn.Sigs[0] = cipher.Sig{}
-	err := txn.VerifyInput(UxArray{ux})
+	err := txn.VerifyInputSignatures(UxArray{ux})
 	testutil.RequireError(t, err, "Signature not valid for output being spent")
 
 	// Valid
 	ux, s = makeUxOutWithSecret(t)
 	txn = makeTransactionFromUxOut(t, ux, s)
-	err = txn.VerifyInput(UxArray{ux})
+	err = txn.VerifyInputSignatures(UxArray{ux})
 	require.NoError(t, err)
 }
 

--- a/src/coin/transactions_test.go
+++ b/src/coin/transactions_test.go
@@ -157,7 +157,24 @@ func TestTransactionVerify(t *testing.T) {
 	txn.Out[1].Coins = 1e6
 	err = txn.UpdateHeader()
 	require.NoError(t, err)
-	require.Nil(t, txn.Verify())
+	require.NoError(t, txn.Verify())
+}
+
+func TestTransactionVerifyUnsigned(t *testing.T) {
+	txn := makeTransaction(t)
+	err := txn.VerifyUnsigned()
+	testutil.RequireError(t, err, "Unsigned transaction signatures must be null")
+
+	txn.Sigs = nil
+	err = txn.VerifyUnsigned()
+	testutil.RequireError(t, err, "Invalid number of signatures")
+
+	txn = makeTransaction(t)
+	for i := range txn.Sigs {
+		txn.Sigs[i] = cipher.Sig{}
+	}
+	err = txn.VerifyUnsigned()
+	require.NoError(t, err)
 }
 
 func TestTransactionVerifyInput(t *testing.T) {
@@ -962,51 +979,6 @@ func TestSortTransactions(t *testing.T) {
 			txns, err := SortTransactions(tc.txns, tc.feeCalc)
 			require.NoError(t, err)
 			require.Equal(t, tc.sortedTxns, txns)
-		})
-	}
-}
-
-func TestUnsignedEstimatedSize(t *testing.T) {
-	multisigsTxn := makeTransaction(t)
-	multisigsTxn.Sigs = append(multisigsTxn.Sigs, make([]cipher.Sig, 3)...)
-	multisigsTxn.In = append(multisigsTxn.In, make([]cipher.SHA256, 3)...)
-
-	cases := []struct {
-		name string
-		txn  Transaction
-	}{
-		{
-			name: "1 sig",
-			txn:  makeTransaction(t),
-		},
-		{
-			name: "4 sigs",
-			txn:  multisigsTxn,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			require.NotEmpty(t, tc.txn.Sigs)
-
-			_, err := tc.txn.UnsignedEstimatedSize()
-			testutil.RequireError(t, err, "Transaction is signed")
-
-			s, err := tc.txn.Size()
-			require.NoError(t, err)
-
-			sigsLen := len(tc.txn.Sigs)
-			tc.txn.Sigs = nil
-
-			u, err := tc.txn.UnsignedEstimatedSize()
-			require.NoError(t, err)
-
-			require.Equal(t, s, u, "%d != %d", s, u)
-
-			s2, err := tc.txn.Size()
-			require.NoError(t, err)
-			require.True(t, s2 < s)
-			require.Equal(t, uint32(len(cipher.Sig{})*sigsLen), s-s2)
 		})
 	}
 }

--- a/src/visor/blockchain.go
+++ b/src/visor/blockchain.go
@@ -416,7 +416,7 @@ func (bc Blockchain) VerifySingleTxnSoftHardConstraints(tx *dbutil.Tx, txn coin.
 		return nil, nil, err
 	}
 
-	if err := VerifySingleTxnSoftConstraints(txn, head.Time(), uxIn, verifyParams, signed); err != nil {
+	if err := VerifySingleTxnSoftConstraints(txn, head.Time(), uxIn, verifyParams); err != nil {
 		return nil, nil, err
 	}
 

--- a/src/visor/blockchain.go
+++ b/src/visor/blockchain.go
@@ -416,7 +416,7 @@ func (bc Blockchain) VerifySingleTxnSoftHardConstraints(tx *dbutil.Tx, txn coin.
 		return nil, nil, err
 	}
 
-	if err := VerifySingleTxnSoftConstraints(txn, head.Time(), uxIn, verifyParams); err != nil {
+	if err := VerifySingleTxnSoftConstraints(txn, head.Time(), uxIn, verifyParams, signed); err != nil {
 		return nil, nil, err
 	}
 

--- a/src/visor/blockchain.go
+++ b/src/visor/blockchain.go
@@ -374,7 +374,7 @@ func (bc Blockchain) verifyBlockTxnHardConstraints(tx *dbutil.Tx, txn coin.Trans
 
 // VerifySingleTxnHardConstraints checks that the transaction does not violate hard constraints.
 // for transactions that are not included in a block.
-func (bc Blockchain) VerifySingleTxnHardConstraints(tx *dbutil.Tx, txn coin.Transaction) error {
+func (bc Blockchain) VerifySingleTxnHardConstraints(tx *dbutil.Tx, txn coin.Transaction, signed TxnSignedFlag) error {
 	// NOTE: Unspent().GetArray() returns an error if not all txn.In can be found
 	// This prevents double spends
 	uxIn, err := bc.Unspent().GetArray(tx, txn.In)
@@ -392,13 +392,13 @@ func (bc Blockchain) VerifySingleTxnHardConstraints(tx *dbutil.Tx, txn coin.Tran
 		return err
 	}
 
-	return bc.verifySingleTxnHardConstraints(tx, txn, head, uxIn)
+	return bc.verifySingleTxnHardConstraints(tx, txn, head, uxIn, signed)
 }
 
 // VerifySingleTxnSoftHardConstraints checks that the transaction does not violate hard or soft constraints,
 // for transactions that are not included in a block.
 // Hard constraints are checked before soft constraints.
-func (bc Blockchain) VerifySingleTxnSoftHardConstraints(tx *dbutil.Tx, txn coin.Transaction, verifyParams params.VerifyTxn) (*coin.SignedBlock, coin.UxArray, error) {
+func (bc Blockchain) VerifySingleTxnSoftHardConstraints(tx *dbutil.Tx, txn coin.Transaction, verifyParams params.VerifyTxn, signed TxnSignedFlag) (*coin.SignedBlock, coin.UxArray, error) {
 	// NOTE: Unspent().GetArray() returns an error if not all txn.In can be found
 	// This prevents double spends
 	uxIn, err := bc.Unspent().GetArray(tx, txn.In)
@@ -412,7 +412,7 @@ func (bc Blockchain) VerifySingleTxnSoftHardConstraints(tx *dbutil.Tx, txn coin.
 	}
 
 	// Hard constraints must be checked before soft constraints
-	if err := bc.verifySingleTxnHardConstraints(tx, txn, head, uxIn); err != nil {
+	if err := bc.verifySingleTxnHardConstraints(tx, txn, head, uxIn, signed); err != nil {
 		return nil, nil, err
 	}
 
@@ -423,8 +423,8 @@ func (bc Blockchain) VerifySingleTxnSoftHardConstraints(tx *dbutil.Tx, txn coin.
 	return head, uxIn, nil
 }
 
-func (bc Blockchain) verifySingleTxnHardConstraints(tx *dbutil.Tx, txn coin.Transaction, head *coin.SignedBlock, uxIn coin.UxArray) error {
-	if err := VerifySingleTxnHardConstraints(txn, head.Head, uxIn); err != nil {
+func (bc Blockchain) verifySingleTxnHardConstraints(tx *dbutil.Tx, txn coin.Transaction, head *coin.SignedBlock, uxIn coin.UxArray, signed TxnSignedFlag) error {
+	if err := VerifySingleTxnHardConstraints(txn, head.Head, uxIn, signed); err != nil {
 		return err
 	}
 

--- a/src/visor/blockchain_verify_test.go
+++ b/src/visor/blockchain_verify_test.go
@@ -159,7 +159,7 @@ func makeTransactionForChain(t *testing.T, tx *dbutil.Tx, bc *Blockchain, ux coi
 	err = txn.Verify()
 	require.NoError(t, err)
 
-	err = bc.VerifySingleTxnHardConstraints(tx, txn)
+	err = bc.VerifySingleTxnHardConstraints(tx, txn, TxnSigned)
 	require.NoError(t, err)
 
 	return txn
@@ -319,14 +319,24 @@ func makeSpendTxWithHoursBurned(t *testing.T, uxs coin.UxArray, keys []cipher.Se
 }
 
 func requireSoftViolation(t *testing.T, msg string, err error) {
-	require.Equal(t, NewErrTxnViolatesSoftConstraint(errors.New(msg)), err)
+	expected := NewErrTxnViolatesSoftConstraint(errors.New(msg))
+	require.Equal(t, expected, err, "Expected: %s\nHave: %v", expected, err)
 }
 
 func requireHardViolation(t *testing.T, msg string, err error) {
-	require.Equal(t, NewErrTxnViolatesHardConstraint(errors.New(msg)), err)
+	expected := NewErrTxnViolatesHardConstraint(errors.New(msg))
+	require.Equal(t, expected, err, "Expected: %s\nHave: %v", expected, err)
 }
 
-func TestVerifyTransactionSoftHardConstraints(t *testing.T) {
+func TestVerifySignedTransactionSoftHardConstraints(t *testing.T) {
+	testVerifyTransactionSoftHardConstraints(t, TxnSigned)
+}
+
+func TestVerifyUnsignedTransactionSoftHardConstraints(t *testing.T) {
+	testVerifyTransactionSoftHardConstraints(t, TxnUnsigned)
+}
+
+func testVerifyTransactionSoftHardConstraints(t *testing.T, signed TxnSignedFlag) {
 	db, closeDB := prepareDB(t)
 	defer closeDB()
 
@@ -348,7 +358,7 @@ func TestVerifyTransactionSoftHardConstraints(t *testing.T) {
 
 	verifySingleTxnSoftHardConstraints := func(txn coin.Transaction, verifyParams params.VerifyTxn) error {
 		return db.View("", func(tx *dbutil.Tx) error {
-			_, _, err := bc.VerifySingleTxnSoftHardConstraints(tx, txn, verifyParams)
+			_, _, err := bc.VerifySingleTxnSoftHardConstraints(tx, txn, verifyParams, signed)
 			return err
 		})
 	}
@@ -356,6 +366,18 @@ func TestVerifyTransactionSoftHardConstraints(t *testing.T) {
 	// create normal spending txn
 	uxs := coin.CreateUnspents(gb.Head, gb.Body.Transactions[0])
 	txn := makeSpendTx(t, uxs, []cipher.SecKey{genSecret}, toAddr, coins)
+	err = verifySingleTxnSoftHardConstraints(txn, params.UserVerifyTxn)
+	if signed == TxnSigned {
+		require.NoError(t, err)
+	} else {
+		requireHardViolation(t, "Unsigned transaction must have zero signatures", err)
+	}
+
+	if signed == TxnUnsigned {
+		txn.Sigs = nil
+		err := txn.UpdateHeader()
+		require.NoError(t, err)
+	}
 	err = verifySingleTxnSoftHardConstraints(txn, params.UserVerifyTxn)
 	require.NoError(t, err)
 
@@ -376,24 +398,45 @@ func TestVerifyTransactionSoftHardConstraints(t *testing.T) {
 		hours += ux.Body.Hours
 	}
 	txn = makeSpendTxWithHoursBurned(t, uxs, []cipher.SecKey{genSecret}, toAddr, coins, 0)
+	if signed == TxnUnsigned {
+		txn.Sigs = nil
+		err := txn.UpdateHeader()
+		require.NoError(t, err)
+	}
+
 	err = verifySingleTxnSoftHardConstraints(txn, params.UserVerifyTxn)
 	requireSoftViolation(t, "Transaction has zero coinhour fee", err)
 
 	// Invalid transaction fee, part 2
 	txn = makeSpendTxWithHoursBurned(t, uxs, []cipher.SecKey{genSecret}, toAddr, coins, 1)
+	originalSigs := txn.Sigs
+	if signed == TxnUnsigned {
+		txn.Sigs = nil
+		err := txn.UpdateHeader()
+		require.NoError(t, err)
+	}
+
 	err = verifySingleTxnSoftHardConstraints(txn, params.UserVerifyTxn)
 	requireSoftViolation(t, "Transaction coinhour fee minimum not met", err)
 
 	// Transaction locking is tested by TestVerifyTransactionIsLocked
 
 	// Test invalid header hash
-	originInnerHash := txn.InnerHash
+	if signed == TxnUnsigned {
+		txn.Sigs = nil
+		err := txn.UpdateHeader()
+		require.NoError(t, err)
+	}
+	originalInnerHash := txn.InnerHash
 	txn.InnerHash = cipher.SHA256{}
+
 	err = verifySingleTxnSoftHardConstraints(txn, params.UserVerifyTxn)
 	requireHardViolation(t, "InnerHash does not match computed hash", err)
 
-	// Set back the originInnerHash
-	txn.InnerHash = originInnerHash
+	txn.Sigs = originalSigs
+	err = txn.UpdateHeader()
+	require.NoError(t, err)
+	require.Equal(t, originalInnerHash, txn.InnerHash)
 
 	// Create new block to spend the coins
 	var b *coin.Block
@@ -424,22 +467,46 @@ func TestVerifyTransactionSoftHardConstraints(t *testing.T) {
 	uxs = coin.CreateUnspents(b.Head, txn)
 	_, key := cipher.GenerateKeyPair()
 	toAddr2 := testutil.MakeAddress()
-	tx2 := makeSpendTx(t, uxs, []cipher.SecKey{key, key}, toAddr2, 5e6)
-	err = verifySingleTxnSoftHardConstraints(tx2, params.UserVerifyTxn)
-	requireHardViolation(t, "Signature not valid for output being spent", err)
+	txn2 := makeSpendTx(t, uxs, []cipher.SecKey{key, key}, toAddr2, 5e6)
+	if signed == TxnUnsigned {
+		txn2.Sigs = nil
+		err := txn2.UpdateHeader()
+		require.NoError(t, err)
+	}
+
+	err = verifySingleTxnSoftHardConstraints(txn2, params.UserVerifyTxn)
+
+	if signed == TxnSigned {
+		requireHardViolation(t, "Signature not valid for output being spent", err)
+	} else {
+		// unsigned transactions ignore the sigs
+		require.NoError(t, err)
+	}
 
 	// Create lost coin transaction
 	uxs2 := coin.CreateUnspents(b.Head, txn)
 	toAddr3 := testutil.MakeAddress()
-	lostCoinTx := makeLostCoinTx(t, coin.UxArray{uxs2[1]}, []cipher.SecKey{genSecret}, toAddr3, 10e5)
-	err = verifySingleTxnSoftHardConstraints(lostCoinTx, params.UserVerifyTxn)
+	lostCoinTxn := makeLostCoinTx(t, coin.UxArray{uxs2[1]}, []cipher.SecKey{genSecret}, toAddr3, 10e5)
+	if signed == TxnUnsigned {
+		lostCoinTxn.Sigs = nil
+		err := lostCoinTxn.UpdateHeader()
+		require.NoError(t, err)
+	}
+
+	err = verifySingleTxnSoftHardConstraints(lostCoinTxn, params.UserVerifyTxn)
 	requireHardViolation(t, "Transactions may not destroy coins", err)
 
 	// Create transaction with duplicate UxOuts
 	uxs = coin.CreateUnspents(b.Head, txn)
 	toAddr4 := testutil.MakeAddress()
-	dupUxOutTx := makeDuplicateUxOutTx(t, coin.UxArray{uxs[0]}, []cipher.SecKey{genSecret}, toAddr4, 1e6)
-	err = verifySingleTxnSoftHardConstraints(dupUxOutTx, params.UserVerifyTxn)
+	dupUxOutTxn := makeDuplicateUxOutTx(t, coin.UxArray{uxs[0]}, []cipher.SecKey{genSecret}, toAddr4, 1e6)
+	if signed == TxnUnsigned {
+		dupUxOutTxn.Sigs = nil
+		err := dupUxOutTxn.UpdateHeader()
+		require.NoError(t, err)
+	}
+
+	err = verifySingleTxnSoftHardConstraints(dupUxOutTxn, params.UserVerifyTxn)
 	requireHardViolation(t, "Duplicate output in transaction", err)
 }
 
@@ -497,7 +564,7 @@ func TestVerifyTxnFeeCoinHoursAdditionFails(t *testing.T) {
 	// uxIn.CoinHours() errors, which is ignored by VerifyTransactionHoursSpending if the error
 	// is because of the earned hours addition overflow
 	head.Block.Head.Time += 1e6
-	err = VerifySingleTxnHardConstraints(txn, head.Head, uxIn)
+	err = VerifySingleTxnHardConstraints(txn, head.Head, uxIn, TxnSigned)
 	testutil.RequireError(t, err, NewErrTxnViolatesHardConstraint(coinHoursErr).Error())
 }
 

--- a/src/visor/blockchain_verify_test.go
+++ b/src/visor/blockchain_verify_test.go
@@ -370,11 +370,11 @@ func testVerifyTransactionSoftHardConstraints(t *testing.T, signed TxnSignedFlag
 	if signed == TxnSigned {
 		require.NoError(t, err)
 	} else {
-		requireHardViolation(t, "Unsigned transaction must have zero signatures", err)
+		requireHardViolation(t, "Unsigned transaction signatures must be null", err)
 	}
 
 	if signed == TxnUnsigned {
-		txn.Sigs = nil
+		txn.Sigs = make([]cipher.Sig, len(txn.Sigs))
 		err := txn.UpdateHeader()
 		require.NoError(t, err)
 	}
@@ -399,7 +399,7 @@ func testVerifyTransactionSoftHardConstraints(t *testing.T, signed TxnSignedFlag
 	}
 	txn = makeSpendTxWithHoursBurned(t, uxs, []cipher.SecKey{genSecret}, toAddr, coins, 0)
 	if signed == TxnUnsigned {
-		txn.Sigs = nil
+		txn.Sigs = make([]cipher.Sig, len(txn.Sigs))
 		err := txn.UpdateHeader()
 		require.NoError(t, err)
 	}
@@ -411,7 +411,7 @@ func testVerifyTransactionSoftHardConstraints(t *testing.T, signed TxnSignedFlag
 	txn = makeSpendTxWithHoursBurned(t, uxs, []cipher.SecKey{genSecret}, toAddr, coins, 1)
 	originalSigs := txn.Sigs
 	if signed == TxnUnsigned {
-		txn.Sigs = nil
+		txn.Sigs = make([]cipher.Sig, len(txn.Sigs))
 		err := txn.UpdateHeader()
 		require.NoError(t, err)
 	}
@@ -423,7 +423,7 @@ func testVerifyTransactionSoftHardConstraints(t *testing.T, signed TxnSignedFlag
 
 	// Test invalid header hash
 	if signed == TxnUnsigned {
-		txn.Sigs = nil
+		txn.Sigs = make([]cipher.Sig, len(txn.Sigs))
 		err := txn.UpdateHeader()
 		require.NoError(t, err)
 	}
@@ -469,7 +469,7 @@ func testVerifyTransactionSoftHardConstraints(t *testing.T, signed TxnSignedFlag
 	toAddr2 := testutil.MakeAddress()
 	txn2 := makeSpendTx(t, uxs, []cipher.SecKey{key, key}, toAddr2, 5e6)
 	if signed == TxnUnsigned {
-		txn2.Sigs = nil
+		txn2.Sigs = make([]cipher.Sig, len(txn2.Sigs))
 		err := txn2.UpdateHeader()
 		require.NoError(t, err)
 	}
@@ -488,7 +488,7 @@ func testVerifyTransactionSoftHardConstraints(t *testing.T, signed TxnSignedFlag
 	toAddr3 := testutil.MakeAddress()
 	lostCoinTxn := makeLostCoinTx(t, coin.UxArray{uxs2[1]}, []cipher.SecKey{genSecret}, toAddr3, 10e5)
 	if signed == TxnUnsigned {
-		lostCoinTxn.Sigs = nil
+		lostCoinTxn.Sigs = make([]cipher.Sig, len(lostCoinTxn.Sigs))
 		err := lostCoinTxn.UpdateHeader()
 		require.NoError(t, err)
 	}
@@ -501,7 +501,7 @@ func testVerifyTransactionSoftHardConstraints(t *testing.T, signed TxnSignedFlag
 	toAddr4 := testutil.MakeAddress()
 	dupUxOutTxn := makeDuplicateUxOutTx(t, coin.UxArray{uxs[0]}, []cipher.SecKey{genSecret}, toAddr4, 1e6)
 	if signed == TxnUnsigned {
-		dupUxOutTxn.Sigs = nil
+		dupUxOutTxn.Sigs = make([]cipher.Sig, len(lostCoinTxn.Sigs))
 		err := dupUxOutTxn.UpdateHeader()
 		require.NoError(t, err)
 	}
@@ -557,7 +557,7 @@ func TestVerifyTxnFeeCoinHoursAdditionFails(t *testing.T) {
 	testutil.RequireError(t, coinHoursErr, "UxOut.CoinHours addition of earned coin hours overflow")
 
 	// VerifySingleTxnSoftConstraints should fail on this, when trying to calculate the TransactionFee
-	err = VerifySingleTxnSoftConstraints(txn, head.Time()+1e6, uxIn, params.UserVerifyTxn, TxnSigned)
+	err = VerifySingleTxnSoftConstraints(txn, head.Time()+1e6, uxIn, params.UserVerifyTxn)
 	testutil.RequireError(t, err, NewErrTxnViolatesSoftConstraint(coinHoursErr).Error())
 
 	// VerifySingleTxnHardConstraints should fail on this, when performing the extra check of
@@ -635,7 +635,7 @@ func testVerifyTransactionAddressLocking(t *testing.T, toAddr string, expectedEr
 	})
 	require.NoError(t, err)
 
-	err = VerifySingleTxnSoftConstraints(txn, head.Time(), uxIn, params.UserVerifyTxn, TxnSigned)
+	err = VerifySingleTxnSoftConstraints(txn, head.Time(), uxIn, params.UserVerifyTxn)
 	if expectedErr == nil {
 		require.NoError(t, err)
 	} else {

--- a/src/visor/blockchain_verify_test.go
+++ b/src/visor/blockchain_verify_test.go
@@ -557,7 +557,7 @@ func TestVerifyTxnFeeCoinHoursAdditionFails(t *testing.T) {
 	testutil.RequireError(t, coinHoursErr, "UxOut.CoinHours addition of earned coin hours overflow")
 
 	// VerifySingleTxnSoftConstraints should fail on this, when trying to calculate the TransactionFee
-	err = VerifySingleTxnSoftConstraints(txn, head.Time()+1e6, uxIn, params.UserVerifyTxn)
+	err = VerifySingleTxnSoftConstraints(txn, head.Time()+1e6, uxIn, params.UserVerifyTxn, TxnSigned)
 	testutil.RequireError(t, err, NewErrTxnViolatesSoftConstraint(coinHoursErr).Error())
 
 	// VerifySingleTxnHardConstraints should fail on this, when performing the extra check of
@@ -635,7 +635,7 @@ func testVerifyTransactionAddressLocking(t *testing.T, toAddr string, expectedEr
 	})
 	require.NoError(t, err)
 
-	err = VerifySingleTxnSoftConstraints(txn, head.Time(), uxIn, params.UserVerifyTxn)
+	err = VerifySingleTxnSoftConstraints(txn, head.Time(), uxIn, params.UserVerifyTxn, TxnSigned)
 	if expectedErr == nil {
 		require.NoError(t, err)
 	} else {

--- a/src/visor/mock_blockchainer_test.go
+++ b/src/visor/mock_blockchainer_test.go
@@ -328,13 +328,13 @@ func (_m *MockBlockchainer) VerifyBlockTxnConstraints(tx *dbutil.Tx, txn coin.Tr
 	return r0
 }
 
-// VerifySingleTxnHardConstraints provides a mock function with given fields: tx, txn
-func (_m *MockBlockchainer) VerifySingleTxnHardConstraints(tx *dbutil.Tx, txn coin.Transaction) error {
-	ret := _m.Called(tx, txn)
+// VerifySingleTxnHardConstraints provides a mock function with given fields: tx, txn, signed
+func (_m *MockBlockchainer) VerifySingleTxnHardConstraints(tx *dbutil.Tx, txn coin.Transaction, signed TxnSignedFlag) error {
+	ret := _m.Called(tx, txn, signed)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*dbutil.Tx, coin.Transaction) error); ok {
-		r0 = rf(tx, txn)
+	if rf, ok := ret.Get(0).(func(*dbutil.Tx, coin.Transaction, TxnSignedFlag) error); ok {
+		r0 = rf(tx, txn, signed)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -342,13 +342,13 @@ func (_m *MockBlockchainer) VerifySingleTxnHardConstraints(tx *dbutil.Tx, txn co
 	return r0
 }
 
-// VerifySingleTxnSoftHardConstraints provides a mock function with given fields: tx, txn, verifyParams
-func (_m *MockBlockchainer) VerifySingleTxnSoftHardConstraints(tx *dbutil.Tx, txn coin.Transaction, verifyParams params.VerifyTxn) (*coin.SignedBlock, coin.UxArray, error) {
-	ret := _m.Called(tx, txn, verifyParams)
+// VerifySingleTxnSoftHardConstraints provides a mock function with given fields: tx, txn, verifyParams, signed
+func (_m *MockBlockchainer) VerifySingleTxnSoftHardConstraints(tx *dbutil.Tx, txn coin.Transaction, verifyParams params.VerifyTxn, signed TxnSignedFlag) (*coin.SignedBlock, coin.UxArray, error) {
+	ret := _m.Called(tx, txn, verifyParams, signed)
 
 	var r0 *coin.SignedBlock
-	if rf, ok := ret.Get(0).(func(*dbutil.Tx, coin.Transaction, params.VerifyTxn) *coin.SignedBlock); ok {
-		r0 = rf(tx, txn, verifyParams)
+	if rf, ok := ret.Get(0).(func(*dbutil.Tx, coin.Transaction, params.VerifyTxn, TxnSignedFlag) *coin.SignedBlock); ok {
+		r0 = rf(tx, txn, verifyParams, signed)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*coin.SignedBlock)
@@ -356,8 +356,8 @@ func (_m *MockBlockchainer) VerifySingleTxnSoftHardConstraints(tx *dbutil.Tx, tx
 	}
 
 	var r1 coin.UxArray
-	if rf, ok := ret.Get(1).(func(*dbutil.Tx, coin.Transaction, params.VerifyTxn) coin.UxArray); ok {
-		r1 = rf(tx, txn, verifyParams)
+	if rf, ok := ret.Get(1).(func(*dbutil.Tx, coin.Transaction, params.VerifyTxn, TxnSignedFlag) coin.UxArray); ok {
+		r1 = rf(tx, txn, verifyParams, signed)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(coin.UxArray)
@@ -365,8 +365,8 @@ func (_m *MockBlockchainer) VerifySingleTxnSoftHardConstraints(tx *dbutil.Tx, tx
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(*dbutil.Tx, coin.Transaction, params.VerifyTxn) error); ok {
-		r2 = rf(tx, txn, verifyParams)
+	if rf, ok := ret.Get(2).(func(*dbutil.Tx, coin.Transaction, params.VerifyTxn, TxnSignedFlag) error); ok {
+		r2 = rf(tx, txn, verifyParams, signed)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/src/visor/unconfirmed.go
+++ b/src/visor/unconfirmed.go
@@ -203,7 +203,7 @@ func (utp *UnconfirmedTransactionPool) SetTransactionsAnnounced(tx *dbutil.Tx, h
 func (utp *UnconfirmedTransactionPool) InjectTransaction(tx *dbutil.Tx, bc Blockchainer, txn coin.Transaction, verifyParams params.VerifyTxn) (bool, *ErrTxnViolatesSoftConstraint, error) {
 	var isValid int8 = 1
 	var softErr *ErrTxnViolatesSoftConstraint
-	if _, _, err := bc.VerifySingleTxnSoftHardConstraints(tx, txn, verifyParams); err != nil {
+	if _, _, err := bc.VerifySingleTxnSoftHardConstraints(tx, txn, verifyParams, TxnSigned); err != nil {
 		logger.Warningf("bc.VerifySingleTxnSoftHardConstraints failed for txn %s: %v", txn.TxIDHex(), err)
 		switch e := err.(type) {
 		case ErrTxnViolatesSoftConstraint:
@@ -313,7 +313,7 @@ func (utp *UnconfirmedTransactionPool) Refresh(tx *dbutil.Tx, bc Blockchainer, v
 	for _, utxn := range utxns {
 		utxn.Checked = now.UnixNano()
 
-		_, _, err := bc.VerifySingleTxnSoftHardConstraints(tx, utxn.Transaction, verifyParams)
+		_, _, err := bc.VerifySingleTxnSoftHardConstraints(tx, utxn.Transaction, verifyParams, TxnSigned)
 
 		switch err.(type) {
 		case ErrTxnViolatesSoftConstraint, ErrTxnViolatesHardConstraint:
@@ -347,7 +347,7 @@ func (utp *UnconfirmedTransactionPool) RemoveInvalid(tx *dbutil.Tx, bc Blockchai
 	}
 
 	for _, utxn := range utxns {
-		err := bc.VerifySingleTxnHardConstraints(tx, utxn.Transaction)
+		err := bc.VerifySingleTxnHardConstraints(tx, utxn.Transaction, TxnSigned)
 		if err != nil {
 			switch err.(type) {
 			case ErrTxnViolatesHardConstraint:

--- a/src/visor/verify.go
+++ b/src/visor/verify.go
@@ -151,31 +151,18 @@ func (e ErrTxnViolatesUserConstraint) Error() string {
 //      * That the transaction burn enough coin hours (the fee)
 //      * That if that transaction does not spend from a locked distribution address
 //      * That the transaction does not create outputs with a higher decimal precision than is allowed
-func VerifySingleTxnSoftConstraints(txn coin.Transaction, headTime uint64, uxIn coin.UxArray, verifyParams params.VerifyTxn, signed TxnSignedFlag) error {
-	if err := verifyTxnSoftConstraints(txn, headTime, uxIn, verifyParams, signed); err != nil {
+func VerifySingleTxnSoftConstraints(txn coin.Transaction, headTime uint64, uxIn coin.UxArray, verifyParams params.VerifyTxn) error {
+	if err := verifyTxnSoftConstraints(txn, headTime, uxIn, verifyParams); err != nil {
 		return NewErrTxnViolatesSoftConstraint(err)
 	}
 
 	return nil
 }
 
-func verifyTxnSoftConstraints(txn coin.Transaction, headTime uint64, uxIn coin.UxArray, verifyParams params.VerifyTxn, signed TxnSignedFlag) error {
-	var txnSize uint32
-	if signed == TxnSigned {
-		var err error
-		txnSize, err = txn.Size()
-		if err != nil {
-			return ErrTxnExceedsMaxBlockSize
-		}
-	} else {
-		var err error
-		txnSize, err = txn.UnsignedEstimatedSize()
-		if err != nil {
-			if err == coin.ErrTransactionSigned {
-				return err
-			}
-			return ErrTxnExceedsMaxBlockSize
-		}
+func verifyTxnSoftConstraints(txn coin.Transaction, headTime uint64, uxIn coin.UxArray, verifyParams params.VerifyTxn) error {
+	txnSize, err := txn.Size()
+	if err != nil {
+		return ErrTxnExceedsMaxBlockSize
 	}
 
 	if txnSize > verifyParams.MaxTransactionSize {

--- a/src/visor/verify.go
+++ b/src/visor/verify.go
@@ -171,6 +171,9 @@ func verifyTxnSoftConstraints(txn coin.Transaction, headTime uint64, uxIn coin.U
 		var err error
 		txnSize, err = txn.UnsignedEstimatedSize()
 		if err != nil {
+			if err == coin.ErrTransactionSigned {
+				return err
+			}
 			return ErrTxnExceedsMaxBlockSize
 		}
 	}

--- a/src/visor/verify.go
+++ b/src/visor/verify.go
@@ -74,6 +74,16 @@ var (
 	ErrTxnIsLocked = errors.New("Transaction has locked address inputs")
 )
 
+// TxnSignedFlag indicates if the transaction is unsigned or not
+type TxnSignedFlag bool
+
+const (
+	// TxnSigned is used for signed transactions
+	TxnSigned TxnSignedFlag = true
+	// TxnUnsigned is used for signed transactions
+	TxnUnsigned TxnSignedFlag = false
+)
+
 // ErrTxnViolatesHardConstraint is returned when a transaction violates hard constraints
 type ErrTxnViolatesHardConstraint struct {
 	Err error
@@ -195,7 +205,7 @@ func verifyTxnSoftConstraints(txn coin.Transaction, headTime uint64, uxIn coin.U
 //      * That the transaction input and output coins do not overflow uint64
 //      * That the transaction input and output hours do not overflow uint64
 // NOTE: Double spends are checked against the unspent output pool when querying for uxIn
-func VerifySingleTxnHardConstraints(txn coin.Transaction, head coin.BlockHeader, uxIn coin.UxArray) error {
+func VerifySingleTxnHardConstraints(txn coin.Transaction, head coin.BlockHeader, uxIn coin.UxArray, signed TxnSignedFlag) error {
 	// Check for output hours overflow
 	// When verifying a single transaction, this is considered a hard constraint.
 	// For transactions inside of a block, it is a soft constraint.
@@ -213,7 +223,7 @@ func VerifySingleTxnHardConstraints(txn coin.Transaction, head coin.BlockHeader,
 		}
 	}
 
-	if err := verifyTxnHardConstraints(txn, head, uxIn); err != nil {
+	if err := verifyTxnHardConstraints(txn, head, uxIn, signed); err != nil {
 		return NewErrTxnViolatesHardConstraint(err)
 	}
 
@@ -236,14 +246,14 @@ func VerifySingleTxnHardConstraints(txn coin.Transaction, head coin.BlockHeader,
 // NOTE: output hours overflow is treated as a soft constraint for transactions inside of a block, due to a bug
 //       which allowed some blocks to be published with overflowing output hours.
 func VerifyBlockTxnConstraints(txn coin.Transaction, head coin.BlockHeader, uxIn coin.UxArray) error {
-	if err := verifyTxnHardConstraints(txn, head, uxIn); err != nil {
+	if err := verifyTxnHardConstraints(txn, head, uxIn, TxnSigned); err != nil {
 		return NewErrTxnViolatesHardConstraint(err)
 	}
 
 	return nil
 }
 
-func verifyTxnHardConstraints(txn coin.Transaction, head coin.BlockHeader, uxIn coin.UxArray) error {
+func verifyTxnHardConstraints(txn coin.Transaction, head coin.BlockHeader, uxIn coin.UxArray, signed TxnSignedFlag) error {
 	//CHECKLIST: DONE: check for duplicate ux inputs/double spending
 	//     NOTE: Double spends are checked against the unspent output pool when querying for uxIn
 
@@ -265,14 +275,19 @@ func verifyTxnHardConstraints(txn coin.Transaction, head coin.BlockHeader, uxIn 
 	// Check for zero coin outputs
 	// Check valid looking signatures
 
-	if err := txn.Verify(); err != nil {
-		return err
-	}
+	if signed == TxnSigned {
+		if err := txn.Verify(); err != nil {
+			return err
+		}
 
-	// Checks whether ux inputs exist,
-	// Check that signatures are allowed to spend inputs
-	if err := txn.VerifyInput(uxIn); err != nil {
-		return err
+		// Check that signatures are allowed to spend inputs
+		if err := txn.VerifyInputSignatures(uxIn); err != nil {
+			return err
+		}
+	} else {
+		if err := txn.VerifyUnsigned(); err != nil {
+			return err
+		}
 	}
 
 	uxOut := coin.CreateUnspents(head, txn)

--- a/src/visor/verify.go
+++ b/src/visor/verify.go
@@ -151,18 +151,28 @@ func (e ErrTxnViolatesUserConstraint) Error() string {
 //      * That the transaction burn enough coin hours (the fee)
 //      * That if that transaction does not spend from a locked distribution address
 //      * That the transaction does not create outputs with a higher decimal precision than is allowed
-func VerifySingleTxnSoftConstraints(txn coin.Transaction, headTime uint64, uxIn coin.UxArray, verifyParams params.VerifyTxn) error {
-	if err := verifyTxnSoftConstraints(txn, headTime, uxIn, verifyParams); err != nil {
+func VerifySingleTxnSoftConstraints(txn coin.Transaction, headTime uint64, uxIn coin.UxArray, verifyParams params.VerifyTxn, signed TxnSignedFlag) error {
+	if err := verifyTxnSoftConstraints(txn, headTime, uxIn, verifyParams, signed); err != nil {
 		return NewErrTxnViolatesSoftConstraint(err)
 	}
 
 	return nil
 }
 
-func verifyTxnSoftConstraints(txn coin.Transaction, headTime uint64, uxIn coin.UxArray, verifyParams params.VerifyTxn) error {
-	txnSize, err := txn.Size()
-	if err != nil {
-		return ErrTxnExceedsMaxBlockSize
+func verifyTxnSoftConstraints(txn coin.Transaction, headTime uint64, uxIn coin.UxArray, verifyParams params.VerifyTxn, signed TxnSignedFlag) error {
+	var txnSize uint32
+	if signed == TxnSigned {
+		var err error
+		txnSize, err = txn.Size()
+		if err != nil {
+			return ErrTxnExceedsMaxBlockSize
+		}
+	} else {
+		var err error
+		txnSize, err = txn.UnsignedEstimatedSize()
+		if err != nil {
+			return ErrTxnExceedsMaxBlockSize
+		}
 	}
 
 	if txnSize > verifyParams.MaxTransactionSize {

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -2234,7 +2234,7 @@ func (vs *Visor) VerifyTxnVerbose(txn *coin.Transaction) ([]wallet.UxBalance, bo
 			return err
 		}
 
-		if err := VerifySingleTxnSoftConstraints(*txn, feeCalcTime, uxa, params.UserVerifyTxn, TxnSigned); err != nil {
+		if err := VerifySingleTxnSoftConstraints(*txn, feeCalcTime, uxa, params.UserVerifyTxn); err != nil {
 			return err
 		}
 

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -2234,7 +2234,7 @@ func (vs *Visor) VerifyTxnVerbose(txn *coin.Transaction) ([]wallet.UxBalance, bo
 			return err
 		}
 
-		if err := VerifySingleTxnSoftConstraints(*txn, feeCalcTime, uxa, params.UserVerifyTxn); err != nil {
+		if err := VerifySingleTxnSoftConstraints(*txn, feeCalcTime, uxa, params.UserVerifyTxn, TxnSigned); err != nil {
 			return err
 		}
 

--- a/src/visor/visor_wallet.go
+++ b/src/visor/visor_wallet.go
@@ -131,9 +131,9 @@ func (vs *Visor) CreateTransaction(p wallet.CreateTransactionParams) (*coin.Tran
 			}
 
 			// Create and sign transaction
-			txn, inputs, err = w.CreateAndSignTransactionAdvanced(p, auxs, head.Time())
+			txn, inputs, err = w.CreateTransaction(p, auxs, head.Time())
 			if err != nil {
-				logger.WithError(err).Error("CreateAndSignTransactionAdvanced failed")
+				logger.WithError(err).Error("CreateTransaction failed")
 				return err
 			}
 
@@ -145,7 +145,12 @@ func (vs *Visor) CreateTransaction(p wallet.CreateTransactionParams) (*coin.Tran
 				return err
 			}
 
-			if _, _, err := vs.Blockchain.VerifySingleTxnSoftHardConstraints(tx, *txn, params.UserVerifyTxn); err != nil {
+			signed := TxnSigned
+			if p.Unsigned {
+				signed = TxnUnsigned
+			}
+
+			if _, _, err := vs.Blockchain.VerifySingleTxnSoftHardConstraints(tx, *txn, params.UserVerifyTxn, signed); err != nil {
 				logger.WithError(err).Error("Created transaction violates transaction constraints")
 				return err
 			}

--- a/src/wallet/service_test.go
+++ b/src/wallet/service_test.go
@@ -1444,8 +1444,11 @@ func TestServiceCreateTransaction(t *testing.T) {
 		require.True(t, reflect.DeepEqual(a.Transaction.Out, b.Transaction.Out))
 		require.Equal(t, a.Transaction.InnerHash, b.Transaction.InnerHash)
 		require.Equal(t, a.Transaction.Type, b.Transaction.Type)
+		require.Equal(t, a.Transaction.Length, b.Transaction.Length)
+		require.Equal(t, len(a.Transaction.Sigs), len(b.Transaction.Sigs))
 
 		if a.Unsigned == b.Unsigned {
+			require.Equal(t, a.Transaction.Hash(), b.Transaction.Hash())
 			// Sigs have a nonce so will vary each run, unset them before comparing the whole transaction
 			require.Equal(t, len(a.Transaction.Sigs), len(b.Transaction.Sigs))
 			at := *a.Transaction
@@ -1454,11 +1457,7 @@ func TestServiceCreateTransaction(t *testing.T) {
 			bt.Sigs = nil
 			require.True(t, reflect.DeepEqual(at, bt))
 		} else {
-			if a.Unsigned {
-				require.True(t, a.Transaction.Length < b.Transaction.Length)
-			} else {
-				require.True(t, b.Transaction.Length < a.Transaction.Length)
-			}
+			require.NotEqual(t, a.Transaction.Hash(), b.Transaction.Hash())
 		}
 	}
 

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -1420,7 +1420,9 @@ func (w *Wallet) CreateTransaction(p CreateTransactionParams, auxs coin.AddressU
 		txn.PushOutput(changeAddress, changeCoins, changeHours)
 	}
 
-	if !p.Unsigned {
+	if p.Unsigned {
+		txn.Sigs = make([]cipher.Sig, len(txn.In))
+	} else {
 		txn.SignInputs(toSign)
 	}
 
@@ -1485,13 +1487,13 @@ func verifyCreatedTransactionInvariants(p CreateTransactionParams, txn *coin.Tra
 		}
 	}
 
+	if len(txn.Sigs) != len(txn.In) {
+		return errors.New("Number of signatures does not match number of inputs")
+	}
+
 	if p.Unsigned {
-		if len(txn.Sigs) != 0 {
-			return errors.New("Unsigned transaction should have no signatures")
-		}
-	} else {
-		if len(txn.Sigs) != len(txn.In) {
-			return errors.New("Number of signatures does not match number of inputs")
+		if !txn.IsUnsigned() {
+			return errors.New("Transaction is not unsigned")
 		}
 	}
 


### PR DESCRIPTION
Fixes part of #1513 (the other part is signing an unsigned transaction from a wallet)

Changes:
- Add `unsigned` as an option to `POST /api/v1/wallet/transaction` to create an unsigned transaction

Later, this can be combined with watch wallets (#1965) to facilitate offline transaction signing

For transaction verification, a `type TxnSignedFlag bool` is added to avoid using a bare `bool` in the verification APIs, which should make reading and assessing the code easier.  The alternative would be making a parallel verification API for unsigned transactions, which is often preferred instead of a `bool` parameter, but the amount of code duplication is onerous, and the code that would be duplicated is of a sensitive, precise nature. The difference in transaction verification between signed and unsigned transactions is minimal.

The differences between an unsigned and signed transaction:

* Unsigned has a signature array of the correct length, but all `cipher.Sig` objects are the null signature (`== cipher.Sig{}`)
* Since it has null signatures, the transaction hash value will change once signed

Does this change need to mentioned in CHANGELOG.md?
Yes