### PR TITLE
Fix #2348. Correct panic in skycoin-cli transaction when zero args passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Return v2-style error for disabled endpoints
 - #2172 Fix electron build failure for linux system
 - Don't send messages that exceed the configured 256kB limit, which caused peers to disconnect from the sender
+- #2348 Fix panic in `skycoin-cli` `transaction` command if no (zero) arguments are passed. Exactly one argument is expected.
 
 ### Changed
 

--- a/src/cli/transaction.go
+++ b/src/cli/transaction.go
@@ -97,7 +97,7 @@ func getAddressTransactionsCmd(c *cobra.Command, args []string) error {
 		}
 	}
 
-	// If one or more addresses have beeb provided, request their transactions - otherwise report an error
+	// If one or more addresses have been provided, request their transactions - otherwise report an error
 	if len(addrs) > 0 {
 		outputs, err := apiClient.TransactionsVerbose(addrs)
 		if err != nil {

--- a/src/cli/transaction.go
+++ b/src/cli/transaction.go
@@ -23,7 +23,7 @@ func transactionCmd() *cobra.Command {
 		Use:                   "transaction [transaction id]",
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
-		Args:                  cobra.MaximumNArgs(1),
+		Args:                  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			txid := args[0]
 			if txid == "" {


### PR DESCRIPTION
Fixes #2348 

Changes:
- Fix panic in `skycoin-cli` `transaction` command if no (zero) arguments are passed. Exactly one argument is expected.

Does this change need to mentioned in CHANGELOG.md?
- Yes. Added and included in PR