### PR TITLE
Improved CSP

### DIFF
--- a/src/api/middleware.go
+++ b/src/api/middleware.go
@@ -14,7 +14,15 @@ import (
 
 // ContentSecurityPolicy represents the value of content-security-policy
 // header in http response
-const ContentSecurityPolicy = "script-src 'self' 127.0.0.1"
+const ContentSecurityPolicy = "default-src 'self'" +
+	"; connect-src 'self' https://api.coinpaprika.com" +
+	"; img-src 'self' 'unsafe-inline' data:" +
+	"; style-src 'self' 'unsafe-inline'" +
+	"; object-src	'none'" +
+	"; form-action 'none'" +
+	"; frame-ancestors 'none'" +
+	"; block-all-mixed-content" +
+	"; base-uri 'self'"
 
 // CSPHandler enables CSP
 func CSPHandler(handler http.Handler) http.Handler {

--- a/src/api/middleware_test.go
+++ b/src/api/middleware_test.go
@@ -209,12 +209,12 @@ func TestContentSecurityPolicy(t *testing.T) {
 		enableGUI       bool
 	}{
 		{
-			name:            "enable CSP GET /",
-			endpoint:        "/",
-			enableCSP:       true,
-			appLoc:          "../gui/static/dist",
-			expectCSPHeader: "script-src 'self' 127.0.0.1",
-			enableGUI:       true,
+			name:      "enable CSP GET /",
+			endpoint:  "/",
+			enableCSP: true,
+			appLoc:    "../gui/static/dist",
+			expectCSPHeader: "default-src 'self'; connect-src 'self' https://api.coinpaprika.com; img-src 'self' 'unsafe-inline' data:; style-src 'self' 'unsafe-inline'; object-src	'none'; form-action 'none'; frame-ancestors 'none'; block-all-mixed-content; base-uri 'self'",
+			enableGUI: true,
 		},
 		{
 			name:            "disable CSP GET /",


### PR DESCRIPTION
This PR improves de CSP header of the wallet.

Changes:
- All connections to servers other than the local server and https://api.coinpaprika.com are blocked.

- It is only possible to obtain content through calls to authorized URLs. Inline elements are prohibited, except for images and styles, since are used by Angular Material.

- Calls to `eval()` are blocked.

- The use of forms and plugins is blocked.

- It is not possible to change the base URL.

- The wallet can’t be opened inside a frame. 

Does this change need to mentioned in CHANGELOG.md?
No