### PR TITLE
Fix the character limitation for the hw wallet labels

### DIFF
--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-added-dialog/hw-added-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-added-dialog/hw-added-dialog.component.html
@@ -17,7 +17,7 @@
     <div class="upper-text">{{ 'hardware-wallet.added.added1' | translate }}</div>
     <div [formGroup]="form">
       <div class="form-field">
-        <input formControlName="label" id="label" (keydown.enter)="saveNameAndCloseModal()" #input>
+        <input formControlName="label" id="label" [maxlength]="maxHwWalletLabelLength" (keydown.enter)="saveNameAndCloseModal()" #input>
       </div>
     </div>
     <div>{{ 'hardware-wallet.added.added2' | translate }}</div>

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-added-dialog/hw-added-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-added-dialog/hw-added-dialog.component.ts
@@ -18,6 +18,7 @@ export class HwAddedDialogComponent extends HwDialogBaseComponent<HwAddedDialogC
   @ViewChild('input') input: ElementRef;
   wallet: Wallet;
   form: FormGroup;
+  maxHwWalletLabelLength = HwWalletService.maxLabelLength;
 
   private initialLabel: string;
 

--- a/src/gui/static/src/app/components/pages/wallets/change-name/change-name.component.html
+++ b/src/gui/static/src/app/components/pages/wallets/change-name/change-name.component.html
@@ -3,7 +3,7 @@
     <div [formGroup]="form">
       <div class="form-field">
         <label for="label">{{ 'wallet.rename.name-label' | translate }}</label>
-        <input formControlName="label" id="label" (keydown.enter)="rename()" maxlength="24">
+        <input formControlName="label" id="label" (keydown.enter)="rename()" [maxlength]="data.wallet.isHardware ? maxHwWalletLabelLength : null">
       </div>
     </div>
     <div class="-buttons">

--- a/src/gui/static/src/app/components/pages/wallets/change-name/change-name.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/change-name/change-name.component.ts
@@ -36,6 +36,7 @@ export class ChangeNameComponent implements OnInit, OnDestroy {
   currentState: States = States.Initial;
   states = States;
   msgIcons = MessageIcons;
+  maxHwWalletLabelLength = HwWalletService.maxLabelLength;
 
   private newLabel: string;
   private hwConnectionSubscription: ISubscription;

--- a/src/gui/static/src/app/services/hw-wallet.service.ts
+++ b/src/gui/static/src/app/services/hw-wallet.service.ts
@@ -65,6 +65,8 @@ interface EventData {
 @Injectable()
 export class HwWalletService {
 
+  public static readonly maxLabelLength = 32;
+
   private readonly storageKey = 'hw-wallets';
 
   showOptionsWhenPossible = false;


### PR DESCRIPTION
Changes:
- Now the modal window for changing the name of a wallet only limits the length for the hw wallets.

- Now the modal window that appears when connecting a new hw wallets does not allow labels with an infinite number of characters.

- The character limit for the hw wallet labels was changes from 24 to 32, which is the real limit allowed by the device.

Does this change need to mentioned in CHANGELOG.md?
No