### PR TITLE
Add the "bulk send" option to the advanced form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add CLI `encodeJsonTransaction` command to retrieve raw transaction given its JSON representation
 - Add `package bip44`, implementing the bip44 spec https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
 - Codesign daemon and standalone binaries
+- Add the "bulk send" option to the GUI advanced form
 
 ### Fixed
 

--- a/src/gui/static/src/app/app.module.ts
+++ b/src/gui/static/src/app/app.module.ts
@@ -111,6 +111,7 @@ import { HwUpdateAlertDialogComponent } from './components/layout/hardware-walle
 import { ChangeNoteComponent } from './components/pages/send-skycoin/send-preview/transaction-info/change-note/change-note.component';
 import { MsgBarComponent } from './components/layout/msg-bar/msg-bar.component';
 import { MsgBarService } from './services/msg-bar.service';
+import { MultipleDestinationsDialogComponent } from './components/layout/multiple-destinations-dialog/multiple-destinations-dialog.component';
 
 
 const ROUTES = [
@@ -250,6 +251,7 @@ const ROUTES = [
     HwUpdateAlertDialogComponent,
     ChangeNoteComponent,
     MsgBarComponent,
+    MultipleDestinationsDialogComponent,
   ],
   entryComponents: [
     AddDepositAddressComponent,
@@ -282,6 +284,7 @@ const ROUTES = [
     HwUpdateFirmwareDialogComponent,
     HwUpdateAlertDialogComponent,
     ChangeNoteComponent,
+    MultipleDestinationsDialogComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/gui/static/src/app/components/layout/multiple-destinations-dialog/multiple-destinations-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/multiple-destinations-dialog/multiple-destinations-dialog.component.html
@@ -1,0 +1,15 @@
+<app-modal class="modal" [headline]="'send.bulk-send.title' | translate" [dialog]="dialogRef">
+  <div class="-body">
+    {{ 'send.bulk-send.indications' | translate }}
+  </div>
+  <div [formGroup]="form" class="form-container">
+    <div class="form-field">
+      <textarea formControlName="data" id="data" rows="5"></textarea>
+    </div>
+  </div>
+  <div class="-buttons">
+    <app-button (action)="processData()" class="primary">
+      {{ 'send.bulk-send.process' | translate }}
+    </app-button>
+  </div>
+</app-modal>

--- a/src/gui/static/src/app/components/layout/multiple-destinations-dialog/multiple-destinations-dialog.component.scss
+++ b/src/gui/static/src/app/components/layout/multiple-destinations-dialog/multiple-destinations-dialog.component.scss
@@ -1,0 +1,3 @@
+.form-container {
+  margin-top: 20px;
+}

--- a/src/gui/static/src/app/components/layout/multiple-destinations-dialog/multiple-destinations-dialog.component.spec.ts
+++ b/src/gui/static/src/app/components/layout/multiple-destinations-dialog/multiple-destinations-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MultipleDestinationsDialogComponent } from './multiple-destinations-dialog.component';
+
+describe('MultipleDestinationsDialogComponent', () => {
+  let component: MultipleDestinationsDialogComponent;
+  let fixture: ComponentFixture<MultipleDestinationsDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ MultipleDestinationsDialogComponent ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MultipleDestinationsDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/gui/static/src/app/components/layout/multiple-destinations-dialog/multiple-destinations-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/multiple-destinations-dialog/multiple-destinations-dialog.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit, OnDestroy, Inject } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MsgBarService } from '../../../services/msg-bar.service';
-import { ChildHwDialogParams } from '../hardware-wallet/hw-options-dialog/hw-options-dialog.component';
 
 @Component({
   selector: 'app-multiple-destinations-dialog',
@@ -14,7 +13,7 @@ export class MultipleDestinationsDialogComponent implements OnInit, OnDestroy {
 
   constructor(
     public dialogRef: MatDialogRef<MultipleDestinationsDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) private data: ChildHwDialogParams,
+    @Inject(MAT_DIALOG_DATA) private data: string,
     private formBuilder: FormBuilder,
     private msgBarService: MsgBarService,
   ) { }

--- a/src/gui/static/src/app/components/layout/multiple-destinations-dialog/multiple-destinations-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/multiple-destinations-dialog/multiple-destinations-dialog.component.ts
@@ -1,0 +1,84 @@
+import { Component, OnInit, OnDestroy, Inject } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MsgBarService } from '../../../services/msg-bar.service';
+import { ChildHwDialogParams } from '../hardware-wallet/hw-options-dialog/hw-options-dialog.component';
+
+@Component({
+  selector: 'app-multiple-destinations-dialog',
+  templateUrl: './multiple-destinations-dialog.component.html',
+  styleUrls: ['./multiple-destinations-dialog.component.scss'],
+})
+export class MultipleDestinationsDialogComponent implements OnInit, OnDestroy {
+  form: FormGroup;
+
+  constructor(
+    public dialogRef: MatDialogRef<MultipleDestinationsDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) private data: ChildHwDialogParams,
+    private formBuilder: FormBuilder,
+    private msgBarService: MsgBarService,
+  ) { }
+
+  ngOnInit() {
+    this.form = this.formBuilder.group({
+      data: [this.data],
+    });
+  }
+
+  ngOnDestroy() {
+    this.msgBarService.hide();
+  }
+
+  processData() {
+    try {
+      if ((this.form.value.data as string).trim().length === 0) {
+        this.msgBarService.showError('send.bulk-send.error-no-data');
+
+        return;
+      }
+
+      let entries = (this.form.value.data as string).split(/\r?\n/);
+      if (!entries || entries.length === 0) {
+        this.msgBarService.showError('send.bulk-send.error-no-data');
+
+        return;
+      }
+
+      entries = entries.filter(entry => entry.trim().length > 0);
+
+      const firstElementParts = entries[0].split(',').length;
+      if (firstElementParts !== 2 && firstElementParts !== 3) {
+        this.msgBarService.showError('send.bulk-send.error-invalid-data');
+
+        return;
+      }
+
+      const splitedEntries = [];
+      let consistentNumberOfParts = true;
+      entries.forEach((entry: string, i: number) => {
+        splitedEntries[i] = entry.split(',');
+        if (splitedEntries[i].length !== firstElementParts) {
+          consistentNumberOfParts = false;
+        }
+      });
+
+      if (!consistentNumberOfParts) {
+        this.msgBarService.showError('send.bulk-send.error-inconsistent-data');
+
+        return;
+      }
+
+      const response = [];
+      splitedEntries.forEach((entry, i) => {
+        response[i] = [];
+        (entry as string[]).forEach((part, j) => {
+          response[i][j] = part.trim();
+        });
+      });
+
+      this.dialogRef.close(response);
+    } catch (e) {
+      this.msgBarService.showError('send.bulk-send.error-invalid-data');
+    }
+  }
+}

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.html
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.html
@@ -105,6 +105,9 @@
         (onStateChange)="changeActiveCurrency($event)"
       ></app-double-button>
     </div>
+    <span class="-options" (click)="openMultipleDestinationsPopup()" [ngClass]="{'element-disabled' : busy}">
+      {{ 'send.bulk-send.title' | translate }} <mat-icon>keyboard_arrow_down</mat-icon>
+    </span>
 
     <div formArrayName="destinations" *ngFor="let dest of destControls; let i = index;" class="-destination">
       <div [formGroupName]="i" class="row">

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.scss
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-form-advanced/send-form-advanced.component.scss
@@ -150,6 +150,7 @@ mat-option ::ng-deep .mat-pseudo-checkbox-checked {
   padding-left: 5px;
   color: $gradient-blue-dark;
   cursor: pointer;
+  font-size: 13px;
 
   mat-icon {
     color: $gradient-blue-dark;

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -207,7 +207,16 @@
     "simple": "Simple",
     "advanced": "Advanced",
     "select-wallet": "Select Wallet",
-    "error-saving-note": "The transaction was successfully sent, but it was not possible to save the note."
+    "error-saving-note": "The transaction was successfully sent, but it was not possible to save the note.",
+
+    "bulk-send": {
+      "title": "Bulk Send",
+      "indications": "To send to multiple destinations in a quick way, type each address, coin amount and hour amount (optional) on a line, separated by a comma. Example: if you want to send 10 coins and 5 hours to the \"xyz\" address, type \"xyz,10,5\"; if you want the hours to be calculated automatically, type \"xyz,10\". Decimal values must be separated with a dot.",
+      "process": "Process",
+      "error-no-data": "There is no text to process.",
+      "error-inconsistent-data": "If you set how many hours you want to send to a destinations, you must do so for all destinations.",
+      "error-invalid-data": "The entered text has an invalid format."
+    }
   },
 
   "reset": {


### PR DESCRIPTION
Fixes #2254

Changes:
- This PR adds the "bulk send" option to the advanced form. It allows to specify multiple destinations (including coins and hours) with a simple text string. The text is entered using this modal window:
![bulk](https://user-images.githubusercontent.com/34079003/60762706-39cd2500-a034-11e9-9ba5-ed3f7410b91f.png)
After processing the string, the code updates the contents of the advanced form.

Does this change need to mentioned in CHANGELOG.md?
Yes