### PR TITLE
Improvements for some messages of integration with the hw wallet

### DIFF
--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-restore-seed-dialog/hw-restore-seed-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-restore-seed-dialog/hw-restore-seed-dialog.component.html
@@ -34,7 +34,7 @@
   </div>
 
   <app-hw-message *ngIf="currentState === states.Processing"
-    [text]="'hardware-wallet.general.confirm-and-more' | translate"
+    [text]="(justCheckingSeed ? 'hardware-wallet.general.follow' : 'hardware-wallet.general.confirm-and-more') | translate"
     [icon]="msgIcons.Confirm"
   ></app-hw-message>
 

--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -337,7 +337,7 @@ export class WalletService {
           throw new Error(this.translate.instant('service.wallet.not-enough-hours'));
         }
         if (minRequiredOutputs.length > 8) {
-          throw new Error(this.translate.instant('hardware-wallet.errors.too-many-inputs'));
+          throw new Error(this.translate.instant('hardware-wallet.errors.too-many-inputs-outputs'));
         }
 
         minRequiredOutputs.map(output => totalHours = totalHours.plus(output.calculated_hours));
@@ -396,7 +396,7 @@ export class WalletService {
 
         // Impossible at this time. Here waiting for when the possibility of sending to multiple addresses is added.
         if (convertedOutputs.length > 8) {
-          throw new Error(this.translate.instant('hardware-wallet.errors.too-many-outputs'));
+          throw new Error(this.translate.instant('hardware-wallet.errors.too-many-inputs-outputs'));
         }
 
         return this.hwWalletService.signTransaction(hwInputs, hwOutputs);

--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -315,10 +315,10 @@ export class WalletService {
 
       if (wallet.isHardware) {
         if (data.transaction.inputs.length > 8) {
-          throw new Error(this.translate.instant('hardware-wallet.errors.too-many-inputs'));
+          throw new Error(this.translate.instant('hardware-wallet.errors.too-many-inputs-outputs'));
         }
         if (data.transaction.outputs.length > 8) {
-          throw new Error(this.translate.instant('hardware-wallet.errors.too-many-outputs'));
+          throw new Error(this.translate.instant('hardware-wallet.errors.too-many-inputs-outputs'));
         }
       }
 

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -331,12 +331,12 @@
       "follow": "Please, follow the instructions indicated in the hardware wallet.",
       "close": "Close",
       "cancel": "Cancel",
-      "continue": "Continue",
+      "continue": "Continue", 
       "completed": "Operation completed successfully.",
       "refused": "The operation failed or was canceled."
     },
     "errors": {
-      "too-many-inputs-outputs": "The transaction has too many inputs or outputs for the hardware wallet. Please try again creating several smaller transactions, each one with a smaller number of recipients or coins."
+      "too-many-inputs-outputs": "The transaction has too many inputs or outputs for the hardware wallet. Please try again creating several smaller transactions, each one with a smaller number of recipients (if the current transaction has many) or coins."
     },
     "security-warning" : {
       "title": "Security warning",

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -328,6 +328,7 @@
       "error-incorrect-pin": "Unable to perform the operation. The PIN you have entered is not correct.",
       "confirm": "Please, confirm the operation in the hardware wallet.",
       "confirm-and-more": "Please, confirm the operation in the hardware wallet and follow the instructions.",
+      "follow": "Please, follow the instructions indicated in the hardware wallet.",
       "close": "Close",
       "cancel": "Cancel",
       "continue": "Continue",
@@ -335,8 +336,7 @@
       "refused": "The operation failed or was canceled."
     },
     "errors": {
-      "too-many-inputs": "The transaction has too many inputs and can not be processed. Please contact technical support.",
-      "too-many-outputs": "The transaction has too many outputs and can not be processed. Please contact technical support."
+      "too-many-inputs-outputs": "The transaction has too many inputs or outputs for the hardware wallet. Please try again creating several smaller transactions, each one with a smaller number of recipients or coins."
     },
     "security-warning" : {
       "title": "Security warning",


### PR DESCRIPTION
Changes:
- Now the error message that tells the user that it is not possible to send the transaction because it has too many inputs or outputs gives the user info about an option for sending the coins (split the transaction into several parts), instead of suggesting to contact support. With this change there are no longer 2 separate messages, because after merging https://github.com/skycoin/skycoin/pull/2221 an additional change will be made and it will not allow knowing if the problem was due to the quantity of inputs or outputs.

- Now the message that is displayed while confirming the seed does not asks the user to confirm the operation in the hardware wallet, because when this operation is made the user is not asked for confirmation.

Does this change need to mentioned in CHANGELOG.md?
No