### PR TITLE
Improvements for the hw wallet integration

### DIFF
--- a/src/gui/static/src/app/app.datatypes.ts
+++ b/src/gui/static/src/app/app.datatypes.ts
@@ -126,6 +126,8 @@ export interface ConfirmationData {
   cancelButtonText?: string;
   redTitle?: boolean;
   disableDismiss?: boolean;
+  linkText?: string;
+  linkFunction?(): void;
 }
 
 /**

--- a/src/gui/static/src/app/components/layout/confirmation/confirmation.component.html
+++ b/src/gui/static/src/app/components/layout/confirmation/confirmation.component.html
@@ -1,6 +1,7 @@
 <app-modal class="modal" [class.red-title]="data.redTitle" [headline]="data.headerText | translate" [dialog]="dialogRef" [disableDismiss]="disableDismiss">
   <div class="-body">
     {{ data.text | translate }}
+    <span *ngIf="data.linkText && data.linkFunction" class="link" (click)="data.linkFunction(); closeModal(false);">{{ data.linkText | translate }}</span>
   </div>
 
   <div class="-check-container" *ngIf="data.checkboxText">

--- a/src/gui/static/src/app/components/layout/confirmation/confirmation.component.scss
+++ b/src/gui/static/src/app/components/layout/confirmation/confirmation.component.scss
@@ -8,3 +8,8 @@
   letter-spacing: 0.0769231em;
   color: $red;
 }
+
+.link {
+  cursor: pointer;
+  color: $gradient-blue-dark;
+}

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-options-dialog/hw-options-dialog.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-options-dialog/hw-options-dialog.component.ts
@@ -16,6 +16,7 @@ import { HwWalletDaemonService } from '../../../../services/hw-wallet-daemon.ser
 import { HwRemovePinDialogComponent } from '../hw-remove-pin-dialog/hw-remove-pin-dialog.component';
 import { HwUpdateFirmwareDialogComponent } from '../hw-update-firmware-dialog/hw-update-firmware-dialog.component';
 import { HwUpdateAlertDialogComponent } from '../hw-update-alert-dialog/hw-update-alert-dialog.component';
+import { MsgBarService } from '../../../../services/msg-bar.service';
 
 export interface ChildHwDialogParams {
   wallet: Wallet;
@@ -57,6 +58,7 @@ export class HwOptionsDialogComponent extends HwDialogBaseComponent<HwOptionsDia
     private hwWalletService: HwWalletService,
     private dialog: MatDialog,
     private walletService: WalletService,
+    private msgBarService: MsgBarService,
   ) {
     super(hwWalletService, dialogRef);
 
@@ -67,6 +69,7 @@ export class HwOptionsDialogComponent extends HwDialogBaseComponent<HwOptionsDia
     super.ngOnDestroy();
     this.removeDialogSubscription();
     this.removeOperationSubscription();
+    this.msgBarService.hide();
   }
 
   hwConnectionChanged(connected: boolean) {
@@ -191,6 +194,10 @@ export class HwOptionsDialogComponent extends HwDialogBaseComponent<HwOptionsDia
 
       if (!dontUpdateWallet) {
         this.walletName = this.wallet.label;
+      }
+
+      if (response.walletNameUpdated) {
+        this.msgBarService.showWarning('hardware-wallet.general.name-updated');
       }
 
       this.firmwareVersion = response.features.fw_major + '.' + response.features.fw_minor + '.' + response.features.fw_patch;

--- a/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/wallet-detail/wallet-detail.component.ts
@@ -70,9 +70,13 @@ export class WalletDetailComponent implements OnDestroy {
       this.editSubscription = this.hwWalletService.checkIfCorrectHwConnected(this.wallet.addresses[0].address)
         .flatMap(() => this.walletService.getHwFeaturesAndUpdateData(this.wallet))
         .subscribe(
-          () => {
+          response => {
             this.continueEditWallet();
             this.preparingToEdit = false;
+
+            if (response.walletNameUpdated) {
+              this.msgBarService.showWarning('hardware-wallet.general.name-updated');
+            }
           },
           err => {
             this.msgBarService.showError(getHardwareWalletErrorMsg(this.translateService, err));

--- a/src/gui/static/src/app/components/pages/wallets/wallets.component.ts
+++ b/src/gui/static/src/app/components/pages/wallets/wallets.component.ts
@@ -85,6 +85,8 @@ export class WalletsComponent implements OnInit, OnDestroy {
         checkboxText: 'hardware-wallet.security-warning.check',
         confirmButtonText: 'hardware-wallet.security-warning.continue',
         cancelButtonText: 'hardware-wallet.security-warning.cancel',
+        linkText: 'hardware-wallet.security-warning.link',
+        linkFunction: this.adminHwWallet.bind(this),
       };
 
       showConfirmationModal(this.dialog, confirmationData).afterClosed().subscribe(confirmationResult => {

--- a/src/gui/static/src/app/services/wallet.service.ts
+++ b/src/gui/static/src/app/services/wallet.service.ts
@@ -34,6 +34,7 @@ export enum HwSecurityWarnings {
 export interface HwFeaturesResponse {
   features: any;
   securityWarnings: HwSecurityWarnings[];
+  walletNameUpdated: boolean;
 }
 
 export interface PendingTransactions {
@@ -246,8 +247,14 @@ export class WalletService {
           }
         }
 
+        let walletNameUpdated = false;
+
         if (wallet) {
-          wallet.label = result.rawResponse.label ? result.rawResponse.label : (result.rawResponse.deviceId ? result.rawResponse.deviceId : result.rawResponse.device_id);
+          const deviceLabel = result.rawResponse.label ? result.rawResponse.label : (result.rawResponse.deviceId ? result.rawResponse.deviceId : result.rawResponse.device_id);
+          if (wallet.label !== deviceLabel) {
+            wallet.label = deviceLabel;
+            walletNameUpdated = true;
+          }
           wallet.hasHwSecurityWarnings = hasHwSecurityWarnings;
           this.saveHardwareWallets();
         }
@@ -255,6 +262,7 @@ export class WalletService {
         const response = {
           features: result.rawResponse,
           securityWarnings: warnings,
+          walletNameUpdated: walletNameUpdated,
         };
 
         return response;

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -401,7 +401,8 @@
       "cancel": "Cancel",
       "continue": "Continue",
       "completed": "Operation completed successfully.",
-      "refused": "The operation failed or was canceled."
+      "refused": "The operation failed or was canceled.",
+      "name-updated": "The name used to identify this Skywallet in the wallet list has been updated to match the one shown on the device."
     },
     "errors": {
       "too-many-inputs-outputs": "The transaction has too many inputs or outputs for the Skywallet. Please try again creating several smaller transactions, each one with a smaller number of recipients (if the current transaction has many) or coins.",
@@ -413,7 +414,8 @@
     },
     "security-warning" : {
       "title": "Security warning",
-      "text": "The last time this Skywallet was connected, one or more security warnings were found. We recommend that you open the Skywallet options (by pressing the \"Skywallet\" button below the wallets list) while the device is connected and solve the security problems before continuing.",
+      "text": "The last time this Skywallet was connected, one or more security warnings were found. We recommend that you open the Skywallet options (by pressing the link below) while the device is connected and solve the security problems before continuing.",
+      "link": "Open the Skywallet options window.",
       "check": "I understand the risks and want to continue",
       "continue": "Continue",
       "cancel": "Cancel"


### PR DESCRIPTION
Changes:
- If the user opens the hw wallet options window or tries to change the device label, the code automatically updates the name used to identify the device in the wallets list, to make it mach the label shown on the device screen. With this PR, if that automatic update happens, the new snackbar is used to show a warning.

- Now, inside the modal window that is shown when the user tries to expand a hw wallet with security warnings, there is a link for opening the hw wallet options window.

Does this change need to mentioned in CHANGELOG.md?
No