### PR TITLE
Use the correct name for the hw wallet firmware file

### DIFF
--- a/src/gui/static/src/app/app.config.ts
+++ b/src/gui/static/src/app/app.config.ts
@@ -3,7 +3,7 @@ export const AppConfig = {
   maxHardwareWalletAddresses: 1,
   useHwWalletDaemon: true,
   urlForHwWalletVersionChecking: 'https://version.skycoin.net/skywallet/version.txt',
-  hwWalletDownloadUrlAndPrefix: 'https://downloads.skycoin.net/skywallet/skyfirmware_',
+  hwWalletDownloadUrlAndPrefix: 'https://downloads.skycoin.net/skywallet/skywallet-firmware-v',
 
   urlForVersionChecking: 'https://version.skycoin.net/skycoin/version.txt',
   walletDownloadUrl: 'https://www.skycoin.net/downloads/',

--- a/src/gui/static/src/app/services/hw-wallet.service.ts
+++ b/src/gui/static/src/app/services/hw-wallet.service.ts
@@ -341,7 +341,10 @@ export class HwWalletService {
           .catch(() => Observable.throw({ _body: this.translate.instant('hardware-wallet.update-firmware.connection-error') }))
           .map((res: any) => res.text())
           .flatMap((res: any) => {
-            const lastestFirmwareVersion = res.trim();
+            let lastestFirmwareVersion: string = res.trim();
+            if (lastestFirmwareVersion.toLowerCase().startsWith('v')) {
+              lastestFirmwareVersion = lastestFirmwareVersion.substr(1, lastestFirmwareVersion.length - 1);
+            }
 
             return this.http.get(AppConfig.hwWalletDownloadUrlAndPrefix + lastestFirmwareVersion + '.bin', { responseType: ResponseContentType.Blob })
               .map(firmwareResponse => firmwareResponse.blob())


### PR DESCRIPTION
Changes:
- Now the hw wallet firmware updater expect the firmware file to be called `skywallet-firmware-v$(VERSION_FIRMWARE).bin` instead of `skyfirmware_$(VERSION_FIRMWARE).bin`. This makes the updater follow the naming convention described in https://github.com/skycoin/hardware-wallet#versioning-policies

IMPORTANT: at this moment the version returned by https://version.skycoin.net/skywallet/version.txt is `v1.0.0-dev` but the server does not have a file called `skywallet-firmware-v1.0.0-dev.bin`, so for this PR to work the file in the server will have to be renamed or, even better, the new firmware version will have to be compiled and uploaded to the server using the correct naming convention.


Does this change need to mentioned in CHANGELOG.md?
No