### PR TITLE
Add live integration tests for /injectTransaction endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   Now all options of a cli command must only use `--` prefix instead of a mix of `--` and `-` prefixes.
   `-` prefix is only allowed when using shorthand notation.
 - Use an optimized `base58` library for faster address decoding and encoding.
+- `/api/v1/injectTransaction` will return 400 error for invalid transactions.
 
 ### Removed
 

--- a/src/api/integration/transactions_test.go
+++ b/src/api/integration/transactions_test.go
@@ -244,7 +244,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				coins, _ = getAddressBalance(t, c, w.Entries[0].Address.String())
 				require.Equal(t, totalCoins, coins)
 			},
-			code: 200,
+			code: http.StatusOK,
 		},
 		{
 			// send 0.003 coin to the second address,
@@ -288,7 +288,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				// Confirms the change coins are matched.
 				require.Equal(t, expectChangeCoins, changeCoins)
 			},
-			code: 200,
+			code: http.StatusOK,
 		},
 		{
 			name: "send to null address",
@@ -299,7 +299,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn.Out[0].Address = cipher.Address{}
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates user constraint: Transaction output is sent to the null address",
 		},
 		{
@@ -313,7 +313,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn.In[0] = hash
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates hard constraint: unspent output of 2f842b0fbf5ef2dd59c8b5127795f1e88bfa6b510a41c62eac28fc2006d279e3 does not exist",
 		},
 		{
@@ -327,7 +327,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn.InnerHash = txn.HashInner()
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates hard constraint: Transaction output hours overflow",
 		},
 		{
@@ -339,7 +339,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn.InnerHash = txn.HashInner()
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates hard constraint: No inputs",
 		},
 		{
@@ -351,7 +351,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn.InnerHash = txn.HashInner()
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates hard constraint: No outputs",
 		},
 		{
@@ -362,7 +362,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn.InnerHash = txn.HashInner()
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates hard constraint: Invalid number of signatures",
 		},
 		{
@@ -376,7 +376,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn.InnerHash = txn.HashInner()
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates hard constraint: Duplicate spend",
 		},
 		{
@@ -386,7 +386,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn.Type = 1
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates hard constraint: transaction type invalid",
 		},
 		{
@@ -397,7 +397,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn.InnerHash = txn.HashInner()
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates hard constraint: Zero coin output",
 		},
 		{
@@ -408,7 +408,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn.Out[1].Coins = 2
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates hard constraint: Output coins overflow",
 		},
 		{
@@ -419,7 +419,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn.InnerHash = txn.HashInner()
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates hard constraint: Incorrect transaction length",
 		},
 		{
@@ -433,7 +433,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn.Length = size
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates hard constraint: Duplicate output in transaction",
 		},
 		{
@@ -443,7 +443,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn.InnerHash = testutil.RandSHA256(t)
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates hard constraint: InnerHash does not match computed hash",
 		},
 		{
@@ -454,7 +454,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn.InnerHash = txn.HashInner()
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates hard constraint: Unsigned input in transaction",
 		},
 		{
@@ -466,7 +466,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn.InnerHash = txn.HashInner()
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates hard constraint: Failed to recover pubkey from signature",
 		},
 		{
@@ -480,7 +480,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates hard constraint: Signature not valid for output being spent",
 		},
 		{
@@ -495,7 +495,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates hard constraint: Insufficient coins",
 		},
 		{
@@ -509,7 +509,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn = reSignTxnFunc(t, txn, txnRsp, w)
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates hard constraint: Transactions may not destroy coins",
 		},
 		{
@@ -524,7 +524,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn = reSignTxnFunc(t, txn, txnRsp, w)
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates hard constraint: Insufficient coin hours",
 		},
 		{
@@ -543,7 +543,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn = reSignTxnFunc(t, txn, txnRsp, w)
 				return &txn
 			},
-			code: 400,
+			code: http.StatusBadRequest,
 			err:  "400 Bad Request - Transaction violates soft constraint: invalid amount, too many decimal places",
 		},
 	}
@@ -566,7 +566,7 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			txn := tc.createTxn(t)
 			txid, err := c.InjectTransaction(txn)
-			if tc.code != 200 {
+			if tc.code != http.StatusOK {
 				assertResponseError(t, err, tc.code, tc.err)
 				return
 			}

--- a/src/api/integration/transactions_test.go
+++ b/src/api/integration/transactions_test.go
@@ -522,8 +522,6 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				txn.InnerHash = txn.HashInner()
 				// Sign the txn again
 				txn = reSignTxnFunc(t, txn, txnRsp, w)
-				l, _ := txn.Size()
-				t.Log("txn size:", l)
 				return &txn
 			},
 			code: 400,

