### PR TITLE
Confirm hardware wallet addresses

### DIFF
--- a/electron/src/hardware-wallet.js
+++ b/electron/src/hardware-wallet.js
@@ -160,8 +160,8 @@ ipcMain.on('hwGetFeatures', (event, requestId) => {
   );
 });
 
-ipcMain.on('hwGetAddresses', (event, requestId, addressN, startIndex) => {
-  const promise = deviceWallet.devAddressGen(addressN, startIndex, false, pinEvent);
+ipcMain.on('hwGetAddresses', (event, requestId, addressN, startIndex, confirm) => {
+  const promise = deviceWallet.devAddressGen(addressN, startIndex, confirm, pinEvent);
   promise.then(
     addresses => { console.log("Addresses promise resolved", addresses); event.sender.send('hwGetAddressesResponse', requestId, addresses); },
     error => { console.log("Addresses promise errored: ", error); event.sender.send('hwGetAddressesResponse', requestId, { error: error.toString() }); }

--- a/src/gui/static/src/app/app.datatypes.ts
+++ b/src/gui/static/src/app/app.datatypes.ts
@@ -9,6 +9,7 @@ export class Address {
   hours: BigNumber = new BigNumber('0');
   copying?: boolean; // Optional parameter indicating whether the address is being copied to clipboard
   outputs?: any;
+  confirmed?: boolean; // Optional parameter for hardware wallets only
 }
 
 export class PurchaseOrder {

--- a/src/gui/static/src/app/app.module.ts
+++ b/src/gui/static/src/app/app.module.ts
@@ -91,6 +91,7 @@ import { HwSeedWordDialogComponent } from './components/layout/hardware-wallet/h
 import { Bip39WordListService } from './services/bip39-word-list.service';
 import { HwDialogBaseComponent } from './components/layout/hardware-wallet/hw-dialog-base.component';
 import { HwConfirmTxDialogComponent } from './components/layout/hardware-wallet/hw-confirm-tx-dialog/hw-confirm-tx-dialog.component';
+import { HwConfirmAddressDialogComponent } from './components/layout/hardware-wallet/hw-confirm-address-dialog/hw-confirm-address-dialog.component';
 
 
 const ROUTES = [
@@ -212,6 +213,7 @@ const ROUTES = [
     HwSeedWordDialogComponent,
     HwDialogBaseComponent,
     HwConfirmTxDialogComponent,
+    HwConfirmAddressDialogComponent,
   ],
   entryComponents: [
     AddDepositAddressComponent,
@@ -237,6 +239,7 @@ const ROUTES = [
     HwRestoreSeedDialogComponent,
     HwSeedWordDialogComponent,
     HwConfirmTxDialogComponent,
+    HwConfirmAddressDialogComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-confirm-address-dialog/hw-confirm-address-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-confirm-address-dialog/hw-confirm-address-dialog.component.html
@@ -1,0 +1,28 @@
+<app-modal class="modal" [headline]="'hardware-wallet.confirm-address.title' | translate" [dialog]="dialogRef" [disableDismiss]="currentState === states.Initial">
+  <app-hw-message *ngIf="currentState === states.Initial"
+    [text]="'hardware-wallet.confirm-address.instructions' | translate"
+    [lowerBigText]="data.address.address"
+    [icon]="msgIcons.Confirm"
+  ></app-hw-message>
+
+  <app-hw-message *ngIf="currentState === states.ReturnedSuccess"
+    [text]="(data.showCompleteConfirmation ? 'hardware-wallet.confirm-address.confirmation' : 'hardware-wallet.confirm-address.short-confirmation') | translate"
+    [icon]="msgIcons.Success"
+  ></app-hw-message>
+
+  <app-hw-message *ngIf="currentState === states.ReturnedRefused"
+    [text]="'hardware-wallet.general.refused' | translate"
+    [icon]="msgIcons.Error"
+  ></app-hw-message>
+
+  <app-hw-message *ngIf="currentState === states.Failed"
+    [text]="'hardware-wallet.general.generic-error' | translate"
+    [icon]="msgIcons.Error"
+  ></app-hw-message>
+
+  <div class="-buttons" *ngIf="currentState !== states.Initial">
+    <app-button (action)="closeModal()" class="primary">
+      {{ 'hardware-wallet.general.close' | translate }}
+    </app-button>
+  </div>
+</app-modal>

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-confirm-address-dialog/hw-confirm-address-dialog.component.spec.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-confirm-address-dialog/hw-confirm-address-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HwConfirmAddressDialogComponent } from './hw-confirm-address-dialog.component';
+
+describe('HwConfirmAddressDialogComponent', () => {
+  let component: HwConfirmAddressDialogComponent;
+  let fixture: ComponentFixture<HwConfirmAddressDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ HwConfirmAddressDialogComponent ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HwConfirmAddressDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-confirm-address-dialog/hw-confirm-address-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-confirm-address-dialog/hw-confirm-address-dialog.component.ts
@@ -1,0 +1,53 @@
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { HwWalletService, OperationResults } from '../../../../services/hw-wallet.service';
+import { HwDialogBaseComponent } from '../hw-dialog-base.component';
+import { Address } from '../../../../app.datatypes';
+import { WalletService } from '../../../../services/wallet.service';
+
+enum States {
+  Initial,
+  ReturnedSuccess,
+  ReturnedRefused,
+  Failed,
+}
+
+export class AddressConfirmationParams {
+  address: Address;
+  addressIndex: number;
+  showCompleteConfirmation: boolean;
+}
+
+@Component({
+  selector: 'app-hw-confirm-address-dialog',
+  templateUrl: './hw-confirm-address-dialog.component.html',
+  styleUrls: ['./hw-confirm-address-dialog.component.scss'],
+})
+export class HwConfirmAddressDialogComponent extends HwDialogBaseComponent<HwConfirmAddressDialogComponent> {
+
+  currentState: States = States.Initial;
+  states = States;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: AddressConfirmationParams,
+    public dialogRef: MatDialogRef<HwConfirmAddressDialogComponent>,
+    private hwWalletService: HwWalletService,
+    private walletService: WalletService,
+  ) {
+    super(hwWalletService, dialogRef);
+    this.operationSubscription = this.hwWalletService.confirmAddress(data.addressIndex).subscribe(
+      () => {
+        this.currentState = States.ReturnedSuccess;
+        this.data.address.confirmed = true;
+        this.walletService.saveHardwareWallets();
+      },
+      err => {
+        if (err.result && err.result === OperationResults.FailedOrRefused) {
+          this.currentState = States.ReturnedRefused;
+        } else {
+          this.currentState = States.Failed;
+        }
+      },
+    );
+  }
+}

--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.html
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.html
@@ -29,21 +29,34 @@
     <div class="-record" *ngIf="!wallet.hideEmpty || address.coins.isGreaterThan(0)">
       <div class="id-column">{{ i + 1 }}</div>
       <div class="address-column">
-        <img src="../../../../../assets/img/qr-code-black.png" (click)="showQrCode($event, address.address)" class="qr-code-button">
-        <p class="click-to-copy" [ngClass]="{ copying: address.copying }" (click)="copyAddress($event, address)" (mouseleave)="address.copying = false">
-          {{ address.address }}
-          <span [attr.data-label]="'wallet.address.copied' | translate" class="copy-label">
-            {{ 'wallet.address.copy' | translate }}
-          </span>
-        </p>
+        <ng-container *ngIf="!wallet.isHardware || address.confirmed">
+          <img src="../../../../../assets/img/qr-code-black.png" (click)="showQrCode($event, address.address)" class="qr-code-button">
+          <p class="click-to-copy" [ngClass]="{ copying: address.copying }" (click)="copyAddress($event, address)" (mouseleave)="address.copying = false">
+            {{ address.address }}
+            <span [attr.data-label]="'wallet.address.copied' | translate" class="copy-label">
+              {{ 'wallet.address.copy' | translate }}
+            </span>
+          </p>
+        </ng-container>
+        <ng-container *ngIf="wallet.isHardware && !address.confirmed">
+          <p class="click-to-copy" (click)="confirmAddress(address, i, true)">
+            <span class="truncated-address">{{ address.address }}</span>
+            <span class="copy-label unconfirmed-label">
+              {{ 'wallet.address.show' | translate }}
+            </span>
+          </p>
+        </ng-container>
       </div>
       <div class="coins-column">{{ (address.coins ? address.coins.decimalPlaces(6).toString() : 0) | number:'1.0-6' }}</div>
       <div class="hours-column">{{ (address.hours ? address.hours.decimalPlaces(0).toString() : 0) | number:'1.0-0' }}</div>
       <div class="options-column">
         <mat-icon [matMenuTriggerFor]="optionsMenu">more_vert</mat-icon>
         <mat-menu #optionsMenu="matMenu" [overlapTrigger]="false" class="compact">
-          <button mat-menu-item (click)="copyAddress($event, address, 1000)">
+          <button mat-menu-item (click)="copyAddress($event, address, 1000)" *ngIf="!wallet.isHardware || address.confirmed">
             {{ 'wallet.address.' + (address.copying ? 'copied': 'copy-address') | translate }}
+          </button>
+          <button mat-menu-item (click)="confirmAddress(address, i, !address.confirmed)" *ngIf="wallet.isHardware">
+            {{ 'wallet.address.confirm' | translate }}
           </button>
           <button mat-menu-item routerLink="/settings/outputs" [queryParams]="{ addr: address.address }">
             {{ 'wallet.address.outputs' | translate }}

--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.scss
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.scss
@@ -38,9 +38,18 @@
       word-break: break-all;
 
       &:hover .copy-label {
-        opacity: .999;
+        opacity: .999 !important;
       }
     }
+  }
+
+  .truncated-address {
+    max-width: 60px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: inline-block;
+    vertical-align: middle;
   }
 
   .hours-column {
@@ -223,6 +232,10 @@
     opacity: 0;
     line-height: 1;
   }
+}
+
+.unconfirmed-label {
+  opacity: 0.5 !important;
 }
 
 .copying .copy-label::after {

--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
@@ -14,6 +14,7 @@ import { Observable } from 'rxjs/Observable';
 import { showConfirmationModal } from '../../../../utils';
 import { AppConfig } from '../../../../app.config';
 import { Router } from '@angular/router';
+import { HwConfirmAddressDialogComponent, AddressConfirmationParams } from '../../../layout/hardware-wallet/hw-confirm-address-dialog/hw-confirm-address-dialog.component';
 
 @Component({
   selector: 'app-wallet-detail',
@@ -130,6 +131,23 @@ export class WalletDetailComponent implements OnDestroy {
           passwordDialog.close();
         }, e => passwordDialog.error(e));
       });
+  }
+
+  confirmAddress(address, addressIndex, showCompleteConfirmation) {
+    this.hwWalletService.checkIfCorrectHwConnected(this.wallet.addresses[0].address).subscribe(response => {
+      const data = new AddressConfirmationParams();
+      data.address = address;
+      data.addressIndex = addressIndex;
+      data.showCompleteConfirmation = showCompleteConfirmation;
+
+      const config = new MatDialogConfig();
+      config.width = '566px';
+      config.autoFocus = false;
+      config.data = data;
+      this.dialog.open(HwConfirmAddressDialogComponent, config);
+    }, err => {
+      showSnackbarError(this.snackbar, getHardwareWalletErrorMsg(this.hwWalletService, this.translateService, err));
+    });
   }
 
   copyAddress(event, address, duration = 500) {

--- a/src/gui/static/src/app/services/api.service.ts
+++ b/src/gui/static/src/app/services/api.service.ts
@@ -61,6 +61,7 @@ export class ApiService {
                 address: entry.address,
                 coins: null,
                 hours: null,
+                confirmed: true,
               };
             }),
             encrypted: wallet.meta.encrypted,
@@ -90,7 +91,7 @@ export class ApiService {
           filename: response.meta.filename,
           coins: null,
           hours: null,
-          addresses: response.entries.map(entry => ({ address: entry.address, coins: null, hours: null })),
+          addresses: response.entries.map(entry => ({ address: entry.address, coins: null, hours: null, confirmed: true })),
           encrypted: response.meta.encrypted,
         }));
   }

--- a/src/gui/static/src/app/services/hw-wallet.service.ts
+++ b/src/gui/static/src/app/services/hw-wallet.service.ts
@@ -177,7 +177,16 @@ export class HwWalletService {
   getAddresses(addressN: number, startIndex: number): Observable<OperationResult> {
     return this.cancelLastAction().flatMap(() => {
       const requestId = this.createRandomIdAndPrepare();
-      window['ipcRenderer'].send('hwGetAddresses', requestId, addressN, startIndex);
+      window['ipcRenderer'].send('hwGetAddresses', requestId, addressN, startIndex, false);
+
+      return this.createRequestResponse(requestId);
+    });
+  }
+
+  confirmAddress(index: number): Observable<OperationResult> {
+    return this.cancelLastAction().flatMap(() => {
+      const requestId = this.createRandomIdAndPrepare();
+      window['ipcRenderer'].send('hwGetAddresses', requestId, 1, index, true);
 
       return this.createRequestResponse(requestId);
     });

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -151,10 +151,12 @@
     },
 
     "address": {
+      "show": "Press to show",
       "copy": "Copy",
       "copy-address": "Copy address",
       "copied": "Copied!",
-      "outputs": "Unspent Outputs",
+      "confirm": "Confirm address",
+      "outputs": "Unspent outputs",
       "history": "History"
     }
   },
@@ -411,6 +413,12 @@
     },
     "create-tx" : {
       "title": "Create transaction"
+    },
+    "confirm-address" : {
+      "title": "Confirm address",
+      "instructions": "Please confirm on the hardware wallet if the address is:",
+      "short-confirmation": "Address confirmed.",
+      "confirmation": "Address confirmed. For security, you can re-show the address in the hardware wallet using the \"Confirm address\" option, in the menu that you can display by pressing the button at the right of the address balance."
     }
   }
 }


### PR DESCRIPTION
Changes:
- Now before being able to see the addresses of the hardware wallet for the first time it is necessary to confirm them first in the hardware wallet, just like it happens with Trezor:
![c1](https://user-images.githubusercontent.com/34079003/53294689-d7c8fd00-37c1-11e9-84c2-dff94e26a9bc.png)
![c2](https://user-images.githubusercontent.com/34079003/53294690-def00b00-37c1-11e9-9570-cbd0463ae774.png)

- It is possible to re-show the address in the hardware wallet by using the menu on the right:
![c3](https://user-images.githubusercontent.com/34079003/53294692-edd6bd80-37c1-11e9-8eae-1a62d6463b27.png)

- This change does not prevent sending coins before confirming the addresses.

Does this change need to mentioned in CHANGELOG.md?
No