### PR TITLE
Improvements for the password modal window

### DIFF
--- a/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.html
@@ -10,7 +10,7 @@
       <input formControlName="confirm_password" id="confirm_password" type="password" appDontSavePassword (keydown.enter)="proceed()">
     </div>
   </div>
-  <a *ngIf="data.wallet" [ngClass]="{'disabled' : working}" [href]="'#/reset/' + data.wallet.filename" class="link">{{ 'password.reset-link' | translate }}</a>
+  <a *ngIf="data.wallet" [ngClass]="{'element-disabled' : working}" [href]="'#/reset/' + data.wallet.filename" class="link">{{ 'password.reset-link' | translate }}</a>
   <div class="-buttons">
     <app-button #button (action)="proceed()" class="primary" [disabled]="!form.valid">
       {{ 'password.button' | translate }}

--- a/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.html
@@ -1,4 +1,4 @@
-<app-modal [headline]="data.title ? (data.title | translate) : ('password.title' | translate)" [dialog]="dialogRef" [disableDismiss]="disableDismiss">
+<app-modal [headline]="data.title ? (data.title | translate) : ('password.title' | translate)" [dialog]="dialogRef" [disableDismiss]="working">
   <p class="-info" [ngClass]="{'-warning' : data.warning}" *ngIf="data.description">{{ data.description | translate }}</p>
   <div [formGroup]="form">
     <div class="form-field">
@@ -10,7 +10,7 @@
       <input formControlName="confirm_password" id="confirm_password" type="password" appDontSavePassword (keydown.enter)="proceed()">
     </div>
   </div>
-  <a *ngIf="data.wallet" [href]="'#/reset/' + data.wallet.filename" class="link">{{ 'password.reset-link' | translate }}</a>
+  <a *ngIf="data.wallet" [ngClass]="{'disabled' : working}" [href]="'#/reset/' + data.wallet.filename" class="link">{{ 'password.reset-link' | translate }}</a>
   <div class="-buttons">
     <app-button #button (action)="proceed()" class="primary" [disabled]="!form.valid">
       {{ 'password.button' | translate }}