--- a/src/api/integration/transactions_test.go
+++ b/src/api/integration/transactions_test.go
@@ -1,10 +1,12 @@
 package integration_test
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
 	"net/http"
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -157,30 +159,80 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 
 	defaultChangeAddress := w.Entries[0].Address.String()
 
+	// prepareTxnFunc prepares a valid transaction
+	prepareTxnFunc := func(t *testing.T, toAddr string, coins uint64, shareFactor string) (coin.Transaction, *api.CreateTransactionResponse) {
+		createTxnReq := api.WalletCreateTransactionRequest{
+			WalletID: w.Filename(),
+			Password: password,
+			CreateTransactionRequest: api.CreateTransactionRequest{
+				HoursSelection: api.HoursSelection{
+					Type:        transaction.HoursSelectionTypeAuto,
+					Mode:        transaction.HoursSelectionModeShare,
+					ShareFactor: shareFactor,
+				},
+				ChangeAddress: &defaultChangeAddress,
+				To: []api.Receiver{
+					{
+						// Address: w.Entries[1].Address.String(),
+						Address: toAddr,
+						Coins:   toDropletString(t, coins),
+					},
+				},
+			},
+		}
+
+		txnResp, err := c.WalletCreateTransaction(createTxnReq)
+		require.NoError(t, err)
+
+		txn, err := coin.DeserializeTransactionHex(txnResp.EncodedTransaction)
+		require.NoError(t, err)
+		return txn, txnResp
+	}
+
+	reSignTxnFunc := func(t *testing.T, txn coin.Transaction, txnRsp *api.CreateTransactionResponse, wlt *wallet.Wallet) coin.Transaction {
+		walletPassword := os.Getenv("WALLET_PASSWORD")
+		err := wlt.GuardView([]byte(walletPassword), func(unlockWlt *wallet.Wallet) error {
+			keyMap := make(map[string]cipher.SecKey, len(unlockWlt.Entries))
+			for _, e := range unlockWlt.Entries {
+				addr := cipher.MustAddressFromSecKey(e.Secret)
+				keyMap[addr.String()] = e.Secret
+			}
+
+			// Get seckeys in wallet of input addresses
+			keys := make([]cipher.SecKey, len(txnRsp.Transaction.In))
+			for i, in := range txnRsp.Transaction.In {
+				k, ok := keyMap[in.Address]
+				if !ok {
+					t.Fatal("seckey does not exist")
+					return errors.New("seckey does not exist")
+				}
+				keys[i] = k
+			}
+			// clear the old signatures
+			txn.Sigs = []cipher.Sig{}
+			txn.SignInputs(keys)
+			return nil
+		})
+		require.NoError(t, err)
+		return txn
+	}
+
 	tt := []struct {
-		name         string
-		createTxnReq api.WalletCreateTransactionRequest
-		checkTxn     func(t *testing.T, tx *readable.TransactionWithStatus)
+		name string
+		// createTxnReq    api.WalletCreateTransactionRequest
+		createTxn func(t *testing.T) (*coin.Transaction, string)
+		// changeTxn    func(t *testing.T, encodedTxn string) string
+		code     int
+		err      string
+		checkTxn func(t *testing.T, tx *readable.TransactionWithStatus)
 	}{
 		{
 			name: "send all coins to the first address",
-			createTxnReq: api.WalletCreateTransactionRequest{
-				WalletID: w.Filename(),
-				Password: password,
-				CreateTransactionRequest: api.CreateTransactionRequest{
-					HoursSelection: api.HoursSelection{
-						Type:        transaction.HoursSelectionTypeAuto,
-						Mode:        transaction.HoursSelectionModeShare,
-						ShareFactor: "1",
-					},
-					ChangeAddress: &defaultChangeAddress,
-					To: []api.Receiver{
-						{
-							Address: w.Entries[0].Address.String(),
-							Coins:   toDropletString(t, totalCoins),
-						},
-					},
-				},
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[0].Address.String(), totalCoins, "1")
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
 			},
 			checkTxn: func(t *testing.T, tx *readable.TransactionWithStatus) {
 				// Confirms the total output coins are equal to the totalCoins
@@ -201,23 +253,11 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 			// send 0.003 coin to the second address,
 			// this amount is chosen to not interfere with TestLiveWalletCreateTransaction
 			name: "send 0.003 coin to second address",
-			createTxnReq: api.WalletCreateTransactionRequest{
-				WalletID: w.Filename(),
-				Password: password,
-				CreateTransactionRequest: api.CreateTransactionRequest{
-					HoursSelection: api.HoursSelection{
-						Type:        transaction.HoursSelectionTypeAuto,
-						Mode:        transaction.HoursSelectionModeShare,
-						ShareFactor: "0.5",
-					},
-					ChangeAddress: &defaultChangeAddress,
-					To: []api.Receiver{
-						{
-							Address: w.Entries[1].Address.String(),
-							Coins:   toDropletString(t, 3e3),
-						},
-					},
-				},
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[1].Address.String(), 3e3, "0.5")
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
 			},
 			checkTxn: func(t *testing.T, tx *readable.TransactionWithStatus) {
 				// Confirms there're two outputs, one to the second address, one as change output to the first address.
@@ -254,32 +294,341 @@ func TestLiveInjectTransactionEnableNetworking(t *testing.T) {
 				require.Equal(t, expectChangeCoins, changeCoins)
 			},
 		},
+		{
+			name: "invalid rawtx",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				return nil, "invalidrawtx"
+			},
+			code: 400,
+			err:  "400 Bad Request - encoding/hex: invalid byte: U+0069 'i'",
+		},
+		{
+			name: "send to null address",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[0].Address.String(), totalCoins, "1")
+
+				// set the transaction output address as null
+				txn.Out[0].Address = cipher.Address{}
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates user constraint: Transaction output is sent to the null address",
+		},
+		{
+			// Use an input from block 1024: 2f842b0fbf5ef2dd59c8b5127795f1e88bfa6b510a41c62eac28fc2006d279e3
+			name: "double spend",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[0].Address.String(), totalCoins, "1")
+
+				hash, err := cipher.SHA256FromHex("2f842b0fbf5ef2dd59c8b5127795f1e88bfa6b510a41c62eac28fc2006d279e3")
+				require.NoError(t, err)
+				txn.In[0] = hash
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates hard constraint: unspent output of 2f842b0fbf5ef2dd59c8b5127795f1e88bfa6b510a41c62eac28fc2006d279e3 does not exist",
+		},
+		{
+			name: "output hours overflow",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[1].Address.String(), 1e6, "1")
+
+				// set one output hours as math.MaxUint64
+				txn.Out[0].Hours = math.MaxUint64 - 1
+				txn.Out[1].Hours = 100
+				txn.InnerHash = txn.HashInner()
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates hard constraint: Transaction output hours overflow",
+		},
+		{
+			name: "no inputs",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[0].Address.String(), totalCoins, "1")
+
+				txn.In = []cipher.SHA256{}
+				txn.InnerHash = txn.HashInner()
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates hard constraint: No inputs",
+		},
+		{
+			name: "no outputs",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[0].Address.String(), totalCoins, "1")
+
+				txn.Out = []coin.TransactionOutput{}
+				txn.InnerHash = txn.HashInner()
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates hard constraint: No outputs",
+		},
+		{
+			name: "invalid number of signatures",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[0].Address.String(), totalCoins, "1")
+				txn.Sigs = []cipher.Sig{}
+				txn.InnerHash = txn.HashInner()
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates hard constraint: Invalid number of signatures",
+		},
+		{
+			name: "duplicate spend",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[0].Address.String(), totalCoins, "1")
+				// Make duplicate inputs
+				txn.In = append(txn.In, txn.In[0])
+				// Make duplicate sigs
+				txn.Sigs = append(txn.Sigs, txn.Sigs[0])
+				txn.InnerHash = txn.HashInner()
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates hard constraint: Duplicate spend",
+		},
+		{
+			name: "transaction type invalid",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[0].Address.String(), totalCoins, "1")
+				txn.Type = 1
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates hard constraint: transaction type invalid",
+		},
+		{
+			name: "zero coin output",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[0].Address.String(), totalCoins, "1")
+				txn.Out[0].Coins = 0
+				txn.InnerHash = txn.HashInner()
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates hard constraint: Zero coin output",
+		},
+		{
+			name: "output coins overflow",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[0].Address.String(), 1e6, "1")
+				txn.Out[0].Coins = math.MaxUint64 - 1
+				txn.Out[1].Coins = 2
+
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates hard constraint: Output coins overflow",
+		},
+		{
+			name: "incorrect transaction length",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[0].Address.String(), totalCoins, "1")
+				txn.Length = 1
+				txn.InnerHash = txn.HashInner()
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates hard constraint: Incorrect transaction length",
+		},
+		{
+			name: "duplicate output",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[0].Address.String(), totalCoins, "1")
+				txn.Out = append(txn.Out, txn.Out[0])
+				txn.InnerHash = txn.HashInner()
+				size, _, err := txn.SizeHash()
+				require.NoError(t, err)
+				txn.Length = size
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates hard constraint: Duplicate output in transaction",
+		},
+		{
+			name: "inner hash does not match",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[0].Address.String(), totalCoins, "1")
+				txn.InnerHash = testutil.RandSHA256(t)
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates hard constraint: InnerHash does not match computed hash",
+		},
+		{
+			name: "unsigned input",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[0].Address.String(), totalCoins, "1")
+				txn.Sigs[0] = cipher.Sig{}
+				txn.InnerHash = txn.HashInner()
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates hard constraint: Unsigned input in transaction",
+		},
+		{
+			name: "invalid sig",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[0].Address.String(), totalCoins, "1")
+				txn.Sigs[0] = testutil.RandSig(t)
+
+				txn.InnerHash = txn.HashInner()
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates hard constraint: Failed to recover pubkey from signature",
+		},
+		{
+			name: "invalid address for sig",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[0].Address.String(), totalCoins, "1")
+
+				txn.InnerHash = txn.HashInner()
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates hard constraint: Address does not match recovered signature",
+		},
+		{
+			name: "signature not valid for output being spent",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, _ := prepareTxnFunc(t, w.Entries[0].Address.String(), totalCoins, "1")
+				// Use a wrong private key to sign txn.In[0] and change txn.Sigs[0]
+				_, seckey := cipher.GenerateKeyPair()
+				h := cipher.AddSHA256(txn.InnerHash, txn.In[0])
+				txn.Sigs[0] = cipher.MustSignHash(h, seckey)
+
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates hard constraint: Signature not valid for output being spent",
+		},
+		{
+			name: "insufficient coins",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, txnRsp := prepareTxnFunc(t, w.Entries[0].Address.String(), totalCoins, "1")
+				// Make output coins > input coins
+				txn.Out[0].Coins = txn.Out[0].Coins + 1
+				txn.InnerHash = txn.HashInner()
+				// Sign txn again as the inner hash is changed
+				txn = reSignTxnFunc(t, txn, txnRsp, w)
+
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates hard constraint: Insufficient coins",
+		},
+		{
+			name: "transaction may not destry coins",
+			createTxn: func(t *testing.T) (*coin.Transaction, string) {
+				txn, txnRsp := prepareTxnFunc(t, w.Entries[0].Address.String(), totalCoins, "1")
+				// Make output coins < input coins
+				txn.Out[0].Coins = txn.Out[0].Coins - 1
+				txn.InnerHash = txn.HashInner()
+				// Sign the txn again as the inner hash is changed
+				txn = reSignTxnFunc(t, txn, txnRsp, w)
+
+				encodedTxnStr, err := txn.SerializeHex()
+				require.NoError(t, err)
+				return nil, encodedTxnStr
+			},
+			code: 400,
+			err:  "400 Bad Request - Transaction violates hard constraint: Transactions may not destroy coins",
+		},
+		// {
+		// 	// Will panic in building the raw transction string, as the
+		// 	// encoder will return Maximum length exceeded error
+		// 	name: "too many signatures and inputs",
+		// 	createTxn: func(t *testing.T) (*coin.Transaction, string) {
+		// 	},
+		// 	code: 400,
+		// 	err:  "400 Bad Request - Transaction violates hard constraint: Too many signatures and inputs",
+		// },
+		// {
+		// 	// Will panic in building the raw txn string, as the encoder
+		// 	// will return Maximum length exceeded error
+		// 	name: "too many outputs",
+		// 	createTxn: func(t *testing.T) (*coin.Transaction, string) {
+		// 	},
+		// 	code: 400,
+		// 	err:  "400 Bad Request - Transaction violates hard constraint: Too many outputs",
+		// },
+		// {
+		// 	name: "duplicate spend",
+		// 	createTxn: func(t *testing.T) (*coin.Transaction, string) {
+		// 	},
+		// 	code: 400,
+		// 	err:  "400 Bad Request - Transaction violates hard constraint: Duplicate spend",
+		// },
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			txnResp, err := c.WalletCreateTransaction(tc.createTxnReq)
-			require.NoError(t, err)
+			txn, encodedTxnStr := tc.createTxn(t)
+			txid, err := c.InjectEncodedTransaction(encodedTxnStr)
+			if tc.code != 200 {
+				assertResponseError(t, err, tc.code, tc.err)
+				return
+			}
 
