### PR TITLE
Remove .zip release of osx electron build

### DIFF
--- a/electron/build-electron-release.sh
+++ b/electron/build-electron-release.sh
@@ -46,8 +46,6 @@ if [ ! -z "$OSX64_ELN" ]; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
         echo "run dist-mac"
         npm run dist-mac
-    elif [[ "$OSTYPE" == "linux"* ]]; then
-        npm run pack-mac
     else
         echo "Can not run build script in $OSTYPE"
     fi
@@ -59,11 +57,7 @@ if [ -e "mac" ]; then
     if [ -e "${PDT_NAME}-${APP_VERSION}.dmg" ]; then
         mv "${PDT_NAME}-${APP_VERSION}.dmg" "../${PKG_NAME}-${APP_VERSION}-gui-electron-osx-x64.dmg"
     elif [ -e "${PDT_NAME}.app" ]; then
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-            rm -rf "${PDT_NAME}.app"
-        elif [[ "$OSTYPE" == "linux"* ]]; then
-            tar czf "../${PKG_NAME}-${APP_VERSION}-gui-electron-osx-x64.zip" --owner=0 --group=0 "${PDT_NAME}.app"
-        fi
+        rm -rf "${PDT_NAME}.app"
     fi
     popd >/dev/null
     rm -rf "mac"

--- a/electron/build-electron-release.sh
+++ b/electron/build-electron-release.sh
@@ -60,7 +60,7 @@ if [ -e "mac" ]; then
         mv "${PDT_NAME}-${APP_VERSION}.dmg" "../${PKG_NAME}-${APP_VERSION}-gui-electron-osx-x64.dmg"
     elif [ -e "${PDT_NAME}.app" ]; then
         if [[ "$OSTYPE" == "darwin"* ]]; then
-            tar czf "../${PKG_NAME}-${APP_VERSION}-gui-electron-osx-x64.zip" "${PDT_NAME}.app"
+            rm -rf "${PDT_NAME}.app"
         elif [[ "$OSTYPE" == "linux"* ]]; then
             tar czf "../${PKG_NAME}-${APP_VERSION}-gui-electron-osx-x64.zip" --owner=0 --group=0 "${PDT_NAME}.app"
         fi


### PR DESCRIPTION
Fixes #2063 

Changes:
- Remove compressed zip release of osx electron build

Does this change need to mentioned in CHANGELOG.md?
No