### PR TITLE
Fix #2442 reset trusted flag on peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - #2287 A `Content-Type` with a `charset` specified, for example `application/json; charset=utf-8`, will not return an HTTP 415 error anymore
 - Fix `fiber.toml` transaction verification parameters ignored by newcoin
 - #2373 Fix and clean-up further panics with various `skycoin-cli` commands (lastBlocks, checkdb) which were not correctly handling arguments.
+- #2442 Reset the "trusted" flag to false for all peers on load, before registering default hardcoded peers in the peerlist
 
 ### Changed
 

--- a/src/daemon/pex/peerlist.go
+++ b/src/daemon/pex/peerlist.go
@@ -199,7 +199,7 @@ func (pl *peerlist) setPrivate(addr string, private bool) error {
 	return fmt.Errorf("set peer.Private failed: %v does not exist in peer list", addr)
 }
 
-// SetTrusted sets peer as trusted peer
+// setTrusted sets peer as trusted peer
 func (pl *peerlist) setTrusted(addr string, trusted bool) error {
 	if p, ok := pl.peers[addr]; ok {
 		p.Trusted = trusted

--- a/src/daemon/pex/pex.go
+++ b/src/daemon/pex/pex.go
@@ -238,15 +238,19 @@ func New(cfg Config) (*Pex, error) {
 		return nil, err
 	}
 
-	// Load default hardcoded peers
+	// Unset trusted status from any existing peers, regenerate
+	// them from the DefaultConnections
+	pex.setAllUntrusted()
+
+	// Load default hardcoded peers, mark them as trusted
 	for _, addr := range cfg.DefaultConnections {
 		// Default peers will mark as trusted peers.
 		if err := pex.AddPeer(addr); err != nil {
 			logger.Critical().WithError(err).Error("Add default peer failed")
 			return nil, err
 		}
-		if err := pex.SetTrusted(addr); err != nil {
-			logger.Critical().WithError(err).Error("pex.SetTrusted for default peer failed")
+		if err := pex.setTrusted(addr); err != nil {
+			logger.Critical().WithError(err).Error("pex.setTrusted for default peer failed")
 			return nil, err
 		}
 	}
@@ -512,8 +516,8 @@ func (px *Pex) SetPrivate(addr string, private bool) error {
 	return px.peerlist.setPrivate(cleanAddr, private)
 }
 
-// SetTrusted updates peer's trusted value
-func (px *Pex) SetTrusted(addr string) error {
+// setTrusted marks a peer as a default peer by setting its trusted flag to true
+func (px *Pex) setTrusted(addr string) error {
 	px.Lock()
 	defer px.Unlock()
 

--- a/src/daemon/pex/pex_test.go
+++ b/src/daemon/pex/pex_test.go
@@ -168,6 +168,14 @@ func TestNewPex(t *testing.T) {
 	config.DataDirectory = dir
 	config.DefaultConnections = testPeers[:]
 
+	// Add a peer and register it as a default peer.
+	// It will be marked as "trusted"
+	// in the peers cache file, but the next time it is loaded,
+	// it will be reset to untrusted because it is not in the
+	// cfg.DefaultConnections
+	addr := "11.22.33.44:5566"
+	config.DefaultConnections = append(config.DefaultConnections, addr)
+
 	_, err = New(config)
 	require.NoError(t, err)
 
@@ -175,11 +183,33 @@ func TestNewPex(t *testing.T) {
 	peers, err := loadCachedPeersFile(filepath.Join(dir, PeerCacheFilename))
 	require.NoError(t, err)
 
+	require.Equal(t, len(testPeers)+1, len(peers))
+
+	for _, p := range append(testPeers, addr) {
+		v, ok := peers[p]
+		require.True(t, ok)
+		require.True(t, v.Trusted)
+	}
+
+	// Recreate pex with the extra peer removed form DefaultConnections
+	config.DefaultConnections = config.DefaultConnections[:len(config.DefaultConnections)-1]
+	_, err = New(config)
+	require.NoError(t, err)
+
+	peers, err = loadCachedPeersFile(filepath.Join(dir, PeerCacheFilename))
+	require.NoError(t, err)
+
+	require.Equal(t, len(testPeers)+1, len(peers))
+
 	for _, p := range testPeers {
 		v, ok := peers[p]
 		require.True(t, ok)
 		require.True(t, v.Trusted)
 	}
+
+	v, ok := peers[addr]
+	require.True(t, ok)
+	require.False(t, v.Trusted)
 }
 
 func TestNewPexDisableTrustedPeers(t *testing.T) {
@@ -1343,7 +1373,7 @@ func TestPexSetTrusted(t *testing.T) {
 			// init peer
 			pex.peerlist.setPeers(tc.initPeers)
 
-			err := pex.SetTrusted(tc.peer)
+			err := pex.setTrusted(tc.peer)
 			require.Equal(t, tc.err, err)
 			if err != nil {
 				return

--- a/src/daemon/pex/pex_test.go
+++ b/src/daemon/pex/pex_test.go
@@ -191,7 +191,7 @@ func TestNewPex(t *testing.T) {
 		require.True(t, v.Trusted)
 	}
 
-	// Recreate pex with the extra peer removed form DefaultConnections
+	// Recreate pex with the extra peer removed from DefaultConnections
 	config.DefaultConnections = config.DefaultConnections[:len(config.DefaultConnections)-1]
 	_, err = New(config)
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes #2442

Changes:
- Reset the "trusted" flag to false for all peers on load, before registering default hardcoded peers in the peerlist

Note: "trusted" simply means that the peer is in the default hardcoded peer list. The only effect that the "trusted" flag has is that the client will try to maintain 1 and only 1 connection to a "trusted" peer. 

When a peer is removed from the default hardcoded peers list, it remains "trusted" due to the peers.json cache file.  This can cause the client to try to maintain a reliable connection to peers that are no longer reliable or up to date, which could cause a poorer experience for the user.

Does this change need to mentioned in CHANGELOG.md?
Yes