### PR TITLE
Hide envvar options from the user

### DIFF
--- a/cmd/skycoin/README.md
+++ b/cmd/skycoin/README.md
@@ -78,7 +78,7 @@
 	- [web-interface-plaintext-auth](#web-interface-plaintext-auth)
 	- [web-interface-port](#web-interface-port)
 	- [web-interface-username](#web-interface-username)
-- [Environment Variables](#environment-variables)
+- [Development Environment Variables](#development-environment-variables)
 	- [USER_BURN_FACTOR](#userburnfactor)
 	- [USER_MAX_TXN_SIZE](#usermax_txnsize)
 	- [USER_MAX_DECIMALS](#usermaxdecimals)
@@ -232,10 +232,6 @@ Usage:
     	port to serve web interface on (default 6420)
   -web-interface-username string
     	username for the web interface
-Additional environment variables:
-* USER_BURN_FACTOR - Set the coin hour burn factor required for user-created transactions. Must be >= 2.
-* USER_MAX_TXN_SIZE - Set the maximum transaction size (in bytes) allowed for user-created transactions. Must be >= 1024.
-* USER_MAX_DECIMALS - Set the maximum decimals allowed for user-created transactions. Must be <= 6.
 ```
 
 ## Scenarios
@@ -677,7 +673,11 @@ Port number for the REST API interface. Default `6420`.
 
 Optional username for the REST API. Used in `Basic` authentication.
 
-## Environment Variables
+## Development Environment Variables
+
+These environment variables are for *development purposes only*. They are not intended
+as part of the normal configuration API. That is why they are not included in the normal
+configuration API (i.e. through cli `--options` or a configuration file).
 
 ### USER_BURN_FACTOR
 

--- a/src/skycoin/config.go
+++ b/src/skycoin/config.go
@@ -346,10 +346,6 @@ func NewNodeConfig(mode string, node fiber.NodeConfig) NodeConfig {
 func (c *Config) postProcess() error {
 	if help {
 		flag.Usage()
-		fmt.Println("Additional environment variables:")
-		fmt.Printf("* USER_BURN_FACTOR - Set the coin hour burn factor required for user-created transactions. Must be >= %d.\n", params.MinBurnFactor)
-		fmt.Printf("* USER_MAX_TXN_SIZE - Set the maximum transaction size (in bytes) allowed for user-created transactions. Must be >= %d.\n", params.MinTransactionSize)
-		fmt.Printf("* USER_MAX_DECIMALS - Set the maximum decimals allowed for user-created transactions. Must be <= %d.\n", droplet.Exponent)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
Hide the envvars from the user because they are too tempting for people to touch.  They were made env vars because they are not part of the normal configuration API, but advertising them suggests that the user should play with them.