### PR TITLE
Stop showing simple errors in the browser console

### DIFF
--- a/src/gui/static/src/app/app-error-handler.config.ts
+++ b/src/gui/static/src/app/app-error-handler.config.ts
@@ -1,0 +1,6 @@
+import { ErrorHandler, Injectable} from '@angular/core';
+
+@Injectable()
+export class AppErrorHandler implements ErrorHandler {
+  handleError(error: Error) { }
+}

--- a/src/gui/static/src/app/app-error-handler.ts
+++ b/src/gui/static/src/app/app-error-handler.ts
@@ -1,4 +1,4 @@
-import { ErrorHandler, Injectable} from '@angular/core';
+import { ErrorHandler, Injectable } from '@angular/core';
 
 @Injectable()
 export class AppErrorHandler implements ErrorHandler {

--- a/src/gui/static/src/app/app.module.ts
+++ b/src/gui/static/src/app/app.module.ts
@@ -100,7 +100,7 @@ import { LanguageService } from './services/language.service';
 import { SelectLanguageComponent } from './components/layout/select-language/select-language.component';
 import { ExchangeHistoryComponent } from './components/pages/exchange/exchange-history/exchange-history.component';
 import { StorageService } from './services/storage.service';
-import { AppErrorHandler } from './app-error-handler.config';
+import { AppErrorHandler } from './app-error-handler';
 
 
 const ROUTES = [

--- a/src/gui/static/src/app/app.module.ts
+++ b/src/gui/static/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule } from '@angular/core';
+import { NgModule, ErrorHandler } from '@angular/core';
 import { AppComponent } from './app.component';
 import { HttpModule } from '@angular/http';
 import { ApiService } from './services/api.service';
@@ -100,6 +100,7 @@ import { LanguageService } from './services/language.service';
 import { SelectLanguageComponent } from './components/layout/select-language/select-language.component';
 import { ExchangeHistoryComponent } from './components/pages/exchange/exchange-history/exchange-history.component';
 import { StorageService } from './services/storage.service';
+import { AppErrorHandler } from './app-error-handler.config';
 
 
 const ROUTES = [
@@ -295,6 +296,10 @@ const ROUTES = [
     }),
   ],
   providers: [
+    {
+      provide: ErrorHandler,
+      useClass: AppErrorHandler,
+    },
     ApiService,
     AppService,
     BlockchainService,


### PR DESCRIPTION
Fixes #2319

Changes:
- This PR deactivates the default error handler used by Angular, to prevent it to continue adding unnecessary entries in the browser console every time there is an error.

Does this change need to mentioned in CHANGELOG.md?
No