### PR TITLE
Show the history link right after creating the first Swaplab operation

### DIFF
--- a/src/gui/static/src/app/components/pages/exchange/exchange.component.ts
+++ b/src/gui/static/src/app/components/pages/exchange/exchange.component.ts
@@ -46,6 +46,7 @@ export class ExchangeComponent implements OnInit, OnDestroy {
 
   showStatus(order) {
     this.currentOrderDetails = order;
+    this.hasHistory = true;
   }
 
   showHistory(event) {


### PR DESCRIPTION
Fixes #2338

Changes:
- The variable that is used for showing the history link is updated after starting an operation.

Does this change need to mentioned in CHANGELOG.md?
No