### PR TITLE
Send a minimum of 1 coin hour when using auto share hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Move package `github.com/skycoin/skycoin/src/cipher/go-bip39` to `github.com/skycoin/skycoin/src/cipher/bip39`
 - The Content-Security-Policy header was modified to make it stricter
 - Update INTR message verify logic to reject connection if blockchain pubkey not matched or provided
+- Send a minimum of 1 coin hour when using auto share hours
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Move package `github.com/skycoin/skycoin/src/cipher/go-bip39` to `github.com/skycoin/skycoin/src/cipher/bip39`
 - The Content-Security-Policy header was modified to make it stricter
 - Update INTR message verify logic to reject connection if blockchain pubkey not matched or provided
-- Send a minimum of 1 coin hour when using auto share hours
+- Update `POST /api/v1/wallet/transaction` endpoint to send a minimum of 1 coin hour when using auto share hours
 
 ### Removed
 

--- a/src/transaction/create.go
+++ b/src/transaction/create.go
@@ -144,6 +144,19 @@ func create(p Params, auxs coin.AddressUxOuts, headTime uint64, callCount int) (
 				toCoins[i] = to.Coins
 			}
 
+			// If sharefactor > 0 and sharehours < len(p.To), the sharehours cannot ensure each destination
+			// address has at least 1 coin hour. In this case, if we have enough hours, i.e the hours >= len(p.To),
+			// set the sharehours as len(p.To). If we don't have enough hours, i.e. hours < len(p.To),
+			// share all hours we have.
+			toNum := uint64(len(p.To))
+			if p.HoursSelection.ShareFactor.GreaterThan(decimal.New(0, 0)) && allocatedHours < toNum {
+				if hours < int64(toNum) {
+					allocatedHours = uint64(hours)
+				} else {
+					allocatedHours = toNum
+				}
+			}
+
 			addrHours, err = DistributeCoinHoursProportional(toCoins, allocatedHours)
 			if err != nil {
 				return nil, nil, err

--- a/src/transaction/create_test.go
+++ b/src/transaction/create_test.go
@@ -80,7 +80,7 @@ func TestCreate(t *testing.T) {
 		uxoutsNoHours[i], uxoutsNoHours[j] = uxoutsNoHours[j], uxoutsNoHours[i]
 	})
 
