### PR TITLE
Change the warning banner message priority

### DIFF
--- a/src/gui/static/src/app/components/layout/header/header.component.html
+++ b/src/gui/static/src/app/components/layout/header/header.component.html
@@ -48,12 +48,12 @@
     <div *ngIf="appService.error === 3">{{ 'header.errors.csrf' | translate }}</div>
   </mat-toolbar>
   <mat-toolbar class="notification-bar" *ngIf="hasPendingTxs || !synchronized">
-    <div *ngIf="hasPendingTxs && synchronized">
+    <div *ngIf="hasPendingTxs">
       {{ 'header.pending-txs1' | translate }}
       <a routerLink='/settings/pending-transactions'>{{ 'header.pending-txs2' | translate }}</a>
       {{ 'header.pending-txs3' | translate }}
     </div>
-    <div *ngIf="!synchronized">
+    <div *ngIf="!synchronized && !hasPendingTxs">
       {{ 'header.synchronizing' | translate }}
     </div>
   </mat-toolbar>

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.ts
@@ -44,6 +44,7 @@ export class SendFormAdvancedComponent implements OnInit, OnDestroy {
 
   private subscriptions: Subscription;
   private getOutputsSubscriptions: ISubscription;
+  private syncCheckSubscription: ISubscription;
 
   constructor(
     public walletService: WalletService,
@@ -119,6 +120,10 @@ export class SendFormAdvancedComponent implements OnInit, OnDestroy {
     this.subscriptions.unsubscribe();
     this.navbarService.hideSwitch();
     this.snackbar.dismiss();
+
+    if (this.syncCheckSubscription) {
+      this.syncCheckSubscription.unsubscribe();
+    }
   }
 
   preview() {
@@ -132,11 +137,33 @@ export class SendFormAdvancedComponent implements OnInit, OnDestroy {
   }
 
   private checkBeforeSending() {
-    this.blockchainService.synchronized.first().subscribe(synchronized => {
-      if (synchronized) {
-        this.unlockAndSend();
+    this.syncCheckSubscription = this.walletService.pendingTransactions().first().subscribe(txs => {
+      if (txs.length > 0) {
+        this.showPendingTransactionsWarning();
       } else {
-        this.showSynchronizingWarning();
+        this.syncCheckSubscription = this.blockchainService.synchronized.first().subscribe(synchronized => {
+          if (synchronized) {
+            this.unlockAndSend();
+          } else {
+            this.showSynchronizingWarning();
+          }
+        });
+      }
+    });
+  }
+
+  private showPendingTransactionsWarning() {
+    const confirmationData: ConfirmationData = {
+      text: 'send.pending-warning',
+      headerText: 'confirmation.header-text',
+      confirmButtonText: 'confirmation.confirm-button',
+      cancelButtonText: 'confirmation.cancel-button',
+      checkboxText: 'send.pending-warning-check',
+    };
+
+    showConfirmationModal(this.dialog, confirmationData).afterClosed().subscribe(confirmationResult => {
+      if (confirmationResult) {
+        this.unlockAndSend();
       }
     });
   }

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.ts
@@ -137,33 +137,11 @@ export class SendFormAdvancedComponent implements OnInit, OnDestroy {
   }
 
   private checkBeforeSending() {
-    this.syncCheckSubscription = this.walletService.pendingTransactions().first().subscribe(txs => {
-      if (txs.length > 0) {
-        this.showPendingTransactionsWarning();
-      } else {
-        this.syncCheckSubscription = this.blockchainService.synchronized.first().subscribe(synchronized => {
-          if (synchronized) {
-            this.unlockAndSend();
-          } else {
-            this.showSynchronizingWarning();
-          }
-        });
-      }
-    });
-  }
-
-  private showPendingTransactionsWarning() {
-    const confirmationData: ConfirmationData = {
-      text: 'send.pending-warning',
-      headerText: 'confirmation.header-text',
-      confirmButtonText: 'confirmation.confirm-button',
-      cancelButtonText: 'confirmation.cancel-button',
-      checkboxText: 'send.pending-warning-check',
-    };
-
-    showConfirmationModal(this.dialog, confirmationData).afterClosed().subscribe(confirmationResult => {
-      if (confirmationResult) {
+    this.syncCheckSubscription = this.blockchainService.synchronized.first().subscribe(synchronized => {
+      if (synchronized) {
         this.unlockAndSend();
+      } else {
+        this.showSynchronizingWarning();
       }
     });
   }

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.ts
@@ -117,13 +117,10 @@ export class SendFormAdvancedComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.closeGetOutputsSubscriptions();
+    this.closeSyncCheckSubscription();
     this.subscriptions.unsubscribe();
     this.navbarService.hideSwitch();
     this.snackbar.dismiss();
-
-    if (this.syncCheckSubscription) {
-      this.syncCheckSubscription.unsubscribe();
-    }
   }
 
   preview() {
@@ -137,6 +134,7 @@ export class SendFormAdvancedComponent implements OnInit, OnDestroy {
   }
 
   private checkBeforeSending() {
+    this.closeSyncCheckSubscription();
     this.syncCheckSubscription = this.blockchainService.synchronized.first().subscribe(synchronized => {
       if (synchronized) {
         this.unlockAndSend();
@@ -504,6 +502,12 @@ export class SendFormAdvancedComponent implements OnInit, OnDestroy {
 
     if (this.getOutputsSubscriptions) {
       this.getOutputsSubscriptions.unsubscribe();
+    }
+  }
+
+  private closeSyncCheckSubscription() {
+    if (this.syncCheckSubscription) {
+      this.syncCheckSubscription.unsubscribe();
     }
   }
 }

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.html
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.html
@@ -5,8 +5,11 @@
       <select formControlName="wallet" id="wallet" [attr.disabled]="busy ? 'true' : null">
         <option disabled hidden [ngValue]="''">{{ 'send.select-wallet' | translate }}</option>
         <option *ngFor="let wallet of walletService.all() | async" [disabled]="!wallet.coins || wallet.coins.isLessThanOrEqualTo(0)" [ngValue]="wallet">
-          {{ wallet.label }} - {{ (wallet.coins ? wallet.coins.decimalPlaces(6).toString() : 0) | number:'1.0-6' }} {{ 'common.coin-id' | translate }}
-          ({{ wallet.hours.decimalPlaces(0).toString() | number:'1.0-0' }} {{ 'common.coin-hours' | translate }})
+          {{ wallet.label }} -
+          <span *ngIf="wallet.coins && wallet.hours">
+            {{ (wallet.coins ? wallet.coins.decimalPlaces(6).toString() : 0) | number:'1.0-6' }} {{ 'common.coin-id' | translate }}
+            ({{ wallet.hours.decimalPlaces(0).toString() | number:'1.0-0' }} {{ 'common.coin-hours' | translate }})
+          </span>
         </option>
       </select>
     </div>

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
@@ -73,33 +73,11 @@ export class SendFormComponent implements OnInit, OnDestroy {
   }
 
   private checkBeforeSending() {
-    this.syncCheckSubscription = this.walletService.pendingTransactions().first().subscribe(txs => {
-      if (txs.length > 0) {
-        this.showPendingTransactionsWarning();
-      } else {
-        this.syncCheckSubscription = this.blockchainService.synchronized.first().subscribe(synchronized => {
-          if (synchronized) {
-            this.unlockAndSend();
-          } else {
-            this.showSynchronizingWarning();
-          }
-        });
-      }
-    });
-  }
-
-  private showPendingTransactionsWarning() {
-    const confirmationData: ConfirmationData = {
-      text: 'send.pending-warning',
-      headerText: 'confirmation.header-text',
-      confirmButtonText: 'confirmation.confirm-button',
-      cancelButtonText: 'confirmation.cancel-button',
-      checkboxText: 'send.pending-warning-check',
-    };
-
-    showConfirmationModal(this.dialog, confirmationData).afterClosed().subscribe(confirmationResult => {
-      if (confirmationResult) {
+    this.syncCheckSubscription = this.blockchainService.synchronized.first().subscribe(synchronized => {
+      if (synchronized) {
         this.unlockAndSend();
+      } else {
+        this.showSynchronizingWarning();
       }
     });
   }

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
@@ -57,6 +57,7 @@ export class SendFormComponent implements OnInit, OnDestroy {
     if (this.processingSubscription && !this.processingSubscription.closed) {
       this.processingSubscription.unsubscribe();
     }
+    this.closeSyncCheckSubscription();
     this.formSubscription.unsubscribe();
     this.navbarService.hideSwitch();
     this.snackbar.dismiss();
@@ -73,6 +74,7 @@ export class SendFormComponent implements OnInit, OnDestroy {
   }
 
   private checkBeforeSending() {
+    this.closeSyncCheckSubscription();
     this.syncCheckSubscription = this.blockchainService.synchronized.first().subscribe(synchronized => {
       if (synchronized) {
         this.unlockAndSend();
@@ -267,5 +269,11 @@ export class SendFormComponent implements OnInit, OnDestroy {
     this.form.get('wallet').setValue('');
     this.form.get('address').setValue('');
     this.form.get('amount').setValue('');
+  }
+
+  private closeSyncCheckSubscription() {
+    if (this.syncCheckSubscription) {
+      this.syncCheckSubscription.unsubscribe();
+    }
   }
 }

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -160,8 +160,6 @@
   },
 
   "send": {
-    "pending-warning": "You have one or more pending transactions. It is highly recommended to wait for the transaction to be confirmed before continuing or the transaction could be created incorrectly and be blocked. Are you sure you want to continue?",
-    "pending-warning-check": "I understand the risks and want to continue",
     "synchronizing-warning": "The wallet is still synchronizing the data, so the balance shown may be incorrect. Are you sure you want to continue?",
     "from-label": "Send from",
     "to-label": "Send to",

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -160,6 +160,8 @@
   },
 
   "send": {
+    "pending-warning": "You have one or more pending transactions. It is highly recommended to wait for the transaction to be confirmed before continuing or the transaction could be created incorrectly and be blocked. Are you sure you want to continue?",
+    "pending-warning-check": "I understand the risks and want to continue",
     "synchronizing-warning": "The wallet is still synchronizing the data, so the balance shown may be incorrect. Are you sure you want to continue?",
     "from-label": "Send from",
     "to-label": "Send to",


### PR DESCRIPTION
Fixes #2171 

Changes:
- The pending transactions warning now has priority over the synchronizing warning.
- If the user tries to send a transaction while there are pending transactions, a warning is shown and the user must explicitly confirm the operation:
![warning](https://user-images.githubusercontent.com/34079003/53213595-f1324380-361f-11e9-89b2-81a4606eb72a.png)

- A small problem that caused error messages to appear in the console when loading the system in the simple form was fixed.

Notes:
- @gz-c this PR does not prevent the user from sending transactions when there are pending transactions, but it shows an alert. Does it seem good to you or should I change it?

Does this change need to mentioned in CHANGELOG.md?
No