### PR TITLE
Correctly clean the advanced form

### DIFF
--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.ts
@@ -480,9 +480,9 @@ export class SendFormAdvancedComponent implements OnInit, OnDestroy {
         }
 
         if (!this.previewTx) {
-            this.processingSubscription = this.walletService.injectTransaction(transaction.encoded)
-              .subscribe(() => this.showSuccess(), error => this.showError(error));
-          } else {
+          this.processingSubscription = this.walletService.injectTransaction(transaction.encoded)
+            .subscribe(() => this.showSuccess(), error => this.showError(error));
+        } else {
           let amount = new BigNumber('0');
           this.destinations.map(destination => amount = amount.plus(destination.coins));
 
@@ -522,6 +522,8 @@ export class SendFormAdvancedComponent implements OnInit, OnDestroy {
     this.form.get('addresses').setValue(null);
     this.form.get('outputs').setValue(null);
     this.form.get('changeAddress').setValue('');
+
+    this.wallet = null;
 
     while (this.destControls.length > 0) {
       (this.form.get('destinations') as FormArray).removeAt(0);


### PR DESCRIPTION
Changes:
- If the user sends a transaction using the advanced form by pressing the “Send” button, after sending the coins the form is cleaned, but the fields that should be only visible after selecting a wallet are still visible (something that should not happen, as the wallet field is cleaned). This PR solves that problem.

- Small code formatting fix.

Does this change need to mentioned in CHANGELOG.md?
No