### PR TITLE
Show the hw wallet firmware version in the GUI

### DIFF
--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-message/hw-message.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-message/hw-message.component.html
@@ -17,5 +17,8 @@
     <div *ngIf="lowerBigText">
       <span class="big-text">{{ lowerBigText }}</span>
     </div>
+    <div *ngIf="lowerLightText">
+      <span class="-grey">{{ lowerLightText }}</span>
+    </div>
   </div>
 </div>

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-message/hw-message.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-message/hw-message.component.ts
@@ -22,6 +22,7 @@ export class HwMessageComponent {
   @Input() linkText: string;
   @Input() upperBigText: string;
   @Input() lowerBigText: string;
+  @Input() lowerLightText: string;
   @Output() linkClicked = new EventEmitter();
 
   icons = MessageIcons;

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-options-dialog/hw-options-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-options-dialog/hw-options-dialog.component.html
@@ -36,12 +36,14 @@
   <div *ngIf="currentState === states.NewConnected || currentState === states.ConfiguredConnected">
     <app-hw-message *ngIf="currentState === states.NewConnected"
       [upperBigText]="'hardware-wallet.options.unconfigured-detected-title' | translate"
+      [lowerLightText]="('hardware-wallet.options.firmware-version' | translate) + firmwareVersion"
       [text]="'hardware-wallet.options.unconfigured-detected' | translate"
       [icon]="msgIcons.HardwareWallet"
     ></app-hw-message>
 
     <app-hw-message *ngIf="currentState === states.ConfiguredConnected"
       [text]="'hardware-wallet.options.configured-detected' | translate"
+      [lowerLightText]="('hardware-wallet.options.firmware-version' | translate) + firmwareVersion"
       [lowerBigText]="walletName"
       [icon]="msgIcons.HardwareWallet"
     ></app-hw-message>

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-options-dialog/hw-options-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-options-dialog/hw-options-dialog.component.ts
@@ -47,6 +47,7 @@ export class HwOptionsDialogComponent extends HwDialogBaseComponent<HwOptionsDia
   states = States;
   walletName = '';
   customErrorMsg = '';
+  firmwareVersion = '';
 
   securityWarnings: string[] = [];
   firmwareVersionNotVerified: boolean;
@@ -184,6 +185,8 @@ export class HwOptionsDialogComponent extends HwDialogBaseComponent<HwOptionsDia
       if (!dontUpdateWallet) {
         this.walletName = this.wallet.label;
       }
+
+      this.firmwareVersion = response.features.fw_major + '.' + response.features.fw_minor + '.' + response.features.fw_patch;
 
       return response;
     });

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -388,7 +388,8 @@
       "change-pin": "Change PIN code",
       "delete-pin": "Delete PIN code",
       "forgotten-pin1": "If you can not access the wallet because you have forgotten the PIN, you can wipe the hardware wallet and then restore it with the seed by clicking",
-      "forgotten-pin2": "here."
+      "forgotten-pin2": "here.",
+      "firmware-version": "Device firmware version: "
     },
     "update-firmware-warning" : {
       "title": "Outdated Firmware",


### PR DESCRIPTION
Changes:
- Now the hw wallet firmware version is shown in the hw wallet options window, in a light colored text:
![version](https://user-images.githubusercontent.com/34079003/58839980-eda45480-8631-11e9-96aa-7de577770e9b.png)


Does this change need to mentioned in CHANGELOG.md?
No