### PR TITLE
Added generateKeyPair cmd to skycoin-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add CLI `generateKeyPair` command generate a new key pair (public and private) based on the Skycoin crypto libraries and return them as Hex strings.
 - Add `bip32` package
 - Add `-disable-header-check` flag to disable host/origin/referer header checks for the node APIs and add `header_check_enabled` parameter in `/health` endpoint.
 - Add CLI `checkDBDecoding` command to verify the `skyencoder`-generated binary decoders match the reflect-based decoder

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -49,6 +49,7 @@ The CLI command APIs can be used directly from a Go application, see [Skycoin CL
 	- [Richlist](#richlist)
     - [Address Count](#address-count)
 	- [CLI version](#cli-version)
+    - [Generate Key Pair](#generate-key-pair)
 - [Note](#note)
 
 <!-- /MarkdownTOC -->
@@ -2791,6 +2792,35 @@ $ skycoin-cli version --json
     "rpc": "0.23.0",
     "wallet": "0.23.0"
 }
+```
+</details>
+
+### Generate Key Pair
+Generates a new key pair (Public and Private) based on the Skycoin crypto library and returns them as Hex strings. 
+If these are intended for actual use, ensure they are kept secure.
+
+```bash
+$ skycoin-cli generateKeyPair
+```
+
+```
+FLAGS:
+  -h, --help   help for richlist
+```
+
+#### Examples
+##### Text output
+```bash
+$ skycoin-cli generateKeyPair
+```
+
+<details>
+ <summary>View Output</summary>
+
+```
+New key pair generated. If you intend to use these, ensure they are kept secure.
+Public:  02e5c1f35cf082822a37d50a478905d63afd46de3cc82caf6d99534a4dc5fbf757
+Private: 3a8e1f6b9ee2603d91f7f1d8d4546122bb9c2337e9492c4fcd965ed0aedd7bb0
 ```
 </details>
 

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -256,6 +256,7 @@ func NewCLI(cfg Config) (*cobra.Command, error) {
 		addressTransactionsCmd(),
 		pendingTransactionsCmd(),
 		addresscountCmd(),
+		generateKeyPairCmd(),
 	}
 
 	skyCLI.Version = Version

--- a/src/cli/generate_keypair.go
+++ b/src/cli/generate_keypair.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/spf13/cobra"
+)
+
+func generateKeyPairCmd() *cobra.Command {
+	return &cobra.Command{
+		Short:                 "Generates a new key pair (Public and Private) as Hex strings.",
+		Long:                  "Generates a new key pair (Public and Private) based on the Skycoin crypto library and returns them as Hex strings. If these are intended for actual use, ensure they are kept secure.",
+		Use:                   "generateKeyPair",
+		Args:                  cobra.NoArgs,
+		DisableFlagsInUseLine: true,
+		SilenceUsage:          true,
+		RunE:                  generateKeyPair,
+	}
+}
+
+func generateKeyPair(_ *cobra.Command, _ []string) error {
+	p, s := cipher.GenerateKeyPair()
+	a, err := cipher.AddressFromSecKey(s)
+	if err != nil {
+		return err
+	}
+
+	if a.Verify(p) != nil {
+		return err
+	}
+
+	fmt.Println("New key pair generated. If you intend to use these, ensure they are kept secure.")
+	fmt.Printf("Public:  %s\n", p.Hex())
+	fmt.Printf("Private: %s\n", s.Hex())
+	return nil
+}


### PR DESCRIPTION
Fixes #NA

Changes:
- Add CLI `generateKeyPair` command generate a new key pair (public and private) based on the Skycoin crypto libraries and return them as Hex strings.

Does this change need to mentioned in CHANGELOG.md?
Yes. Updated included in the PR