### PR TITLE
Modify the procedure for creating transactions (front-end)

### DIFF
--- a/src/gui/static/src/app/app.datatypes.ts
+++ b/src/gui/static/src/app/app.datatypes.ts
@@ -39,6 +39,7 @@ export class PreviewTransaction extends Transaction {
   from: string;
   to: string[];
   encoded: string;
+  wallet?: Wallet;
 }
 
 export class NormalTransaction extends Transaction {

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.html
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.html
@@ -2,10 +2,10 @@
   <div class="form-field">
     <label for="wallets">{{ 'send.wallet-label' | translate }}</label>
     <div class="-select">
-      <select formControlName="wallet" id="wallets">
+      <select formControlName="wallet" id="wallets" [attr.disabled]="busy ? 'true' : null" [ngClass]="{'element-disabled' : busy}">
         <option disabled hidden [ngValue]="''">{{ 'send.select-wallet' | translate }}</option>
         <ng-container *ngFor="let wallet of walletService.all() | async">
-          <option *ngIf="!wallet.isHardware" [disabled]="!wallet.coins || wallet.coins.isLessThanOrEqualTo(0)" [ngValue]="wallet">
+          <option [disabled]="!wallet.coins || wallet.coins.isLessThanOrEqualTo(0)" [ngValue]="wallet">
             {{ wallet.label }} - {{ (wallet.coins ? wallet.coins.decimalPlaces(6).toString() : 0) | number:'1.0-6' }} {{ 'common.coin-id' | translate }}
             ({{ wallet.hours.decimalPlaces(0).toString() | number:'1.0-0' }} {{ 'common.coin-hours' | translate }})
           </option>
@@ -16,7 +16,7 @@
 
   <ng-container *ngIf="wallet">
     <div class="form-field">
-      <label for="addresses" (click)="selectAddresses.open()">
+      <label [for]="!busy ? 'addresses' : ''" (click)="!busy ? selectAddresses.open() : null">
         {{ 'send.addresses-label' | translate }}
         <mat-icon [matTooltip]="'send.addresses-help' | translate">help</mat-icon>
       </label>
@@ -26,7 +26,9 @@
           formControlName="addresses"
           [compareWith]="addressCompare"
           id="addresses"
-          [placeholder]="'send.all-addresses' | translate">
+          [placeholder]="'send.all-addresses' | translate"
+          [attr.disabled]="busy ? 'true' : null"
+          [ngClass]="{'element-disabled' : busy}">
           <mat-option *ngFor="let addr of addresses" [value]="addr">
             {{ addr.address }} - {{ (addr.coins ? addr.coins.decimalPlaces(6).toString() : 0) | number:'1.0-6' }} {{ 'common.coin-id' | translate }}
             ({{ addr.hours.decimalPlaces(0).toString() | number:'1.0-0' }} {{ 'common.coin-hours' | translate }})
@@ -42,7 +44,7 @@
     </div>
 
     <div class="form-field">
-      <label for="outputs" (click)="selectOutputs.open()">
+      <label [for]="!busy ? 'outputs' : null" (click)="!busy ? selectOutputs.open() : null">
         {{ 'send.outputs-label' | translate }}
         <mat-icon [matTooltip]="'send.outputs-help' | translate">help</mat-icon>
         <mat-spinner *ngIf="loadingUnspentOutputs"></mat-spinner>
@@ -53,7 +55,9 @@
           formControlName="outputs"
           [compareWith]="outputCompare"
           id="outputs"
-          [placeholder]="'send.all-outputs' | translate">
+          [placeholder]="'send.all-outputs' | translate"
+          [attr.disabled]="busy ? 'true' : null"
+          [ngClass]="{'element-disabled' : busy}">
           <mat-option *ngFor="let out of unspentOutputs" [value]="out">
             {{ out.hash }} - {{ (out.coins ? out.coins.decimalPlaces(6).toString() : 0) | number:'1.0-6' }} {{ 'common.coin-id' | translate }}
             ({{ out.calculated_hours.decimalPlaces(0).toString() | number:'1.0-0' }} {{ 'common.coin-hours' | translate }})
@@ -99,21 +103,21 @@
     <div formArrayName="destinations" *ngFor="let dest of destControls; let i = index;" class="-destination">
       <div [formGroupName]="i" class="row">
         <div class="col-lg-5 col-md-4">
-          <input formControlName="address" [id]="i === 0 ? 'destination' : ''">
+          <input formControlName="address" [id]="i === 0 ? 'destination' : ''" [attr.disabled]="busy ? 'true' : null">
         </div>
         <div class="col-md-3">
           <div class="-input-addon">
-            <input formControlName="coins">
+            <input formControlName="coins" [attr.disabled]="busy ? 'true' : null">
             <span>{{ 'common.coin-id' | translate }}</span>
           </div>
         </div>
         <div class="col-lg-3 col-md-4">
           <div [ngClass]="{ '-input-addon': true, '-hidden': autoHours }">
-            <input formControlName="hours">
+            <input formControlName="hours" [attr.disabled]="busy ? 'true' : null">
             <span>{{ 'common.coin-hours' | translate }}</span>
           </div>
         </div>
-        <div class="col-md-1 -icons">
+        <div class="col-md-1 -icons" [ngClass]="{'element-disabled' : busy}">
           <img *ngIf="i === 0" (click)="addDestination()" src="../../../../../assets/img/plus-green.png" alt="plus">
           <img *ngIf="i !== 0" (click)="removeDestination(i)" src="../../../../../assets/img/minus-grey.png" alt="minus">
         </div>
@@ -125,17 +129,17 @@
     <label for="change-address">
       {{ 'send.change-address-label' | translate }}
       <mat-icon [matTooltip]="'send.change-address-help' | translate">help</mat-icon>
-      <span class="-options" (click)="selectChangeAddress($event)">
+      <span class="-options" (click)="selectChangeAddress($event)" [ngClass]="{'element-disabled' : busy}">
         {{ 'send.change-address-select' | translate }} <mat-icon>keyboard_arrow_down</mat-icon>
       </span>
     </label>
-    <input formControlName="changeAddress" id="change-address" (keydown.enter)="preview()">
+    <input formControlName="changeAddress" id="change-address" (keydown.enter)="preview()" [attr.disabled]="busy ? 'true' : null">
   </div>
 
-  <div class="-autohours">
+  <div class="-autohours" [ngClass]="{'element-disabled' : busy}">
     <div class="row">
       <div class="col-xl-4 col-lg-5 col-md-7">
-        <mat-checkbox class="-check" (change)="setAutoHours($event)" [checked]="autoHours">
+        <mat-checkbox class="-check" (change)="setAutoHours($event)" [checked]="autoHours" [attr.disabled]="busy ? 'true' : null">
           <div class="-space-between">
             <span>{{ 'send.hours-allocation-label' | translate }}</span>
             <span class="-options" (mousedown)="$event.stopPropagation();" (click)="toggleOptions($event)" *ngIf="autoHours">
@@ -158,6 +162,7 @@
           </label>
           <mat-slider class="-slider" min="0.1" max="1" step="0.01" id="value"
                       (input)="setShareValue($event)" [value]="autoShareValue"
+                      [attr.disabled]="busy ? 'true' : null"
           ></mat-slider>
         </div>
       </div>

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.html
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.html
@@ -2,7 +2,7 @@
   <div class="form-field">
     <label for="wallet">{{ 'send.from-label' | translate }}</label>
     <div class="-select">
-      <select formControlName="wallet" id="wallet" [attr.disabled]="busy ? 'true' : null">
+      <select formControlName="wallet" id="wallet" [attr.disabled]="busy ? 'true' : null" [ngClass]="{'element-disabled' : busy}">
         <option disabled hidden [ngValue]="''">{{ 'send.select-wallet' | translate }}</option>
         <option *ngFor="let wallet of walletService.all() | async" [disabled]="!wallet.coins || wallet.coins.isLessThanOrEqualTo(0)" [ngValue]="wallet">
           {{ wallet.label }} -

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
@@ -10,8 +10,7 @@ import { showSnackbarError, getHardwareWalletErrorMsg } from '../../../../utils/
 import { ISubscription } from 'rxjs/Subscription';
 import { NavBarService } from '../../../../services/nav-bar.service';
 import { BigNumber } from 'bignumber.js';
-import { Observable } from 'rxjs/Observable';
-import { PreviewTransaction, Wallet, ConfirmationData } from '../../../../app.datatypes';
+import { Wallet, ConfirmationData } from '../../../../app.datatypes';
 import { HwWalletService } from '../../../../services/hw-wallet.service';
 import { TranslateService } from '@ngx-translate/core';
 import { BlockchainService } from '../../../../services/blockchain.service';
@@ -74,10 +73,14 @@ export class SendFormComponent implements OnInit, OnDestroy {
   }
 
   private checkBeforeSending() {
+    if (!this.form.valid || this.previewButton.isLoading() || this.sendButton.isLoading()) {
+      return;
+    }
+
     this.closeSyncCheckSubscription();
     this.syncCheckSubscription = this.blockchainService.synchronized.first().subscribe(synchronized => {
       if (synchronized) {
-        this.unlockAndSend();
+        this.prepareTransaction();
       } else {
         this.showSynchronizingWarning();
       }
@@ -94,21 +97,17 @@ export class SendFormComponent implements OnInit, OnDestroy {
 
     showConfirmationModal(this.dialog, confirmationData).afterClosed().subscribe(confirmationResult => {
       if (confirmationResult) {
-        this.unlockAndSend();
+        this.prepareTransaction();
       }
     });
   }
 
-  private unlockAndSend() {
-    if (!this.form.valid || this.previewButton.isLoading() || this.sendButton.isLoading()) {
-      return;
-    }
-
+  private prepareTransaction() {
     this.snackbar.dismiss();
     this.previewButton.resetState();
     this.sendButton.resetState();
 
-    if (this.form.value.wallet.encrypted && !this.form.value.wallet.isHardware) {
+    if (this.form.value.wallet.encrypted && !this.form.value.wallet.isHardware && !this.previewTx) {
       const config = new MatDialogConfig();
       config.data = {
         wallet: this.form.value.wallet,
@@ -119,7 +118,7 @@ export class SendFormComponent implements OnInit, OnDestroy {
           this.createTransaction(passwordDialog);
         });
     } else {
-      if (!this.form.value.wallet.isHardware) {
+      if (!this.form.value.wallet.isHardware || this.previewTx) {
         this.createTransaction();
       } else {
         this.showBusy();
@@ -149,34 +148,23 @@ export class SendFormComponent implements OnInit, OnDestroy {
 
     this.showBusy();
 
-    let createTxRequest: Observable<PreviewTransaction>;
-
-    if (!this.form.value.wallet.isHardware) {
-      createTxRequest = this.walletService.createTransaction(
-        this.form.value.wallet,
-        null,
-        null,
-        [{
-          address: this.form.value.address,
-          coins: this.form.value.amount,
-        }],
-        {
-          type: 'auto',
-          mode: 'share',
-          share_factor: '0.5',
-        },
-        null,
-        passwordDialog ? passwordDialog.password : null,
-      );
-    } else {
-      createTxRequest = this.walletService.createHwTransaction(
-        this.form.value.wallet,
-        this.form.value.address,
-        new BigNumber(this.form.value.amount),
-      );
-    }
-
-     this.processingSubscription = createTxRequest.subscribe(transaction => {
+    this.processingSubscription = this.walletService.createTransaction(
+      this.form.value.wallet,
+      (this.form.value.wallet as Wallet).addresses.map(address => address.address),
+      null,
+      [{
+        address: this.form.value.address,
+        coins: this.form.value.amount,
+      }],
+      {
+        type: 'auto',
+        mode: 'share',
+        share_factor: '0.5',
+      },
+      null,
+      passwordDialog ? passwordDialog.password : null,
+      this.previewTx,
+    ).subscribe(transaction => {
         if (!this.previewTx) {
           this.processingSubscription = this.walletService.injectTransaction(transaction.encoded)
             .subscribe(() => this.showSuccess(), error => this.showError(error));

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-preview/send-preview.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-preview/send-preview.component.ts
@@ -1,9 +1,13 @@
 import { Component, EventEmitter, Input, OnDestroy, Output, ViewChild } from '@angular/core';
 import { WalletService } from '../../../../services/wallet.service';
 import { ButtonComponent } from '../../../layout/button/button.component';
-import { MatSnackBar } from '@angular/material';
-import { showSnackbarError } from '../../../../utils/errors';
-import { PreviewTransaction } from '../../../../app.datatypes';
+import { MatSnackBar, MatDialogConfig, MatDialog } from '@angular/material';
+import { showSnackbarError, getHardwareWalletErrorMsg } from '../../../../utils/errors';
+import { PreviewTransaction, Wallet } from '../../../../app.datatypes';
+import { ISubscription } from 'rxjs/Subscription';
+import { PasswordDialogComponent } from '../../../layout/password-dialog/password-dialog.component';
+import { HwWalletService } from '../../../../services/hw-wallet.service';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-send-preview',
@@ -16,13 +20,26 @@ export class SendVerifyComponent implements OnDestroy {
   @Input() transaction: PreviewTransaction;
   @Output() onBack = new EventEmitter<boolean>();
 
+  private sendSubscription: ISubscription;
+
   constructor(
     private walletService: WalletService,
     private snackbar: MatSnackBar,
+    private dialog: MatDialog,
+    private hwWalletService: HwWalletService,
+    private translate: TranslateService,
   ) {}
 
   ngOnDestroy() {
     this.snackbar.dismiss();
+
+    if (this.sendSubscription) {
+      this.sendSubscription.unsubscribe();
+    }
+  }
+
+  back() {
+    this.onBack.emit(false);
   }
 
   send() {
@@ -32,10 +49,49 @@ export class SendVerifyComponent implements OnDestroy {
 
     this.snackbar.dismiss();
     this.sendButton.resetState();
+
+    if (this.transaction.wallet.encrypted && !this.transaction.wallet.isHardware) {
+      const config = new MatDialogConfig();
+      config.data = {
+        wallet: this.transaction.wallet,
+      };
+
+      this.dialog.open(PasswordDialogComponent, config).componentInstance.passwordSubmit
+        .subscribe(passwordDialog => {
+          this.finishSending(passwordDialog);
+        });
+    } else {
+      if (!this.transaction.wallet.isHardware) {
+        this.finishSending();
+      } else {
+        this.showBusy();
+        this.sendSubscription = this.hwWalletService.checkIfCorrectHwConnected(this.transaction.wallet.addresses[0].address).subscribe(
+          () => this.finishSending(),
+          err => this.showError(getHardwareWalletErrorMsg(this.hwWalletService, this.translate, err)),
+        );
+      }
+    }
+  }
+
+  private showBusy() {
     this.sendButton.setLoading();
     this.backButton.setDisabled();
+  }
 
-    this.walletService.injectTransaction(this.transaction.encoded).subscribe(() => {
+  private finishSending(passwordDialog?: any) {
+    if (passwordDialog) {
+      passwordDialog.close();
+    }
+
+    this.showBusy();
+
+    this.sendSubscription = this.walletService.signTransaction(
+      this.transaction.wallet,
+      passwordDialog ? passwordDialog.password : null,
+      this.transaction,
+    ).flatMap(result => {
+      return this.walletService.injectTransaction(result.encoded);
+    }).subscribe(() => {
       this.sendButton.setSuccess();
       this.sendButton.setDisabled();
 
@@ -45,14 +101,17 @@ export class SendVerifyComponent implements OnDestroy {
         this.onBack.emit(true);
       }, 3000);
     }, error => {
-      showSnackbarError(this.snackbar, error);
-
-      this.sendButton.setError(error);
-      this.backButton.setEnabled();
+      if (error && error.result) {
+        this.showError(getHardwareWalletErrorMsg(this.hwWalletService, this.translate, error));
+      } else {
+        this.showError(error);
+      }
     });
   }
 
-  back() {
-    this.onBack.emit(false);
+  private showError(error) {
+    showSnackbarError(this.snackbar, error);
+    this.sendButton.resetState().setError(error);
+    this.backButton.resetState().setEnabled();
   }
 }

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/transaction-info.component.html
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/transaction-info.component.html
@@ -28,7 +28,7 @@
             {{ transaction.hoursBurned.decimalPlaces(0).toString() | number:'1.0-0' }} {{ 'tx.hours-burned' | translate }}
           </span>
         </div>
-        <div class="-data" *ngIf="transaction.txid">
+        <div class="-data" *ngIf="!isPreview">
           <span>{{ 'tx.id' | translate }}:</span> <span>{{ transaction.txid }}</span>
         </div>
       </div>

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-skycoin.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-skycoin.component.ts
@@ -45,6 +45,7 @@ export class SendSkycoinComponent implements OnDestroy {
   get transaction() {
     const transaction = this.formData.transaction;
 
+    transaction.wallet = this.formData.form.wallet;
     transaction.from = this.formData.form.wallet.label;
     transaction.to = this.formData.to;
     transaction.balance = this.formData.amount;

--- a/src/gui/static/src/app/services/hw-wallet.service.ts
+++ b/src/gui/static/src/app/services/hw-wallet.service.ts
@@ -116,12 +116,12 @@ export class HwWalletService {
       });
 
       window['ipcRenderer'].on('hwSignTransactionResponse', (event, requestId, result) => {
-        this.dispatchEvent(requestId, result, true);
-
         if (this.signTransactionDialog) {
           this.signTransactionDialog.close();
           this.signTransactionDialog = null;
         }
+
+        this.dispatchEvent(requestId, result, true);
       });
 
       const data: EventData[] = [

--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -312,6 +312,15 @@ export class WalletService {
     ).map(transaction => {
       const data = useV2Endpoint ? transaction.data : transaction;
 
+      if (wallet.isHardware) {
+        if (data.transaction.inputs.length > 8) {
+          throw new Error(this.translate.instant('hardware-wallet.errors.too-many-inputs'));
+        }
+        if (data.transaction.outputs.length > 8) {
+          throw new Error(this.translate.instant('hardware-wallet.errors.too-many-outputs'));
+        }
+      }
+
       return {
         ...data.transaction,
         hoursBurned: new BigNumber(data.transaction.fee),

--- a/src/gui/static/src/styles.scss
+++ b/src/gui/static/src/styles.scss
@@ -421,3 +421,8 @@ On-boarding components
 .mouse-disabled {
   pointer-events: none;
 }
+
+.element-disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}


### PR DESCRIPTION
Fixes #2184 

Changes:
- Now when sending coins, if the user selects the preview option, it is not necessary to enter the password or confirm the transaction in the hardware wallet before viewing the preview.

- When the preview option is selected, the transaction is created with `/transaction`. `/wallet/transaction` is not used because it is necessary to enter the password even when `unsigned` is `true`.

- Now the advanced form works with the hardware wallets.

- The ID of the transaction was removed from the preview, since it changes after signing and sending the transaction.

Notes:
- This PR includes changes in important parts of the wallet, so it should be reviewed carefully. In any case, I plan to review it again in a day or so.

Does this change need to mentioned in CHANGELOG.md?
No