### PR TITLE
Allow to use up to 8 inputs and 8 outputs with the hw wallet

### DIFF
--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -409,10 +409,10 @@ export class WalletService {
       const data = useV2Endpoint ? transaction.data : transaction;
 
       if (wallet.isHardware) {
-        if (data.transaction.inputs.length > 7) {
+        if (data.transaction.inputs.length > 8) {
           throw new Error(this.translate.instant('hardware-wallet.errors.too-many-inputs-outputs'));
         }
-        if (data.transaction.outputs.length > 7) {
+        if (data.transaction.outputs.length > 8) {
           throw new Error(this.translate.instant('hardware-wallet.errors.too-many-inputs-outputs'));
         }
       }


### PR DESCRIPTION
Changes:
- Some time ago the hw wallet transactions were limited to 7 inputs and 7 outputs due to a problem with the JS library. However, the problem is not pressent in the hw wallet daemon, so this PR changes the limit to 8, the maximum amount possible with the hw wallet daemon.

Does this change need to mentioned in CHANGELOG.md?
No