### PR TITLE
Create transactions with /wallet/transaction instead of /transaction

### DIFF
--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -304,7 +304,7 @@ export class WalletService {
       unspents: unspents,
       to: destinations,
       change_address: changeAddress,
-    }
+    };
 
     if (!useV2Endpoint) {
       params['unsigned'] = unsigned;

--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -294,19 +294,25 @@ export class WalletService {
       changeAddress = wallet.addresses[0].address;
     }
 
-    const useV2Endpoint = unsigned || wallet.isHardware;
+    const useV2Endpoint = !!wallet.isHardware;
+
+    const params = {
+      hours_selection: hoursSelection,
+      wallet_id: wallet ? wallet.filename : null,
+      password: password,
+      addresses: addresses,
+      unspents: unspents,
+      to: destinations,
+      change_address: changeAddress,
+    }
+
+    if (!useV2Endpoint) {
+      params['unsigned'] = unsigned;
+    }
 
     let response: Observable<PreviewTransaction> = this.apiService.post(
       useV2Endpoint ? 'transaction' : 'wallet/transaction',
-      {
-        hours_selection: hoursSelection,
-        wallet_id: wallet ? wallet.filename : null,
-        password: password,
-        addresses: addresses,
-        unspents: unspents,
-        to: destinations,
-        change_address: changeAddress,
-      },
+      params,
       {
         json: true,
       },


### PR DESCRIPTION
Fixes #2286 

Changes:
- Now the `/wallet/transaction` API endpoint is used instead of `/transaction` to create all the transactions for the software wallets. `/transaction` is still being used for the hardware wallets.

Does this change need to mentioned in CHANGELOG.md?
No