### PR TITLE
Update electron/package.json to v0.26.0

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -3,7 +3,7 @@
     "productName": "Skycoin",
     "author": "skycoin",
     "main": "src/electron-main.js",
-    "version": "0.25.1",
+    "version": "0.26.0",
     "description": "skycoin wallet",
     "license": "MIT",
     "build": {


### PR DESCRIPTION
Changes:
- Changes the `version` field of `electron/package.json` to 0.26.0. If this is not done, the standalone and Electron builds are still indentified as 0.25.1.

Does this change need to mentioned in CHANGELOG.md?
No