### PR TITLE
Ignore charset in Content-Type header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- #2287 A `Content-Type` with a `charset` specified, for example `application/json; charset=utf-8`, will not return an HTTP 415 error anymore
+
 ### Changed
 
 ### Removed

--- a/src/api/address.go
+++ b/src/api/address.go
@@ -27,12 +27,6 @@ func addressVerifyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.Header.Get("Content-Type") != ContentTypeJSON {
-		resp := NewHTTPErrorResponse(http.StatusUnsupportedMediaType, "")
-		writeHTTPResponse(w, resp)
-		return
-	}
-
 	var req VerifyAddressRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		resp := NewHTTPErrorResponse(http.StatusBadRequest, err.Error())

--- a/src/api/csrf_test.go
+++ b/src/api/csrf_test.go
@@ -62,6 +62,11 @@ func TestCSRFWrapper(t *testing.T) {
 
 					setCSRFParameters(t, c, req)
 
+					isAPIV2 := strings.HasPrefix(endpoint, "/api/v2")
+					if isAPIV2 {
+						req.Header.Set("Content-Type", ContentTypeJSON)
+					}
+
 					rr := httptest.NewRecorder()
 					handler := newServerMux(muxConfig{
 						host:           configuredHost,
@@ -86,7 +91,7 @@ func TestCSRFWrapper(t *testing.T) {
 						errMsg = ErrCSRFExpired
 					}
 
-					if strings.HasPrefix(endpoint, "/api/v2") {
+					if isAPIV2 {
 						require.Equal(t, fmt.Sprintf("{\n    \"error\": {\n        \"message\": \"%s\",\n        \"code\": 403\n    }\n}", errMsg), rr.Body.String())
 					} else {
 						require.Equal(t, fmt.Sprintf("403 Forbidden - %s\n", errMsg), rr.Body.String())
@@ -128,6 +133,11 @@ func TestCSRFWrapperConcurrent(t *testing.T) {
 
 							setCSRFParameters(t, c, req)
 
+							isAPIV2 := strings.HasPrefix(endpoint, "/api/v2")
+							if isAPIV2 {
+								req.Header.Set("Content-Type", ContentTypeJSON)
+							}
+
 							rr := httptest.NewRecorder()
 
 							handler.ServeHTTP(rr, req)
@@ -145,7 +155,7 @@ func TestCSRFWrapperConcurrent(t *testing.T) {
 								errMsg = ErrCSRFExpired
 							}
 
-							if strings.HasPrefix(endpoint, "/api/v2") {
+							if isAPIV2 {
 								require.Equal(t, fmt.Sprintf("{\n    \"error\": {\n        \"message\": \"%s\",\n        \"code\": 403\n    }\n}", errMsg), rr.Body.String())
 							} else {
 								require.Equal(t, fmt.Sprintf("403 Forbidden - %s\n", errMsg), rr.Body.String())

--- a/src/api/http.go
+++ b/src/api/http.go
@@ -390,6 +390,10 @@ func newServerMux(c muxConfig, gateway Gatewayer) *http.ServeMux {
 			handler = headerCheck(apiVersion, c.host, c.hostWhitelist, handler)
 		}
 
+		if apiVersion == apiVersion2 {
+			handler = ContentTypeJSONRequired(handler)
+		}
+
 		handler = basicAuth(apiVersion, c.username, c.password, "skycoin daemon", handler)
 		handler = gziphandler.GzipHandler(handler)
 		mux.Handle(endpoint, handler)
@@ -415,7 +419,7 @@ func newServerMux(c muxConfig, gateway Gatewayer) *http.ServeMux {
 
 	indexHandler := newIndexHandler(c.appLoc, c.enableGUI)
 	if !c.disableCSP {
-		indexHandler = CSPHandler(indexHandler)
+		indexHandler = CSPHandler(indexHandler, ContentSecurityPolicy)
 	}
 	webHandler(apiVersion1, "/", indexHandler, nil)
 
@@ -427,7 +431,7 @@ func newServerMux(c muxConfig, gateway Gatewayer) *http.ServeMux {
 
 		fs := http.FileServer(http.Dir(c.appLoc))
 		if !c.disableCSP {
-			fs = CSPHandler(fs)
+			fs = CSPHandler(fs, ContentSecurityPolicy)
 		}
 
 		for _, fileInfo := range fileInfos {

--- a/src/api/http_test.go
+++ b/src/api/http_test.go
@@ -296,6 +296,11 @@ func TestAPISetDisabled(t *testing.T) {
 		req, err := http.NewRequest(method, endpoint, nil)
 		require.NoError(t, err)
 
+		isAPIV2 := strings.HasPrefix(endpoint, "/api/v2/")
+		if isAPIV2 {
+			req.Header.Set("Content-Type", ContentTypeJSON)
+		}
+
 		cfg := defaultMuxConfig()
 		cfg.disableCSRF = disableCSRF
 		cfg.enabledAPISets = map[string]struct{}{} // disable all API sets
@@ -310,7 +315,7 @@ func TestAPISetDisabled(t *testing.T) {
 			require.Equal(t, http.StatusOK, rr.Code)
 		default:
 			require.Equal(t, http.StatusForbidden, rr.Code)
-			if strings.HasPrefix(endpoint, "/api/v2/") {
+			if isAPIV2 {
 				require.Equal(t, "{\n    \"error\": {\n        \"message\": \"Endpoint is disabled\",\n        \"code\": 403\n    }\n}", rr.Body.String())
 			} else {
 				require.Equal(t, "403 Forbidden - Endpoint is disabled", strings.TrimSpace(rr.Body.String()))
@@ -369,6 +374,11 @@ func TestCORS(t *testing.T) {
 					require.NoError(t, err)
 
 					setCSRFParameters(t, tokenValid, req)
+
+					isAPIV2 := strings.HasPrefix(e, "/api/v2/")
+					if isAPIV2 {
+						req.Header.Set("Content-Type", ContentTypeJSON)
+					}
 
 					req.Header.Set("Origin", fmt.Sprintf("http://%s", tc.origin))
 					req.Header.Set("Access-Control-Request-Method", m)

--- a/src/api/middleware_test.go
+++ b/src/api/middleware_test.go
@@ -80,6 +80,11 @@ func TestOriginRefererCheck(t *testing.T) {
 
 				setCSRFParameters(t, tokenValid, req)
 
+				isAPIV2 := strings.HasPrefix(endpoint, "/api/v2")
+				if isAPIV2 {
+					req.Header.Set("Content-Type", ContentTypeJSON)
+				}
+
 				if tc.origin != "" {
 					req.Header.Set("Origin", tc.origin)
 				}
@@ -102,7 +107,7 @@ func TestOriginRefererCheck(t *testing.T) {
 				case http.StatusForbidden:
 					require.Equal(t, tc.status, rr.Code)
 
-					if strings.HasPrefix(endpoint, "/api/v2") {
+					if isAPIV2 {
 						require.Equal(t, tc.errV2, rr.Body.String())
 					} else {
 						require.Equal(t, tc.errV1, rr.Body.String())
@@ -164,6 +169,11 @@ func TestHostCheck(t *testing.T) {
 
 					setCSRFParameters(t, tokenValid, req)
 
+					isAPIV2 := strings.HasPrefix(endpoint, "/api/v2")
+					if isAPIV2 {
+						req.Header.Set("Content-Type", ContentTypeJSON)
+					}
+
 					req.Host = "example.com"
 
 					rr := httptest.NewRecorder()
@@ -181,7 +191,7 @@ func TestHostCheck(t *testing.T) {
 					switch tc.status {
 					case http.StatusForbidden:
 						require.Equal(t, http.StatusForbidden, rr.Code)
-						if strings.HasPrefix(endpoint, "/api/v2") {
+						if isAPIV2 {
 							require.Equal(t, tc.errV2, rr.Body.String())
 						} else {
 							require.Equal(t, tc.errV1, rr.Body.String())
@@ -263,4 +273,12 @@ func TestContentSecurityPolicy(t *testing.T) {
 			require.Equal(t, tc.expectCSPHeader, csp)
 		})
 	}
+}
+
+func TestIsContentTypeJSON(t *testing.T) {
+	require.True(t, isContentTypeJSON(ContentTypeJSON))
+	require.True(t, isContentTypeJSON("application/json"))
+	require.True(t, isContentTypeJSON("application/json; charset=utf-8"))
+	require.False(t, isContentTypeJSON("application/x-www-form-urlencoded"))
+	require.False(t, isContentTypeJSON(ContentTypeForm))
 }

--- a/src/api/spend.go
+++ b/src/api/spend.go
@@ -487,12 +487,6 @@ func transactionHandlerV2(gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 
-		if r.Header.Get("Content-Type") != ContentTypeJSON {
-			resp := NewHTTPErrorResponse(http.StatusUnsupportedMediaType, "")
-			writeHTTPResponse(w, resp)
-			return
-		}
-
 		var req createTransactionRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			resp := NewHTTPErrorResponse(http.StatusBadRequest, err.Error())
@@ -578,7 +572,7 @@ func walletCreateTransactionHandler(gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 
-		if r.Header.Get("Content-Type") != ContentTypeJSON {
+		if !isContentTypeJSON(r.Header.Get("Content-Type")) {
 			wh.Error415(w)
 			return
 		}
@@ -658,12 +652,6 @@ func walletSignTransactionHandler(gateway Gatewayer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			resp := NewHTTPErrorResponse(http.StatusMethodNotAllowed, "")
-			writeHTTPResponse(w, resp)
-			return
-		}
-
-		if r.Header.Get("Content-Type") != ContentTypeJSON {
-			resp := NewHTTPErrorResponse(http.StatusUnsupportedMediaType, "")
 			writeHTTPResponse(w, resp)
 			return
 		}

--- a/src/api/storage.go
+++ b/src/api/storage.go
@@ -111,12 +111,6 @@ type StorageRequest struct {
 //     key: key
 //     val: value
 func addStorageValueHandler(w http.ResponseWriter, r *http.Request, gateway Gatewayer) {
-	if r.Header.Get("Content-Type") != ContentTypeJSON {
-		resp := NewHTTPErrorResponse(http.StatusUnsupportedMediaType, "")
-		writeHTTPResponse(w, resp)
-		return
-	}
-
 	var req StorageRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		resp := NewHTTPErrorResponse(http.StatusBadRequest, err.Error())

--- a/src/api/transaction.go
+++ b/src/api/transaction.go
@@ -498,12 +498,6 @@ func verifyTxnHandler(gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 
-		if r.Header.Get("Content-Type") != ContentTypeJSON {
-			resp := NewHTTPErrorResponse(http.StatusUnsupportedMediaType, "")
-			writeHTTPResponse(w, resp)
-			return
-		}
-
 		var req VerifyTransactionRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			resp := NewHTTPErrorResponse(http.StatusBadRequest, err.Error())

--- a/src/api/wallet.go
+++ b/src/api/wallet.go
@@ -691,12 +691,6 @@ func walletVerifySeedHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.Header.Get("Content-Type") != ContentTypeJSON {
-		resp := NewHTTPErrorResponse(http.StatusUnsupportedMediaType, "")
-		writeHTTPResponse(w, resp)
-		return
-	}
-
 	var req VerifySeedRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		resp := NewHTTPErrorResponse(http.StatusBadRequest, err.Error())
@@ -871,12 +865,6 @@ func walletRecoverHandler(gateway Gatewayer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			resp := NewHTTPErrorResponse(http.StatusMethodNotAllowed, "")
-			writeHTTPResponse(w, resp)
-			return
-		}
-
-		if r.Header.Get("Content-Type") != ContentTypeJSON {
-			resp := NewHTTPErrorResponse(http.StatusUnsupportedMediaType, "")
 			writeHTTPResponse(w, resp)
 			return
 		}


### PR DESCRIPTION
Fixes #2287

Changes:
- Allow `Content-Type` header to be `application/json` or start with `application/json;`, for V2 API requests. Some clients incorrectly send a `Content-Type` of `application/json; charset=utf-8`, which is not valid according to spec but which we should accept anyway to accommodate 3rd party development tooling

Does this change need to mentioned in CHANGELOG.md?
Yes