-			txid, err := c.InjectEncodedTransaction(txnResp.EncodedTransaction)
 			require.NoError(t, err)
-			require.Equal(t, txnResp.Transaction.TxID, txid)
+			require.Equal(t, txn.Hash().Hex(), txid)
 
 			tk := time.NewTicker(time.Second)
-			var txn *readable.TransactionWithStatus
+			var txnStatus *readable.TransactionWithStatus
 		loop:
 			for {
 				select {
 				case <-time.After(30 * time.Second):
 					t.Fatal("Waiting for transaction to be confirmed timeout")
 				case <-tk.C:
-					txn = getTransaction(t, c, txnResp.Transaction.TxID)
-					if txn.Status.Confirmed {
+					txnStatus = getTransaction(t, c, txn.Hash().Hex())
+					if txnStatus.Status.Confirmed {
 						break loop
 					}
 				}
 			}
-			tc.checkTxn(t, txn)
+			tc.checkTxn(t, txnStatus)
 		})
 	}
 }

--- a/src/api/spend.go
+++ b/src/api/spend.go
@@ -567,7 +567,7 @@ func (r walletCreateTransactionRequest) Validate() error {
 	return r.createTransactionRequest.Validate()
 }
 
-// walletCreateTransactionHandler creates a signed transaction
+// walletCreateTransactionHandler creates a transaction
 // Method: POST
 // URI: /api/v1/wallet/transaction
 // Args: JSON body