-	// Create unspents outputs with only 1 hour
+	// Create unspents outputs with small coin hours
 	var uxoutsSmallHours []coin.UxOut
 	for i := uint64(0); i < 10; i++ {
 		uxout := makeUxOut(t, secKey, 2e6, 1+i)

--- a/src/transaction/create_test.go
+++ b/src/transaction/create_test.go
@@ -702,10 +702,52 @@ func TestCreate(t *testing.T) {
 			chosenUnspents: []coin.UxOut{uxoutsSmallHours[0], uxoutsSmallHours[1], uxoutsSmallHours[2]},
 			changeOutput: &coin.TransactionOutput{
 				Address: changeAddress,
-				Hours:   0,
+				Hours:   1,
 				Coins:   1e6 - 1e3,
 			},
-			toExpectedHours: []uint64{1, 1, 1, 0},
+			toExpectedHours: []uint64{1, 1, 0, 0},
+		},
+
+		{
+			name: "1 hour to change, 0 to outputs",
+			params: Params{
+				ChangeAddress: &changeAddress,
+				HoursSelection: HoursSelection{
+					Type:        HoursSelectionTypeAuto,
+					Mode:        HoursSelectionModeShare,
+					ShareFactor: newShareFactor("0.5"),
+				},
+				To: []coin.TransactionOutput{
+					{
+						Address: addrs[1],
+						Coins:   1e6,
+					},
+					{
+						Address: addrs[0],
+						Coins:   2e6,
+					},
+					{
+						Address: addrs[1],
+						Coins:   2e6,
+					},
+					{
+						Address: addrs[4],
+						Coins:   1e3,
+					},
+				},
+			},
+			addressUnspents: coin.AddressUxOuts{
+				addrs[0]: uxoutsSmallHours[1:2],
+				addrs[1]: uxoutsNoHours[0:1],
+				addrs[2]: uxoutsNoHours[1:2],
+			},
+			chosenUnspents: []coin.UxOut{uxoutsSmallHours[1], uxoutsNoHours[0], uxoutsNoHours[1]},
+			changeOutput: &coin.TransactionOutput{
+				Address: changeAddress,
+				Hours:   1,
+				Coins:   1e6 - 1e3,
+			},
+			toExpectedHours: []uint64{0, 0, 0, 0},
 		},
 
 		{

--- a/src/transaction/hours.go
+++ b/src/transaction/hours.go
@@ -95,6 +95,20 @@ func DistributeCoinHoursProportional(coins []uint64, hours uint64) ([]uint64, er
 		coinsInt[i] = big.NewInt(cInt64)
 	}
 
+	addrHours := make([]uint64, len(coins))
+	// When total hours > the number of outputs, assign each output 1 hour, then
+	// assign the remaining hours proportionally.
+	if hours > uint64(len(coins)) {
+		for i := 0; i < len(coins); i++ {
+			addrHours[i] = uint64(1)
+			hours--
+		}
+	}
+
+	if hours == 0 {
+		return addrHours, nil
+	}
+
 	totalInt64, err := mathutil.Uint64ToInt64(total)
 	if err != nil {
 		return nil, err
@@ -108,7 +122,6 @@ func DistributeCoinHoursProportional(coins []uint64, hours uint64) ([]uint64, er
 	hoursInt := big.NewInt(hoursInt64)
 
 	var assignedHours uint64
-	addrHours := make([]uint64, len(coins))
 	for i, c := range coinsInt {
 		// Scale the ratio of coins to total coins proportionally by calculating
 		// (coins * totalHours) / totalCoins
@@ -125,7 +138,7 @@ func DistributeCoinHoursProportional(coins []uint64, hours uint64) ([]uint64, er
 
 		fracHours := fracInt.Uint64()
 
-		addrHours[i] = fracHours
+		addrHours[i] = addrHours[i] + fracHours
 		assignedHours, err = mathutil.AddUint64(assignedHours, fracHours)
 		if err != nil {
 			return nil, err

--- a/src/transaction/hours_test.go
+++ b/src/transaction/hours_test.go
@@ -54,7 +54,7 @@ func TestDistributeCoinHoursProportional(t *testing.T) {
 		{
 			name:  "hours too large",
 			coins: []uint64{10},
-			hours: math.MaxInt64 + 1,
+			hours: math.MaxInt64 + 2,
 			err:   mathutil.ErrUint64OverflowsInt64,
 		},
 
@@ -73,45 +73,38 @@ func TestDistributeCoinHoursProportional(t *testing.T) {
 		},
 
 		{
-			name:   "valid, multiple inputs, all equal",
+			name:   "valid, multiple inputs",
 			coins:  []uint64{2, 4, 8, 16},
 			hours:  30,
-			output: []uint64{2, 4, 8, 16},
-		},
-
-		{
-			name:   "valid, multiple inputs, rational division in coins and hours",
-			coins:  []uint64{2, 4, 8, 16},
-			hours:  30,
-			output: []uint64{2, 4, 8, 16},
+			output: []uint64{3, 5, 8, 14},
 		},
 
 		{
 			name:   "valid, multiple inputs, rational division in coins, irrational in hours",
 			coins:  []uint64{2, 4, 8, 16},
 			hours:  31,
-			output: []uint64{3, 4, 8, 16},
+			output: []uint64{3, 5, 8, 15},
 		},
 
 		{
 			name:   "valid, multiple inputs, irrational division in coins, rational in hours",
 			coins:  []uint64{2, 3, 5, 7, 11, 13},
 			hours:  41,
-			output: []uint64{2, 3, 5, 7, 11, 13},
+			output: []uint64{3, 4, 6, 6, 10, 12},
 		},
 
 		{
 			name:   "valid, multiple inputs, irrational division in coins and hours",
 			coins:  []uint64{2, 3, 5, 7, 11, 13},
 			hours:  50,
-			output: []uint64{3, 4, 7, 8, 13, 15},
+			output: []uint64{4, 5, 7, 8, 12, 14},
 		},
 
 		{
 			name:   "valid, multiple inputs that would receive 0 hours but get compensated from remainder as priority",
 			coins:  []uint64{16, 8, 4, 2, 1, 1},
 			hours:  14,
-			output: []uint64{7, 3, 1, 1, 1, 1},
+			output: []uint64{6, 3, 2, 1, 1, 1},
 		},
 
 		{
@@ -126,6 +119,13 @@ func TestDistributeCoinHoursProportional(t *testing.T) {
 			coins:  []uint64{1, 1, 1, 1, 1},
 			hours:  3,
 			output: []uint64{1, 1, 1, 0, 0},
+		},
+
+		{
+			name:   "valid, multiple inputs, hours equal number of outputs",
+			coins:  []uint64{1, 2, 3, 4},
+			hours:  4,
+			output: []uint64{1, 1, 1, 1},
 		},
 	}
 


### PR DESCRIPTION
Fixes #1604 

Changes:
- Update the POST `/wallet/transaction` endpoint to send a minimum of 1 coin hour to all outputs when possible. 

Does this change need to mentioned in CHANGELOG.md?
Yes