### PR TITLE
Show the tx details in the UI when confirming a tx in the hw wallet

### DIFF
--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-confirm-tx-dialog/hw-confirm-tx-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-confirm-tx-dialog/hw-confirm-tx-dialog.component.html
@@ -1,6 +1,8 @@
 <app-modal class="modal" [headline]="'hardware-wallet.create-tx.title' | translate" [dialog]="dialogRef" [disableDismiss]="true">
   <app-hw-message
-    [text]="'hardware-wallet.general.confirm' | translate"
+    [text]="'hardware-wallet.create-tx.upper-text' | translate"
+    [lowerText]="'hardware-wallet.create-tx.lower-text' | translate"
     [icon]="msgIcons.Confirm"
+    [outputsList]="data"
   ></app-hw-message>
 </app-modal>

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-confirm-tx-dialog/hw-confirm-tx-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-confirm-tx-dialog/hw-confirm-tx-dialog.component.ts
@@ -1,6 +1,6 @@
-import { Component } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
-import { HwWalletService } from '../../../../services/hw-wallet.service';
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { HwWalletService, TxData } from '../../../../services/hw-wallet.service';
 import { HwDialogBaseComponent } from '../hw-dialog-base.component';
 
 @Component({
@@ -11,6 +11,7 @@ import { HwDialogBaseComponent } from '../hw-dialog-base.component';
 export class HwConfirmTxDialogComponent extends HwDialogBaseComponent<HwConfirmTxDialogComponent> {
 
   constructor(
+    @Inject(MAT_DIALOG_DATA) public data: TxData[],
     public dialogRef: MatDialogRef<HwConfirmTxDialogComponent>,
     hwWalletService: HwWalletService,
   ) {

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-message/hw-message.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-message/hw-message.component.html
@@ -14,6 +14,14 @@
     </div>
     <span *ngIf="text">{{ text }}</span>
     <span *ngIf="linkText" class="link" (click)="activateLink()">{{ linkText }}</span>
+    <div *ngIf="outputsList" class="list">
+      <div *ngFor="let output of outputsList" class="list-element">
+        <span>• {{ output.coins.decimalPlaces(6).toString() }} {{ 'common.coin-id' | translate }}</span>
+        <span>{{ 'hardware-wallet.create-tx.send-p1' | translate }} {{ output.hours.decimalPlaces(0).toString() }} {{ 'common.coin-hours' | translate }}</span>
+        <span>{{ 'hardware-wallet.create-tx.send-p2' | translate }} {{ output.address }}</span>
+      </div>
+    </div>
+    <span *ngIf="lowerText">{{ lowerText }}</span>
     <div *ngIf="lowerBigText">
       <span class="big-text">{{ lowerBigText }}</span>
     </div>

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-message/hw-message.component.scss
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-message/hw-message.component.scss
@@ -35,6 +35,17 @@
       color: $blue;
       cursor: pointer;
     }
+
+    .list {
+      padding: 10px 0;
+
+      .list-element {
+        margin: 10px 0;
+        font-size: 12px;
+        color: #000000;
+        font-weight: bold;
+      }
+    }
   }
 
   .-red {

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-message/hw-message.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-message/hw-message.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { TxData } from '../../../../services/hw-wallet.service';
 
 export enum MessageIcons {
   None,
@@ -19,6 +20,8 @@ export enum MessageIcons {
 export class HwMessageComponent {
   @Input() icon: MessageIcons = MessageIcons.HardwareWallet;
   @Input() text: string;
+  @Input() outputsList: TxData[];
+  @Input() lowerText: string;
   @Input() linkText: string;
   @Input() upperBigText: string;
   @Input() lowerBigText: string;

--- a/src/gui/static/src/app/services/hw-wallet.service.ts
+++ b/src/gui/static/src/app/services/hw-wallet.service.ts
@@ -35,6 +35,12 @@ export enum OperationResults {
   NotInFirmwareMode,
 }
 
+export class TxData {
+  address: string;
+  coins: BigNumber;
+  hours: BigNumber;
+}
+
 export class OperationResult {
   result: OperationResults;
   rawResponse: any;
@@ -483,8 +489,22 @@ export class HwWalletService {
   }
 
   signTransaction(inputs: any, outputs: any): Observable<OperationResult> {
+
+    const previewData: TxData[] = [];
+    outputs.forEach(output => {
+      if (output.address_index === undefined || output.address_index === null) {
+        const currentOutput = new TxData();
+        currentOutput.address = output.address;
+        currentOutput.coins = new BigNumber(output.coin).dividedBy(1000000);
+        currentOutput.hours = new BigNumber(output.hour);
+
+        previewData.push(currentOutput);
+      }
+    });
+
     this.signTransactionDialog = this.dialog.open(this.signTransactionConfirmationComponentInternal, <MatDialogConfig> {
-      width: '450px',
+      width: '560px',
+      data: previewData,
     });
 
     return this.cancelLastAction().flatMap(() => {

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -464,7 +464,11 @@
       "part3": "If you wish, you can also use the numpad on your keyboard to enter the PIN. However, as in the previous example, if the PIN is \"23\", you can not simply type \"23\" with the numpad, but you will have to press the keys that are in the position where the numbers 2 and 3 are shown on the screen of the hardware wallet."
     },
     "create-tx" : {
-      "title": "Create transaction"
+      "title": "Create transaction",
+      "upper-text": "Please confirm the operation in the hardware wallet after verifying if the following data matches EXACTLY with the transaction you wish to send and with those shown by the hardware wallet:",
+      "lower-text": "If any data does not correspond to what the hardware wallet shows or the transaction you wish to send, cancel the operation in your hardware wallet.",
+      "send-p1": "and",
+      "send-p2": "to"
     },
     "confirm-address" : {
       "title": "Confirm address",


### PR DESCRIPTION
Fixes #2400

Changes:
- Now, when creating a transaction with the hw wallet, the popup that ask the user to confirm the transaction in the device shows the data about the tx and more instructions:
![confirm](https://user-images.githubusercontent.com/34079003/59151480-db476380-8a01-11e9-8a93-8e1c818b9f02.png)

Does this change need to mentioned in CHANGELOG.md?
No