### PR TITLE
Fix /data response and guard against trailing response data

### DIFF
--- a/src/api/address_test.go
+++ b/src/api/address_test.go
@@ -127,7 +127,7 @@ func TestVerifyAddress(t *testing.T) {
 			require.Equal(t, tc.status, status, "got `%v` want `%v`", status, tc.status)
 
 			var rsp ReceivedHTTPResponse
-			err = json.NewDecoder(rr.Body).Decode(&rsp)
+			err = json.Unmarshal(rr.Body.Bytes(), &rsp)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.httpResponse.Error, rsp.Error)

--- a/src/api/spend_test.go
+++ b/src/api/spend_test.go
@@ -849,7 +849,7 @@ func TestCreateTransaction(t *testing.T) {
 			require.Equal(t, tc.status, status, "got `%v` want `%v` (%v)", status, tc.status, rr.Body)
 
 			var rsp ReceivedHTTPResponse
-			err = json.NewDecoder(rr.Body).Decode(&rsp)
+			err = json.Unmarshal(rr.Body.Bytes(), &rsp)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.httpResponse.Error, rsp.Error)
@@ -2172,7 +2172,7 @@ func TestWalletSignTransaction(t *testing.T) {
 			require.Equal(t, tc.status, status, "got `%v` want `%v`", status, tc.status)
 
 			var rsp ReceivedHTTPResponse
-			err = json.NewDecoder(rr.Body).Decode(&rsp)
+			err = json.Unmarshal(rr.Body.Bytes(), &rsp)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.httpResponse.Error, rsp.Error)

--- a/src/api/storage.go
+++ b/src/api/storage.go
@@ -19,10 +19,10 @@ func storageHandler(gateway Gatewayer) http.HandlerFunc {
 			addStorageValueHandler(w, r, gateway)
 		case http.MethodDelete:
 			removeStorageValueHandler(w, r, gateway)
+		default:
+			resp := NewHTTPErrorResponse(http.StatusMethodNotAllowed, "")
+			writeHTTPResponse(w, resp)
 		}
-
-		resp := NewHTTPErrorResponse(http.StatusMethodNotAllowed, "")
-		writeHTTPResponse(w, resp)
 	}
 }
 

--- a/src/api/storage_test.go
+++ b/src/api/storage_test.go
@@ -168,7 +168,7 @@ func TestGetAllStorageValuesHandler(t *testing.T) {
 			require.Equal(t, tc.status, status, "got `%v` want `%v`", status, tc.status)
 
 			var rsp ReceivedHTTPResponse
-			err = json.NewDecoder(rr.Body).Decode(&rsp)
+			err = json.Unmarshal(rr.Body.Bytes(), &rsp)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.httpResponse.Error, rsp.Error)
@@ -363,7 +363,7 @@ func TestGetStorageValueHandler(t *testing.T) {
 			require.Equal(t, tc.status, status, "got `%v` want `%v`", status, tc.status)
 
 			var rsp ReceivedHTTPResponse
-			err = json.NewDecoder(rr.Body).Decode(&rsp)
+			err = json.Unmarshal(rr.Body.Bytes(), &rsp)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.httpResponse.Error, rsp.Error)
@@ -583,7 +583,7 @@ func TestAddStorageValueHandler(t *testing.T) {
 			require.Equal(t, tc.status, status, "got `%v` want `%v`", status, tc.status)
 
 			var rsp ReceivedHTTPResponse
-			err = json.NewDecoder(rr.Body).Decode(&rsp)
+			err = json.Unmarshal(rr.Body.Bytes(), &rsp)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.httpResponse.Error, rsp.Error)
@@ -758,7 +758,7 @@ func TestRemoveStorageValueHandler(t *testing.T) {
 			require.Equal(t, tc.status, status, "got `%v` want `%v`", status, tc.status)
 
 			var rsp ReceivedHTTPResponse
-			err = json.NewDecoder(rr.Body).Decode(&rsp)
+			err = json.Unmarshal(rr.Body.Bytes(), &rsp)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.httpResponse.Error, rsp.Error)

--- a/src/api/transaction_test.go
+++ b/src/api/transaction_test.go
@@ -1599,7 +1599,7 @@ func TestVerifyTransaction(t *testing.T) {
 			require.Equal(t, tc.status, status, "got `%v` want `%v`", status, tc.status)
 
 			var rsp ReceivedHTTPResponse
-			err = json.NewDecoder(rr.Body).Decode(&rsp)
+			err = json.Unmarshal(rr.Body.Bytes(), &rsp)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.httpResponse.Error, rsp.Error)

--- a/src/api/wallet_test.go
+++ b/src/api/wallet_test.go
@@ -1371,7 +1371,7 @@ func TestVerifySeed(t *testing.T) {
 			require.Equal(t, tc.status, status, "got `%v` want `%v`", status, tc.status)
 
 			var rsp ReceivedHTTPResponse
-			err = json.NewDecoder(rr.Body).Decode(&rsp)
+			err = json.Unmarshal(rr.Body.Bytes(), &rsp)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.httpResponse.Error, rsp.Error)
@@ -2284,10 +2284,10 @@ func TestEncryptWallet(t *testing.T) {
 				return
 			}
 
-			var rlt WalletResponse
-			err = json.NewDecoder(rr.Body).Decode(&rlt)
+			var rsp WalletResponse
+			err = json.Unmarshal(rr.Body.Bytes(), &rsp)
 			require.NoError(t, err)
-			require.Equal(t, tc.expectWallet, rlt)
+			require.Equal(t, tc.expectWallet, rsp)
 		})
 	}
 }
@@ -2467,10 +2467,10 @@ func TestDecryptWallet(t *testing.T) {
 				return
 			}
 
-			var r WalletResponse
-			err = json.NewDecoder(rr.Body).Decode(&r)
+			var rsp WalletResponse
+			err = json.Unmarshal(rr.Body.Bytes(), &rsp)
 			require.NoError(t, err)
-			require.Equal(t, tc.expectWallet, r)
+			require.Equal(t, tc.expectWallet, rsp)
 		})
 	}
 }
@@ -2731,7 +2731,7 @@ func TestWalletRecover(t *testing.T) {
 			require.Equal(t, tc.status, status, "got `%v` want `%v`", status, tc.status)
 
 			var rsp ReceivedHTTPResponse
-			err = json.NewDecoder(rr.Body).Decode(&rsp)
+			err = json.Unmarshal(rr.Body.Bytes(), &rsp)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.httpResponse.Error, rsp.Error)


### PR DESCRIPTION
Fixes #2276 

Changes:
- Fixes bug where the /data APIs always wrote out an extra MethodNotAllowed statement
- Adds protection against this happening in the future.  The tests failed to notice this, because the JSON decoder stops after it decodes the first valid JSON object. Any extra data after that point is ignored. Since the invalid response was two JSON objects in sequence, the second JSON object was ignored by the decoder, and went unnoticed.  `api.Client` now fails if the response has any data remaining after the JSON object is decoded

Does this change need to mentioned in CHANGELOG.md?
No