### PR TITLE
Add new methods to Visor's public method set

### DIFF
--- a/src/visor/blockchain.go
+++ b/src/visor/blockchain.go
@@ -255,7 +255,7 @@ func (bc *Blockchain) processBlock(tx *dbutil.Tx, b coin.SignedBlock) (coin.Sign
 			}
 			b.Body.Transactions = txns
 
-			if err = bc.verifyUxHash(tx, b.Block); err != nil {
+			if err := bc.verifyUxHash(tx, b.Block); err != nil {
 				return coin.SignedBlock{}, err
 			}
 

--- a/src/visor/interfaces.go
+++ b/src/visor/interfaces.go
@@ -42,6 +42,7 @@ type Blockchainer interface {
 	Time(tx *dbutil.Tx) (uint64, error)
 	NewBlock(tx *dbutil.Tx, txns coin.Transactions, currentTime uint64) (*coin.Block, error)
 	ExecuteBlock(tx *dbutil.Tx, sb *coin.SignedBlock) error
+	VerifyBlock(tx *dbutil.Tx, sb *coin.SignedBlock) error
 	VerifyBlockTxnConstraints(tx *dbutil.Tx, txn coin.Transaction) error
 	VerifySingleTxnHardConstraints(tx *dbutil.Tx, txn coin.Transaction, signed TxnSignedFlag) error
 	VerifySingleTxnSoftHardConstraints(tx *dbutil.Tx, txn coin.Transaction, distParams params.Distribution, verifyParams params.VerifyTxn, signed TxnSignedFlag) (*coin.SignedBlock, coin.UxArray, error)

--- a/src/visor/mock_blockchainer_test.go
+++ b/src/visor/mock_blockchainer_test.go
@@ -314,6 +314,20 @@ func (_m *MockBlockchainer) Unspent() blockdb.UnspentPooler {
 	return r0
 }
 
+// VerifyBlock provides a mock function with given fields: tx, sb
+func (_m *MockBlockchainer) VerifyBlock(tx *dbutil.Tx, sb *coin.SignedBlock) error {
+	ret := _m.Called(tx, sb)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*dbutil.Tx, *coin.SignedBlock) error); ok {
+		r0 = rf(tx, sb)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // VerifyBlockTxnConstraints provides a mock function with given fields: tx, txn
 func (_m *MockBlockchainer) VerifyBlockTxnConstraints(tx *dbutil.Tx, txn coin.Transaction) error {
 	ret := _m.Called(tx, txn)

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -406,6 +406,14 @@ func (vs *Visor) CreateBlock(txns coin.Transactions, when uint64) (coin.Block, e
 	return sb, err
 }
 
+// VerifyBlock verifies specified block against local copy of blockchain.
+// Signature is not verified.
+func (vs *Visor) VerifyBlock(b coin.SignedBlock) error {
+	return vs.db.View("VeirfyBlock", func(tx *dbutil.Tx) error {
+		return vs.blockchain.VerifyBlock(tx, &b)
+	})
+}
+
 // ExecuteSignedBlock adds a block to the blockchain, or returns error.
 // Blocks must be executed in sequence, and be signed by a block publisher node.
 func (vs *Visor) ExecuteSignedBlock(b coin.SignedBlock) error {

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -1501,6 +1501,26 @@ func (vs *Visor) GetAllValidUnconfirmedTxHashes() ([]cipher.SHA256, error) {
 	return hashes, nil
 }
 
+// GetConfirmedTransaction returns transaction, which has been already included in some block.
+func (vs *Visor) GetConfirmedTransaction(txnHash cipher.SHA256) (*coin.Transaction, error) {
+	var histTxn *historydb.Transaction
+
+	if err := vs.db.View("GetConfirmedTransaction", func(tx *dbutil.Tx) error {
+		var err error
+		histTxn, err = vs.history.GetTransaction(tx, txnHash)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	// Transaction not found.
+	if histTxn == nil {
+		return nil, nil
+	}
+
+	return &histTxn.Txn, nil
+}
+
 // GetSignedBlockByHash get block of specific hash header, return nil on not found.
 func (vs *Visor) GetSignedBlockByHash(hash cipher.SHA256) (*coin.SignedBlock, error) {
 	var sb *coin.SignedBlock

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -390,11 +390,11 @@ func (vs *Visor) CreateAndExecuteBlock() (coin.SignedBlock, error) {
 	return sb, err
 }
 
-// CreateBlock creates a Block from specified set of transactions according to set of determinstic rules.
-func (vs *Visor) CreateBlock(txns coin.Transactions, when uint64) (coin.Block, error) {
+// CreateBlockFromTxns creates a Block from specified set of transactions according to set of determinstic rules.
+func (vs *Visor) CreateBlockFromTxns(txns coin.Transactions, when uint64) (coin.Block, error) {
 	var sb coin.Block
 
-	err := vs.db.Update("CreateBlock", func(tx *dbutil.Tx) error {
+	err := vs.db.Update("CreateBlockFromTxns", func(tx *dbutil.Tx) error {
 		var err error
 		if sb, err = vs.createBlockFromTxns(tx, txns, when); err != nil {
 			return err

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -409,7 +409,7 @@ func (vs *Visor) CreateBlock(txns coin.Transactions, when uint64) (coin.Block, e
 // VerifyBlock verifies specified block against local copy of blockchain.
 // Signature is not verified.
 func (vs *Visor) VerifyBlock(b coin.SignedBlock) error {
-	return vs.db.View("VeirfyBlock", func(tx *dbutil.Tx) error {
+	return vs.db.View("VerifyBlock", func(tx *dbutil.Tx) error {
 		return vs.blockchain.VerifyBlock(tx, &b)
 	})
 }

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -429,7 +429,7 @@ func (vs *Visor) ExecuteSignedBlock(b coin.SignedBlock) error {
 // ExecuteSignedBlockUnsafe adds block to the blockchain, or returns error.
 // Blocks must be executed in sequence. Block signature is not verified.
 func (vs *Visor) ExecuteSignedBlockUnsafe(b coin.SignedBlock) error {
-	return vs.db.Update("ExecuteSignedBlock", func(tx *dbutil.Tx) error {
+	return vs.db.Update("ExecuteSignedBlockUnsafe", func(tx *dbutil.Tx) error {
 		return vs.executeSignedBlock(tx, b)
 	})
 }

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -431,7 +431,7 @@ func (vs *Visor) ExecuteSignedBlockUnsafe(b coin.SignedBlock) error {
 }
 
 // executeSignedBlock adds a block to the blockchain, or returns error.
-// Blocks must be executed in sequence. Block must have valid signature.
+// Blocks must be executed in sequence, and be signed by a block publisher node.
 func (vs *Visor) executeSignedBlock(tx *dbutil.Tx, b coin.SignedBlock) error {
 	if err := b.VerifySignature(vs.Config.BlockchainPubkey); err != nil {
 		return err
@@ -441,7 +441,7 @@ func (vs *Visor) executeSignedBlock(tx *dbutil.Tx, b coin.SignedBlock) error {
 }
 
 // executeSignedBlockUnsafe add a block to the blockchain, or returns error.
-// Blocks must be executed in sequence.
+// Blocks must be executed in sequence. Block signature is not verified.
 func (vs *Visor) executeSignedBlockUnsafe(tx *dbutil.Tx, b coin.SignedBlock) error {
 	if err := vs.blockchain.ExecuteBlock(tx, &b); err != nil {
 		return err

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -294,7 +294,7 @@ func (vs *Visor) createBlock(tx *dbutil.Tx, when uint64) (coin.SignedBlock, erro
 
 	b, err := vs.createBlockFromTxns(tx, txns, when)
 	if err != nil {
-		return coin.SignedBlock{}, nil
+		return coin.SignedBlock{}, err
 	}
 
 	return vs.signBlock(b), nil

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -390,6 +390,22 @@ func (vs *Visor) CreateAndExecuteBlock() (coin.SignedBlock, error) {
 	return sb, err
 }
 
+// CreateBlock creates a Block from specified set of transactions according to set of determinstic rules.
+func (vs *Visor) CreateBlock(txns coin.Transactions, when uint64) (coin.Block, error) {
+	var sb coin.Block
+
+	err := vs.db.Update("CreateBlock", func(tx *dbutil.Tx) error {
+		var err error
+		if sb, err = vs.createBlockFromTxns(tx, txns, when); err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	return sb, err
+}
+
 // ExecuteSignedBlock adds a block to the blockchain, or returns error.
 // Blocks must be executed in sequence, and be signed by a block publisher node
 func (vs *Visor) ExecuteSignedBlock(b coin.SignedBlock) error {

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -427,7 +427,7 @@ func (vs *Visor) ExecuteSignedBlock(b coin.SignedBlock) error {
 }
 
 // ExecuteSignedBlockUnsafe adds block to the blockchain, or returns error.
-// Blocks must be executed in sequence. Block singature is not verified.
+// Blocks must be executed in sequence. Block signature is not verified.
 func (vs *Visor) ExecuteSignedBlockUnsafe(b coin.SignedBlock) error {
 	return vs.db.Update("ExecuteSignedBlock", func(tx *dbutil.Tx) error {
 		return vs.executeSignedBlock(tx, b)

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -417,10 +417,6 @@ func (vs *Visor) VerifyBlock(b coin.SignedBlock) error {
 // ExecuteSignedBlock adds a block to the blockchain, or returns error.
 // Blocks must be executed in sequence, and be signed by a block publisher node.
 func (vs *Visor) ExecuteSignedBlock(b coin.SignedBlock) error {
-	if err := b.VerifySignature(vs.Config.BlockchainPubkey); err != nil {
-		return err
-	}
-
 	return vs.db.Update("ExecuteSignedBlock", func(tx *dbutil.Tx) error {
 		return vs.executeSignedBlock(tx, b)
 	})


### PR DESCRIPTION
Three public methods are added to visor:

1. CreateBlock
2. VerifyBlock
3. ExecuteSignedBlockUnsafe

Those methods are necessary for applications, which:

1. Want decoupled block creation, block verification and block execution.
2. Are going to perform block signing and block signature verification on their own.
