### PR TITLE
Add a warning to the Swaplab addresses

### DIFF
--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -548,7 +548,7 @@
       "date": "Date"
     },
     "details": {
-      "exchange-addr": "Exchange address",
+      "exchange-addr": "Exchange address (valid for this exchange operation only)",
       "exchange-addr-tag": "Payment ID or Destination Tag which must be used for the transaction",
       "tx-id": "Transaction ID",
       "order-id": "Order ID",


### PR DESCRIPTION
Changes:
- I saw a comment in Telegram about someone apparently sending coins to an old address of the service used for buying coins in the website. As it may not be good to do that with Swaplab, this PR changes the title of the deposit address from "Exchange address" to "Exchange address (valid for this exchange operation only)", as a "better safe than sorry" measure.

Does this change need to mentioned in CHANGELOG.md?
No