### PR TITLE
Add the STORAGE API set to the API documentation

### DIFF
--- a/src/api/README.md
+++ b/src/api/README.md
@@ -142,6 +142,7 @@ These API sets are:
 * `PROMETHEUS` - This is the `/api/v2/metrics` method exposing in Prometheus text format the default metrics for Skycoin node application
 * `NET_CTRL` - The `/api/v1/network/connection/disconnect` method, intended for network administration endpoints
 * `INSECURE_WALLET_SEED` - This is the `/api/v1/wallet/seed` endpoint, used to decrypt and return the seed from an encrypted wallet. It is only intended for use by the desktop client.
+* `STORAGE` - This is the `/api/v2/data` endpoint, used to interact with the key-value storage.
 
 ## Authentication
 


### PR DESCRIPTION
Changes:
- Add the STORAGE API set to the API readme file.

Does this change need to mentioned in CHANGELOG.md?
No