### PR TITLE
Don't show the error#1 page on loading errors

### DIFF
--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -20,7 +20,6 @@ require('electron-context-menu')({});
 global.eval = function() { throw new Error('bad!!'); }
 
 let currentURL;
-let showErrorCalled = false;
 let splashLoaded = false
 
 // Detect if the code is running with the "dev" arg. The "dev" arg is added when running npm
@@ -157,7 +156,6 @@ function startSkycoin() {
 
 function showError() {
   if (win) {
-    showErrorCalled = true;
     win.loadURL('file://' + process.resourcesPath + '/app/dist/assets/error-alert/index.html');
     console.log('Showing the error message');
   }
@@ -199,12 +197,6 @@ function createWindow(url) {
 	if (!splashLoaded) {
 	  splashLoaded = true;
 	}
-  });
-
-  win.webContents.on('did-fail-load', function() {
-    if (!showErrorCalled) {
-      showError();
-    }
   });
 
   // patch out eval


### PR DESCRIPTION
Changes:
-  With this PR the error#1 page is no longer displayed when there is a load problem in the Electron window. The error#1 page is supposed to appear when there is a problem with the node, which means that showing it when there are loading errors is not very appropriate and can cause problems in many unrelated cases, such as when pressing f5 repeatedly.

Does this change need to mentioned in CHANGELOG.md?
No