### PR TITLE
Deactivate the hw wallet integration

### DIFF
--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -8,7 +8,7 @@ const childProcess = require('child_process');
 
 const axios = require('axios');
 
-const hwCode = require('./hardware-wallet');
+//const hwCode = require('./hardware-wallet');
 
 // This adds refresh and devtools console keybindings
 // Page can refresh with cmd+r, ctrl+r, F5
@@ -148,7 +148,7 @@ function startSkycoin() {
       .get('http://localhost:4200/api/v1/wallets/folderName')
       .then(response => {
         walletsFolder = response.data.address;
-        hwCode.setWalletsFolderPath(walletsFolder);
+        //hwCode.setWalletsFolderPath(walletsFolder);
       })
       .catch(() => {});
   }
@@ -192,7 +192,7 @@ function createWindow(url) {
       preload: __dirname + '/electron-api.js',
     },
   });
-  hwCode.setWinRef(win);
+  //hwCode.setWinRef(win);
 
   win.webContents.on('did-finish-load', function() {
 	if (!splashLoaded) {
@@ -224,7 +224,7 @@ function createWindow(url) {
     // in an array if your app supports multi windows, this is the time
     // when you should delete the corresponding element.
     win = null;
-    hwCode.setWinRef(win);
+    //hwCode.setWinRef(win);
   });
 
   // If in dev mode, allow to open URLs.
@@ -332,7 +332,7 @@ app.on('skycoin-ready', (e) => {
     .get(e.url + '/api/v1/wallets/folderName')
     .then(response => {
       walletsFolder = response.data.address;
-      hwCode.setWalletsFolderPath(walletsFolder);
+      //hwCode.setWalletsFolderPath(walletsFolder);
     })
     .catch(() => {});
 });

--- a/electron/src/hardware-wallet.js
+++ b/electron/src/hardware-wallet.js
@@ -1,3 +1,4 @@
+/*
 'use strict'
 
 const { ipcMain } = require('electron');
@@ -228,3 +229,4 @@ module.exports = {
   setWinRef,
   setWalletsFolderPath
 }
+*/

--- a/electron/src/install-dependencies.sh
+++ b/electron/src/install-dependencies.sh
@@ -3,4 +3,4 @@
 set -e -o pipefail
 
 npm install
-./node_modules/.bin/electron-rebuild --only="node-hid"
+#./node_modules/.bin/electron-rebuild --only="node-hid"

--- a/electron/src/package.json
+++ b/electron/src/package.json
@@ -6,8 +6,7 @@
     "axios": "^0.18.0",
     "electron-context-menu": "^0.9.1",
     "electron-debug": "^1.5.0",
-    "rxjs": "^5.5.12",
-    "hardware-wallet-js": "git+https://git@github.com/skycoin/hardware-wallet-js.git#b56e7f5"
+    "rxjs": "^5.5.12"
   },
   "devDependencies": {
     "electron-rebuild": "^1.8.2"

--- a/src/gui/static/src/app/services/hw-wallet.service.ts
+++ b/src/gui/static/src/app/services/hw-wallet.service.ts
@@ -149,7 +149,7 @@ export class HwWalletService {
   }
 
   get hwWalletCompatibilityActivated(): boolean {
-    //return !environment.production && window['isElectron'] && window['ipcRenderer'].sendSync('hwCompatibilityActivated');
+    // return !environment.production && window['isElectron'] && window['ipcRenderer'].sendSync('hwCompatibilityActivated');
     return false;
   }
 

--- a/src/gui/static/src/app/services/hw-wallet.service.ts
+++ b/src/gui/static/src/app/services/hw-wallet.service.ts
@@ -149,7 +149,8 @@ export class HwWalletService {
   }
 
   get hwWalletCompatibilityActivated(): boolean {
-    return !environment.production && window['isElectron'] && window['ipcRenderer'].sendSync('hwCompatibilityActivated');
+    //return !environment.production && window['isElectron'] && window['ipcRenderer'].sendSync('hwCompatibilityActivated');
+    return false;
   }
 
   get walletConnectedAsyncEvent(): Observable<boolean> {


### PR DESCRIPTION
Changes:
- This PR removes de dependencies needed for the hw wallet integration and deactivates it. The code was commented and not removed to be able to reactivate it when necessary.

This PR is to be merged only if a launch should be done and the integration must be deactivated quickly.

Does this change need to mentioned in CHANGELOG.md?
No