### PR TITLE
[ci] fixes #2213 - Fix keychain with the same name already exists in Travis

### DIFF
--- a/ci-scripts/add-key.sh
+++ b/ci-scripts/add-key.sh
@@ -4,7 +4,7 @@ set -e -o pipefail
 
 KEY_CHAIN=login.keychain
 echo "security create keychain"
-security create-keychain -p travis $KEY_CHAIN
+security create-keychain -p travis $KEY_CHAIN || { if [[ "$?" != "48" ]]; then true ; else exit $? ; fi }
 # Make the keychain the default so identities are found
 echo "security default-keychain"
 security default-keychain -s $KEY_CHAIN

--- a/ci-scripts/add-key.sh
+++ b/ci-scripts/add-key.sh
@@ -4,7 +4,7 @@ set -e -o pipefail
 
 KEY_CHAIN=login.keychain
 echo "security create keychain"
-if ! security show-keychain-info ; then 
+if ! security show-keychain-info $KEY_CHAIN ; then 
 	security create-keychain -p travis $KEY_CHAIN ;
 fi
 # Make the keychain the default so identities are found

--- a/ci-scripts/add-key.sh
+++ b/ci-scripts/add-key.sh
@@ -4,7 +4,9 @@ set -e -o pipefail
 
 KEY_CHAIN=login.keychain
 echo "security create keychain"
-security create-keychain -p travis $KEY_CHAIN || { if [[ "$?" != "48" ]]; then true ; else exit $? ; fi }
+if ! security show-keychain-info ; then 
+	security create-keychain -p travis $KEY_CHAIN ;
+fi
 # Make the keychain the default so identities are found
 echo "security default-keychain"
 security default-keychain -s $KEY_CHAIN


### PR DESCRIPTION

Fixes #2213 

Changes:
-  Do not fail if `security create keychain` fails with code 48 in osx

Does this change need to mentioned in CHANGELOG.md?
no