### PR TITLE
Retry faster if there is a problem when updating the price

### DIFF
--- a/src/gui/static/src/app/services/price.service.ts
+++ b/src/gui/static/src/app/services/price.service.ts
@@ -1,8 +1,9 @@
 import { Injectable, NgZone } from '@angular/core';
-import { Http } from '@angular/http';
 import { Subject } from 'rxjs/Subject';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
+import { HttpClient } from '@angular/common/http';
+import { ISubscription, Subscription } from 'rxjs/Subscription';
 
 @Injectable()
 export class PriceService {
@@ -10,18 +11,48 @@ export class PriceService {
 
   price: Subject<number> = new BehaviorSubject<number>(null);
 
+  private readonly updatePeriod = 10 * 60 * 1000;
+  private lastPriceSubscription: ISubscription;
+  private timerSubscription: Subscription;
+
   constructor(
-    private http: Http,
+    private http: HttpClient,
     private ngZone: NgZone,
   ) {
+    this.startTimer();
+  }
+
+  private startTimer(firstConnectionDelay = 0) {
+    if (this.timerSubscription) {
+      this.timerSubscription.unsubscribe();
+    }
     this.ngZone.runOutsideAngular(() => {
-      Observable.timer(0, 10 * 60 * 1000).subscribe(() => {
-        this.http.get(`https://api.coinpaprika.com/v1/tickers/${this.PRICE_API_ID}?quotes=USD`)
-          .map(response => response.json())
-          .subscribe(response => this.ngZone.run(() => {
-            this.price.next(response.quotes.USD.price);
-          }));
-      });
+      this.timerSubscription = Observable.timer(this.updatePeriod, this.updatePeriod)
+        .subscribe(() => {
+          this.ngZone.run(() => !this.lastPriceSubscription ? this.loadPrice() : null );
+        });
     });
+
+    this.timerSubscription.add(
+      Observable.of(1).delay(firstConnectionDelay).subscribe(() => {
+        this.ngZone.run(() => this.loadPrice());
+      }));
+  }
+
+  private loadPrice() {
+    if (!this.PRICE_API_ID) {
+      return;
+    }
+
+    if (this.lastPriceSubscription) {
+      this.lastPriceSubscription.unsubscribe();
+    }
+
+    this.lastPriceSubscription = this.http.get(`https://api.coinpaprika.com/v1/tickers/${this.PRICE_API_ID}?quotes=USD`)
+      .subscribe((response: any) => {
+        this.lastPriceSubscription = null;
+        this.price.next(response.quotes.USD.price);
+      },
+      () => this.startTimer(30000));
   }
 }


### PR DESCRIPTION
Fixes #2173 

Changes:
- Now if there is a problem when obtaining the price, the connection is made again after 30 seconds, instead of 600. The code is based on the one used by the web wallet.

Does this change need to mentioned in CHANGELOG.md?
No