### PR TITLE
Make the hw wallet integration work in prod builds

### DIFF
--- a/src/gui/static/.angular-cli.json
+++ b/src/gui/static/.angular-cli.json
@@ -31,8 +31,7 @@
       "environmentSource": "environments/environment.ts",
       "environments": {
         "dev": "environments/environment.ts",
-        "prod": "environments/environment.prod.ts",
-        "prod-hw": "environments/environment.ts"
+        "prod": "environments/environment.prod.ts"
       }
     }
   ],

--- a/src/gui/static/package.json
+++ b/src/gui/static/package.json
@@ -6,7 +6,6 @@
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.config.js --delete-output-path false",
     "build": "ng build --prod",
-    "build-prod-hw": "ng build --prod --environment prod-hw",
     "build-travis": "ng build --prod --output-path=$BUILD_UI_TRAVIS_DIR",
     "test": "ng test --watch=false",
     "lint": "ng lint",

--- a/src/gui/static/src/app/services/hw-wallet.service.ts
+++ b/src/gui/static/src/app/services/hw-wallet.service.ts
@@ -147,9 +147,9 @@ export class HwWalletService {
 
   get hwWalletCompatibilityActivated(): boolean {
     if (!AppConfig.useHwWalletDaemon) {
-      return !environment.production && window['isElectron'] && window['ipcRenderer'].sendSync('hwCompatibilityActivated');
+      return window['isElectron'] && window['ipcRenderer'].sendSync('hwCompatibilityActivated');
     } else {
-      return !environment.production;
+      return true;
     }
   }
 


### PR DESCRIPTION
Changes:
- Now the hw wallet integration works in both dev and prod buils, so it is a bit easier to test it.

- The special build mode that allowed to build the wallet in prod mode with the hw wallet integration enabled was removed, as it is not longer needed.

Does this change need to mentioned in CHANGELOG.md?
No