### PR TITLE
Check the addresses coming out from the hardware wallet

### DIFF
--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-added-dialog/hw-added-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-added-dialog/hw-added-dialog.component.html
@@ -24,7 +24,7 @@
   </div>
 
   <div class="-buttons" *ngIf="currentState === states.Finished || currentState === states.Failed">
-    <app-button (action)="saveNameAndCloseModal()" class="primary" [disabled]="!form.valid">
+    <app-button (action)="currentState === states.Finished ? saveNameAndCloseModal() : closeModal()" class="primary" [disabled]="currentState === states.Finished && !form.valid">
       {{ 'hardware-wallet.general.close' | translate }}
     </app-button>
   </div>

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-added-dialog/hw-added-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-added-dialog/hw-added-dialog.component.ts
@@ -55,7 +55,10 @@ export class HwAddedDialogComponent extends HwDialogBaseComponent<HwAddedDialogC
         this.currentState = States.Finished;
         this.data.requestOptionsComponentRefresh();
       });
-    }, () => {
+    }, err => {
+      if (err['_body']) {
+        this.errorMsg = err['_body'];
+      }
       this.currentState = States.Failed;
       this.data.requestOptionsComponentRefresh(this.errorMsg);
     });

--- a/src/gui/static/src/app/services/hw-wallet.service.ts
+++ b/src/gui/static/src/app/services/hw-wallet.service.ts
@@ -230,6 +230,24 @@ export class HwWalletService {
           ),
         );
       }
+    }).flatMap(response => {
+      return this.verifyAddresses(response.rawResponse, 0)
+        .catch(() => Observable.throw({ _body: this.translate.instant('hardware-wallet.errors.invalid-address-generated') }))
+        .map(() => response);
+    });
+  }
+
+  private verifyAddresses(addresses: string[], currentIndex: number): Observable<any> {
+    const params = {
+      address: addresses[currentIndex],
+    }
+
+    return this.apiService.post('address/verify', params, {}, true).flatMap(() => {
+      if (currentIndex !== addresses.length - 1) {
+        return this.verifyAddresses(addresses, currentIndex + 1);
+      } else {
+        return Observable.of(0);
+      }
     });
   }
 

--- a/src/gui/static/src/app/services/hw-wallet.service.ts
+++ b/src/gui/static/src/app/services/hw-wallet.service.ts
@@ -240,7 +240,7 @@ export class HwWalletService {
   private verifyAddresses(addresses: string[], currentIndex: number): Observable<any> {
     const params = {
       address: addresses[currentIndex],
-    }
+    };
 
     return this.apiService.post('address/verify', params, {}, true).flatMap(() => {
       if (currentIndex !== addresses.length - 1) {

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -355,6 +355,7 @@
       "too-many-inputs-outputs": "The transaction has too many inputs or outputs for the hardware wallet. Please try again creating several smaller transactions, each one with a smaller number of recipients (if the current transaction has many) or coins.",
       "daemon-connection": "Problem connecting to the hardware wallet service.",
       "timeout": "The operation was cancelled due to inactivity.",
+      "invalid-address-generated": "There was a problem with the address generator and the operation had to be canceled for security.",
       "invalid-address": "Invalid address.",
       "not-in-firmware-mode": "To use this option the hardware wallet must be in firmware mode."
     },


### PR DESCRIPTION
Fixes #2233

Changes:
- Now all the addresses returned by the hw wallet are checked with the `/api/v2/address/verify` API endpoint, as an additional security measure. If the check fails, the operation is cancelled.

- Some small fixes for the code that shows errors when adding a new wallet to the wallets list.

Does this change need to mentioned in CHANGELOG.md?
No