### PR TITLE
Small fixes for the hw wallet integration

### DIFF
--- a/src/gui/static/src/app/components/pages/wallets/change-name/change-name.component.html
+++ b/src/gui/static/src/app/components/pages/wallets/change-name/change-name.component.html
@@ -7,7 +7,7 @@
       </div>
     </div>
     <div class="-buttons">
-      <app-button (action)="closePopup()">
+      <app-button (action)="closePopup()" [disabled]="button && button.isLoading()">
         {{ 'wallet.rename.cancel-button' | translate }}
       </app-button>
       <app-button (action)="rename()" class="primary" [disabled]="!form.valid" #button>

--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
@@ -130,6 +130,8 @@ export class WalletDetailComponent implements OnDestroy {
   }
 
   deleteWallet() {
+    this.snackbar.dismiss();
+
     const confirmationData: ConfirmationData = {
       text: this.translateService.instant('wallet.delete-confirmation', {name: this.wallet.label}),
       headerText: 'confirmation.header-text',
@@ -177,6 +179,8 @@ export class WalletDetailComponent implements OnDestroy {
   }
 
   confirmAddress(address, addressIndex, showCompleteConfirmation) {
+    this.snackbar.dismiss();
+
     this.hwWalletService.checkIfCorrectHwConnected(this.wallet.addresses[0].address).subscribe(response => {
       const data = new AddressConfirmationParams();
       data.address = address;

--- a/src/gui/static/src/app/services/hw-wallet-daemon.service.ts
+++ b/src/gui/static/src/app/services/hw-wallet-daemon.service.ts
@@ -31,11 +31,7 @@ export class HwWalletDaemonService {
     private hwWalletPinService: HwWalletPinService,
     private hwWalletSeedWordService: HwWalletSeedWordService,
     private ngZone: NgZone,
-  ) {
-    if (AppConfig.useHwWalletDaemon) {
-      this.checkHw(false);
-    }
-  }
+  ) { }
 
   get(route: string) {
     return this.checkResponse(this.http.get(

--- a/src/gui/static/src/app/services/hw-wallet-daemon.service.ts
+++ b/src/gui/static/src/app/services/hw-wallet-daemon.service.ts
@@ -65,7 +65,7 @@ export class HwWalletDaemonService {
 
   private checkResponse(response: Observable<any>, checkingConnected = false, smallTimeout = false) {
     return response
-      .timeout(smallTimeout ? 3000 : 50000)
+      .timeout(smallTimeout ? 5000 : 50000)
       .flatMap((res: any) => {
         const finalResponse = res.json();
 


### PR DESCRIPTION
Fixes #2379

Changes:
- Now the procedure that periodically checks if the hw wallet is connected does not start running just after opening the app, but only after getting a response from the daemon.

- Now the snackbar is closed before starting some operations in `WalletDetailComponent`

Does this change need to mentioned in CHANGELOG.md?
No