### PR TITLE
Show a warning if the user tries to add too many addresses

### DIFF
--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
@@ -77,7 +77,7 @@ export class WalletDetailComponent implements OnDestroy {
             let lastWithBalance = 0;
             this.wallet.addresses.forEach((address, i) => {
               if (address.coins.isGreaterThan(0)) {
-                lastWithBalance = 1;
+                lastWithBalance = i;
               }
             });
 

--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
@@ -73,7 +73,30 @@ export class WalletDetailComponent implements OnDestroy {
         .subscribe(response => {
           if (response) {
             this.howManyAddresses = response;
-            this.continueNewAddress();
+
+            let lastWithBalance = 0;
+            this.wallet.addresses.forEach((address, i) => {
+              if (address.coins.isGreaterThan(0)) {
+                lastWithBalance = 1;
+              }
+            });
+
+            if ((this.wallet.addresses.length - (lastWithBalance + 1)) + response < 20) {
+              this.continueNewAddress();
+            } else {
+              const confirmationData: ConfirmationData = {
+                text: 'wallet.add-many-confirmation',
+                headerText: 'confirmation.header-text',
+                confirmButtonText: 'confirmation.confirm-button',
+                cancelButtonText: 'confirmation.cancel-button',
+              };
+
+              showConfirmationModal(this.dialog, confirmationData).afterClosed().subscribe(confirmationResult => {
+                if (confirmationResult) {
+                  this.continueNewAddress();
+                }
+              });
+            }
           }
         });
     } else {

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -113,6 +113,7 @@
     "delete-confirmation": "WARNING: The wallet \"{{ name }}\" will be removed from the list. To add it again, you will have to reconnect the device and open the hardware wallet options (by pressing the \"Hardware Wallet\" button below the wallets list). Do you want to continue?",
     "delete-confirmation-check": "Yeah, I want to delete the wallet.",
     "max-hardware-wallets-error": "You have already reached the max number of addresses that can be added to the hardware wallet.",
+    "add-many-confirmation": "WARNING: If you add too many addresses without using the previous ones or if you use the last ones and not the first ones, some addresses may not be recovered automatically if you try to restore the wallet using the seed (you will have to add them manually). Do you want to continue?",
 
     "new": {
       "create-title": "Create Wallet",


### PR DESCRIPTION
Fixes #2229 

Changes:
- If the user tries to create too many addres, so that it would be posible to use the last address and then left 20 or more unused address before it, an alert is shown informing the user that there could be problems when restoring the wallet using the seed.

Notes:
- The code checks if the address has been used simply by checking if it has balance, as the node is doing now when restoring a wallet. This must be changed after solving https://github.com/skycoin/skycoin/issues/2206

Does this change need to mentioned in CHANGELOG.md?
No