### PR TITLE
Limit the hw wallet addresses

### DIFF
--- a/src/gui/static/src/app/app.config.ts
+++ b/src/gui/static/src/app/app.config.ts
@@ -1,4 +1,4 @@
 export const AppConfig = {
   otcEnabled: false,
-  maxHardwareWalletAddresses: 8,
+  maxHardwareWalletAddresses: 1,
 };

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-restore-seed-dialog/hw-restore-seed-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-restore-seed-dialog/hw-restore-seed-dialog.component.html
@@ -21,6 +21,8 @@
       </div>
     </div>
 
+    <div class="warning" *ngIf="!justCheckingSeed">{{ 'hardware-wallet.restore-seed.warning' | translate }}</div>
+
     <div class="-buttons">
       <app-button (action)="closeModal()">
         {{ 'hardware-wallet.general.cancel' | translate }}

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-restore-seed-dialog/hw-restore-seed-dialog.component.scss
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-restore-seed-dialog/hw-restore-seed-dialog.component.scss
@@ -1,4 +1,11 @@
+@import '../../../../../theme/variables';
 .form-field {
   margin-bottom: 0px;
   margin-top: 15px;
+}
+
+.warning {
+  margin-top: 15px;
+  color: $red;
+  text-align: center;
 }

--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.html
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.html
@@ -1,23 +1,25 @@
 <div class="-row -actions">
-  <div class="-button" (click)="newAddress()" [ngClass]="{ 'mouse-disabled': creatingAddress }">
-    <span [ngClass]="{ '-img -new-address': !creatingAddress, '-disabled-span': creatingAddress, '-enabled-span': !creatingAddress }">
-      <mat-spinner *ngIf="creatingAddress" class="in-button small"></mat-spinner>
-      {{ (wallet.isHardware ? 'wallet.new-address' : 'wallet.new-addresses') | translate }}
-    </span>
-  </div>
-  <div class="-button" (click)="toggleEmpty()">
-    <span [ngClass]="{ '-img': true, '-show-empty': wallet.hideEmpty, '-hide-empty': !wallet.hideEmpty }">
-      {{ 'wallet.' + (wallet.hideEmpty ? 'show' : 'hide') + '-empty' | translate }}
-    </span>
+  <ng-container *ngIf="!wallet.isHardware">
+    <div class="-button" (click)="newAddress()" [ngClass]="{ 'mouse-disabled': creatingAddress }">
+      <span [ngClass]="{ '-img -new-address': !creatingAddress, '-disabled-span': creatingAddress, '-enabled-span': !creatingAddress }">
+        <mat-spinner *ngIf="creatingAddress" class="in-button small"></mat-spinner>
+        {{ (wallet.isHardware ? 'wallet.new-address' : 'wallet.new-addresses') | translate }}
+      </span>
+    </div>
+    <div class="-button" (click)="toggleEmpty()">
+      <span [ngClass]="{ '-img': true, '-show-empty': wallet.hideEmpty, '-hide-empty': !wallet.hideEmpty }">
+        {{ 'wallet.' + (wallet.hideEmpty ? 'show' : 'hide') + '-empty' | translate }}
+      </span>
+    </div>
+  </ng-container>
+  <div *ngIf="wallet.isHardware" class="-button btn-delete-wallet" (click)="deleteWallet()">
+    <span class="-img -btn-delete -enabled-span">{{ 'wallet.delete' | translate }}</span>
   </div>
   <div class="flex-fill"></div>
   <div *ngIf="!wallet.isHardware" class="-button" (click)="toggleEncryption()">
     <span [ngClass]="{ '-img': true, '-enable-encryption': !wallet.encrypted, '-disable-encryption': wallet.encrypted }">
       {{ 'wallet.' + (wallet.encrypted ? 'decrypt' : 'encrypt') | translate }}
     </span>
-  </div>
-  <div *ngIf="wallet.isHardware" class="-button btn-delete-wallet" (click)="deleteWallet()">
-    <span class="-img -btn-delete -enabled-span">{{ 'wallet.delete' | translate }}</span>
   </div>
   <div class="-button" (click)="editWallet()">
     <span class="-img -edit-wallet">{{ 'wallet.edit' | translate }}</span>

