### PR TITLE
Add new cli command `addresscount`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `unsigned` option to `POST /api/v2/transaction/verify` for verifying an unsigned transaction
 - Add `POST /api/v2/transaction` to create an unsigned transaction from addresses or unspent outputs without a wallet
 - Add `-max-inc-msg-len` and `-max-out-msg-len` options to control the size of incoming and outgoing wire messages
+- Add CLI `addresscount` command to return the count of addresses that currently have unspent outputs (coins) associated with them.
 
 ### Fixed
 

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -47,6 +47,7 @@ The CLI command APIs can be used directly from a Go application, see [Skycoin CL
 	- [List wallet transaction history](#list-wallet-transaction-history)
 	- [List wallet outputs](#list-wallet-outputs)
 	- [Richlist](#richlist)
+    - [Address Count](#address-count)
 	- [CLI version](#cli-version)
 - [Note](#note)
 
@@ -2720,6 +2721,31 @@ $ skycoin-cli richlist 2 true
 }
 ```
 </details>
+
+### Address Count
+Returns the count of all addresses that currenty have unspent outputs (coins) associated with them.
+
+```bash
+$ skycoin-cli addresscount
+```
+
+```
+FLAGS:
+  -h, --help   help for richlist
+```
+
+#### Example
+```bash
+$ skycoin-cli addresscount 
+```
+<details>
+ <summary>View Output</summary>
+
+```json
+12961
+```
+</details>
+
 
 ### CLI version
 Get version of current skycoin cli.

--- a/src/cli/addresscount.go
+++ b/src/cli/addresscount.go
@@ -16,7 +16,7 @@ func addresscountCmd() *cobra.Command {
 	}
 }
 
-func getAddresscount(_ *cobra.Command, args []string) error {
+func getAddresscount(_ *cobra.Command, _ []string) error {
 	addresscount, err := apiClient.AddressCount()
 	if err != nil {
 		return err

--- a/src/cli/addresscount.go
+++ b/src/cli/addresscount.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func addresscountCmd() *cobra.Command {
+	return &cobra.Command{
+		Short:                 "Get the count of addresses with unspent outputs (coins).",
+		Long:                  "Returns the count of all addresses that currenty have unspent outputs (coins) associated with them.",
+		Use:                   "addresscount",
+		Args:                  cobra.NoArgs,
+		DisableFlagsInUseLine: true,
+		SilenceUsage:          true,
+		RunE:                  getAddresscount,
+	}
+}
+
+func getAddresscount(_ *cobra.Command, args []string) error {
+	addresscount, err := apiClient.AddressCount()
+	if err != nil {
+		return err
+	}
+
+	return printJSON(addresscount)
+}

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -255,6 +255,7 @@ func NewCLI(cfg Config) (*cobra.Command, error) {
 		richlistCmd(),
 		addressTransactionsCmd(),
 		pendingTransactionsCmd(),
+		addresscountCmd(),
 	}
 
 	skyCLI.Version = Version


### PR DESCRIPTION
Changes:
- Added new cli command - `addresscount`. This returns the number of addresses that currently have unspent outputs (coins) associated with them.

Does this change need to mentioned in CHANGELOG.md?
Yes. Changelog updated as part of the PR.
