### PR TITLE
Add the `pendingTransactions` CLI command

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -253,6 +253,7 @@ func NewCLI(cfg Config) (*cobra.Command, error) {
 		walletOutputsCmd(),
 		richlistCmd(),
 		addressTransactionsCmd(),
+		pendingTransactionsCmd(),
 	}
 
 	skyCLI.Version = Version

--- a/src/cli/transaction.go
+++ b/src/cli/transaction.go
@@ -18,8 +18,8 @@ type TxnResult struct {
 
 func transactionCmd() *cobra.Command {
 	return &cobra.Command{
-		Short: "Show detail info of specific transaction",
-		Use:   "transaction [transaction id]",
+		Short:                 "Show detail info of specific transaction",
+		Use:                   "transaction [transaction id]",
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
 		Args:                  cobra.MaximumNArgs(1),
@@ -49,8 +49,8 @@ func transactionCmd() *cobra.Command {
 
 func decodeRawTxnCmd() *cobra.Command {
 	return &cobra.Command{
-		Short: "Decode raw transaction",
-		Use:   "decodeRawTransaction [raw transaction]",
+		Short:                 "Decode raw transaction",
+		Use:                   "decodeRawTransaction [raw transaction]",
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
 		Args:                  cobra.ExactArgs(1),
@@ -111,8 +111,8 @@ func getAddressTransactionsCmd(c *cobra.Command, args []string) error {
 
 func pendingTransactionsCmd() *cobra.Command {
 	return &cobra.Command{
-		Short: "Get all unconfirmed transactions",
-		Use:   "pendingTransactions",
+		Short:                 "Get all unconfirmed transactions",
+		Use:                   "pendingTransactions",
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
 		Args:                  cobra.NoArgs,

--- a/src/cli/transaction.go
+++ b/src/cli/transaction.go
@@ -138,13 +138,27 @@ func verifyTransactionCmd() *cobra.Command {
 }
 
 func pendingTransactionsCmd() *cobra.Command {
-	return &cobra.Command{
+	pendingTxnsCmd := &cobra.Command{
 		Short:                 "Get all unconfirmed transactions",
 		Use:                   "pendingTransactions",
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
 		Args:                  cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(c *cobra.Command, _ []string) error {
+			isVerbose, err := c.Flags().GetBool("verbose")
+			if err != nil {
+				return err
+			}
+
+			if isVerbose {
+				pendingTxns, err := apiClient.PendingTransactionsVerbose()
+				if err != nil {
+					return err
+				}
+
+				return printJSON(pendingTxns)
+			}
+
 			pendingTxns, err := apiClient.PendingTransactions()
 			if err != nil {
 				return err
@@ -153,4 +167,12 @@ func pendingTransactionsCmd() *cobra.Command {
 			return printJSON(pendingTxns)
 		},
 	}
+
+	pendingTxnsCmd.Flags().BoolP("verbose", "v", false,
+		`Require the transaction inputs to include the owner address, coins, hours and calculated hours.
+	The hours are the original hours the output was created with.
+	The calculated hours are calculated based upon the current system time, and provide an approximate 
+	coin hour value of the output if it were to be confirmed at that instant.`)
+
+	return pendingTxnsCmd
 }

--- a/src/cli/transaction.go
+++ b/src/cli/transaction.go
@@ -116,7 +116,7 @@ func pendingTransactionsCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
 		Args:                  cobra.NoArgs,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			pendingTxns, err := apiClient.PendingTransactions()
 			if err != nil {
 				return err

--- a/src/cli/transaction.go
+++ b/src/cli/transaction.go
@@ -18,8 +18,8 @@ type TxnResult struct {
 
 func transactionCmd() *cobra.Command {
 	return &cobra.Command{
-		Short:                 "Show detail info of specific transaction",
-		Use:                   "transaction [transaction id]",
+		Short: "Show detail info of specific transaction",
+		Use:   "transaction [transaction id]",
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
 		Args:                  cobra.MaximumNArgs(1),
@@ -49,8 +49,8 @@ func transactionCmd() *cobra.Command {
 
 func decodeRawTxnCmd() *cobra.Command {
 	return &cobra.Command{
-		Short:                 "Decode raw transaction",
-		Use:                   "decodeRawTransaction [raw transaction]",
+		Short: "Decode raw transaction",
+		Use:   "decodeRawTransaction [raw transaction]",
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
 		Args:                  cobra.ExactArgs(1),
@@ -107,4 +107,22 @@ func getAddressTransactionsCmd(c *cobra.Command, args []string) error {
 	}
 
 	return fmt.Errorf("at least one address must be specified. Example: %s addr1 addr2 addr3", c.Name())
+}
+
+func pendingTransactionsCmd() *cobra.Command {
+	return &cobra.Command{
+		Short: "Get all unconfirmed transactions",
+		Use:   "pendingTransactions",
+		DisableFlagsInUseLine: true,
+		SilenceUsage:          true,
+		Args:                  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, args []string) error {
+			pendingTxns, err := apiClient.PendingTransactions()
+			if err != nil {
+				return err
+			}
+
+			return printJSON(pendingTxns)
+		},
+	}
 }


### PR DESCRIPTION
Fixes #1033 

Changes:
- Added the `pendingTransactions` CLI command to view all unconfirmed transactions. 

Does this change need to mentioned in CHANGELOG.md?
Yes

As for now, does not provide the `verbose` flag. Should this be done?