### PR TITLE
Travis deploy on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,4 +90,4 @@ deploy:
   region: $AWS_REGION
   on:
     repo: skycoin/skycoin
-    branch: master
+    tags: true


### PR DESCRIPTION
Fixes #2392 

Changes:
- Update to make the travis deploy only when the build is a tagged build.

Does this change need to mentioned in CHANGELOG.md?
No