--- a/src/gui/static/src/app/services/hw-wallet.service.ts
+++ b/src/gui/static/src/app/services/hw-wallet.service.ts
@@ -217,10 +217,6 @@ export class HwWalletService {
     });
   }
 
-  getMaxAddresses(): Observable<string[]> {
-    return this.getAddressesRecursively(AppConfig.maxHardwareWalletAddresses - 1, []);
-  }
-
   generateMnemonic(wordCount: number): Observable<OperationResult> {
     return this.cancelLastAction().flatMap(() => {
       const requestId = this.createRandomIdAndPrepare();
@@ -309,26 +305,6 @@ export class HwWalletService {
     return new Observable(observer => {
       this.eventsObservers.set(requestId, observer);
     });
-  }
-
-  private getAddressesRecursively(index: number, addresses: string[]): Observable<string[]> {
-    let chain: Observable<any>;
-    if (index > 0) {
-      chain = this.getAddressesRecursively(index - 1, addresses).first();
-    } else {
-      chain = Observable.of(1);
-    }
-
-    chain = chain.flatMap(() => {
-      return this.getAddresses(1, index)
-      .map(response => {
-        addresses.push(response.rawResponse[0]);
-
-        return addresses;
-      });
-    });
-
-    return chain;
   }
 
   private createRandomIdAndPrepare() {

--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -18,6 +18,7 @@ import { BigNumber } from 'bignumber.js';
 import { HwWalletService } from './hw-wallet.service';
 import { TranslateService } from '@ngx-translate/core';
 import { AppService } from './app.service';
+import { AppConfig } from '../app.config';
 
 declare var Cipher: any;
 
@@ -101,8 +102,8 @@ export class WalletService {
     const addressesMap: Map<string, boolean> = new Map<string, boolean>();
     const addressesWithTxMap: Map<string, boolean> = new Map<string, boolean>();
 
-    return this.hwWalletService.getMaxAddresses().flatMap(response => {
-      addresses = response;
+    return this.hwWalletService.getAddresses(AppConfig.maxHardwareWalletAddresses, 0).flatMap(response => {
+      addresses = response.rawResponse;
       addresses.forEach(address => {
         addressesMap.set(address, true);
       });

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -370,6 +370,7 @@
     "restore-seed" : {
       "text": "Before proceeding, please select the number of words that the seed you want to recover has.",
       "check-text": "You can use this option to enter a seed and check if it is equal to the one in the hardware wallet. Before start, select the number of words the seed you want to check has.",
+      "warning" : "WARNING: to avoid potential problems, use only seeds created with a hardware wallet form the same brand/model.",
       "error-wrong-word": "Error: The retyped word does not match the one requested by the hardware wallet.",
       "error-invalid-seed": "Error: The seed is not valid. Please be sure to enter the correct words in the correct order.",
       "error-wrong-seed": "Error: The seed is valid but does not match the one in the device."

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -370,7 +370,7 @@
     "restore-seed" : {
       "text": "Before proceeding, please select the number of words that the seed you want to recover has.",
       "check-text": "You can use this option to enter a seed and check if it is equal to the one in the hardware wallet. Before start, select the number of words the seed you want to check has.",
-      "warning" : "WARNING: to avoid potential problems, use only seeds created with a hardware wallet form the same brand/model.",
+      "warning" : "WARNING: to avoid potential problems, use only seeds created with a hardware wallet from the same brand/model.",
       "error-wrong-word": "Error: The retyped word does not match the one requested by the hardware wallet.",
       "error-invalid-seed": "Error: The seed is not valid. Please be sure to enter the correct words in the correct order.",
       "error-wrong-seed": "Error: The seed is valid but does not match the one in the device."


### PR DESCRIPTION
This PR includes most of the changes recently discused about the hw wallet.

Changes:
- The recursive method for obtaining addresses from the hardware wallet was removed, since it is now more efficient to obtain several addresses at a time.

- The integration with the hardware wallet was limited to one address only. Due to this, the buttons for adding addresses and hiding the addresses without funds were hidden.

- Little code related to compatibility with several addresses was deleted, in case it is useful in the future.

- A warning message was added to the modal window that allows to recover an old seed in the hardware wallet, indicating that only seeds created with a hardware wallet should be used.

Does this change need to mentioned in CHANGELOG.md?
No