### PR TITLE
Check pubkey validity in upper layer of secp256k1-go

### DIFF
--- a/src/cipher/secp256k1-go/secp256k1-go2/ec.go
+++ b/src/cipher/secp256k1-go/secp256k1-go2/ec.go
@@ -56,13 +56,7 @@ func RecoverPublicKey(sigBytes, msgBytes []byte, recid int) ([]byte, int) {
 		return nil, -6
 	}
 
-	pkb := pubkey.Bytes()
-
-	if PubkeyIsValid(pkb) != 1 {
-		return nil, -7
-	}
-
-	return pkb, 1
+	return pubkey.Bytes(), 1
 }
 
 // Multiply standard EC multiplication k(xy)

--- a/src/cipher/secp256k1-go/secp256k1.go
+++ b/src/cipher/secp256k1-go/secp256k1.go
@@ -408,8 +408,8 @@ func RecoverPubkey(msg []byte, sig []byte) []byte {
 	if pubkey == nil {
 		log.Panic("ERROR: impossible, pubkey nil and ret == 1")
 	}
-	if len(pubkey) != 33 {
-		log.Panic("pubkey length wrong")
+	if secp.PubkeyIsValid(pubkey) != 1 {
+		log.Panicf("secp.RecoverPublicKey returned invalid pubkey %s", hex.EncodeToString(pubkey))
 	}
 
 	return pubkey


### PR DESCRIPTION
This undoes a recent change, moving the validation of the pubkey to a different layer, so that we can panic on the unexpected condition rather than return an integer error