### PR TITLE
Fix #2373 - Correct misc panics with `skycoin-cli` command argument handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Don't send wire protocol messages that exceed the configured 256kB limit, which caused peers to disconnect from the sender
 - #2348 Fix panic in `skycoin-cli` `transaction` command if no (zero) arguments are passed. Exactly one argument is expected.
 - #2373 Fix and clean-up further panics with various `skycoin-cli` commands which were not correctly handling arguments.
+    - lastBlocks, checkdb
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - #2172 Fix electron build failure for linux systems
 - Don't send wire protocol messages that exceed the configured 256kB limit, which caused peers to disconnect from the sender
 - #2348 Fix panic in `skycoin-cli` `transaction` command if no (zero) arguments are passed. Exactly one argument is expected.
-- #2373 Fix and clean-up further panics with various `skycoin-cli` commands which were not correctly handling arguments.
-    - lastBlocks, checkdb
+- #2373 Fix and clean-up further panics with various `skycoin-cli` commands (lastBlocks, checkdb) which were not correctly handling arguments.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - #2172 Fix electron build failure for linux systems
 - Don't send wire protocol messages that exceed the configured 256kB limit, which caused peers to disconnect from the sender
 - #2348 Fix panic in `skycoin-cli` `transaction` command if no (zero) arguments are passed. Exactly one argument is expected.
+- #2373 Fix and clean-up further panics with various `skycoin-cli` commands which were not correctly handling arguments.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - #2287 A `Content-Type` with a `charset` specified, for example `application/json; charset=utf-8`, will not return an HTTP 415 error anymore
 - Fix `fiber.toml` transaction verification parameters ignored by newcoin
+- #2373 Fix and clean-up further panics with various `skycoin-cli` commands (lastBlocks, checkdb) which were not correctly handling arguments.
 
 ### Changed
 
@@ -51,7 +52,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - #2172 Fix electron build failure for linux systems
 - Don't send wire protocol messages that exceed the configured 256kB limit, which caused peers to disconnect from the sender
 - #2348 Fix panic in `skycoin-cli` `transaction` command if no (zero) arguments are passed. Exactly one argument is expected.
-- #2373 Fix and clean-up further panics with various `skycoin-cli` commands (lastBlocks, checkdb) which were not correctly handling arguments.
 
 ### Changed
 

--- a/src/cli/checkdb.go
+++ b/src/cli/checkdb.go
@@ -35,7 +35,7 @@ func checkDBCmd() *cobra.Command {
 		Use:   "checkdb [db path]",
 		Long: `Checks if the given database file contains valid skycoin blockchain data.
     If no argument is specificed, the default data.db in $HOME/.$COIN/ will be checked.`,
-		Args:                  cobra.ExactArgs(1),
+		Args:                  cobra.MaximumNArgs(1),
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
 		RunE:                  checkDB,

--- a/src/cli/last_blocks.go
+++ b/src/cli/last_blocks.go
@@ -12,7 +12,7 @@ func lastBlocksCmd() *gcli.Command {
 	return &gcli.Command{
 		Short:                 "Displays the content of the most recently N generated blocks",
 		Use:                   "lastBlocks [numberOfBlocks]",
-		Args:                  gcli.MaximumNArgs(1),
+		Args:                  gcli.ExactArgs(1),
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
 		RunE:                  getLastBlocks,


### PR DESCRIPTION
Fixes #2373
Changes:
- Correct panic in lastBlocks and checkdb command argument handling

Does this change need to mentioned in CHANGELOG.md?
Yes. Included in PR
