### PR TITLE
Add passphrase compatibility

### DIFF
--- a/src/gui/static/src/app/app.component.ts
+++ b/src/gui/static/src/app/app.component.ts
@@ -9,6 +9,7 @@ import { HwPinDialogComponent } from './components/layout/hardware-wallet/hw-pin
 import { HwSeedWordDialogComponent } from './components/layout/hardware-wallet/hw-seed-word-dialog/hw-seed-word-dialog.component';
 import { Bip39WordListService } from './services/bip39-word-list.service';
 import { HwConfirmTxDialogComponent } from './components/layout/hardware-wallet/hw-confirm-tx-dialog/hw-confirm-tx-dialog.component';
+import { HwPassphraseDialogComponent } from './components/layout/hardware-wallet/hw-passphrase-dialog/hw-passphrase-dialog.component';
 
 @Component({
   selector: 'app-root',
@@ -27,6 +28,7 @@ export class AppComponent implements OnInit {
     translateService.use('en');
 
     hwWalletService.requestPinComponent = HwPinDialogComponent;
+    hwWalletService.requestPassphraseComponent = HwPassphraseDialogComponent;
     hwWalletService.requestWordComponent = HwSeedWordDialogComponent;
     hwWalletService.signTransactionConfirmationComponent = HwConfirmTxDialogComponent;
 

--- a/src/gui/static/src/app/app.module.ts
+++ b/src/gui/static/src/app/app.module.ts
@@ -92,6 +92,9 @@ import { Bip39WordListService } from './services/bip39-word-list.service';
 import { HwDialogBaseComponent } from './components/layout/hardware-wallet/hw-dialog-base.component';
 import { HwConfirmTxDialogComponent } from './components/layout/hardware-wallet/hw-confirm-tx-dialog/hw-confirm-tx-dialog.component';
 import { HwConfirmAddressDialogComponent } from './components/layout/hardware-wallet/hw-confirm-address-dialog/hw-confirm-address-dialog.component';
+import { HwPassphraseDialogComponent } from './components/layout/hardware-wallet/hw-passphrase-dialog/hw-passphrase-dialog.component';
+import { HwPassphraseActivationDialogComponent } from './components/layout/hardware-wallet/hw-passphrase-activation-dialog/hw-passphrase-activation-dialog.component';
+import { HwPassphraseHelpDialogComponent } from './components/layout/hardware-wallet/hw-passphrase-help-dialog/hw-passphrase-help-dialog.component';
 
 
 const ROUTES = [
@@ -214,6 +217,9 @@ const ROUTES = [
     HwDialogBaseComponent,
     HwConfirmTxDialogComponent,
     HwConfirmAddressDialogComponent,
+    HwPassphraseDialogComponent,
+    HwPassphraseActivationDialogComponent,
+    HwPassphraseHelpDialogComponent,
   ],
   entryComponents: [
     AddDepositAddressComponent,
@@ -240,6 +246,9 @@ const ROUTES = [
     HwSeedWordDialogComponent,
     HwConfirmTxDialogComponent,
     HwConfirmAddressDialogComponent,
+    HwPassphraseDialogComponent,
+    HwPassphraseActivationDialogComponent,
+    HwPassphraseHelpDialogComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-added-dialog/hw-added-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-added-dialog/hw-added-dialog.component.html
@@ -1,5 +1,28 @@
-<app-modal class="modal" [headline]="'hardware-wallet.added.title' | translate" [dialog]="dialogRef" [disableDismiss]="currentState === states.Initial || currentState === states.Finished">
+<app-modal class="modal" [headline]="'hardware-wallet.added.title' | translate" [dialog]="dialogRef" [disableDismiss]="currentState !== states.Failed">
   <app-hw-message *ngIf="currentState === states.Initial"
+    [text]="'hardware-wallet.added.wait' | translate"
+    [icon]="msgIcons.Spinner"
+  ></app-hw-message>
+
+  <div *ngIf="currentState === states.PassphraseWarning">
+    <app-hw-message
+      [text]="'hardware-wallet.added.passphrase-warning' | translate"
+      [linkText]="'hardware-wallet.passphrase-help.link' | translate"
+      [icon]="msgIcons.Warning"
+      (linkClicked)="openHelp()"
+    ></app-hw-message>
+
+    <div class="-buttons">
+      <app-button (action)="cancel()">
+        {{ 'hardware-wallet.general.cancel' | translate }}
+      </app-button>
+      <app-button (action)="startAdding()" class="primary">
+        {{ 'hardware-wallet.general.continue' | translate }}
+      </app-button>
+    </div>
+  </div>
+
+  <app-hw-message *ngIf="currentState === states.Adding"
     [text]="'hardware-wallet.added.configuring' | translate"
     [icon]="msgIcons.Spinner"
   ></app-hw-message>
@@ -24,7 +47,7 @@
   </div>
 
   <div class="-buttons" *ngIf="currentState === states.Finished || currentState === states.Failed">
-    <app-button (action)="saveNameAndCloseModal()" class="primary" [disabled]="!form.valid">
+    <app-button (action)="currentState === states.Finished ? saveNameAndCloseModal() : closeModal()" class="primary" [disabled]="form && !form.valid">
       {{ 'hardware-wallet.general.close' | translate }}
     </app-button>
   </div>

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-options-dialog/hw-options-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-options-dialog/hw-options-dialog.component.html
@@ -68,6 +68,9 @@
         <button mat-button color="primary" (click)="changePin()">
           <div class="label">{{ (!needsPin ? 'hardware-wallet.options.change-pin' : 'hardware-wallet.options.create-pin') | translate }}</div>
         </button>
+        <button mat-button color="primary" (click)="changePassphraseActivation()">
+          <div class="label">{{ (!hasPassphrase ? 'hardware-wallet.options.activate-passphrase' : 'hardware-wallet.options.deactivate-passphrase') | translate }}</div>
+        </button>
         <button mat-button color="primary" (click)="confirmSeed()" *ngIf="!needsBackup">
           <div class="label">{{ 'hardware-wallet.options.confirm-seed' | translate }}</div>
         </button>

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-options-dialog/hw-options-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-options-dialog/hw-options-dialog.component.ts
@@ -12,6 +12,7 @@ import { HwChangePinDialogComponent } from '../hw-change-pin-dialog/hw-change-pi
 import { HwRestoreSeedDialogComponent } from '../hw-restore-seed-dialog/hw-restore-seed-dialog.component';
 import { Observable } from 'rxjs/Observable';
 import { HwDialogBaseComponent } from '../hw-dialog-base.component';
+import { HwPassphraseActivationDialogComponent } from '../hw-passphrase-activation-dialog/hw-passphrase-activation-dialog.component';
 
 enum States {
   Disconnected,
@@ -26,6 +27,7 @@ enum States {
 export interface ChildHwDialogParams {
   wallet: Wallet;
   walletHasPin: boolean;
+  walletHasPassphrase: boolean;
   requestOptionsComponentRefresh: any;
 }
 
@@ -44,6 +46,7 @@ export class HwOptionsDialogComponent extends HwDialogBaseComponent<HwOptionsDia
   customErrorMsg = '';
   needsBackup: boolean;
   needsPin: boolean;
+  hasPassphrase: boolean;
 
   private dialogSubscription: ISubscription;
 
@@ -97,6 +100,10 @@ export class HwOptionsDialogComponent extends HwDialogBaseComponent<HwOptionsDia
     this.openDialog(HwRestoreSeedDialogComponent);
   }
 
+  changePassphraseActivation() {
+    this.openDialog(HwPassphraseActivationDialogComponent);
+  }
+
   private openDialog(dialogType) {
     this.customErrorMsg = '';
 
@@ -108,6 +115,7 @@ export class HwOptionsDialogComponent extends HwDialogBaseComponent<HwOptionsDia
     config.data = <ChildHwDialogParams> {
       wallet: this.wallet,
       walletHasPin: !this.needsPin,
+      walletHasPassphrase: this.hasPassphrase,
       requestOptionsComponentRefresh: ((error: string = null, recheckSecurityOnly: boolean = false) => {
         if (!error) {
           if (!recheckSecurityOnly) {
@@ -147,6 +155,7 @@ export class HwOptionsDialogComponent extends HwDialogBaseComponent<HwOptionsDia
     return this.walletService.updateWalletHasHwSecurityWarnings(this.wallet).map(warnings => {
       this.needsBackup = warnings.includes(HwSecurityWarnings.NeedsBackup);
       this.needsPin = warnings.includes(HwSecurityWarnings.NeedsPin);
+      this.hasPassphrase = warnings.includes(HwSecurityWarnings.HasPassphrase);
 
       return warnings;
     });

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-activation-dialog/hw-passphrase-activation-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-activation-dialog/hw-passphrase-activation-dialog.component.html
@@ -1,0 +1,50 @@
+<app-modal class="modal"
+  [headline]="(activating ? 'hardware-wallet.options.activate-passphrase' : 'hardware-wallet.options.deactivate-passphrase') | translate"
+  [dialog]="dialogRef"
+  [disableDismiss]="currentState === states.Processing">
+  <div *ngIf="currentState === states.Initial">
+    <app-hw-message
+      [text]="(activating ? 'hardware-wallet.activate-passphrase.warning-activate' : 'hardware-wallet.activate-passphrase.warning-deactivate') | translate"
+      [linkText]="'hardware-wallet.passphrase-help.link' | translate"
+      [icon]="msgIcons.Warning"
+      (linkClicked)="openHelp()"
+    ></app-hw-message>
+
+    <div class="-buttons">
+      <app-button (action)="closeModal()">
+        {{ 'hardware-wallet.general.cancel' | translate }}
+      </app-button>
+      <app-button (action)="changeConfig()" class="primary">
+        {{ 'hardware-wallet.general.continue' | translate }}
+      </app-button>
+    </div>
+  </div>
+
+  <div *ngIf="currentState !== states.Initial">
+    <app-hw-message *ngIf="currentState === states.Processing"
+      [text]="'hardware-wallet.general.confirm' | translate"
+      [icon]="msgIcons.Confirm"
+    ></app-hw-message>
+
+    <app-hw-message *ngIf="currentState === states.ReturnedSuccess"
+      [text]="'hardware-wallet.general.completed' | translate"
+      [icon]="msgIcons.Success"
+    ></app-hw-message>
+
+    <app-hw-message *ngIf="currentState === states.ReturnedRefused"
+      [text]="'hardware-wallet.general.refused' | translate"
+      [icon]="msgIcons.Error"
+    ></app-hw-message>
+
+    <app-hw-message *ngIf="currentState === states.Failed"
+      [text]="'hardware-wallet.general.generic-error' | translate"
+      [icon]="msgIcons.Error"
+    ></app-hw-message>
+
+    <div class="-buttons" *ngIf="currentState !== states.Processing">
+      <app-button (action)="closeModal()" class="primary">
+        {{ 'hardware-wallet.general.close' | translate }}
+      </app-button>
+    </div>
+  </div>
+</app-modal>

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-activation-dialog/hw-passphrase-activation-dialog.component.spec.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-activation-dialog/hw-passphrase-activation-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HwPassphraseActivationDialogComponent } from './hw-passphrase-activation-dialog.component';
+
+describe('HwPassphraseActivationDialogComponent', () => {
+  let component: HwPassphraseActivationDialogComponent;
+  let fixture: ComponentFixture<HwPassphraseActivationDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ HwPassphraseActivationDialogComponent ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HwPassphraseActivationDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-activation-dialog/hw-passphrase-activation-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-activation-dialog/hw-passphrase-activation-dialog.component.ts
@@ -1,0 +1,60 @@
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog, MatDialogConfig } from '@angular/material/dialog';
+import { HwWalletService, OperationResults } from '../../../../services/hw-wallet.service';
+import { ChildHwDialogParams } from '../hw-options-dialog/hw-options-dialog.component';
+import { HwDialogBaseComponent } from '../hw-dialog-base.component';
+import { HwPassphraseHelpDialogComponent } from '../hw-passphrase-help-dialog/hw-passphrase-help-dialog.component';
+
+enum States {
+  Initial,
+  Processing,
+  ReturnedSuccess,
+  ReturnedRefused,
+  Failed,
+}
+
+@Component({
+  selector: 'app-hw-passphrase-activation-dialog',
+  templateUrl: './hw-passphrase-activation-dialog.component.html',
+  styleUrls: ['./hw-passphrase-activation-dialog.component.scss'],
+})
+export class HwPassphraseActivationDialogComponent extends HwDialogBaseComponent<HwPassphraseActivationDialogComponent> {
+
+  currentState: States = States.Initial;
+  states = States;
+  activating: boolean;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: ChildHwDialogParams,
+    public dialogRef: MatDialogRef<HwPassphraseActivationDialogComponent>,
+    private hwWalletService: HwWalletService,
+    private dialog: MatDialog,
+  ) {
+    super(hwWalletService, dialogRef);
+    this.activating = !data.walletHasPassphrase;
+  }
+
+  changeConfig() {
+    this.currentState = States.Processing;
+
+    this.operationSubscription = this.hwWalletService.applySettings(this.activating).subscribe(
+      () => {
+        this.currentState = States.ReturnedSuccess;
+        this.data.requestOptionsComponentRefresh();
+      },
+      err => {
+        if (err.result && err.result === OperationResults.FailedOrRefused) {
+          this.currentState = States.ReturnedRefused;
+        } else {
+          this.currentState = States.Failed;
+        }
+      },
+    );
+  }
+
+  openHelp() {
+    this.dialog.open(HwPassphraseHelpDialogComponent, <MatDialogConfig> {
+      width: '450px',
+    });
+  }
+}

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-dialog/hw-passphrase-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-dialog/hw-passphrase-dialog.component.html
@@ -1,0 +1,19 @@
+<app-modal class="modal" [headline]="'hardware-wallet.passphrase.title' | translate" [dialog]="dialogRef">
+  <app-hw-message
+    [text]="'hardware-wallet.passphrase.info' | translate"
+    [linkText]="'hardware-wallet.passphrase-help.link' | translate"
+    [icon]="msgIcons.None"
+    (linkClicked)="openHelp()"
+  ></app-hw-message>
+  <div [formGroup]="form" class="form-container">
+    <div class="form-field">
+      <label for="passphrase">{{ 'hardware-wallet.passphrase.passphrase' | translate }}</label>
+      <input formControlName="passphrase" id="passphrase" (keydown.enter)="sendPassphrase()">
+    </div>
+  </div>
+  <div class="-buttons">
+    <app-button (action)="sendPassphrase()" class="primary" [disabled]="!form.valid">
+      {{ 'hardware-wallet.general.continue' | translate }}
+    </app-button>
+  </div>
+</app-modal>

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-dialog/hw-passphrase-dialog.component.scss
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-dialog/hw-passphrase-dialog.component.scss
@@ -1,0 +1,5 @@
+@import '../../../../../theme/variables';
+
+.form-container {
+  margin-top: 20px;
+}

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-dialog/hw-passphrase-dialog.component.spec.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-dialog/hw-passphrase-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HwPassphraseDialogComponent } from './hw-passphrase-dialog.component';
+
+describe('HwPassphraseDialogComponent', () => {
+  let component: HwPassphraseDialogComponent;
+  let fixture: ComponentFixture<HwPassphraseDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ HwPassphraseDialogComponent ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HwPassphraseDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-dialog/hw-passphrase-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-dialog/hw-passphrase-dialog.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { FormBuilder, Validators, FormGroup } from '@angular/forms';
+import { MatDialogRef, MatDialog, MatDialogConfig } from '@angular/material/dialog';
+import { HwWalletService } from '../../../../services/hw-wallet.service';
+import { HwDialogBaseComponent } from '../hw-dialog-base.component';
+import { HwPassphraseHelpDialogComponent } from '../hw-passphrase-help-dialog/hw-passphrase-help-dialog.component';
+
+@Component({
+  selector: 'app-hw-passphrase-dialog',
+  templateUrl: './hw-passphrase-dialog.component.html',
+  styleUrls: ['./hw-passphrase-dialog.component.scss'],
+})
+export class HwPassphraseDialogComponent extends HwDialogBaseComponent<HwPassphraseDialogComponent> implements OnInit, OnDestroy {
+  form: FormGroup;
+
+  constructor(
+    public dialogRef: MatDialogRef<HwPassphraseDialogComponent>,
+    private formBuilder: FormBuilder,
+    private dialog: MatDialog,
+    hwWalletService: HwWalletService,
+  ) {
+    super(hwWalletService, dialogRef);
+  }
+
+  ngOnInit() {
+    this.form = this.formBuilder.group({
+      passphrase: ['', Validators.required],
+    });
+  }
+
+  ngOnDestroy() {
+    super.ngOnDestroy();
+  }
+
+  sendPassphrase() {
+    this.dialogRef.close(this.form.value.passphrase);
+  }
+
+  openHelp() {
+    this.dialog.open(HwPassphraseHelpDialogComponent, <MatDialogConfig> {
+      width: '450px',
+    });
+  }
+}

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-help-dialog/hw-passphrase-help-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-help-dialog/hw-passphrase-help-dialog.component.html
@@ -1,0 +1,5 @@
+<app-modal class="modal" [headline]="'hardware-wallet.passphrase-help.title' | translate" [dialog]="dialogRef">
+  <p>{{ 'hardware-wallet.passphrase-help.part1' | translate }}</p>
+  <p>{{ 'hardware-wallet.passphrase-help.part2' | translate }}</p>
+  <p>{{ 'hardware-wallet.passphrase-help.part3' | translate }}</p>
+</app-modal>

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-help-dialog/hw-passphrase-help-dialog.component.spec.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-help-dialog/hw-passphrase-help-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HwPassphraseHelpDialogComponent } from './hw-passphrase-help-dialog.component';
+
+describe('HwPassphraseHelpDialogComponent', () => {
+  let component: HwPassphraseHelpDialogComponent;
+  let fixture: ComponentFixture<HwPassphraseHelpDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ HwPassphraseHelpDialogComponent ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HwPassphraseHelpDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-help-dialog/hw-passphrase-help-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-passphrase-help-dialog/hw-passphrase-help-dialog.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-hw-passphrase-help-dialog',
+  templateUrl: './hw-passphrase-help-dialog.component.html',
+  styleUrls: ['./hw-passphrase-help-dialog.component.scss'],
+})
+export class HwPassphraseHelpDialogComponent {
+
+  constructor(
+    public dialogRef: MatDialogRef<HwPassphraseHelpDialogComponent>,
+  ) { }
+}

--- a/src/gui/static/src/app/services/hw-wallet.service.ts
+++ b/src/gui/static/src/app/services/hw-wallet.service.ts
@@ -60,6 +60,10 @@ export class HwWalletService {
   set requestPinComponent(value) {
     this.requestPinComponentInternal = value;
   }
+  private requestPassphraseComponentInternal;
+  set requestPassphraseComponent(value) {
+    this.requestPassphraseComponentInternal = value;
+  }
   private requestWordComponentInternal;
   set requestWordComponent(value) {
     this.requestWordComponentInternal = value;
@@ -103,6 +107,16 @@ export class HwWalletService {
           window['ipcRenderer'].send('hwSendPin', pin);
         });
       });
+      window['ipcRenderer'].on('hwPassphraseRequested', (event) => {
+        dialog.open(this.requestPassphraseComponentInternal, <MatDialogConfig> {
+          width: '350px',
+        }).afterClosed().subscribe(passphrase => {
+          if (!passphrase) {
+            this.cancelAllOperations();
+          }
+          window['ipcRenderer'].send('hwSendPassphrase', passphrase);
+        });
+      });
       window['ipcRenderer'].on('hwSeedWordRequested', (event) => {
         dialog.open(this.requestWordComponentInternal, <MatDialogConfig> {
           width: '350px',
@@ -134,6 +148,7 @@ export class HwWalletService {
         { event: 'hwGetAddressesResponse' },
         { event: 'hwGetFeaturesResponse' },
         { event: 'hwSignMessageResponse' },
+        { event: 'hwApplySettingsResponse' },
       ];
 
       data.forEach(item => {
@@ -276,6 +291,15 @@ export class HwWalletService {
       const requestId = this.createRandomIdAndPrepare();
       this.signingTx = true;
       window['ipcRenderer'].send('hwSignTransaction', requestId, inputs, outputs);
+
+      return this.createRequestResponse(requestId);
+    });
+  }
+
+  applySettings(usePassphrase: boolean): Observable<OperationResult> {
+    return this.cancelLastAction().flatMap(() => {
+      const requestId = this.createRandomIdAndPrepare();
+      window['ipcRenderer'].send('hwApplySettings', requestId, usePassphrase);
 
       return this.createRequestResponse(requestId);
     });

--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -24,6 +24,7 @@ declare var Cipher: any;
 export enum HwSecurityWarnings {
   NeedsBackup,
   NeedsPin,
+  HasPassphrase,
 }
 
 @Injectable()
@@ -162,6 +163,9 @@ export class WalletService {
         if (!result.rawResponse.pinProtection) {
           warnings.push(HwSecurityWarnings.NeedsPin);
           wallet.hasHwSecurityWarnings = true;
+        }
+        if (result.rawResponse.passphraseProtection) {
+          warnings.push(HwSecurityWarnings.HasPassphrase);
         }
         this.saveHardwareWallets();
 

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -360,6 +360,8 @@
       "confirm-seed": "Confirm seed",
       "create-pin": "Create PIN code",
       "change-pin": "Change PIN code",
+      "activate-passphrase": "Activate passphrase protection",
+      "deactivate-passphrase": "Deactivate passphrase protection",
       "forgotten-pin1": "If you can not access the wallet because you have forgotten the PIN, you can wipe the hardware wallet and then restore it with the seed by clicking",
       "forgotten-pin2": "here."
     },
@@ -376,6 +378,9 @@
     },
     "added" : {
       "title": "New Hardware Wallet",
+      "wait": "Please wait...",
+      "canceled": "Operation cancelled",
+      "passphrase-warning": "A new hardware wallet has been detected and is about to be added to your wallet list. If your hardware wallet is already in the wallet list using the current passphrase, this may be because you entered your passphrase incorrectly, so it is advisable to unplug the device now and try again. If not, you can ignore this warning.",
       "configuring": "New hardware wallet detected. Configuring...",
       "done": "Done",
       "added1": "The connected hardware wallet has been added to the wallets list with the following name:",
@@ -388,6 +393,10 @@
     "create-backup" : {
       "warning": "WARNING: You can only use this option to backup your hardware wallet seed once. If you decide to continue, you will have to write down a group of words (it is recommended to do it on paper and not on a computer) that will appear on the screen of the hardware wallet and store the list in a safe place. Anyone with access to the word list (the \"seed\") will be able access the wallet balance, so extreme caution is advised.",
       "instructions": "Write down the word list that appear on the screen of the hardware wallet. Make sure you respect the order and write each word correctly."
+    },
+    "activate-passphrase" : {
+      "warning-activate": "When activating this option the addresses of the hardware wallet will change depending on the secret passphrase used, so you will not have access to the current addresses. You will recover access to the current addresses after deactivating this option.",
+      "warning-deactivate": "When deactivating this option you will not have access to the addresses you would have created using a passphrase. You will have access to them again after reactivating this option."
     },
     "seed-word" : {
       "title": "Enter word",
@@ -415,6 +424,18 @@
       "part1": "When it is necessary to enter the PIN to continue, the hardware wallet screen will display a matrix of 9 boxes with numbers in random order (the order changes each time) and you will be asked to enter the PIN in the software wallet using a matrix of 9 buttons that simply show the symbol #.",
       "part2": "To enter the PIN, look at the position of the PIN numbers in numbers matrix on the screen of the hardware wallet and press the corresponding buttons in the software wallet. For example, if the PIN is \"23\" and the number 2 is in the upper left, number 3 in the middle of the hardware wallet numbers matrix, press the upper left and middle button in that order in the software wallet.",
       "part3": "If you wish, you can also use the numpad on your keyboard to enter the PIN. However, as in the previous example, if the PIN is \"23\", you can not simply type \"23\" with the numpad, but you will have to press the keys that are in the position where the numbers 2 and 3 are shown on the screen of the hardware wallet."
+    },
+    "passphrase" : {
+      "title": "Passphrase",
+      "info": "Please enter your passphrase. The passphrase will be saved until you disconnect the device.",
+      "passphrase": "Passphrase"
+    },
+    "passphrase-help" : {
+      "link": "More info.",
+      "title": "Help",
+      "part1": "The passphrase is a mechanism that serves both to protect your hardware wallet and to make it more versatile. If you activate the passphrase option, when you connect your hardware wallet and try to do certain operations you will be asked to enter a text (it may be what you want) which will be mixed with the seed on the hardware wallet before creating addresses and transactions.",
+      "part2": "When using a different passphrase the hardware wallet will behave like a totally different wallet, with different addresses and without the possibility of accessing any address created with the same hardware wallet but with a different passphrase. This means that you can use the passphrase both to keep funds in different accounts and to prevent anyone from accessing the funds without having the passphrase.",
+      "part3": "WARNING: note that for two passphrases must be exactly the same to be considered equal, respecting uppercases, numbers, spaces and any special characters. For example, \"word\" is different than \"Word\"."
     },
     "create-tx" : {
       "title": "Create transaction"


### PR DESCRIPTION
Changes:
- Now it is possible to add passphrases to the hardware wallet.

This PR includes many texts, so it would be good to check them with some care, since there may be errors.

Does this change need to mentioned in CHANGELOG.md?
