### PR TITLE
Limit the hw wallet txs to 7 inputs/outputs

### DIFF
--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -314,10 +314,10 @@ export class WalletService {
       const data = useV2Endpoint ? transaction.data : transaction;
 
       if (wallet.isHardware) {
-        if (data.transaction.inputs.length > 8) {
+        if (data.transaction.inputs.length > 7) {
           throw new Error(this.translate.instant('hardware-wallet.errors.too-many-inputs'));
         }
-        if (data.transaction.outputs.length > 8) {
+        if (data.transaction.outputs.length > 7) {
           throw new Error(this.translate.instant('hardware-wallet.errors.too-many-outputs'));
         }
       }


### PR DESCRIPTION
Fixes #2284

Changes:
- Now the hw wallet txs can have a maximum of 7 inputs and 7 outputs.

Does this change need to mentioned in CHANGELOG.md?
No