### PR TITLE
Trim the destination address in the Swaplab integration

### DIFF
--- a/src/gui/static/src/app/components/pages/exchange/exchange-create/exchange-create.component.ts
+++ b/src/gui/static/src/app/components/pages/exchange/exchange-create/exchange-create.component.ts
@@ -116,13 +116,15 @@ export class ExchangeCreateComponent implements OnInit, OnDestroy {
 
     const amount = parseFloat(this.form.get('fromAmount').value);
 
+    const toAddress = (this.form.get('toAddress').value as string).trim();
+
     this.removeExchangeSubscription();
-    this.exchangeSubscription = this.walletService.verifyAddress(this.form.get('toAddress').value).subscribe(addressIsValid => {
+    this.exchangeSubscription = this.walletService.verifyAddress(toAddress).subscribe(addressIsValid => {
       if (addressIsValid) {
         this.exchangeSubscription = this.exchangeService.exchange(
           this.activeTradingPair.pair,
           amount,
-          this.form.get('toAddress').value,
+          toAddress,
           this.activeTradingPair.price,
         ).subscribe((order: ExchangeOrder) => {
           this.submitted.emit({


### PR DESCRIPTION
Changes:
- Now the code trims the destination address before starting an exchange with the Swaplab integration, so there is not problem if the user adds white spaces at the start or end of the address.

Does this change need to mentioned in CHANGELOG.md?
No