### PR TITLE
Run electron-rebuild post install

### DIFF
--- a/electron/src/package.json
+++ b/electron/src/package.json
@@ -11,5 +11,8 @@
   },
   "devDependencies": {
     "electron-rebuild": "^1.8.2"
+  },
+  "scripts": {
+    "postinstall": "electron-rebuild"
   }
 }


### PR DESCRIPTION
Changes:
- Runs `electron-rebuild` automatically after `npm install` to rebuild native deps 
