### PR TITLE
Add coin_hours_display_name_singular to fiber.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - `type` is now a required parameter for `POST /api/v1/wallet`
-- Add `display_name`, `ticker`, `coin_hours_display_name`, `coin_hours_ticker`, `explorer_url` to the `/health` endpoint response
+- Add `display_name`, `ticker`, `coin_hours_display_name`, `coin_hours_display_name_singular`, `coin_hours_ticker`, `explorer_url` to the `/health` endpoint response
 - `cli addPrivateKey` will only work on a `collection` type wallet. Create one with `cli walletCreate -t collection`
 - Don't print the wallet in the terminal after `cli encryptWallet` or `cli decryptWallet`
 

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -2007,6 +2007,7 @@ $ skycoin-cli status
             "display_name": "Skycoin",
             "ticker": "SKY",
             "coin_hours_display_name": "Coin Hours",
+            "coin_hours_display_name_singular": "Coin Hour",
             "coin_hours_ticker": "SCH",
             "explorer_url": "https://explorer.skycoin.net"
         }

--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -90,12 +90,13 @@ var (
 		CreateBlockMaxDropletPrecision: 3,
 		MaxBlockTransactionsSize:       32768,
 
-		DisplayName:     "Skycoin",
-		Ticker:          "SKY",
-		CoinHoursName:   "Coin Hours",
-		CoinHoursTicker: "SCH",
-		ExplorerURL:     "https://explorer.skycoin.net",
-		Bip44Coin:       8000,
+		DisplayName:           "Skycoin",
+		Ticker:                "SKY",
+		CoinHoursName:         "Coin Hours",
+		CoinHoursNameSingular: "Coin Hour",
+		CoinHoursTicker:       "SCH",
+		ExplorerURL:           "https://explorer.skycoin.net",
+		Bip44Coin:             8000,
 	})
 
 	parseFlags = true

--- a/fiber.toml
+++ b/fiber.toml
@@ -37,6 +37,7 @@ peer_list_url = "https://downloads.skycoin.net/blockchain/peers.txt"
 # display_name = "Skycoin"
 # ticker = "SKY"
 # coin_hours_display_name = "Coin Hours"
+# coin_hours_display_name_singular = "Coin Hour"
 # coin_hours_ticker = "SCH"
 # explorer_url = "https://explorer.skycoin.net"
 # bip44_coin = 8000

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -251,6 +251,7 @@ Response:
         "display_name": "Skycoin",
         "ticker": "SKY",
         "coin_hours_display_name": "Coin Hours",
+        "coin_hours_display_name_singular": "Coin Hour",
         "coin_hours_ticker": "SCH",
         "explorer_url": "https://explorer.skycoin.net",
         "bip44_coin": 8000

--- a/src/cli/integration/testdata/status-csrf-enabled-header-check-disabled.golden
+++ b/src/cli/integration/testdata/status-csrf-enabled-header-check-disabled.golden
@@ -47,6 +47,7 @@
 			"display_name": "Skycoin",
 			"ticker": "SKY",
 			"coin_hours_display_name": "Coin Hours",
+			"coin_hours_display_name_singular": "Coin Hour",
 			"coin_hours_ticker": "SCH",
 			"explorer_url": "https://explorer.skycoin.net",
 			"bip44_coin": 8000

--- a/src/cli/integration/testdata/status-no-unconfirmed.golden
+++ b/src/cli/integration/testdata/status-no-unconfirmed.golden
@@ -47,6 +47,7 @@
 			"display_name": "Skycoin",
 			"ticker": "SKY",
 			"coin_hours_display_name": "Coin Hours",
+			"coin_hours_display_name_singular": "Coin Hour",
 			"coin_hours_ticker": "SCH",
 			"explorer_url": "https://explorer.skycoin.net",
 			"bip44_coin": 8000

--- a/src/cli/integration/testdata/status.golden
+++ b/src/cli/integration/testdata/status.golden
@@ -47,6 +47,7 @@
 			"display_name": "Skycoin",
 			"ticker": "SKY",
 			"coin_hours_display_name": "Coin Hours",
