### PR TITLE
Improve the hw wallet firmware updater UX

### DIFF
--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-options-dialog/hw-options-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-options-dialog/hw-options-dialog.component.ts
@@ -77,6 +77,7 @@ export class HwOptionsDialogComponent extends HwDialogBaseComponent<HwOptionsDia
   ngOnDestroy() {
     super.ngOnDestroy();
     this.removeDialogSubscription();
+    this.removeOperationSubscription();
   }
 
   hwConnectionChanged(connected: boolean) {
@@ -196,14 +197,12 @@ export class HwOptionsDialogComponent extends HwDialogBaseComponent<HwOptionsDia
     this.wallet = null;
     this.currentState = States.Processing;
 
-    this.hwWalletService.getDeviceConnected().subscribe(connected => {
+    this.removeOperationSubscription();
+
+    this.operationSubscription = this.hwWalletService.getDeviceConnected().subscribe(connected => {
       if (!connected) {
         this.currentState = States.Disconnected;
       } else {
-        if (this.operationSubscription) {
-          this.operationSubscription.unsubscribe();
-        }
-
         this.operationSubscription = this.hwWalletService.getAddresses(1, 0).subscribe(
           response => {
             this.walletService.wallets.first().subscribe(wallets => {
@@ -268,6 +267,12 @@ export class HwOptionsDialogComponent extends HwDialogBaseComponent<HwOptionsDia
         this.currentState = States.Error;
       }
     });
+  }
+
+  private removeOperationSubscription() {
+    if (this.operationSubscription) {
+      this.operationSubscription.unsubscribe();
+    }
   }
 
   private openUpdateWarning() {

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-options-dialog/hw-options-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-options-dialog/hw-options-dialog.component.ts
@@ -77,7 +77,6 @@ export class HwOptionsDialogComponent extends HwDialogBaseComponent<HwOptionsDia
   ngOnDestroy() {
     super.ngOnDestroy();
     this.removeDialogSubscription();
-    this.removeOperationSubscription();
   }
 
   hwConnectionChanged(connected: boolean) {
@@ -197,12 +196,14 @@ export class HwOptionsDialogComponent extends HwDialogBaseComponent<HwOptionsDia
     this.wallet = null;
     this.currentState = States.Processing;
 
-    this.removeOperationSubscription();
-
-    this.operationSubscription = this.hwWalletService.getDeviceConnected().subscribe(connected => {
+    this.hwWalletService.getDeviceConnected().subscribe(connected => {
       if (!connected) {
         this.currentState = States.Disconnected;
       } else {
+        if (this.operationSubscription) {
+          this.operationSubscription.unsubscribe();
+        }
+
         this.operationSubscription = this.hwWalletService.getAddresses(1, 0).subscribe(
           response => {
             this.walletService.wallets.first().subscribe(wallets => {
@@ -267,12 +268,6 @@ export class HwOptionsDialogComponent extends HwDialogBaseComponent<HwOptionsDia
         this.currentState = States.Error;
       }
     });
-  }
-
-  private removeOperationSubscription() {
-    if (this.operationSubscription) {
-      this.operationSubscription.unsubscribe();
-    }
   }
 
   private openUpdateWarning() {

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-update-firmware-dialog/hw-update-firmware-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-update-firmware-dialog/hw-update-firmware-dialog.component.html
@@ -25,7 +25,7 @@
 
   <div *ngIf="currentState !== states.Initial">
     <app-hw-message *ngIf="currentState === states.Connecting"
-      [text]="'hardware-wallet.options.connecting' | translate"
+      [text]="'hardware-wallet.update-firmware.title-connecting' | translate"
       [icon]="msgIcons.Spinner"
     ></app-hw-message>
 

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-update-firmware-dialog/hw-update-firmware-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-update-firmware-dialog/hw-update-firmware-dialog.component.html
@@ -1,11 +1,11 @@
-<app-modal class="modal" [headline]="'hardware-wallet.update-firmware.title' | translate" [dialog]="dialogRef" [disableDismiss]="currentState === states.Processing">
+<app-modal class="modal" [headline]="this.title | translate" [dialog]="dialogRef" [disableDismiss]="currentState === states.Processing">
   <div *ngIf="currentState === states.Initial">
     <app-hw-message
-      [text]="'hardware-wallet.update-firmware.text' | translate"
-      [icon]="msgIcons.Warning"
+      [text]="(text | translate)"
+      [icon]="deviceHasFirmware ? msgIcons.Warning : msgIcons.HardwareWallet"
     ></app-hw-message>
 
-    <div class="-check-container">
+    <div class="-check-container" *ngIf="deviceHasFirmware">
       <mat-checkbox type="checkbox"
                     class="-check"
                     [checked]="confirmed"
@@ -17,15 +17,20 @@
       <app-button (action)="closeModal()" [disabled]="currentState === states.Processing">
         {{ 'hardware-wallet.general.cancel' | translate }}
       </app-button>
-      <app-button (action)="startUpdating()" class="primary" [disabled]="!confirmed" #button>
+      <app-button (action)="startUpdating()" class="primary" [disabled]="deviceHasFirmware && !confirmed" #button>
         {{ 'hardware-wallet.general.continue' | translate }}
       </app-button>
     </div>
   </div>
 
   <div *ngIf="currentState !== states.Initial">
-      <app-hw-message *ngIf="currentState === states.Processing"
-      [text]="'hardware-wallet.general.confirm' | translate"
+    <app-hw-message *ngIf="currentState === states.Connecting"
+      [text]="'hardware-wallet.options.connecting' | translate"
+      [icon]="msgIcons.Spinner"
+    ></app-hw-message>
+
+     <app-hw-message *ngIf="currentState === states.Processing"
+      [text]="'hardware-wallet.general.follow' | translate"
       [icon]="msgIcons.Confirm"
     ></app-hw-message>
 

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-update-firmware-dialog/hw-update-firmware-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-update-firmware-dialog/hw-update-firmware-dialog.component.ts
@@ -6,8 +6,11 @@ import { ButtonComponent } from '../../button/button.component';
 import { MatSnackBar } from '@angular/material';
 import { showSnackbarError, getHardwareWalletErrorMsg } from '../../../../utils/errors';
 import { TranslateService } from '@ngx-translate/core';
+import { ISubscription } from 'rxjs/Subscription';
+import { Observable } from 'rxjs/Observable';
 
 enum States {
+  Connecting,
   Initial,
   Processing,
   ReturnedSuccess,
@@ -25,9 +28,37 @@ export class HwUpdateFirmwareDialogComponent extends HwDialogBaseComponent<HwUpd
 
   @ViewChild('button') button: ButtonComponent;
 
-  currentState: States = States.Initial;
+  currentState: States = States.Connecting;
   states = States;
   confirmed = false;
+
+  deviceInBootloaderMode = false;
+  deviceHasFirmware = true;
+
+  private checkDeviceSubscription: ISubscription;
+  private mustCheckDevice = true;
+
+  get title(): string {
+    if (this.currentState === States.Connecting) {
+      return 'hardware-wallet.update-firmware.title-connecting';
+    } else if (this.deviceHasFirmware) {
+      return 'hardware-wallet.update-firmware.title-update';
+    }
+
+    return 'hardware-wallet.update-firmware.title-install';
+  }
+
+  get text(): string {
+    if (!this.deviceHasFirmware) {
+      return 'hardware-wallet.update-firmware.text-no-firmware';
+    }
+
+    if (this.deviceInBootloaderMode) {
+      return 'hardware-wallet.update-firmware.text-bootloader';
+    }
+
+    return 'hardware-wallet.update-firmware.text-not-bootloader';
+  }
 
   constructor(
     public dialogRef: MatDialogRef<HwUpdateFirmwareDialogComponent>,
@@ -36,11 +67,14 @@ export class HwUpdateFirmwareDialogComponent extends HwDialogBaseComponent<HwUpd
     private translateService: TranslateService,
   ) {
     super(hwWalletService, dialogRef);
+    this.checkDevice(false);
   }
 
   ngOnDestroy() {
     super.ngOnDestroy();
     this.snackbar.dismiss();
+    this.mustCheckDevice = false;
+    this.closeCheckDeviceSubscription();
   }
 
   setConfirmed(event) {
@@ -50,6 +84,9 @@ export class HwUpdateFirmwareDialogComponent extends HwDialogBaseComponent<HwUpd
   startUpdating() {
     this.snackbar.dismiss();
     this.currentState = States.Processing;
+
+    this.mustCheckDevice = false;
+    this.closeCheckDeviceSubscription();
 
     this.operationSubscription = this.hwWalletService.updateFirmware().subscribe(
       () => {
@@ -74,9 +111,45 @@ export class HwUpdateFirmwareDialogComponent extends HwDialogBaseComponent<HwUpd
             });
           }
 
+          this.mustCheckDevice = true;
+          this.checkDevice(false);
+
           this.currentState = States.Initial;
         }
       },
     );
+  }
+
+  private checkDevice(delay = true) {
+    this.closeCheckDeviceSubscription();
+
+    this.checkDeviceSubscription = Observable.of(0).delay(delay ? 1000 : 0).flatMap(() => this.hwWalletService.getFeatures(false)).subscribe(response => {
+      this.deviceInBootloaderMode = response.rawResponse.bootloader_mode;
+      this.deviceHasFirmware = response.rawResponse.firmware_present;
+
+      if (this.currentState === States.Connecting) {
+        this.currentState = States.Initial;
+      }
+
+      if (this.mustCheckDevice) {
+        this.checkDevice();
+      }
+    }, err => {
+      this.deviceInBootloaderMode = false;
+
+      if (this.currentState === States.Connecting) {
+        this.currentState = States.Initial;
+      }
+
+      if (this.mustCheckDevice) {
+        this.checkDevice();
+      }
+    });
+  }
+
+  private closeCheckDeviceSubscription() {
+    if (this.checkDeviceSubscription) {
+      this.checkDeviceSubscription.unsubscribe();
+    }
   }
 }

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -398,8 +398,12 @@
       "update": "Update"
     },
     "update-firmware" : {
-      "title": "Update Firmware",
-      "text": "To update the firmware of your hardware wallet you must connect it in firmware mode (connect it to the computer while pressing the two physical buttons of the device). WARNING: before continuing you must have a backup of your seed or you can permanently lose access to the funds.",
+      "title-connecting": "Connecting...",
+      "title-update": "Update Firmware",
+      "title-install": "Install Firmware",
+      "text-bootloader": "WARNING: if you have already configured this device, before continuing you must have a backup of your seed or you could permanently lose access to the funds.",
+      "text-not-bootloader": "To update the firmware of your hardware wallet you must connect it in bootloader mode (connect it to the computer while pressing the two physical buttons of the device). WARNING: if you have already configured this device, before continuing you must have a backup of your seed or you could permanently lose access to the funds.",
+      "text-no-firmware": "Welcome. The currently connected wallet hardware does not have a firmware (internal software), we will install one so you can start using it. NOTE: if you have already configured this device and want to recover the funds, you will need your seed.",
       "check": "I understand the risks and want to continue",
       "completed": "The firmware update has been sent to the hardware wallet. Please continue the process on the device.",
       "connection-error": "It was not possible download the firmware. This could be due to problems with your internet connection or because the service is in maintenance.",


### PR DESCRIPTION
Changes:
- Now the hw wallet firmware updater checks the state of the connected device and shows different messages to the user depending on what the user should do. This is more important after knowing that the devices may not have a firmware, but just a bootloader, so the messages must be more specific to be able to have a good UX.

Does this change need to mentioned in CHANGELOG.md?
No