### PR TITLE
Update /metrics to add health data ref #2245

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `unsigned` option to `POST /api/v2/transaction/verify` for verifying an unsigned transaction
 - Add `POST /api/v2/transaction` to create an unsigned transaction from addresses or unspent outputs without a wallet
 - Add `-max-inc-msg-len` and `-max-out-msg-len` options to control the size of incoming and outgoing wire messages
+- Update `/metrics` endpoint to add metrics from `/health`: `unspent_outputs`, `unconfirmed_txns`, `time_since_last_block_seconds`, `open_connections`, `outgoing_connections`, `incoming_connections`, `start_at`, `uptime_seconds`, `lasst_block_seq`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `unsigned` option to `POST /api/v2/transaction/verify` for verifying an unsigned transaction
 - Add `POST /api/v2/transaction` to create an unsigned transaction from addresses or unspent outputs without a wallet
 - Add `-max-inc-msg-len` and `-max-out-msg-len` options to control the size of incoming and outgoing wire messages
-- Update `/metrics` endpoint to add metrics from `/health`: `unspent_outputs`, `unconfirmed_txns`, `time_since_last_block_seconds`, `open_connections`, `outgoing_connections`, `incoming_connections`, `start_at`, `uptime_seconds`, `lasst_block_seq`.
+- Update `/metrics` endpoint to add metrics from `/health`: `unspent_outputs`, `unconfirmed_txns`, `time_since_last_block_seconds`, `open_connections`, `outgoing_connections`, `incoming_connections`, `start_at`, `uptime_seconds`, `last_block_seq`.
 
 ### Fixed
 

--- a/src/api/health.go
+++ b/src/api/health.go
@@ -37,6 +37,62 @@ type HealthResponse struct {
 	StartedAt            int64              `json:"started_at"`
 }
 
+func getHealthData(c muxConfig, gateway Gatewayer) (*HealthResponse, error) {
+	metadata, err := gateway.GetBlockchainMetadata()
+	if err != nil {
+		return nil, fmt.Errorf("gateway.GetBlockchainMetadata failed: %v", err)
+	}
+
+	conns, err := gateway.GetConnections(func(c daemon.Connection) bool {
+		return c.State != daemon.ConnectionStatePending
+	})
+	if err != nil {
+		return nil, fmt.Errorf("gateway.GetConnections failed: %v", err)
+	}
+
+	outgoingConns := 0
+	incomingConns := 0
+	for _, c := range conns {
+		if c.Outgoing {
+			outgoingConns++
+		} else {
+			incomingConns++
+		}
+	}
+
+	elapsedBlockTime := time.Now().UTC().Unix() - int64(metadata.HeadBlock.Head.Time)
+	timeSinceLastBlock := time.Second * time.Duration(elapsedBlockTime)
+
+	_, walletAPIEnabled := c.enabledAPISets[EndpointsWallet]
+
+	userAgent, err := c.health.DaemonUserAgent.Build()
+	if err != nil {
+		return nil, err
+	}
+
+	return &HealthResponse{
+		BlockchainMetadata: BlockchainMetadata{
+			BlockchainMetadata: readable.NewBlockchainMetadata(*metadata),
+			TimeSinceLastBlock: wh.FromDuration(timeSinceLastBlock),
+		},
+		Version:              c.health.BuildInfo,
+		CoinName:             c.health.CoinName,
+		DaemonUserAgent:      userAgent,
+		OpenConnections:      len(conns),
+		OutgoingConnections:  outgoingConns,
+		IncomingConnections:  incomingConns,
+		CSRFEnabled:          !c.disableCSRF,
+		HeaderCheckEnabled:   !c.disableHeaderCheck,
+		CSPEnabled:           !c.disableCSP,
+		GUIEnabled:           c.enableGUI,
+		WalletAPIEnabled:     walletAPIEnabled,
+		UserVerifyTxn:        readable.NewVerifyTxn(params.UserVerifyTxn),
+		UnconfirmedVerifyTxn: readable.NewVerifyTxn(gateway.DaemonConfig().UnconfirmedVerifyTxn),
+		Uptime:               wh.FromDuration(time.Since(gateway.StartedAt())),
+		StartedAt:            gateway.StartedAt().Unix(),
+	}, nil
+}
+
 // healthHandler returns node health data
 // URI: /api/v1/health
 // Method: GET