+			"coin_hours_display_name_singular": "Coin Hour",
 			"coin_hours_ticker": "SCH",
 			"explorer_url": "https://explorer.skycoin.net",
 			"bip44_coin": 8000

--- a/src/fiber/config.go
+++ b/src/fiber/config.go
@@ -64,6 +64,8 @@ type NodeConfig struct {
 	Ticker string `mapstructure:"ticker"`
 	// CoinHoursName is the name of the coinhour asset type, e.g. Coin Hours
 	CoinHoursName string `mapstructure:"coin_hours_display_name"`
+	// CoinHoursNameSingular is the singular form of the name of the coinhour asset type, e.g. Coin Hour
+	CoinHoursNameSingular string `mapstructure:"coin_hours_display_name_singular"`
 	// CoinHoursTicker is the name of the coinhour asset type's price ticker, e.g. SCH (Skycoin Coin Hours)
 	CoinHoursTicker string `mapstructure:"coin_hours_ticker"`
 	// ExplorerURL is the URL of the public explorer
@@ -152,6 +154,7 @@ func setDefaults() {
 	viper.SetDefault("node.display_name", "Skycoin")
 	viper.SetDefault("node.ticker", "SKY")
 	viper.SetDefault("node.coin_hours_display_name", "Coin Hours")
+	viper.SetDefault("node.coin_hours_display_name_singular", "Coin Hour")
 	viper.SetDefault("node.coin_hours_ticker", "SCH")
 	viper.SetDefault("node.explorer_url", "https://explorer.skycoin.net")
 	viper.SetDefault("node.bip44_coin", bip44.CoinTypeSkycoin)

--- a/src/fiber/config_test.go
+++ b/src/fiber/config_test.go
@@ -41,6 +41,7 @@ func TestNewConfig(t *testing.T) {
 			DisplayName:                    "Testcoin",
 			Ticker:                         "TST",
 			CoinHoursName:                  "Testcoin Hours",
+			CoinHoursNameSingular:          "Testcoin Hour",
 			CoinHoursTicker:                "TCH",
 			ExplorerURL:                    "https://explorer.testcoin.com",
 			Bip44Coin:                      bip44.CoinTypeSkycoin,

--- a/src/fiber/testdata/test.fiber.toml
+++ b/src/fiber/testdata/test.fiber.toml
@@ -27,6 +27,7 @@ max_block_transactions_size = 1111
 display_name = "Testcoin"
 ticker = "TST"
 coin_hours_display_name = "Testcoin Hours"
+coin_hours_display_name_singular = "Testcoin Hour"
 coin_hours_ticker = "TCH"
 explorer_url = "https://explorer.testcoin.com"
 

--- a/src/gui/static/src/app/pipes/amount.pipe.ts
+++ b/src/gui/static/src/app/pipes/amount.pipe.ts
@@ -27,7 +27,7 @@ export class AmountPipe implements PipeTransform {
       }
     }
     if (partToReturn !== 'first') {
-      response += showingCoins ? this.appService.coinName : this.appService.hoursName;
+      response += showingCoins ? this.appService.coinName : (Number(value) === 1 || Number(value) === -1 ? this.appService.hoursNameSingular : this.appService.hoursName);
     }
 
     return response;

--- a/src/gui/static/src/app/services/app.service.ts
+++ b/src/gui/static/src/app/services/app.service.ts
@@ -13,6 +13,7 @@ export class AppService {
   fullCoinName = ' ';
   coinName = ' ';
   hoursName = ' ';
+  hoursNameSingular = ' ';
   explorerUrl = ' ';
 
   get burnRate() {
@@ -44,6 +45,7 @@ export class AppService {
         this.fullCoinName = response.fiber.display_name;
         this.coinName = response.fiber.ticker;
         this.hoursName = response.fiber.coin_hours_display_name;
+        this.hoursNameSingular = response.fiber.coin_hours_display_name_singular;
         this.explorerUrl = response.fiber.explorer_url;
 
         if (this.explorerUrl.endsWith('/')) {

--- a/src/readable/fiber.go
+++ b/src/readable/fiber.go
@@ -4,11 +4,12 @@ import "github.com/skycoin/skycoin/src/cipher/bip44"
 
 // FiberConfig is fiber configuration parameters
 type FiberConfig struct {
-	Name            string         `json:"name"`
-	DisplayName     string         `json:"display_name"`
-	Ticker          string         `json:"ticker"`
-	CoinHoursName   string         `json:"coin_hours_display_name"`
-	CoinHoursTicker string         `json:"coin_hours_ticker"`
-	ExplorerURL     string         `json:"explorer_url"`
-	Bip44Coin       bip44.CoinType `json:"bip44_coin"`
+	Name                  string         `json:"name"`
+	DisplayName           string         `json:"display_name"`
+	Ticker                string         `json:"ticker"`
+	CoinHoursName         string         `json:"coin_hours_display_name"`
+	CoinHoursNameSingular string         `json:"coin_hours_display_name_singular"`
+	CoinHoursTicker       string         `json:"coin_hours_ticker"`
+	ExplorerURL           string         `json:"explorer_url"`
+	Bip44Coin             bip44.CoinType `json:"bip44_coin"`
 }

--- a/src/skycoin/config.go
+++ b/src/skycoin/config.go
@@ -329,13 +329,14 @@ func NewNodeConfig(mode string, node fiber.NodeConfig) NodeConfig {
 		HTTPProfHost: "localhost:6060",
 
 		Fiber: readable.FiberConfig{
-			Name:            node.CoinName,
-			DisplayName:     node.DisplayName,
-			Ticker:          node.Ticker,
-			CoinHoursName:   node.CoinHoursName,
-			CoinHoursTicker: node.CoinHoursTicker,
-			ExplorerURL:     node.ExplorerURL,
-			Bip44Coin:       node.Bip44Coin,
+			Name:                  node.CoinName,
+			DisplayName:           node.DisplayName,
+			Ticker:                node.Ticker,
+			CoinHoursName:         node.CoinHoursName,
+			CoinHoursNameSingular: node.CoinHoursNameSingular,
+			CoinHoursTicker:       node.CoinHoursTicker,
+			ExplorerURL:           node.ExplorerURL,
+			Bip44Coin:             node.Bip44Coin,
 		},
 	}
 

--- a/template/coin.template
+++ b/template/coin.template
@@ -79,12 +79,13 @@ var (
 		CreateBlockMaxDropletPrecision: {{.CreateBlockMaxDropletPrecision}},
 		MaxBlockTransactionsSize:       {{.MaxBlockTransactionsSize}},
 
-		DisplayName:     "{{.DisplayName}}",
-		Ticker:          "{{.Ticker}}",
-		CoinHoursName:   "{{.CoinHoursName}}",
-		CoinHoursTicker: "{{.CoinHoursTicker}}",
-		ExplorerURL:     "{{.ExplorerURL}}",
-		Bip44Coin:       {{.Bip44Coin}},
+		DisplayName:           "{{.DisplayName}}",
+		Ticker:                "{{.Ticker}}",
+		CoinHoursName:         "{{.CoinHoursName}}",
+		CoinHoursNameSingular: "{{.CoinHoursNameSingular}}",
+		CoinHoursTicker:       "{{.CoinHoursTicker}}",
+		ExplorerURL:           "{{.ExplorerURL}}",
+		Bip44Coin:             {{.Bip44Coin}},
 	})
 
 	parseFlags = true


### PR DESCRIPTION
Fixes #2375
Fixes #2452 

Changes:
- Add `coin_hours_display_name_singular` to `fiber.toml` for configuring the singular form of "Coin Hours" ("Coin Hour")

Does this change need to mentioned in CHANGELOG.md?
Yes

@Senyoret1 #2452