### PR TITLE
Change the warning icon position

### DIFF
--- a/src/gui/static/src/styles.scss
+++ b/src/gui/static/src/styles.scss
@@ -266,7 +266,6 @@ Alerts
   background-color: #ffdede;
   padding: 15px;
   display: flex;
-  align-items: center;
   margin-bottom: 20px;
 
   .title {
@@ -274,6 +273,7 @@ Alerts
   }
 
   mat-icon {
+    margin-top: 5px;
     margin-right: 10px;
     animation: alert-blinking 1s linear infinite;
   }


### PR DESCRIPTION
Fixes #2236

Changes:
- The warning icon is now at the top of the warning boxes, instead of the middle. This should help to have a greater consistency in the UI.

Does this change need to mentioned in CHANGELOG.md?
No