### PR TITLE
Improvements for the translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add CLI `addresscount` command to return the count of addresses that currently have unspent outputs (coins) associated with them.
 - Add `/api/v2/data` APIs for transaction notes and generic key-value storage.
 - Update `/metrics` endpoint to add metrics from `/health`: `unspent_outputs`, `unconfirmed_txns`, `time_since_last_block_seconds`, `open_connections`, `outgoing_connections`, `incoming_connections`, `start_at`, `uptime_seconds`, `last_block_seq`.
+- Add the option for changing the language of the GUI.
 
 ### Fixed
 

--- a/src/gui/static/src/app/app.component.ts
+++ b/src/gui/static/src/app/app.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import 'rxjs/add/operator/takeWhile';
-import { TranslateService } from '@ngx-translate/core';
 import { MatDialog } from '@angular/material';
 
 import { AppService } from './services/app.service';

--- a/src/gui/static/src/app/app.config.ts
+++ b/src/gui/static/src/app/app.config.ts
@@ -9,17 +9,12 @@ export const AppConfig = {
     },
     {
       code: 'zh',
-      name: 'Chinese',
+      name: '中文',
       iconName: 'zh.png',
     },
     {
-      code: 'ru',
-      name: 'Russian',
-      iconName: 'ru.png',
-    },
-    {
       code: 'es',
-      name: 'Spanish',
+      name: 'Español',
       iconName: 'es.png',
     },
   ],

--- a/src/gui/static/src/app/components/layout/header/header.component.ts
+++ b/src/gui/static/src/app/components/layout/header/header.component.ts
@@ -36,7 +36,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   private subscription: Subscription;
   private synchronizedSubscription: ISubscription;
