### PR TITLE
React correctly to the user-deposit-timeout code returned by Swaplab

### DIFF
--- a/src/gui/static/src/app/components/pages/exchange/exchange-status/exchange-status.component.ts
+++ b/src/gui/static/src/app/components/pages/exchange/exchange-status/exchange-status.component.ts
@@ -25,6 +25,7 @@ export class ExchangeStatusComponent implements OnDestroy {
     'market_withdraw_waiting',
     'complete',
     'error',
+    'user_deposit_timeout',
   ];
 
   loading = true;
@@ -78,7 +79,7 @@ export class ExchangeStatusComponent implements OnDestroy {
       return 'done';
     }
 
-    if (this.order.status === this.statuses[6]) {
+    if (this.order.status === this.statuses[6] || this.order.status === this.statuses[7]) {
       return 'close';
     }
 

--- a/src/gui/static/src/app/services/exchange.service.ts
+++ b/src/gui/static/src/app/services/exchange.service.ts
@@ -91,7 +91,7 @@ export class ExchangeService {
   }
 
   isOrderFinished(order: ExchangeOrder) {
-    return ['complete', 'error'].indexOf(order.status) > -1;
+    return ['complete', 'error', 'user_deposit_timeout'].indexOf(order.status) > -1;
   }
 
   private post(url: string, body?: any, headers?: any): Observable<any> {

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -532,7 +532,9 @@
       "complete": "Exchange completed!",
       "complete-info": "The funds have been successfully sent to your address.",
       "error": "Error occurred",
-      "error-info": "There was an error in the operation, you can find more information below. If you need help, please save all the operation data shown below and contact technical support using the link in the lower right part of this page."
+      "error-info": "There was an error in the operation, you can find more information below. If you need help, please save all the operation data shown below and contact technical support using the link in the lower right part of this page.",
+      "user-deposit-timeout": "Order canceled due to inactivity",
+      "user-deposit-timeout-info": "The system has canceled the order because no deposit was detected, please open a new order. If you need help, please save all the operation data shown below and contact technical support using the link in the lower right part of this page."
     },
     "history-window": {
       "address": "Address",


### PR DESCRIPTION
Changes:
- There is an undocumented status code that Swaplab may return when requesting the status of an operation: `user-deposit-timeout`. As the response is not documented in the Swaplab API documentation ( https://swaplab.cc/api-v3-skycoin/index.html#status-2 ), it was not possible to react correctly to it before and it is still unknow how many time the system waits before returning that status. This PR makes the UI to react correctly to that status, telling the user that the operation was canceled and that a new one must be created for continuing.

Does this change need to mentioned in CHANGELOG.md?
No