### PR TITLE
Use arrays instead of subscription collections

### DIFF
--- a/src/gui/static/src/app/components/pages/buy/buy.component.ts
+++ b/src/gui/static/src/app/components/pages/buy/buy.component.ts
@@ -4,7 +4,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { WalletService } from '../../../services/wallet.service';
 import { Address, PurchaseOrder, Wallet } from '../../../app.datatypes';
 import { ButtonComponent } from '../../layout/button/button.component';
-import { Subscription } from 'rxjs/Subscription';
+import { ISubscription } from 'rxjs/Subscription';
 import { MsgBarService } from '../../../services/msg-bar.service';
 
 @Component({
@@ -21,7 +21,7 @@ export class BuyComponent implements OnInit, OnDestroy {
   order: PurchaseOrder;
   wallets: Wallet[];
 
-  private subscription: Subscription;
+  private subscriptionsGroup: ISubscription[] = [];
 
   constructor(
     private formBuilder: FormBuilder,
@@ -36,7 +36,7 @@ export class BuyComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.subscription.unsubscribe();
+    this.subscriptionsGroup.forEach(sub => sub.unsubscribe());
   }
 
   checkStatus() {
@@ -60,14 +60,14 @@ export class BuyComponent implements OnInit, OnDestroy {
       wallet: ['', Validators.required],
     });
 
-    this.subscription = this.form.get('wallet').valueChanges.subscribe(filename => {
+    this.subscriptionsGroup.push(this.form.get('wallet').valueChanges.subscribe(filename => {
       const wallet = this.wallets.find(wlt => wlt.filename === filename);
       console.log('changing wallet value', filename);
       this.purchaseService.generate(wallet).subscribe(
         order => this.saveData(order),
         error => this.msgBarService.showError(error.toString()),
       );
-    });
+    }));
   }
 
   private loadConfig() {
@@ -81,7 +81,7 @@ export class BuyComponent implements OnInit, OnDestroy {
     this.loadConfig();
     this.loadOrder();
 
-    this.subscription.add(this.walletService.all().subscribe(wallets => {
+    this.subscriptionsGroup.push(this.walletService.all().subscribe(wallets => {
       this.wallets = wallets;
 
       if (this.order) {

--- a/src/gui/static/src/app/components/pages/exchange/exchange-create/exchange-create.component.ts
+++ b/src/gui/static/src/app/components/pages/exchange/exchange-create/exchange-create.component.ts
@@ -11,7 +11,7 @@ import { ButtonComponent } from '../../../layout/button/button.component';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ExchangeService } from '../../../../services/exchange.service';
 import { ExchangeOrder, TradingPair, StoredExchangeOrder } from '../../../../app.datatypes';
-import { ISubscription, Subscription } from 'rxjs/Subscription';
+import { ISubscription } from 'rxjs/Subscription';
 import 'rxjs/add/observable/merge';
 import { MatDialog, MatDialogConfig } from '@angular/material';
 import { SelectAddressComponent } from '../../send-skycoin/send-form-advanced/select-address/select-address';
@@ -40,7 +40,7 @@ export class ExchangeCreateComponent implements OnInit, OnDestroy {
   problemGettingPairs = false;
 
   private agreement = false;
-  private subscriptions: Subscription;
+  private subscriptionsGroup: ISubscription[] = [];
   private exchangeSubscription: ISubscription;
   private priceUpdateSubscription: ISubscription;
 
@@ -79,7 +79,7 @@ export class ExchangeCreateComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.subscriptions.unsubscribe();
+    this.subscriptionsGroup.forEach(sub => sub.unsubscribe());
     this.removeExchangeSubscription();
     this.msgBarService.hide();
 
@@ -168,13 +168,13 @@ export class ExchangeCreateComponent implements OnInit, OnDestroy {
       validator: this.validate.bind(this),
     });
 
-    this.subscriptions = this.form.get('fromCoin').valueChanges.subscribe(() => {
+    this.subscriptionsGroup.push(this.form.get('fromCoin').valueChanges.subscribe(() => {
       this.updateActiveTradingPair();
-    });
+    }));
   }
 
   private loadData() {
-    this.subscriptions.add(this.exchangeService.tradingPairs()
+    this.subscriptionsGroup.push(this.exchangeService.tradingPairs()
       .retryWhen(errors => errors.delay(2000).take(10).concat(Observable.throw('')))
       .subscribe(pairs => {
         this.tradingPairs = [];

--- a/src/gui/static/src/app/components/pages/settings/blockchain/blockchain.component.ts
+++ b/src/gui/static/src/app/components/pages/settings/blockchain/blockchain.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import 'rxjs/add/operator/switchMap';
 import { IntervalObservable } from 'rxjs/observable/IntervalObservable';
-import { Subscription } from 'rxjs/Subscription';
+import { ISubscription } from 'rxjs/Subscription';
 import { BlockchainService } from '../../../../services/blockchain.service';
 
 @Component({
@@ -13,19 +13,19 @@ export class BlockchainComponent implements OnInit, OnDestroy {
   block: any;
   coinSupply: any;
 
-  private subscriptions: Subscription;
+  private subscriptionsGroup: ISubscription[] = [];
 
   constructor(
     private blockchainService: BlockchainService,
   ) { }
 
   ngOnInit() {
-    this.subscriptions = IntervalObservable
+    this.subscriptionsGroup.push(IntervalObservable
       .create(5000)
       .switchMap(() => this.blockchainService.lastBlock())
-      .subscribe(block => this.block = block);
+      .subscribe(block => this.block = block));
 
-    this.subscriptions.add(IntervalObservable
+    this.subscriptionsGroup.push(IntervalObservable
       .create(5000)
       .switchMap(() => this.blockchainService.coinSupply())
       .subscribe(coinSupply => this.coinSupply = coinSupply),
@@ -33,6 +33,6 @@ export class BlockchainComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.subscriptions.unsubscribe();
+    this.subscriptionsGroup.forEach(sub => sub.unsubscribe());
   }
 }


### PR DESCRIPTION
Changes:
- Currently, when there are several subscriptions that must be closed at the same time, a `Subscription` object is created and all the subscriptions are added to it. However, this is prone to errors, due to misscalculations and possible changes made to the rxjs library, as it happened recently with some changes I was making in the explorer. To avoid that, this PR changes the aproach of using a single `Subscription` object for using a subscriptions array, which is more predictable and simpler to manage.

Does this change need to mentioned in CHANGELOG.md?
No