### PR TITLE
Allow to add notes to the transactions

### DIFF
--- a/src/gui/static/src/app/app.datatypes.ts
+++ b/src/gui/static/src/app/app.datatypes.ts
@@ -33,6 +33,7 @@ export class Transaction {
   hoursSent?: BigNumber;
   hoursBurned?: BigNumber;
   coinsMovedInternally?: boolean;
+  note?: string;
 }
 
 export class PreviewTransaction extends Transaction {

--- a/src/gui/static/src/app/app.module.ts
+++ b/src/gui/static/src/app/app.module.ts
@@ -106,6 +106,7 @@ import { StorageService } from './services/storage.service';
 import { HwRemovePinDialogComponent } from './components/layout/hardware-wallet/hw-remove-pin-dialog/hw-remove-pin-dialog.component';
 import { HwUpdateFirmwareDialogComponent } from './components/layout/hardware-wallet/hw-update-firmware-dialog/hw-update-firmware-dialog.component';
 import { HwUpdateAlertDialogComponent } from './components/layout/hardware-wallet/hw-update-alert-dialog/hw-update-alert-dialog.component';
+import { ChangeNoteComponent } from './components/pages/send-skycoin/send-preview/transaction-info/change-note/change-note.component';
 
 
 const ROUTES = [
@@ -241,6 +242,7 @@ const ROUTES = [
     HwRemovePinDialogComponent,
     HwUpdateFirmwareDialogComponent,
     HwUpdateAlertDialogComponent,
+    ChangeNoteComponent,
   ],
   entryComponents: [
     AddDepositAddressComponent,
@@ -272,6 +274,7 @@ const ROUTES = [
     HwRemovePinDialogComponent,
     HwUpdateFirmwareDialogComponent,
     HwUpdateAlertDialogComponent,
+    ChangeNoteComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.html
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.html
@@ -154,6 +154,14 @@
     <input formControlName="changeAddress" id="change-address" (keydown.enter)="preview()" [attr.disabled]="busy ? 'true' : null">
   </div>
 
+  <div class="form-field">
+    <label for="note">
+      {{ 'send.personal-note-label' | translate }}
+      <mat-icon [matTooltip]="'send.personal-note-help' | translate">help</mat-icon>
+    </label>
+    <input formControlName="note" id="note" [maxlength]="maxNoteChars" [attr.disabled]="busy ? 'true' : null">
+  </div>
+
   <div class="-autohours" [ngClass]="{'element-disabled' : busy}">
     <div class="row">
       <div class="col-xl-4 col-lg-5 col-md-7">

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.html
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.html
@@ -40,6 +40,13 @@
       </span>
     </div>
   </div>
+  <div class="form-field">
+    <label for="note">
+      {{ 'send.personal-note-label' | translate }}
+      <mat-icon [matTooltip]="'send.personal-note-help' | translate">help</mat-icon>
+    </label>
+    <input formControlName="note" id="note" [maxlength]="maxNoteChars" [attr.disabled]="busy ? 'true' : null">
+  </div>
   <div class="-buttons">
     <app-button #previewButton (action)="preview()" [disabled]="!form.valid">
       {{ 'send.preview-button' | translate }}

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.scss
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form/send-form.component.scss
@@ -1,7 +1,17 @@
+@import '../../../../../theme/variables';
+
 .-buttons {
   text-align: center;
 }
 
 .amount-label {
   display: inline-block;
+}
+
+label mat-icon {
+  display: inline;
+  font-size: 14px;
+  color: lighten($grey, 40%);
+  vertical-align: text-bottom;
+  padding-left: 5px;
 }

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-preview/send-preview.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-preview/send-preview.component.ts
@@ -81,6 +81,8 @@ export class SendVerifyComponent implements OnDestroy {
   private finishSending(passwordDialog?: any) {
     this.showBusy();
 
+    const note = this.transaction.note.trim();
+
     this.sendSubscription = this.walletService.signTransaction(
       this.transaction.wallet,
       passwordDialog ? passwordDialog.password : null,
@@ -90,8 +92,12 @@ export class SendVerifyComponent implements OnDestroy {
         passwordDialog.close();
       }
 
-      return this.walletService.injectTransaction(result.encoded);
-    }).subscribe(() => {
+      return this.walletService.injectTransaction(result.encoded, note);
+    }).subscribe(noteSaved => {
+      if (note && !noteSaved) {
+        showSnackbarError(this.snackbar, this.translate.instant('send.error-saving-note'));
+      }
+
       this.sendButton.setSuccess();
       this.sendButton.setDisabled();
 

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/change-note/change-note.component.html
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/change-note/change-note.component.html
@@ -1,0 +1,19 @@
+<app-modal class="modal" [headline]="'edit-note.title' | translate" [dialog]="dialogRef" [disableDismiss]="button && button.isLoading()">
+  <div [formGroup]="form">
+    <div class="form-field">
+      <label for="note">
+        {{ 'send.personal-note-label' | translate }}
+        <mat-icon [matTooltip]="'send.personal-note-help' | translate">help</mat-icon>
+      </label>
+      <input formControlName="note" id="note" (keydown.enter)="changeNote()" [maxlength]="maxNoteChars">
+    </div>
+  </div>
+  <div class="-buttons">
+    <app-button (action)="closePopup()">
+      {{ 'edit-note.cancel-button' | translate }}
+    </app-button>
+    <app-button (action)="changeNote()" class="primary" #button>
+      {{ 'edit-note.change-button' | translate }}
+    </app-button>
+  </div>
+</app-modal>

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/change-note/change-note.component.scss
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/change-note/change-note.component.scss
@@ -1,0 +1,17 @@
+@import '../../../../../../../theme/variables';
+
+mat-input-container {
+  width: 100%;
+}
+
+.-buttons {
+  text-align: center;
+}
+
+mat-icon {
+  display: inline;
+  font-size: 14px;
+  color: lighten($grey, 40%);
+  vertical-align: text-bottom;
+  padding-left: 5px;
+}

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/change-note/change-note.component.spec.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/change-note/change-note.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChangeNoteComponent } from './change-note.component';
+
+describe('ChangeNoteComponent', () => {
+  let component: ChangeNoteComponent;
+  let fixture: ComponentFixture<ChangeNoteComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ChangeNoteComponent ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChangeNoteComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/change-note/change-note.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/change-note/change-note.component.ts
@@ -60,6 +60,7 @@ export class ChangeNoteComponent implements OnInit, OnDestroy {
 
     if (this.originalNote === newNote) {
       this.closePopup();
+
       return;
     }
 

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/change-note/change-note.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/change-note/change-note.component.ts
@@ -1,0 +1,76 @@
+import { Component, OnInit, Inject, ViewChild, OnDestroy } from '@angular/core';
+import { FormBuilder, Validators, FormGroup } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material';
+import { ISubscription } from 'rxjs/Subscription';
+import { ButtonComponent } from '../../../../../layout/button/button.component';
+import { Transaction } from '../../../../../../app.datatypes';
+import { StorageService, StorageType } from '../../../../../../services/storage.service';
+import { showSnackbarError } from '../../../../../../utils/errors';
+
+@Component({
+  selector: 'app-change-note',
+  templateUrl: './change-note.component.html',
+  styleUrls: ['./change-note.component.scss'],
+})
+export class ChangeNoteComponent implements OnInit, OnDestroy {
+
+  public static readonly MAX_NOTE_CHARS = 64;
+
+  @ViewChild('button') button: ButtonComponent;
+  form: FormGroup;
+  maxNoteChars = ChangeNoteComponent.MAX_NOTE_CHARS;
+
+  private OperationSubscription: ISubscription;
+  private originalNote: string;
+
+  constructor(
+    public dialogRef: MatDialogRef<ChangeNoteComponent>,
+    @Inject(MAT_DIALOG_DATA) private data: Transaction,
+    private formBuilder: FormBuilder,
+    private snackbar: MatSnackBar,
+    private storageService: StorageService,
+  ) {}
+
+  ngOnInit() {
+    this.originalNote = this.data.note ? this.data.note : '';
+
+    this.form = this.formBuilder.group({
+      note: [this.data.note],
+    });
+  }
+
+  ngOnDestroy() {
+    this.snackbar.dismiss();
+    if (this.OperationSubscription) {
+      this.OperationSubscription.unsubscribe();
+    }
+  }
+
+  closePopup() {
+    this.dialogRef.close();
+  }
+
+  changeNote() {
+    if (this.button.isLoading()) {
+      return;
+    }
+
+    const newNote = this.form.value.note ? this.form.value.note.trim() : '';
+
+    if (this.originalNote === newNote) {
+      this.closePopup();
+      return;
+    }
+
+    this.snackbar.dismiss();
+    this.button.setLoading();
+
+    this.OperationSubscription = this.storageService.store(StorageType.NOTES, this.data.txid, newNote).subscribe(() => {
+      this.dialogRef.close(newNote);
+    }, error => {
+      showSnackbarError(this.snackbar, error);
+      this.button.resetState().setEnabled();
+    });
+  }
+}

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/transaction-info.component.html
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/transaction-info.component.html
@@ -31,6 +31,12 @@
         <div class="-data" *ngIf="!isPreview">
           <span>{{ 'tx.id' | translate }}:</span> <span>{{ transaction.txid }}</span>
         </div>
+        <div class="-data" *ngIf="transaction.note || !isPreview">
+          <span>{{ 'tx.note' | translate }}:</span>
+          <span *ngIf="transaction.note">{{ transaction.note }}</span>
+          <span *ngIf="!transaction.note" class="-grey">{{ 'tx.without-note' | translate }}</span>
+          <mat-icon (click)="editNote()" *ngIf="!isPreview">edit</mat-icon>
+        </div>
       </div>
 
       <div class="col-md-3 -tx-price">

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/transaction-info.component.scss
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/transaction-info.component.scss
@@ -50,8 +50,19 @@ h4 {
     width: 60px;
     flex-shrink: 0;
   }
-  span:last-child {
-    word-break: break-all;
+  span:nth-child(2) {
+    word-break: break-word;
+  }
+
+  mat-icon {
+    font-size: 20px;
+    padding-left: 5px;
+    color: $gradient-blue-dark;
+    cursor: pointer;
+  }
+
+  .-grey {
+    color: $grey;
   }
 
   &.-more {

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/transaction-info.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-preview/transaction-info/transaction-info.component.ts
@@ -3,6 +3,8 @@ import { PreviewTransaction, Transaction } from '../../../../../app.datatypes';
 import { PriceService } from '../../../../../services/price.service';
 import { ISubscription } from 'rxjs/Subscription';
 import { BigNumber } from 'bignumber.js';
+import { MatDialogConfig, MatDialog } from '@angular/material';
+import { ChangeNoteComponent } from './change-note/change-note.component';
 
 @Component({
   selector: 'app-transaction-info',
@@ -17,7 +19,7 @@ export class TransactionInfoComponent implements OnInit, OnDestroy {
 
   private subscription: ISubscription;
 
-  constructor(private priceService: PriceService) {
+  constructor(private priceService: PriceService, private dialog: MatDialog) {
     this.subscription = this.priceService.price.subscribe(price => this.price = price);
   }
 
@@ -54,5 +56,16 @@ export class TransactionInfoComponent implements OnInit, OnDestroy {
     event.preventDefault();
 
     this.showInputsOutputs = !this.showInputsOutputs;
+  }
+
+  editNote() {
+    const config = new MatDialogConfig();
+      config.width = '566px';
+      config.data = this.transaction;
+      this.dialog.open(ChangeNoteComponent, config).afterClosed().subscribe(newNote => {
+        if (newNote || newNote === '') {
+          this.transaction.note = newNote;
+        }
+      });
   }
 }

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-skycoin.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-skycoin.component.ts
@@ -49,6 +49,7 @@ export class SendSkycoinComponent implements OnDestroy {
     transaction.from = this.formData.form.wallet.label;
     transaction.to = this.formData.to;
     transaction.balance = this.formData.amount;
+    transaction.note = this.formData.form.note;
 
     return transaction;
   }

--- a/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.html
+++ b/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.html
@@ -81,6 +81,9 @@
             <img src="../../../../assets/img/qr-code-black.png" (click)="showQrCode($event, address)" class="qr-code-button">
             <span>{{ address }}</span>
           </div>
+          <div class="-item" *ngIf="transaction.note">
+            <span>{{ 'history.note' | translate }}: <span class="note">{{ transaction.note }}</span></span>
+          </div>
         </div>
         <div class="-balance">
           <h4>{{ transaction.balance.decimalPlaces(6).toString() | number:'1.0-6' }} {{ 'common.coin-id' | translate }}</h4>

--- a/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.scss
+++ b/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.scss
@@ -173,6 +173,12 @@ mat-option ::ng-deep .mat-pseudo-checkbox-checked {
         line-height: 15px;
         margin: 0;
       }
+
+      .note {
+        color: #1e2227;
+        word-break: break-word;
+        display: inline;
+      }
     }
   }
 

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -173,7 +173,8 @@
     "from-label": "Send from",
     "to-label": "Send to",
     "amount-label": "Amount",
-    "notes-label": "Notes",
+    "personal-note-label": "Personal note",
+    "personal-note-help": "Use this field to add a text for allowing you to identify the transaction in the future. This text is saved locally, so it will only be visible from this computer",
     "wallet-label": "Wallet",
     "addresses-label": "Addresses",
     "invalid-amount": "Please enter a valid amount",
@@ -201,7 +202,8 @@
     "back-button": "Back",
     "simple": "Simple",
     "advanced": "Advanced",
-    "select-wallet": "Select Wallet"
+    "select-wallet": "Select Wallet",
+    "error-saving-note": "The transaction was successfully sent, but it was not possible to save the note."
   },
 
   "reset": {
@@ -222,6 +224,8 @@
     "coins": "Coins",
     "hours": "Hours",
     "id": "Tx ID",
+    "note": "Note",
+    "without-note": "Without note",
     "show-more": "Show more",
     "hours-moved": "moved",
     "hours-sent": "sent",
@@ -232,6 +236,12 @@
     "confirmed": "Confirmed",
     "pending": "Pending",
     "current-rate": "Calculated at the current rate"
+  },
+
+  "edit-note": {
+    "title": "Edit note",
+    "cancel-button": "Cancel",
+    "change-button": "Change"
   },
 
   "backup": {
@@ -290,6 +300,7 @@
     "received": "Received",
     "receiving": "Receiving",
     "pending": "Pending",
+    "note": "Note",
     "no-txs": "You have no transaction history",
     "no-txs-filter": "There are no transactions matching the current filter criteria",
     "no-filter": "No filter active (press to select wallets/addresses)",


### PR DESCRIPTION
Fixes #2296

Changes:
- Now the user can add a note when creating a transaction, with the simple and advanced forms.

- The notes are saved locally with the `/data` api endpoint.

- The user can see the notes in the history.

- The user can modify the notes at any time.

- As the procedures for injecting the transaction and saving the note are different, the code first injects the tx and then saves the note. If the transaction is sent but the note is not saved, a message indicating that is shown.

- It is possible to add notes to old transactions to which no notes were added before.

Does this change need to mentioned in CHANGELOG.md?
No