### PR TITLE
Small changes for the hw wallet integration

### DIFF
--- a/electron/src/install-dependencies.sh
+++ b/electron/src/install-dependencies.sh
@@ -4,3 +4,6 @@ set -e -o pipefail
 
 npm install
 ./node_modules/.bin/electron-rebuild --only="node-hid"
+cd node_modules/hardware-wallet-js
+npm run make-protobuf-files
+cd ../..

--- a/electron/src/package.json
+++ b/electron/src/package.json
@@ -7,7 +7,7 @@
     "electron-context-menu": "^0.9.1",
     "electron-debug": "^1.5.0",
     "rxjs": "^5.5.12",
-    "hardware-wallet-js": "git+https://git@github.com/skycoin/hardware-wallet-js.git#b56e7f5"
+    "hardware-wallet-js": "git+https://git@github.com/skycoin/hardware-wallet-js.git#953ffc8"
   },
   "devDependencies": {
     "electron-rebuild": "^1.8.2"

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-generate-seed-dialog/hw-generate-seed-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-generate-seed-dialog/hw-generate-seed-dialog.component.html
@@ -1,4 +1,4 @@
-<app-modal class="modal" [headline]="'hardware-wallet.options.configure-automatically' | translate" [dialog]="dialogRef" [disableDismiss]="currentState === states.Initial">
+<app-modal class="modal" [headline]="'hardware-wallet.options.configure-automatically' | translate" [dialog]="dialogRef" [disableDismiss]="currentState === states.Processing">
   <div *ngIf="currentState === states.Initial">
     <app-hw-message
       [text]="'hardware-wallet.generate-seed.text' | translate"
@@ -46,7 +46,7 @@
     [icon]="msgIcons.Error"
   ></app-hw-message>
 
-  <div class="-buttons" *ngIf="currentState !== states.Initial">
+  <div class="-buttons" *ngIf="currentState !== states.Initial && currentState !== states.Processing">
     <app-button (action)="closeModal()" class="primary">
       {{ 'hardware-wallet.general.close' | translate }}
     </app-button>

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-pin-dialog/hw-pin-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-pin-dialog/hw-pin-dialog.component.html
@@ -19,19 +19,19 @@
   </div>
   <div class="select-address-theme">
     <div class="num-pad-row">
-      <button mat-button color="primary" (click)="addNumber('7')"><span>•</span></button>
-      <button mat-button color="primary" (click)="addNumber('8')"><span>•</span></button>
-      <button mat-button color="primary" (click)="addNumber('9')"><span>•</span></button>
+      <button mat-button color="primary" (click)="addNumber('7')"><span>{{ buttonsContent }}</span></button>
+      <button mat-button color="primary" (click)="addNumber('8')"><span>{{ buttonsContent }}</span></button>
+      <button mat-button color="primary" (click)="addNumber('9')"><span>{{ buttonsContent }}</span></button>
     </div>
     <div class="num-pad-row">
-      <button mat-button color="primary" (click)="addNumber('4')"><span>•</span></button>
-      <button mat-button color="primary" (click)="addNumber('5')"><span>•</span></button>
-      <button mat-button color="primary" (click)="addNumber('6')"><span>•</span></button>
+      <button mat-button color="primary" (click)="addNumber('4')"><span>{{ buttonsContent }}</span></button>
+      <button mat-button color="primary" (click)="addNumber('5')"><span>{{ buttonsContent }}</span></button>
+      <button mat-button color="primary" (click)="addNumber('6')"><span>{{ buttonsContent }}</span></button>
     </div>
     <div class="num-pad-row">
-      <button mat-button color="primary" (click)="addNumber('1')"><span>•</span></button>
-      <button mat-button color="primary" (click)="addNumber('2')"><span>•</span></button>
-      <button mat-button color="primary" (click)="addNumber('3')"><span>•</span></button>
+      <button mat-button color="primary" (click)="addNumber('1')"><span>{{ buttonsContent }}</span></button>
+      <button mat-button color="primary" (click)="addNumber('2')"><span>{{ buttonsContent }}</span></button>
+      <button mat-button color="primary" (click)="addNumber('3')"><span>{{ buttonsContent }}</span></button>
     </div>
     <div class="num-pad-row">
       <button mat-button color="primary" (click)="removeNumber()"><span class="material-icons">backspace</span></button>

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-pin-dialog/hw-pin-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-pin-dialog/hw-pin-dialog.component.html
@@ -19,19 +19,19 @@
   </div>
   <div class="select-address-theme">
     <div class="num-pad-row">
-      <button mat-button color="primary" (click)="addNumber('7')"><span>#</span></button>
-      <button mat-button color="primary" (click)="addNumber('8')"><span>#</span></button>
-      <button mat-button color="primary" (click)="addNumber('9')"><span>#</span></button>
+      <button mat-button color="primary" (click)="addNumber('7')"><span>•</span></button>
+      <button mat-button color="primary" (click)="addNumber('8')"><span>•</span></button>
+      <button mat-button color="primary" (click)="addNumber('9')"><span>•</span></button>
     </div>
     <div class="num-pad-row">
-      <button mat-button color="primary" (click)="addNumber('4')"><span>#</span></button>
-      <button mat-button color="primary" (click)="addNumber('5')"><span>#</span></button>
-      <button mat-button color="primary" (click)="addNumber('6')"><span>#</span></button>
+      <button mat-button color="primary" (click)="addNumber('4')"><span>•</span></button>
+      <button mat-button color="primary" (click)="addNumber('5')"><span>•</span></button>
+      <button mat-button color="primary" (click)="addNumber('6')"><span>•</span></button>
     </div>
     <div class="num-pad-row">
-      <button mat-button color="primary" (click)="addNumber('1')"><span>#</span></button>
-      <button mat-button color="primary" (click)="addNumber('2')"><span>#</span></button>
-      <button mat-button color="primary" (click)="addNumber('3')"><span>#</span></button>
+      <button mat-button color="primary" (click)="addNumber('1')"><span>•</span></button>
+      <button mat-button color="primary" (click)="addNumber('2')"><span>•</span></button>
+      <button mat-button color="primary" (click)="addNumber('3')"><span>•</span></button>
     </div>
     <div class="num-pad-row">
       <button mat-button color="primary" (click)="removeNumber()"><span class="material-icons">backspace</span></button>

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-pin-dialog/hw-pin-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-pin-dialog/hw-pin-dialog.component.ts
@@ -19,6 +19,7 @@ export interface HwPinDialogParams {
 export class HwPinDialogComponent extends HwDialogBaseComponent<HwPinDialogComponent> implements OnInit {
   form: FormGroup;
   changePinStates = ChangePinStates;
+  buttonsContent = '•';
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: HwPinDialogParams,

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-restore-seed-dialog/hw-restore-seed-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-restore-seed-dialog/hw-restore-seed-dialog.component.html
@@ -2,7 +2,7 @@
   class="modal"
   [headline]="(justCheckingSeed ? 'hardware-wallet.options.confirm-seed' : 'hardware-wallet.options.restore-backup') | translate"
   [dialog]="dialogRef"
-  [disableDismiss]="currentState === states.Initial">
+  [disableDismiss]="currentState === states.Processing">
 
   <div *ngIf="currentState === states.Initial">
     <app-hw-message


### PR DESCRIPTION
Fixes #2237 
Fixes #2238 

Changes:
- The ability to close the modal windows for creating a new seed and restoring an old one was beign disable when asking for the number of words of the seed, but in fact it had to be blocked while waiting for the user to confirm the action on the device (as it happens in other parts of the hw wallet integration). The error was added in the PR for adding compatibility with seeds with 12/24 words. This PR solves the problem.

- The “#” simbol on the modal window for entering the PIN code were replaced with “•” simbols:
![pin](https://user-images.githubusercontent.com/34079003/54727590-ff0bb380-4b4e-11e9-9e13-accec9c90db0.png)


Does this change need to mentioned in CHANGELOG.md?
No