@@ -47,63 +103,12 @@ func healthHandler(c muxConfig, gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 
-		metadata, err := gateway.GetBlockchainMetadata()
-		if err != nil {
-			err = fmt.Errorf("gateway.GetBlockchainMetadata failed: %v", err)
-			wh.Error500(w, err.Error())
-			return
-		}
-
-		conns, err := gateway.GetConnections(func(c daemon.Connection) bool {
-			return c.State != daemon.ConnectionStatePending
-		})
-		if err != nil {
-			err = fmt.Errorf("gateway.GetConnections failed: %v", err)
-			wh.Error500(w, err.Error())
-			return
-		}
-
-		outgoingConns := 0
-		incomingConns := 0
-		for _, c := range conns {
-			if c.Outgoing {
-				outgoingConns++
-			} else {
-				incomingConns++
-			}
-		}
-
-		elapsedBlockTime := time.Now().UTC().Unix() - int64(metadata.HeadBlock.Head.Time)
-		timeSinceLastBlock := time.Second * time.Duration(elapsedBlockTime)
-
-		_, walletAPIEnabled := c.enabledAPISets[EndpointsWallet]
-
-		userAgent, err := c.health.DaemonUserAgent.Build()
+		health, err := getHealthData(c, gateway)
 		if err != nil {
 			wh.Error500(w, err.Error())
 			return
 		}
 
-		wh.SendJSONOr500(logger, w, HealthResponse{
-			BlockchainMetadata: BlockchainMetadata{
-				BlockchainMetadata: readable.NewBlockchainMetadata(*metadata),
-				TimeSinceLastBlock: wh.FromDuration(timeSinceLastBlock),
-			},
-			Version:              c.health.BuildInfo,
-			CoinName:             c.health.CoinName,
-			DaemonUserAgent:      userAgent,
-			OpenConnections:      len(conns),
-			OutgoingConnections:  outgoingConns,
-			IncomingConnections:  incomingConns,
-			CSRFEnabled:          !c.disableCSRF,
-			HeaderCheckEnabled:   !c.disableHeaderCheck,
-			CSPEnabled:           !c.disableCSP,
-			GUIEnabled:           c.enableGUI,
-			WalletAPIEnabled:     walletAPIEnabled,
-			UserVerifyTxn:        readable.NewVerifyTxn(params.UserVerifyTxn),
-			UnconfirmedVerifyTxn: readable.NewVerifyTxn(gateway.DaemonConfig().UnconfirmedVerifyTxn),
-			Uptime:               wh.FromDuration(time.Since(gateway.StartedAt())),
-			StartedAt:            gateway.StartedAt().Unix(),
-		})
+		wh.SendJSONOr500(logger, w, health)
 	}
 }

--- a/src/api/http.go
+++ b/src/api/http.go
@@ -16,7 +16,6 @@ import (
 	"unicode"
 
 	"github.com/NYTimes/gziphandler"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
 
 	"github.com/skycoin/skycoin/src/cipher"
@@ -590,7 +589,7 @@ func newServerMux(c muxConfig, gateway Gatewayer) *http.ServeMux {
 	})
 
 	// golang process internal metrics for Prometheus