--- a/src/api/transaction.go
+++ b/src/api/transaction.go
@@ -366,7 +366,8 @@ func injectTransactionHandler(gateway Gatewayer) http.HandlerFunc {
 		if err := gateway.InjectBroadcastTransaction(txn); err != nil {
 			switch err.(type) {
 			case visor.ErrTxnViolatesUserConstraint,
-				visor.ErrTxnViolatesHardConstraint:
+				visor.ErrTxnViolatesHardConstraint,
+				visor.ErrTxnViolatesSoftConstraint:
 				wh.Error400(w, err.Error())
 			default:
 				if daemon.IsBroadcastFailure(err) {

--- a/src/api/transaction.go
+++ b/src/api/transaction.go
@@ -364,10 +364,16 @@ func injectTransactionHandler(gateway Gatewayer) http.HandlerFunc {
 		}
 
 		if err := gateway.InjectBroadcastTransaction(txn); err != nil {
-			if daemon.IsBroadcastFailure(err) {
-				wh.Error503(w, err.Error())
-			} else {
-				wh.Error500(w, err.Error())
+			switch err.(type) {
+			case visor.ErrTxnViolatesUserConstraint,
+				visor.ErrTxnViolatesHardConstraint:
+				wh.Error400(w, err.Error())
+			default:
+				if daemon.IsBroadcastFailure(err) {
+					wh.Error503(w, err.Error())
+				} else {
+					wh.Error500(w, err.Error())
+				}
 			}
 			return
 		}

--- a/src/daemon/messages.go
+++ b/src/daemon/messages.go
@@ -1346,7 +1346,7 @@ func (gtm *GiveTxnsMessage) process(d daemoner) {
 			logger.WithError(err).WithField("txid", txn.Hash().Hex()).Warning("Failed to record transaction")
 			continue
 		} else if softErr != nil {
-			logger.WithError(err).WithField("txid", txn.Hash().Hex()).Warning("Transaction soft violation")
+			logger.WithError(softErr).WithField("txid", txn.Hash().Hex()).Warning("Transaction soft violation")
 			// Allow soft txn violations to rebroadcast
 		} else if known {
 			logger.WithField("txid", txn.Hash().Hex()).Debug("Duplicate transaction")

--- a/src/visor/verify.go
+++ b/src/visor/verify.go
@@ -80,7 +80,7 @@ type TxnSignedFlag int
 const (
 	// TxnSigned is used for signed transactions
 	TxnSigned TxnSignedFlag = 1
-	// TxnUnsigned is used for signed transactions
+	// TxnUnsigned is used for unsigned transactions
 	TxnUnsigned TxnSignedFlag = 2
 )
 


### PR DESCRIPTION
Fixes #2166
Fixes #1363 

Changes:
- Return 400 error for invalid txns
- Add live integration tests for /injectTransaction endpoint. We do not do the stable integration tests, as the `/injectTransaction` endpoint will update db, while the stable integration test runs db in read-only mode.
- Fix soft transaction violations: <nil> in logs

Does this change need to mentioned in CHANGELOG.md?
Yes