--- a/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/password-dialog/password-dialog.component.ts
@@ -17,7 +17,7 @@ export class PasswordDialogComponent implements OnInit, OnDestroy {
   @ViewChild('button') button: ButtonComponent;
   form: FormGroup;
   passwordSubmit = new Subject<any>();
-  disableDismiss = false;
+  working = false;
 
   private subscriptions: ISubscription[] = [];
   private errors: any;
@@ -66,6 +66,8 @@ export class PasswordDialogComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    this.snackbar.dismiss();
+
     this.form.get('password').setValue('');
     this.form.get('confirm_password').setValue('');
 
@@ -79,8 +81,10 @@ export class PasswordDialogComponent implements OnInit, OnDestroy {
       return;
     }
 
+    this.snackbar.dismiss();
+
     this.button.setLoading();
-    this.disableDismiss = true;
+    this.working = true;
 
     this.passwordSubmit.next({
       password: this.form.get('password').value,
@@ -109,6 +113,7 @@ export class PasswordDialogComponent implements OnInit, OnDestroy {
 
   private error(error: any) {
     if (typeof error === 'object') {
+      if (error.status) {
       switch (error.status) {
         case 400:
           error = parseResponseMessage(error['_body']);
@@ -123,11 +128,17 @@ export class PasswordDialogComponent implements OnInit, OnDestroy {
           error = this.errors['errors.no-wallet'];
           break;
         default:
-          showSnackbarError(this.snackbar, error, 5000);
+            error = this.errors['errors.error-decrypting'];
+        }
+      } else {
+        error = this.errors['errors.error-decrypting'];
       }
     }
 
-    this.button.setError(error ? error : this.errors['errors.incorrect-password']);
-    this.disableDismiss = false;
+    error = error ? error : this.errors['errors.error-decrypting'];
+
+    showSnackbarError(this.snackbar, error, 5000);
+    this.button.setError(error);
+    this.working = false;
   }
 }

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.ts
@@ -429,10 +429,6 @@ export class SendFormAdvancedComponent implements OnInit, OnDestroy {
   }
 
   private createTransaction(passwordDialog?: any) {
-    if (passwordDialog) {
-      passwordDialog.close();
-    }
-
     if (this.previewTx) {
       this.previewButton.setLoading();
       this.sendButton.setDisabled();
@@ -458,6 +454,10 @@ export class SendFormAdvancedComponent implements OnInit, OnDestroy {
     )
       .toPromise()
       .then(transaction => {
+        if (passwordDialog) {
+          passwordDialog.close();
+        }
+
         if (!this.previewTx) {
           return this.walletService.injectTransaction(transaction.encoded).toPromise();
         }
@@ -491,6 +491,10 @@ export class SendFormAdvancedComponent implements OnInit, OnDestroy {
         }, 3000);
       })
       .catch(error => {
+        if (passwordDialog) {
+          passwordDialog.error(error);
+        }
+
         showSnackbarError(this.snackbar, error);
 
         this.previewButton.resetState().setEnabled();

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
@@ -211,6 +211,10 @@ export class SendFormComponent implements OnInit, OnDestroy {
       passwordDialog ? passwordDialog.password : null,
       this.previewTx,
     ).subscribe(transaction => {
+        if (passwordDialog) {
+          passwordDialog.close();
+        }
+
         if (!this.previewTx) {
           this.processingSubscription = this.walletService.injectTransaction(transaction.encoded)
             .subscribe(() => this.showSuccess(), error => this.showError(error));

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.ts
@@ -193,10 +193,6 @@ export class SendFormComponent implements OnInit, OnDestroy {
   }
 
   private createTransaction(passwordDialog?: any) {
-    if (passwordDialog) {
-      passwordDialog.close();
-    }
-
     this.showBusy();
 
     let createTxRequest: Observable<PreviewTransaction>;
@@ -226,7 +222,12 @@ export class SendFormComponent implements OnInit, OnDestroy {
       );
     }
 
-     this.processingSubscription = createTxRequest.subscribe(transaction => {
+     this.processingSubscription = createTxRequest.subscribe(
+       transaction => {
+        if (passwordDialog) {
+          passwordDialog.close();
+        }
+
         if (!this.previewTx) {
           this.processingSubscription = this.walletService.injectTransaction(transaction.encoded)
             .subscribe(() => this.showSuccess(), error => this.showError(error));
@@ -246,6 +247,10 @@ export class SendFormComponent implements OnInit, OnDestroy {
         }
       },
       error => {
+        if (passwordDialog) {
+          passwordDialog.error(error);
+        }
+
         if (error && error.result) {
           this.showError(getHardwareWalletErrorMsg(this.hwWalletService, this.translate, error));
         } else {

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-preview/send-preview.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-preview/send-preview.component.ts
@@ -79,10 +79,6 @@ export class SendVerifyComponent implements OnDestroy {
   }
 
   private finishSending(passwordDialog?: any) {
-    if (passwordDialog) {
-      passwordDialog.close();
-    }
-
     this.showBusy();
 
     this.sendSubscription = this.walletService.signTransaction(
@@ -90,6 +86,10 @@ export class SendVerifyComponent implements OnDestroy {
       passwordDialog ? passwordDialog.password : null,
       this.transaction,
     ).flatMap(result => {
+      if (passwordDialog) {
+        passwordDialog.close();
+      }
+
       return this.walletService.injectTransaction(result.encoded);
     }).subscribe(() => {
       this.sendButton.setSuccess();
@@ -101,6 +101,10 @@ export class SendVerifyComponent implements OnDestroy {
         this.onBack.emit(true);
       }, 3000);
     }, error => {
+      if (passwordDialog) {
+        passwordDialog.error(error);
+      }
+
       if (error && error.result) {
         this.showError(getHardwareWalletErrorMsg(this.hwWalletService, this.translate, error));
       } else {

--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
@@ -224,7 +224,7 @@ export class WalletDetailComponent implements OnDestroy {
       dialogRef.componentInstance.passwordSubmit
         .subscribe(passwordDialog => {
           this.walletService.addAddress(this.wallet, this.howManyAddresses, passwordDialog.password)
-            .subscribe(() => passwordDialog.close(), () => passwordDialog.error());
+            .subscribe(() => passwordDialog.close(), error => passwordDialog.error(error));
         });
     } else {
 

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -12,6 +12,7 @@
     "error": "Error",
     "fetch-version": "Unable to fetch latest release version from Github",
     "incorrect-password": "Incorrect password",
+    "error-decrypting": "Error decrypting the wallet",
     "api-disabled": "API disabled",
     "no-wallet": "Wallet does not exist",
     "no-outputs": "No unspent outputs",


### PR DESCRIPTION
Changes:
- Now the password modal uses the snackbar as it should.
- The link for restoring the password is disabled while the operation is being done.
- The modal window stays open while decrypting the wallet in the forms for sending coins, which is more consistent with the rest of the application.
- Fixed a case in which the error response was not being send to the modal window, when it should.
- A new error text was added.

Notes:
- The behavior of the password modal window will change a bit while sending coins with https://github.com/skycoin/skycoin/pull/2221, so some additional changes could be necessary.

Does this change need to mentioned in CHANGELOG.md?
No