-  private fetchVersionError: string;
+  // This should be deleted. View the comment in the constructor.
+  // private fetchVersionError: string;
 
   get loading() {
     return !this.current || !this.highest || this.current !== this.highest || !this.coins || this.coins === 'NaN' || !this.hours || this.hours === 'NaN';
@@ -66,9 +67,12 @@ export class HeaderComponent implements OnInit, OnDestroy {
     private http: Http,
     private translateService: TranslateService,
   ) {
+    // This should not be used anymore, as this does not allow to update the text if the user changes the language.
+    /*
     this.translateService.get('errors.fetch-version').subscribe(msg => {
       this.fetchVersionError = msg;
     });
+    */
   }
 
   ngOnInit() {
@@ -128,6 +132,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
     /*
     // Old method for checking if an update is available. Must be replaced after adding the
     // number of the lastest version in a Skycoin domain.
+    // Also, note that the catch block does not seem to do anything relevant.
     this.http.get('https://api.github.com/repos/skycoin/skycoin/tags')
       .map((res: any) => res.json())
       .catch((error: any) => Observable.throw(error || this.fetchVersionError))

--- a/src/gui/static/src/app/components/pages/onboarding/onboarding.component.html
+++ b/src/gui/static/src/app/components/pages/onboarding/onboarding.component.html
@@ -1,4 +1,4 @@
-<button mat-icon-button (click)="changelanguage()">
+<button mat-icon-button (click)="changelanguage()" *ngIf="language">
   <img [src]="'assets/img/lang/' + language.iconName" class="flag">
 </button>
 

--- a/src/gui/static/src/app/components/pages/onboarding/onboarding.component.html
+++ b/src/gui/static/src/app/components/pages/onboarding/onboarding.component.html
@@ -1,3 +1,7 @@
+<button mat-icon-button (click)="changelanguage()">
+  <img [src]="'assets/img/lang/' + language.iconName" class="flag">
+</button>
+
 <app-onboarding-create-wallet
   *ngIf="step === 1"
   (onLabelAndSeedCreated)="onLabelAndSeedCreated($event)"

--- a/src/gui/static/src/app/components/pages/onboarding/onboarding.component.scss
+++ b/src/gui/static/src/app/components/pages/onboarding/onboarding.component.scss
@@ -1,0 +1,12 @@
+button {
+  position: fixed;
+  right: 30px;
+  top: 10px;
+}
+
+.flag {
+  width: 16px;
+  height: 16px;
+  position: relative;
+  top: -3px;
+}

--- a/src/gui/static/src/app/components/pages/onboarding/onboarding.component.ts
+++ b/src/gui/static/src/app/components/pages/onboarding/onboarding.component.ts
@@ -1,23 +1,41 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { WalletService } from '../../../services/wallet.service';
+import { LanguageData, LanguageService } from '../../../services/language.service';
+import { ISubscription } from 'rxjs/Subscription';
+import { openChangeLanguageModal } from '../../../utils';
+import { MatDialog } from '@angular/material';
 
 @Component({
   selector: 'app-onboarding',
   templateUrl: './onboarding.component.html',
   styleUrls: ['./onboarding.component.scss'],
 })
-export class OnboardingComponent {
+export class OnboardingComponent implements OnInit, OnDestroy {
   step = 1;
   label: string;
   seed: string;
   create: boolean;
   password: string|null;
+  language: LanguageData;
+
+  private subscription: ISubscription;
 
   constructor(
     private router: Router,
     private walletService: WalletService,
+    private languageService: LanguageService,
+    private dialog: MatDialog,
   ) { }
+
+  ngOnInit() {
+    this.subscription = this.languageService.currentLanguage
+      .subscribe(lang => this.language = lang);
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
 
   onLabelAndSeedCreated(data: [string, string, boolean]) {
     this.label = data[0];
@@ -35,6 +53,15 @@ export class OnboardingComponent {
 
   onBack() {
     this.step = 1;
+  }
+
+  changelanguage() {
+    openChangeLanguageModal(this.dialog)
+      .subscribe(response => {
+        if (response) {
+          this.languageService.changeLanguage(response);
+        }
+      });
   }
 
   get fill() {

--- a/src/gui/static/src/app/pipes/date-from-now.pipe.spec.ts
+++ b/src/gui/static/src/app/pipes/date-from-now.pipe.spec.ts
@@ -2,7 +2,7 @@ import { DateFromNowPipe } from './date-from-now.pipe';
 
 describe('DateFromNowPipe', () => {
   it('create an instance', () => {
-    const pipe = new DateFromNowPipe();
+    const pipe = new DateFromNowPipe(null);
     expect(pipe).toBeTruthy();
   });
 });

--- a/src/gui/static/src/app/pipes/date-from-now.pipe.ts
+++ b/src/gui/static/src/app/pipes/date-from-now.pipe.ts
@@ -1,11 +1,33 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import * as moment from 'moment';
+import { TranslateService } from '@ngx-translate/core';
 
 @Pipe({
   name: 'dateFromNow',
+  pure: false,
 })
 export class DateFromNowPipe implements PipeTransform {
+  constructor(
+    public translateService: TranslateService,
+  ) { }
+
   transform(value: any) {
-    return moment.unix(value).fromNow();
+    const diff: number = moment().unix() - value;
+
+    if (diff < 60) {
+      return this.translateService.instant('time-from-now.few-seconds');
+    } else if (diff < 120) {
+      return this.translateService.instant('time-from-now.minute');
+    } else if (diff < 3600) {
+      return this.translateService.instant('time-from-now.minutes', { time: Math.floor(diff / 60) });
+    } else if (diff < 7200) {
+      return this.translateService.instant('time-from-now.hour');
+    } else if (diff < 86400) {
+      return this.translateService.instant('time-from-now.hours', { time: Math.floor(diff / 3600) });
+    } else if (diff < 172800) {
+      return this.translateService.instant('time-from-now.day');
+    }
+
+    return this.translateService.instant('time-from-now.days', { time: Math.floor(diff / 86400) });
   }
 }

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -436,6 +436,16 @@
     }
   },
 
+  "time-from-now": {
+    "few-seconds": "a few seconds ago",
+    "minute": "one minute ago",
+    "minutes": "{{time}} minutes ago",
+    "hour": "one hour ago",
+    "hours": "{{time}} hours ago",
+    "day": "one day ago",
+    "days": "{{time}} days ago"
+  },
+
   "exchange": {
     "you-send": "You send",
     "you-get": "You get",

--- a/src/gui/static/src/assets/i18n/es.json
+++ b/src/gui/static/src/assets/i18n/es.json
@@ -12,6 +12,7 @@
     "error": "Error",
     "fetch-version": "No ha sido posible verificar la última versión desde Github",
     "incorrect-password": "Contraseña incorrecta",
+    "error-decrypting": "Error al desencriptar la billetera",
     "api-disabled": "API desabilitada",
     "no-wallet": "La billetera no existe",
     "no-outputs": "No hay salidas no gastadas",
@@ -33,7 +34,10 @@
     "explorer": "Explorador de Skycoin",
     "seed": "Semilla de la Billetera",
     "qrcode": "Código QR",
-    "reset": "Restablecer contraseña"
+    "reset": "Restablecer contraseña",
+    "exchange": "Intercambiar",
+    "select-address": "Seleccionar Dirección",
+    "order-history": "Historial de órdenes"
   },
 
   "header": {
@@ -429,6 +433,57 @@
       "instructions": "Por favor confirme en la billetera de hardware si la dirección es:",
       "short-confirmation": "Dirección confirmada.",
       "confirmation": "Dirección confirmada. Por seguridad, puede volver a mostrar la dirección en la billetera de hardware usando la opción \"Confirmar dirección\", en el menú que puede mostrar presionando el botón a la derecha del balance de la direccion."
+    }
+  },
+
+  "time-from-now": {
+    "few-seconds": "hace pocos segundos",
+    "minute": "hace un minuto",
+    "minutes": "hace {{time}} minutos",
+    "hour": "hace una hora",
+    "hours": "hace {{time}} horas",
+    "day": "hace un día",
+    "days": "hace {{time}} días"
+  },
+
+  "exchange": {
+    "you-send": "Usted envía",
+    "you-get": "Usted recibe",
+    "to-address": "A la dirección de {{coin}}",
+    "price": "Tasa de cambio",
+    "time-15": "Duración del intercambio",
+    "exchange-button": "Intercambiar",
+    "min-amount": "Monto minimo:",
+    "max-amount": "Monto maximo:",
+    "agree-1": "Acepto los",
+    "agree-2": "Términos de Uso",
+    "agree-3": "y la ",
+    "agree-4": "Política de Privacidad",
+    "powered-by": "Manejado por",
+    "need-help": "¿Necesita ayuda?",
+    "support-portal": "Portal de soporte",
+    "history": "Historial de órdenes",
+    "history-details": "Detalles",
+    "order-not-found": "Orden no encontrada",
+    "status": "Estado",
+    "exchanging": "Intercambiando {{from}} por {{to}}",
+    "select": "Seleccionar",
+    "offline": "El servicio está temporalmente offline",
+    "statuses": {
+      "user-waiting": "Esperando el deposito. Por favor, envíe {{amount}} {{from}} a la dirección de intercambio",
+      "market-waiting-confirmations": "Esperando las confirmaciones de la transacción",
+      "market-confirmed": "Transacción aceptada",
+      "market-exchanged": "{{from}} intercambiado por {{to}}",
+      "market-withdraw-waiting": "Enviando {{to}} a su dirección",
+      "complete": "¡Intercambio completado!",
+      "error": "Se produjo un error"
+    },
+    "details": {
+      "exchange-addr": "Dirección de intercambio",
+      "exchange-addr-tag": "Tag que debe adjuntarse a la transacción",
+      "tx-id": "ID de la transacción",
+      "order-id": "ID de la orden",
+      "error-msg": "Mensaje de error"
     }
   }
 }

--- a/src/gui/static/src/assets/i18n/es_base.json
+++ b/src/gui/static/src/assets/i18n/es_base.json
@@ -12,6 +12,7 @@
     "error": "Error",
     "fetch-version": "Unable to fetch latest release version from Github",
     "incorrect-password": "Incorrect password",
+    "error-decrypting": "Error decrypting the wallet",
     "api-disabled": "API disabled",
     "no-wallet": "Wallet does not exist",
     "no-outputs": "No unspent outputs",
@@ -33,7 +34,10 @@
     "explorer": "Skycoin Explorer",
     "seed": "Wallet Seed",
     "qrcode": "QR Code",
-    "reset": "Reset Password"
+    "reset": "Reset Password",
+    "exchange": "Exchange",
+    "select-address": "Select Address",
+    "order-history": "Order history"
   },
 
   "header": {
@@ -429,6 +433,57 @@
       "instructions": "Please confirm on the hardware wallet if the address is:",
       "short-confirmation": "Address confirmed.",
       "confirmation": "Address confirmed. For security, you can re-show the address in the hardware wallet using the \"Confirm address\" option, in the menu that you can display by pressing the button at the right of the address balance."
+    }
+  },
+
+  "time-from-now": {
+    "few-seconds": "a few seconds ago",
+    "minute": "one minute ago",
+    "minutes": "{{time}} minutes ago",
+    "hour": "one hour ago",
+    "hours": "{{time}} hours ago",
+    "day": "one day ago",
+    "days": "{{time}} days ago"
+  },
+
+  "exchange": {
+    "you-send": "You send",
+    "you-get": "You get",
+    "to-address": "To {{coin}} address",
+    "price": "Exchange rate",
+    "time-15": "Exchange time",
+    "exchange-button": "Exchange",
+    "min-amount": "Minimum amount:",
+    "max-amount": "Maximum amount:",
+    "agree-1": "I agree with",
+    "agree-2": "Terms of Use",
+    "agree-3": "and",
+    "agree-4": "Privacy Policy",
+    "powered-by": "Powered by",
+    "need-help": "Need help?",
+    "support-portal": "Support portal",
+    "history": "Order history",
+    "history-details": "Details",
+    "order-not-found": "Order not found",
+    "status": "Status",
+    "exchanging": "Exchanging {{from}} for {{to}}",
+    "select": "Select",
+    "offline": "Exchange is temporarily offline",
+    "statuses": {
+      "user-waiting": "Waiting for deposit. Please send {{amount}} {{from}} to the exchange address",
+      "market-waiting-confirmations": "Waiting for transaction confirmations",
+      "market-confirmed": "Transaction accepted",
+      "market-exchanged": "Traded {{from}} for {{to}}",
+      "market-withdraw-waiting": "Sending {{to}} to your address",
+      "complete": "Exchange completed!",
+      "error": "Error occurred"
+    },
+    "details": {
+      "exchange-addr": "Exchange address",
+      "exchange-addr-tag": "Tag which must be attached to transaction",
+      "tx-id": "Transaction ID",
+      "order-id": "Order ID",
+      "error-msg": "Error message"
     }
   }
 }


### PR DESCRIPTION
Changes:
- The russian translation was removed from the UI, as it is very old and needs to be updated. The Spanish and Chinese translations are still available.

- The name of the languages was translated, so now the UI does not show "Spanish" and "Chinese", but "Español" and "中文".

- The Spanish translation was updated.

- `DateFromNowPipe` was updated, because it always showed the texts in English. I included the code for generating the texts inside it instead of using the translations of the `moment` module to avoid all the hassles of having to use only the languages defined within that module, making the language codes match, etc.

- Added a button for allowing the user to change the language in the wizard. It could be useful if the user accidentally selects the wrong language when opening the app for the first time.

- Commented a part of the code that does not use the translation functions in a optimal way.

- The changelog now includes the addition of the options for changing the language.

Does this change need to mentioned in CHANGELOG.md?
Yes