### PR TITLE
package bip44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Document the daemon's CLI options
 - Add the ability to save transaction notes
+- Add `package bip44`, implementing the bip44 spec https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
 
 ### Fixed
 

--- a/src/cipher/bip32/bip32_test.go
+++ b/src/cipher/bip32/bip32_test.go
@@ -1162,6 +1162,25 @@ func TestParsePath(t *testing.T) {
 	}
 }
 
+func TestMaxChildDepthError(t *testing.T) {
+	key, err := NewMasterKey(make([]byte, 32))
+	require.NoError(t, err)
+
+	reached := false
+	for i := 0; i < 256; i++ {
+		key, err = key.NewPrivateChildKey(0)
+		switch i {
+		case 255:
+			require.Equal(t, err, ErrMaxDepthReached)
+			reached = true
+		default:
+			require.NoError(t, err)
+		}
+	}
+
+	require.True(t, reached)
+}
+
 func TestImpossibleChildError(t *testing.T) {
 	baseErr := errors.New("foo")
 	childNumber := uint32(4)

--- a/src/cipher/bip39/bip39.go
+++ b/src/cipher/bip39/bip39.go
@@ -182,7 +182,7 @@ func EntropyFromMnemonic(mnemonic string) ([]byte, error) {
 	entropy := b.Bytes()
 	entropy = padByteSlice(entropy, len(words)/3*4)
 
-	// Generate the checksum and compare with the one we got from the mneomnic.
+	// Generate the checksum and compare with the one we got from the mnemonic.
 	entropyChecksumBytes := computeChecksum(entropy)
 	entropyChecksum := big.NewInt(int64(entropyChecksumBytes[0]))
 	if l := len(words); l != 24 {

--- a/src/cipher/bip44/bip44.go
+++ b/src/cipher/bip44/bip44.go
@@ -1,0 +1,88 @@
+/*
+Package bip44 implements the bip44 spec https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+*/
+package bip44
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/skycoin/skycoin/src/cipher/bip32"
+)
+
+// Bip44's bip32 path: m / purpose' / coin_type' / account' / change / address_index
+
+var (
+	// ErrInvalidCoinType coin_type is less than 0x80000000
+	ErrInvalidCoinType = errors.New("Invalid coin type")
+
+	// ErrInvalidAccount account is >= 0x80000000
+	ErrInvalidAccount = errors.New("account index must be < 0x80000000")
+)
+
+// CoinType is the coin_type part of the bip44 path
+type CoinType uint32
+
+const (
+	// CoinTypeBitcoin is the coin_type for Bitcoin
+	CoinTypeBitcoin CoinType = 0x80000000
+	// CoinTypeBitcoinTestnet is the coin_type for Skycoin
+	CoinTypeBitcoinTestnet CoinType = 0x80000001
+	// CoinTypeSkycoin is the coin_type for Skycoin
+	CoinTypeSkycoin CoinType = 0x88800000
+)
+
+// Coin is a bip32 node at the `coin_type` level of a bip44 path
+type Coin struct {
+	*bip32.PrivateKey
+}
+
+// NewCoin creates a bip32 node at the `coin_type` level of a bip44 path
+func NewCoin(seed []byte, coinType CoinType) (*Coin, error) {
+	if uint32(coinType) < bip32.FirstHardenedChild {
+		return nil, ErrInvalidCoinType
+	}
+
+	path := fmt.Sprintf("m/44'/%d'", uint32(coinType)-bip32.FirstHardenedChild)
+	pk, err := bip32.NewPrivateKeyFromPath(seed, path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Coin{
+		pk,
+	}, nil
+}
+
+// Account creates a bip32 node at the `account'` level of the bip44 path.
+// The account number should be as it would appear in the path string, without
+// the apostrophe that indicates hardening
+func (c *Coin) Account(account uint32) (*Account, error) {
+	if account >= bip32.FirstHardenedChild {
+		return nil, ErrInvalidAccount
+	}
+
+	pk, err := c.NewPrivateChildKey(account + bip32.FirstHardenedChild)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Account{
+		pk,
+	}, nil
+}
+
+// Account is a bip32 node at the `account` level of a bip44 path
+type Account struct {
+	*bip32.PrivateKey
+}
+
+// External returns the external chain node, to be used for receiving coins
+func (a *Account) External() (*bip32.PrivateKey, error) {
+	return a.NewPrivateChildKey(0)
+}
+
+// Change returns the change chain node, to be used for change addresses
+func (a *Account) Change() (*bip32.PrivateKey, error) {
+	return a.NewPrivateChildKey(1)
+}

--- a/src/cipher/bip44/bip44_test.go
+++ b/src/cipher/bip44/bip44_test.go
@@ -1,0 +1,74 @@
+package bip44
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skycoin/src/cipher/bip32"
+	"github.com/skycoin/skycoin/src/cipher/bip39"
+)
+
+func mustDefaultSeed(t *testing.T) []byte {
+	mnemonic := "dizzy cigar grant ramp inmate uniform gold success able payment faith practice"
+	passphrase := ""
+	seed, err := bip39.NewSeed(mnemonic, passphrase)
+	require.NoError(t, err)
+	require.Equal(t, "24e563fb095d766df3862c70432cc1b2210b24d232da69af7af09d2ec86d28782ce58035bae29994c84081836aebe36a9b46af1578262fefc53e37efbe94be57", hex.EncodeToString(seed))
+	return seed
+}
+
+func TestNewCoin(t *testing.T) {
+	// bad seed
+	_, err := NewCoin(make([]byte, 3), CoinTypeBitcoin)
+	require.Equal(t, err, bip32.ErrInvalidSeedLength)
+
+	// bad coin_type
+	_, err = NewCoin(mustDefaultSeed(t), CoinType(1))
+	require.Equal(t, err, ErrInvalidCoinType)
+
+	c, err := NewCoin(mustDefaultSeed(t), CoinTypeBitcoin)
+	require.NoError(t, err)
+
+	account, err := c.Account(0)
+	require.NoError(t, err)
+	require.Equal(t, "xprv9yKAFQtFghZSe4mfdpdqFm1WWmGeQbYMB4MSGUB85zbKGQgSxty4duZb8k6hNoHVd2UR7Y3QhWU3rS9wox9ewgVG7gDLyYTL4yzEuqUCjvF", account.String())
+	require.Equal(t, "xpub6CJWevR9X57jrYr8jrAqctxF4o78p4GCYHH34rajeL8J9D1bWSHKBht4yzwiTQ4FP4HyQpx99iLxvU54rbEbcxBUgxzTGGudBVXb1N2gcHF", account.PublicKey().String())
+
+	account, err = c.Account(1)
+	require.NoError(t, err)
+	require.Equal(t, "xprv9yKAFQtFghZSgShGXkxHsYQfFaqMyutf3izng8tV4Tmp7gidQUPB8kCuv66yukidivM2oSaUvGus8ffnYvYKChB7DME2H2AvUq8LM2rXUzF", account.String())
+	require.Equal(t, "xpub6CJWevR9X57jtvmjdnVJEgMPocfrPNcWQwvPUXJ6coJnzV3mx1hRgYXPmQJh5vLQvrVCY8LtJB5xLLiPJVmpSwBe2yhonQLoQuSsCF8YPLN", account.PublicKey().String())
+
+	_, err = c.Account(0x80000000)
+	require.Equal(t, err, ErrInvalidAccount)
+	_, err = c.Account(0x80000001)
+	require.Equal(t, err, ErrInvalidAccount)
+
+	external, err := account.External()
+	require.NoError(t, err)
+	require.Equal(t, "xprv9zjsvjLiqSerDzbeRXPeXwz8tuQ7eRUABkgFAgLPHw1KzGKkgBhJhGaMYHM8j2KDXBZTCv4m19qjxrrD7gusrtdpZ7xzJywdXHaMZEjf3Uv", external.String())
+	require.Equal(t, "xpub6DjELEscfpD9SUg7XYveu5vsSwEc3tC1Yybqy4jzrGYJs4euDj1ZF4tqPZYvViMn9cvBobHyubuuh69PZ1szaBBx5oxPiQzD492B6C4QDHe", external.PublicKey().String())
+
+	external0, err := external.NewPublicChildKey(0)
+	require.NoError(t, err)
+	require.Equal(t, "034d36f3bcd74e19204e75b81b9c0726e41b799858b92bab73f4cd7498308c5c8b", hex.EncodeToString(external0.Key))
+
+	external1, err := external.NewPublicChildKey(1)
+	require.NoError(t, err)
+	require.Equal(t, "02f7309e9f559d847ee9cc9ee144cfa490791e33e908fdbde2dade50a389408b01", hex.EncodeToString(external1.Key))
+
+	change, err := account.Change()
+	require.NoError(t, err)
+	require.Equal(t, "xprv9zjsvjLiqSerGzJyBrpZgCaGpQCeFDnZEuAV714WigmFyHT4nFLhZLeuHzLNE19PgkZeQ5Uf2pjFZjQTHbkugDbmw5TAPAvgo2jsaTnZo2A", change.String())
+	require.Equal(t, "xpub6DjELEscfpD9VUPSHtMa3LX1NS38egWQc865uPU8H2JEr5nDKnex78yP9GxhFr5cnCRgiQF1dkv7aR7moraPrv73KHwSkDaXdWookR1Sh9p", change.PublicKey().String())
+
+	change0, err := change.NewPublicChildKey(0)
+	require.NoError(t, err)
+	require.Equal(t, "026d3eb891e81ecabedfa8560166af383457aedaf172af9d57d00508faa5f57c4c", hex.EncodeToString(change0.Key))
+
+	change1, err := change.NewPublicChildKey(1)
+	require.NoError(t, err)
+	require.Equal(t, "02681b301293fdf0292cd679b37d60b92a71b389fd994b2b57c8daf99532bfb4a5", hex.EncodeToString(change1.Key))
+}

--- a/src/cipher/bip44/example_test.go
+++ b/src/cipher/bip44/example_test.go
@@ -1,0 +1,114 @@
+package bip44
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/skycoin/skycoin/src/cipher/bip39"
+)
+
+func Example() {
+	// Create a bip39 seed from a mnenomic
+	// import "github.com/skycoin/skycoin/src/cipher/bip39"
+	// mnemonic := bip39.NewDefaultMnemonic()
+	mnemonic := "dizzy cigar grant ramp inmate uniform gold success able payment faith practice"
+	passphrase := ""
+	seed, err := bip39.NewSeed(mnemonic, passphrase)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("bip39 seed")
+	fmt.Println(hex.EncodeToString(seed))
+
+	// Create a root node for Bitcoin
+	c, err := NewCoin(seed, CoinTypeBitcoin)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create an account node
+	fmt.Println("m/44'/0'/0'")
+	account, err := c.Account(0)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(account.PrivateKey)
+	fmt.Println(account.PublicKey())
+
+	// Create an external address node
+	fmt.Println("m/44'/0'/0'/0")
+	external, err := account.External()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(external)
+	fmt.Println(external.PublicKey())
+
+	// Create the first child of the external address chain
+	fmt.Println("m/44'/0'/0'/0/0")
+	external0, err := external.NewPrivateChildKey(0)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("pubkey:", hex.EncodeToString(external0.PublicKey().Key))
+
+	// Create the second child of the external address chain
+	fmt.Println("m/44'/0'/0'/0/1")
+	external1, err := external.NewPrivateChildKey(1)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("pubkey:", hex.EncodeToString(external1.PublicKey().Key))
+
+	// Create a change address node
+	fmt.Println("m/44'/0'/0'/1")
+	change, err := account.Change()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(change)
+	fmt.Println(change.PublicKey())
+
+	// Create the first child of the change address chain
+	fmt.Println("m/44'/0'/0'/1/0")
+	change0, err := change.NewPrivateChildKey(0)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("pubkey:", hex.EncodeToString(change0.PublicKey().Key))
+
+	// Create the second child of the change address chain
+	fmt.Println("m/44'/0'/0'/1/1")
+	change1, err := change.NewPrivateChildKey(1)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("pubkey:", hex.EncodeToString(change1.PublicKey().Key))
+
+	// Output: bip39 seed
+	// 24e563fb095d766df3862c70432cc1b2210b24d232da69af7af09d2ec86d28782ce58035bae29994c84081836aebe36a9b46af1578262fefc53e37efbe94be57
+	// m/44'/0'/0'
+	// xprv9yKAFQtFghZSe4mfdpdqFm1WWmGeQbYMB4MSGUB85zbKGQgSxty4duZb8k6hNoHVd2UR7Y3QhWU3rS9wox9ewgVG7gDLyYTL4yzEuqUCjvF
+	// xpub6CJWevR9X57jrYr8jrAqctxF4o78p4GCYHH34rajeL8J9D1bWSHKBht4yzwiTQ4FP4HyQpx99iLxvU54rbEbcxBUgxzTGGudBVXb1N2gcHF
+	// m/44'/0'/0'/0
+	// xprv9zeGUHRUFEwnEAY21z9XBWsY2LpS1ZKhViJt9dhTqsqb8wjnhP2B2rv2mXAzvcUnUnSNZTzTs2sEUSqxAXaD6ptwjrLAmFrRHw6QkwN7KEa
+	// xpub6DdcsnxN5cW5SecV81gXYepGaNevR23YrwEUx275QDNa1k4wEvLRafEWcpP5gKP3AkR67td8nx2PykEWxzUvJCgeoUKuM8px7uhAmYCQWEg
+	// m/44'/0'/0'/0/0
+	// pubkey: 021008142807feb53f67baa91c166d97cf74f7f059f3eb29f24ff8a6d1f2c80500
+	// m/44'/0'/0'/0/1
+	// pubkey: 020606c2577bb430dcaf405246e85456638dfb266d774c1e8386f9276892fd6fdc
+	// m/44'/0'/0'/1
+	// xprv9zeGUHRUFEwnGcomH56JtQ7Xp66GYMH3o77jHDfVaLG1gN6dVtDp7ndvEcpvEK7JjYg3sTkteV8FziQ3HGjzSp3KxAcFAy3u84EQFYDqkPq
+	// xpub6DdcsnxN5cW5V6tEP6dKFY4GN7vkwozuAL3L5c578fnzZARn3RY4faxQ5rqy1dR8mY8GUWoQJtLBLyXnFiGE9j3r4ShiVb12W5NPSmkgrpp
+	// m/44'/0'/0'/1/0
+	// pubkey: 030d61ebd6f36a4552127b35d1b8e13b1d8060534c6ccbb2f77c76cfbea56cf87f
+	// m/44'/0'/0'/1/1
+	// pubkey: 03513484252259b77c8aeb594e2cfd0437e1650da18fe6296be8a3aa3979313219
+}


### PR DESCRIPTION
Fixes #2247 

Changes:
- Add `package bip44`, which implements the bip44 spec: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
- Check for depth overflow in bip32 child key generation

Does this change need to mentioned in CHANGELOG.md?
Yes