### PR TITLE
Update newcoin readme to clarify usage and defaults

### DIFF
--- a/cmd/newcoin/README.md
+++ b/cmd/newcoin/README.md
@@ -38,8 +38,10 @@ GLOBAL OPTIONS:
 ```
 
 ### Create New Coin
+When using the `newcoin` command, you should run it from the `$GOPATH/src/github.com/skycoin/skycoin` folder to utilise the built in default templates.
 
 ```bash
+$ cd $GOPATH/src/github.com/skycoin/skycoin
 $ newcoin createcoin [command options]
 ```
 
@@ -54,13 +56,14 @@ OPTIONS:
 ```
 
 #### Example
-Create a test coin.
+Create a test coin using application defaults.
 
 ```bash
-$ newcoin --coin testcoin
+$ cd $GOPATH/src/github.com/skycoin/skycoin
+$ newcoin createcoin --coin testcoin
 ```
 
-This will create a new directory, `testcoin`, in `cmd` folder and
-a `testcoin.go` file inside that folder.
+This will create a new directory, `testcoin`, in `cmd` folder and a `testcoin.go` file inside that folder.
+It will also use the built-in defaul options (specified above) and draw template configuration from `$GOPATH/src/github.com/skycoin/skycoin/template`
 
 This file can be used to run a "testcoin" node.


### PR DESCRIPTION
Fixes #NA

Changes:
- Minor update to cmd/newcoin/README.md to clarify usage and defaults (including folder you need to run `newcoin` from for the default application paths to work.

Does this change need to mentioned in CHANGELOG.md?
No