-	webHandlerV2("/metrics", promhttp.Handler().(http.Handler), map[string][]string{
+	webHandlerV2("/metrics", metricsHandler(c, gateway), map[string][]string{
 		http.MethodGet: []string{EndpointsPrometheus},
 	})
 

--- a/src/api/metrics.go
+++ b/src/api/metrics.go
@@ -20,8 +20,8 @@ var (
 			Name: "unconfirmed_txns",
 			Help: "Number of unconfirmed transactions",
 		})
-	promTimeSinceLastBlock = prometheus.NewGauge(
-		prometheus.GaugeOpts{
+	promTimeSinceLastBlock = prometheus.NewCounter(
+		prometheus.CounterOpts{
 			Name: "time_since_last_block_seconds",
 			Help: "Time since the last block created",
 		})

--- a/src/api/metrics.go
+++ b/src/api/metrics.go
@@ -50,6 +50,11 @@ var (
 			Name: "uptime_seconds",
 			Help: "Uptime of the node",
 		})
+	promLastBlockSeq = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "last_block_seq",
+			Help: "Last block sequence number",
+		})
 )
 
 func init() {
@@ -61,6 +66,7 @@ func init() {
 	prometheus.MustRegister(promIncomingConns)
 	prometheus.MustRegister(promStartedAt)
 	prometheus.MustRegister(promUptime)
+	prometheus.MustRegister(promLastBlockSeq)
 }
 
 func metricsHandler(c muxConfig, gateway Gatewayer) http.HandlerFunc {
@@ -79,6 +85,7 @@ func metricsHandler(c muxConfig, gateway Gatewayer) http.HandlerFunc {
 		promIncomingConns.Set(float64(health.IncomingConnections))
 		promStartedAt.Set(float64(gateway.StartedAt().Unix()))
 		promUptime.Set(wh.FromDuration(time.Since(gateway.StartedAt())).Seconds())
+		promLastBlockSeq.Set(float64(health.BlockchainMetadata.Head.BkSeq))
 
 		promhttp.Handler().ServeHTTP(w, r)
 	}

--- a/src/api/metrics.go
+++ b/src/api/metrics.go
@@ -20,8 +20,8 @@ var (
 			Name: "unconfirmed_txns",
 			Help: "Number of unconfirmed transactions",
 		})
-	promTimeSinceLastBlock = prometheus.NewCounter(
-		prometheus.CounterOpts{
+	promTimeSinceLastBlock = prometheus.NewGauge(
+		prometheus.GaugeOpts{
 			Name: "time_since_last_block_seconds",
 			Help: "Time since the last block created",
 		})

--- a/src/api/metrics.go
+++ b/src/api/metrics.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	wh "github.com/skycoin/skycoin/src/util/http"
+)
+
+var (
+	promUnspents = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "unspent_outputs",
+			Help: "Number of unspent outputs",
+		})
+	promUnconfirmedTxns = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "unconfirmed_txns",
+			Help: "Number of unconfirmed transactions",
+		})
+	promTimeSinceLastBlock = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "time_since_last_block_seconds",
+			Help: "Time since the last block created",
+		})
+	promOpenConns = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "open_connections",
+			Help: "Number of open connections",
+		})
+	promOutgoingConns = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "outgoing_connections",
+			Help: "Number of outgoing connections",
+		})
+	promIncomingConns = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "incoming_connections",
+			Help: "Number of incoming connections",
+		})
+	promStartedAt = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "start_at",
+			Help: "Unix timestamp when started",
+		})
+	promUptime = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "uptime_seconds",
+			Help: "Uptime of the node",
+		})
+)
+
+func init() {
+	prometheus.MustRegister(promUnspents)
+	prometheus.MustRegister(promUnconfirmedTxns)
+	prometheus.MustRegister(promTimeSinceLastBlock)
+	prometheus.MustRegister(promOpenConns)
+	prometheus.MustRegister(promOutgoingConns)
+	prometheus.MustRegister(promIncomingConns)
+	prometheus.MustRegister(promStartedAt)
+	prometheus.MustRegister(promUptime)
+}
+
+func metricsHandler(c muxConfig, gateway Gatewayer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		health, err := getHealthData(c, gateway)
+		if err != nil {
+			wh.Error500(w, err.Error())
+			return
+		}
+
+		promUnspents.Set(float64(health.BlockchainMetadata.Unspents))
+		promUnconfirmedTxns.Set(float64(health.BlockchainMetadata.Unconfirmed))
+		promTimeSinceLastBlock.Set(health.BlockchainMetadata.TimeSinceLastBlock.Seconds())
+		promOpenConns.Set(float64(health.OpenConnections))
+		promOutgoingConns.Set(float64(health.OutgoingConnections))
+		promIncomingConns.Set(float64(health.IncomingConnections))
+		promStartedAt.Set(float64(gateway.StartedAt().Unix()))
+		promUptime.Set(wh.FromDuration(time.Since(gateway.StartedAt())).Seconds())
+
+		promhttp.Handler().ServeHTTP(w, r)
+	}
+}

--- a/src/api/metrics.go
+++ b/src/api/metrics.go
@@ -2,10 +2,10 @@ package api
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	wh "github.com/skycoin/skycoin/src/util/http"
 )
 
@@ -40,18 +40,13 @@ var (
 			Name: "incoming_connections",
 			Help: "Number of incoming connections",
 		})
-	promStartedAt = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: "start_at",
-			Help: "Unix timestamp when started",
+	promStartedAt = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "started_at",
+			Help: "Node start time, in unixtime",
 		})
-	promUptime = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: "uptime_seconds",
-			Help: "Uptime of the node",
-		})
-	promLastBlockSeq = prometheus.NewCounter(
-		prometheus.CounterOpts{
+	promLastBlockSeq = prometheus.NewGauge(
+		prometheus.GaugeOpts{
 			Name: "last_block_seq",
 			Help: "Last block sequence number",
 		})
@@ -65,7 +60,6 @@ func init() {
 	prometheus.MustRegister(promOutgoingConns)
 	prometheus.MustRegister(promIncomingConns)
 	prometheus.MustRegister(promStartedAt)
-	prometheus.MustRegister(promUptime)
 	prometheus.MustRegister(promLastBlockSeq)
 }
 
@@ -84,7 +78,6 @@ func metricsHandler(c muxConfig, gateway Gatewayer) http.HandlerFunc {
 		promOutgoingConns.Set(float64(health.OutgoingConnections))
 		promIncomingConns.Set(float64(health.IncomingConnections))
 		promStartedAt.Set(float64(gateway.StartedAt().Unix()))
-		promUptime.Set(wh.FromDuration(time.Since(gateway.StartedAt())).Seconds())
 		promLastBlockSeq.Set(float64(health.BlockchainMetadata.Head.BkSeq))
 
 		promhttp.Handler().ServeHTTP(w, r)


### PR DESCRIPTION
Fixes #2245 

Changes:
- Add metrics: `unspent_outputs`, `unconfirmed_txns`, `time_since_last_block_seconds`, `open_connections`, `outgoing_connections`, `incoming_connections`, `start_at`, `uptime_seconds`, `last_block_seq` to `/metrics` endpoint.

Does this change need to mentioned in CHANGELOG.md?
Yes.