### PR TITLE
Do not download remote peers.txt if -disable-networking

### DIFF
--- a/src/daemon/pex/pex.go
+++ b/src/daemon/pex/pex.go
@@ -269,8 +269,8 @@ func New(cfg Config) (*Pex, error) {
 		return nil, err
 	}
 
-	// Download peers from remote peers list
-	if pex.Config.DownloadPeerList {
+	// Download peers from remote peers list if networking is enabled
+	if pex.Config.DownloadPeerList && !pex.Config.NetworkDisabled {
 		go func() {
 			if err := pex.downloadPeers(); err != nil {
 				logger.WithError(err).Error("Failed to download peers list")

--- a/src/skycoin/skycoin.go
+++ b/src/skycoin/skycoin.go
@@ -354,6 +354,7 @@ func (c *Coin) ConfigureDaemon() daemon.Config {
 
 	dc.Pex.DataDirectory = c.config.Node.DataDirectory
 	dc.Pex.Disabled = c.config.Node.DisablePEX
+	dc.Pex.NetworkDisabled = c.config.Node.DisableNetworking
 	dc.Pex.Max = c.config.Node.PeerlistSize
 	dc.Pex.DownloadPeerList = c.config.Node.DownloadPeerList
 	dc.Pex.PeerListURL = c.config.Node.PeerListURL


### PR DESCRIPTION
Fixes #2162 

Changes:
- If `-disable-networking flag` is set, downloading of remote `peers.txt` does not happen.

Does this change need to mentioned in CHANGELOG.md?
yes
