### PR TITLE
Use 24 words by default for the hardware wallet seeds

### DIFF
--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-generate-seed-dialog/hw-generate-seed-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-generate-seed-dialog/hw-generate-seed-dialog.component.ts
@@ -33,7 +33,7 @@ export class HwGenerateSeedDialogComponent extends HwDialogBaseComponent<HwGener
     super(hwWalletService, dialogRef);
 
     this.form = formBuilder.group({
-      words: [12, Validators.required],
+      words: [24, Validators.required],
     });
   }
 

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-restore-seed-dialog/hw-restore-seed-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-restore-seed-dialog/hw-restore-seed-dialog.component.ts
@@ -37,7 +37,7 @@ export class HwRestoreSeedDialogComponent extends HwDialogBaseComponent<HwRestor
     super(hwWalletService, dialogRef);
 
     this.form = formBuilder.group({
-      words: [12, Validators.required],
+      words: [24, Validators.required],
     });
 
     this.justCheckingSeed = !!this.data.wallet;


### PR DESCRIPTION
Changes:
- Now the option to create/recover seeds with 24 words, instead of 12, in the options of the hardware wallet is selected by default. This is in accordance with the observations that I wrote a few days ago in Telegram.

Does this change need to mentioned in CHANGELOG.md?
No