### PR TITLE
Fix the Swaplab links in Electron

### DIFF
--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -235,6 +235,12 @@ function createWindow(url) {
     });
   }
 
+  // Open links with target='_blank' in the default browser.
+  win.webContents.on('new-window', function(e, url) {
+    e.preventDefault();
+    require('electron').shell.openExternal(url);
+  });
+
   // create application's main menu
   var template = [{
     label: 'Skycoin',


### PR DESCRIPTION
Changes:
- Previously, when opening a link with `target='_blank'` in the Electron version, the URL was opened in a new Electron window. With this PR the link is opened in the default web browser.

Does this change need to mentioned in CHANGELOG.md?
No