### PR TITLE
Add distributeGenesis cli command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add the "bulk send" option to the GUI advanced form
 - Add `cli walletKeyExport` command to export `xpub`, `xprv`, `pub` and `prv` key from a `bip44` wallet
 - Add `xpub` type wallet, which can generate addresses without exposing private keys
+- Add `block_publisher` flag to `/api/v1/health`
+- Add `no_broadcast` option to `POST /api/v1/injectTransaction` to disable broadcast of the transaction. The transaction will only be added to the local pool.
+- Add `cli distributeGenesis` command to split the genesis block into distribution addresses when setting up a new fiber coin
 
 ### Fixed
 

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -8,45 +8,46 @@ The CLI command APIs can be used directly from a Go application, see [Skycoin CL
 
 - [Install](#install)
 - [Environment Settings](#environment-settings)
-    - [RPC_ADDR](#rpc_addr)
-    - [RPC_USER](#rpc_user)
-    - [RPC_PASS](#rpc_pass)
+	- [RPC_ADDR](#rpc_addr)
+	- [RPC_USER](#rpc_user)
+	- [RPC_PASS](#rpc_pass)
 - [Usage](#usage)
-    - [Add Private Key](#add-private-key)
-    - [Check address balance](#check-address-balance)
-    - [Generate addresses](#generate-addresses)
-    - [Generate distribution addresses for a new fiber coin](#generate-distribution-addresses-for-a-new-fiber-coin)
-    - [Check address outputs](#check-address-outputs)
-    - [Check block data](#check-block-data)
-    - [Check database integrity](#check-database-integrity)
-    - [Create a raw transaction](#create-a-raw-transaction)
-    - [Decode a raw transaction](#decode-a-raw-transaction)
-    - [Encode a JSON transaction](#encode-a-json-transaction)
-    - [Broadcast a raw transaction](#broadcast-a-raw-transaction)
-    - [Create a wallet](#create-a-wallet)
-    - [Add addresses to a wallet](#add-addresses-to-a-wallet)
-    - [Export a specific key from an HD wallet](#export-a-specific-key-from-an-hd-wallet)
-    - [Encrypt Wallet](#encrypt-wallet)
-    - [Examples](#examples)
-    - [Decrypt Wallet](#decrypt-wallet)
-    - [Example](#example)
-    - [Last blocks](#last-blocks)
-    - [List wallet addresses](#list-wallet-addresses)
-    - [List wallets](#list-wallets)
-    - [Rich list](#rich-list)
-    - [Send](#send)
-    - [Show Seed](#show-seed)
-    - [Show Config](#show-config)
-    - [Status](#status)
-    - [Get transaction](#get-transaction)
-    - [Get address transactions](#get-address-transactions)
-    - [Verify address](#verify-address)
-    - [Check wallet balance](#check-wallet-balance)
-    - [List wallet transaction history](#list-wallet-transaction-history)
-    - [List wallet outputs](#list-wallet-outputs)
-    - [Richlist](#richlist)
-    - [Address Count](#address-count)
-    - [CLI version](#cli-version)
+	- [Add Private Key](#add-private-key)
+	- [Check address balance](#check-address-balance)
+	- [Generate addresses](#generate-addresses)
+	- [Generate distribution addresses for a new fiber coin](#generate-distribution-addresses-for-a-new-fiber-coin)
+	- [Check address outputs](#check-address-outputs)
+	- [Check block data](#check-block-data)
+	- [Check database integrity](#check-database-integrity)
+	- [Create a raw transaction](#create-a-raw-transaction)
+	- [Decode a raw transaction](#decode-a-raw-transaction)
+	- [Encode a JSON transaction](#encode-a-json-transaction)
+	- [Broadcast a raw transaction](#broadcast-a-raw-transaction)
+	- [Create a wallet](#create-a-wallet)
+	- [Add addresses to a wallet](#add-addresses-to-a-wallet)
+	- [Export a specific key from an HD wallet](#export-a-specific-key-from-an-hd-wallet)
+	- [Encrypt Wallet](#encrypt-wallet)
+	- [Examples](#examples)
+	- [Decrypt Wallet](#decrypt-wallet)
+	- [Example](#example)
+	- [Last blocks](#last-blocks)
+	- [List wallet addresses](#list-wallet-addresses)
+	- [List wallets](#list-wallets)
+	- [Rich list](#rich-list)
+	- [Send](#send)
+	- [Show Seed](#show-seed)
+	- [Show Config](#show-config)
+	- [Status](#status)
+	- [Get transaction](#get-transaction)
+	- [Get address transactions](#get-address-transactions)
+	- [Verify address](#verify-address)
+	- [Check wallet balance](#check-wallet-balance)
+	- [List wallet transaction history](#list-wallet-transaction-history)
+	- [List wallet outputs](#list-wallet-outputs)
+	- [Richlist](#richlist)
+	- [Address Count](#address-count)
+	- [CLI version](#cli-version)
+	- [Distribute coins from genesis block](#distribute-coins-from-genesis-block)
 
 <!-- /MarkdownTOC -->
 
@@ -109,7 +110,7 @@ COMMANDS:
   addressGen            Generate skycoin or bitcoin addresses
   addressOutputs        Display outputs of specific addresses
   addressTransactions   Show detail for transaction associated with one or more specified addresses
-  addresscount          Get the count of addresses with unspent outputs (coins).
+  addresscount          Get the count of addresses with unspent outputs (coins)
   blocks                Lists the content of a single block or a range of blocks
   broadcastTransaction  Broadcast a raw transaction to the network
   checkDBDecoding       Verify the database data encoding
@@ -117,6 +118,7 @@ COMMANDS:
   createRawTransaction  Create a raw transaction that can be broadcast to the network later
   decodeRawTransaction  Decode raw transaction
   decryptWallet         Decrypt a wallet
+  distributeGenesis     Distributes the genesis block coins into the configured distribution addresses
   encodeJsonTransaction Encode JSON transaction
   encryptWallet         Encrypt wallet
   fiberAddressGen       Generate addresses and seeds for a new fiber coin
@@ -129,7 +131,7 @@ COMMANDS:
   send                  Send skycoin from a wallet or an address to a recipient address
   showConfig            Show cli configuration
   showSeed              Show wallet seed and seed passphrase
-  status                Check the status of current skycoin node
+  status                Check the status of current Skycoin node
   transaction           Show detail info of specific transaction
   verifyAddress         Verify a skycoin address
   verifyTransaction     Verify if the specific transaction is spendable
@@ -3025,5 +3027,34 @@ $ skycoin-cli version --json
     "rpc": "0.23.0",
     "wallet": "0.23.0"
 }
+```
+</details>
+
+### Distribute coins from genesis block
+
+Distribute the genesis block coins into the configured distribution addresses.
+This is part of the fiber coin initialization procedure. After creating genesis
+key configuration and running the initial node, use this command to divide the
+genesis block into distribution addresses.
+
+```bash
+$ skycoin-cli distributeGenesis [genesis address secret key]
+```
+
+The secret key is the secret key of the genesis address, which you would have
+created when setting up the genesis block parameters.
+
+#### Example
+
+```bash
+$ skycoin-cli distributeGenesis 87b2ae65a7475481f73288b617242261e2a451815e1c6a5478862dbb95e23e3e
+```
+
+<details>
+ <summary>View Output</summary>
+
+There is no output in the terminal if the command succeeds.
+
+```
 ```
 </details>

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -2377,6 +2377,11 @@ the transaction was saved to the database, when you restart the client, it will 
 
 It is safe to retry the injection after a `503` failure.
 
+To disable the network broadcast, add `"no_broadcast": true` to the JSON request body.
+The transaction will be added to the local transaction pool but not be broadcast at the same time.
+Note that transactions from the pool are periodically announced, so this transaction will still
+be announced eventually if the daemon continues running with connectivity for enough time.
+
 Example:
 
 ```sh
@@ -2390,6 +2395,22 @@ Result:
 ```json
 "3615fc23cc12a5cb9190878a2151d1cf54129ff0cd90e5fc4f4e7debebad6868"
 ```
+
+Example, without broadcasting the transaction:
+
+```sh
+curl -X POST http://127.0.0.1:6420/api/v1/injectTransaction -H 'content-type: application/json' -d '{
+    "rawtx":"dc0000000008b507528697b11340f5a3fcccbff031c487bad59d26c2bdaea0cd8a0199a1720100000017f36c9d8bce784df96a2d6848f1b7a8f5c890986846b7c53489eb310090b91143c98fd233830055b5959f60030b3ca08d95f22f6b96ba8c20e548d62b342b5e0001000000ec9cf2f6052bab24ec57847c72cfb377c06958a9e04a077d07b6dd5bf23ec106020000000072116096fe2207d857d18565e848b403807cd825c044840300000000330100000000000000575e472f8c5295e8fa644e9bc5e06ec10351c65f40420f000000000066020000000000000",
+    "no_broadcast": true
+}'
+```
+
+Result:
+
+```json
+"3615fc23cc12a5cb9190878a2151d1cf54129ff0cd90e5fc4f4e7debebad6868"
+```
+
 
 ### Get transactions for addresses
 

--- a/src/api/client.go
+++ b/src/api/client.go
@@ -1081,13 +1081,33 @@ func (c *Client) InjectTransaction(txn *coin.Transaction) (string, error) {
 	return c.InjectEncodedTransaction(rawTxn)
 }
 
+// InjectTransactionNoBroadcast makes a request to POST /api/v1/injectTransaction
+// but does not broadcast the transaction.
+func (c *Client) InjectTransactionNoBroadcast(txn *coin.Transaction) (string, error) {
+	rawTxn, err := txn.SerializeHex()
+	if err != nil {
+		return "", err
+	}
+	return c.InjectEncodedTransactionNoBroadcast(rawTxn)
+}
+
 // InjectEncodedTransaction makes a request to POST /api/v1/injectTransaction.
 // rawTxn is a hex-encoded, serialized transaction
 func (c *Client) InjectEncodedTransaction(rawTxn string) (string, error) {
-	v := struct {
-		Rawtxn string `json:"rawtx"`
-	}{
-		Rawtxn: rawTxn,
+	return c.injectEncodedTransaction(rawTxn, false)
+}
+
+// InjectEncodedTransactionNoBroadcast makes a request to POST /api/v1/injectTransaction
+// but does not broadcast the transaction.
+// rawTxn is a hex-encoded, serialized transaction
+func (c *Client) InjectEncodedTransactionNoBroadcast(rawTxn string) (string, error) {
+	return c.injectEncodedTransaction(rawTxn, true)
+}
+
+func (c *Client) injectEncodedTransaction(rawTxn string, noBroadcast bool) (string, error) {
+	v := InjectTransactionRequest{
+		RawTxn:      rawTxn,
+		NoBroadcast: noBroadcast,
 	}
 
 	var txid string

--- a/src/api/gateway.go
+++ b/src/api/gateway.go
@@ -52,6 +52,7 @@ type Daemoner interface {
 	GetExchgConnection() []string
 	GetBlockchainProgress(headSeq uint64) *daemon.BlockchainProgress
 	InjectBroadcastTransaction(txn coin.Transaction) error
+	InjectTransaction(txn coin.Transaction) error
 }
 
 // Visorer interface for visor.Visor methods used by the API

--- a/src/api/health.go
+++ b/src/api/health.go
@@ -32,6 +32,7 @@ type HealthResponse struct {
 	CSPEnabled           bool                 `json:"csp_enabled"`
 	WalletAPIEnabled     bool                 `json:"wallet_api_enabled"`
 	GUIEnabled           bool                 `json:"gui_enabled"`
+	BlockPublisher       bool                 `json:"block_publisher"`
 	UserVerifyTxn        readable.VerifyTxn   `json:"user_verify_transaction"`
 	UnconfirmedVerifyTxn readable.VerifyTxn   `json:"unconfirmed_verify_transaction"`
 	StartedAt            int64                `json:"started_at"`
@@ -87,6 +88,7 @@ func getHealthData(c muxConfig, gateway Gatewayer) (*HealthResponse, error) {
 		HeaderCheckEnabled:   !c.disableHeaderCheck,
 		CSPEnabled:           !c.disableCSP,
 		GUIEnabled:           c.enableGUI,
+		BlockPublisher:       c.health.BlockPublisher,
 		WalletAPIEnabled:     walletAPIEnabled,
 		UserVerifyTxn:        readable.NewVerifyTxn(params.UserVerifyTxn),
 		UnconfirmedVerifyTxn: readable.NewVerifyTxn(gateway.DaemonConfig().UnconfirmedVerifyTxn),

--- a/src/api/health_test.go
+++ b/src/api/health_test.go
@@ -72,6 +72,9 @@ func TestHealthHandler(t *testing.T) {
 			method: http.MethodGet,
 			code:   http.StatusOK,
 			cfg: muxConfig{
+				health: HealthConfig{
+					BlockPublisher: true,
+				},
 				host:        configuredHost,
 				appLoc:      ".",
 				disableCSRF: false,
@@ -224,6 +227,7 @@ func TestHealthHandler(t *testing.T) {
 			require.Equal(t, len(conns), r.OpenConnections)
 			require.Equal(t, "skycoin", r.CoinName)
 			require.Equal(t, "skycoin:0.25.0(test)", r.DaemonUserAgent)
+			require.Equal(t, tc.cfg.health.BlockPublisher, r.BlockPublisher)
 
 			require.Equal(t, unconfirmed, r.BlockchainMetadata.Unconfirmed)
 			require.Equal(t, unspents, r.BlockchainMetadata.Unspents)

--- a/src/api/http.go
+++ b/src/api/http.go
@@ -89,6 +89,7 @@ type HealthConfig struct {
 	BuildInfo       readable.BuildInfo
 	Fiber           readable.FiberConfig
 	DaemonUserAgent useragent.Data
+	BlockPublisher  bool
 }
 
 type muxConfig struct {

--- a/src/api/mock_gatewayer_test.go
+++ b/src/api/mock_gatewayer_test.go
@@ -1170,6 +1170,20 @@ func (_m *MockGatewayer) InjectBroadcastTransaction(txn coin.Transaction) error 
 	return r0
 }
 
+// InjectTransaction provides a mock function with given fields: txn
+func (_m *MockGatewayer) InjectTransaction(txn coin.Transaction) error {
+	ret := _m.Called(txn)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(coin.Transaction) error); ok {
+		r0 = rf(txn)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // NewAddresses provides a mock function with given fields: wltID, password, n
 func (_m *MockGatewayer) NewAddresses(wltID string, password []byte, n uint64) ([]cipher.Address, error) {
 	ret := _m.Called(wltID, password, n)

--- a/src/api/transaction.go
+++ b/src/api/transaction.go
@@ -327,6 +327,12 @@ func transactionsHandler(gateway Gatewayer) http.HandlerFunc {
 	}
 }
 
+// InjectTransactionRequest is sent to POST /api/v1/injectTransaction
+type InjectTransactionRequest struct {
+	RawTxn      string `json:"rawtx"`
+	NoBroadcast bool   `json:"no_broadcast,omitempty"`
+}
+
 // URI: /api/v1/injectTransaction
 // Method: POST
 // Content-Type: application/json
@@ -342,41 +348,52 @@ func injectTransactionHandler(gateway Gatewayer) http.HandlerFunc {
 			wh.Error405(w)
 			return
 		}
-		// get the rawtransaction
-		v := struct {
-			Rawtx string `json:"rawtx"`
-		}{}
 
+		var v InjectTransactionRequest
 		if err := json.NewDecoder(r.Body).Decode(&v); err != nil {
 			wh.Error400(w, err.Error())
 			return
 		}
 
-		if v.Rawtx == "" {
+		if v.RawTxn == "" {
 			wh.Error400(w, "rawtx is required")
 			return
 		}
 
-		txn, err := coin.DeserializeTransactionHex(v.Rawtx)
+		txn, err := coin.DeserializeTransactionHex(v.RawTxn)
 		if err != nil {
 			wh.Error400(w, err.Error())
 			return
 		}
 
-		if err := gateway.InjectBroadcastTransaction(txn); err != nil {
-			switch err.(type) {
-			case visor.ErrTxnViolatesUserConstraint,
-				visor.ErrTxnViolatesHardConstraint,
-				visor.ErrTxnViolatesSoftConstraint:
-				wh.Error400(w, err.Error())
-			default:
-				if daemon.IsBroadcastFailure(err) {
-					wh.Error503(w, err.Error())
-				} else {
+		if v.NoBroadcast {
+			if err := gateway.InjectTransaction(txn); err != nil {
+				switch err.(type) {
+				case visor.ErrTxnViolatesUserConstraint,
+					visor.ErrTxnViolatesHardConstraint,
+					visor.ErrTxnViolatesSoftConstraint:
+					wh.Error400(w, err.Error())
+				default:
 					wh.Error500(w, err.Error())
 				}
+				return
 			}
-			return
+		} else {
+			if err := gateway.InjectBroadcastTransaction(txn); err != nil {
+				switch err.(type) {
+				case visor.ErrTxnViolatesUserConstraint,
+					visor.ErrTxnViolatesHardConstraint,
+					visor.ErrTxnViolatesSoftConstraint:
+					wh.Error400(w, err.Error())
+				default:
+					if daemon.IsBroadcastFailure(err) {
+						wh.Error503(w, err.Error())
+					} else {
+						wh.Error500(w, err.Error())
+					}
+				}
+				return
+			}
 		}
 
 		wh.SendJSONOr500(logger, w, txn.Hash().Hex())

--- a/src/cli/addresscount.go
+++ b/src/cli/addresscount.go
@@ -6,7 +6,7 @@ import (
 
 func addresscountCmd() *cobra.Command {
 	return &cobra.Command{
-		Short:                 "Get the count of addresses with unspent outputs (coins).",
+		Short:                 "Get the count of addresses with unspent outputs (coins)",
 		Long:                  "Returns the count of all addresses that currently have unspent outputs (coins) associated with them.",
 		Use:                   "addresscount",
 		Args:                  cobra.NoArgs,

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -211,6 +211,7 @@ func NewCLI(cfg Config) (*cobra.Command, error) {
 		addressTransactionsCmd(),
 		pendingTransactionsCmd(),
 		addresscountCmd(),
+		distributeGenesisCmd(),
 	}
 
 	skyCLI.Version = Version

--- a/src/cli/distribute_genesis.go
+++ b/src/cli/distribute_genesis.go
@@ -1,0 +1,147 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/coin"
+	"github.com/skycoin/skycoin/src/params"
+	"github.com/skycoin/skycoin/src/util/droplet"
+)
+
+func distributeGenesisCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Args:  cobra.ExactArgs(1),
+		Use:   "distributeGenesis [genesis address secret key]",
+		Short: "Distributes the genesis block coins into the configured distribution addresses",
+		Long: `Distributes the genesis block coins into the configured distribution addresses.
+
+    The genesis block contains a single transaction with a single output that creates all coins
+    in existence. Skycoin expects the second block to be a "distribution" transaction, where
+    the genesis coins are split into N distribution addresses, each holding an equal amount.
+
+    RPC_ADDR must be set, to communicate with a running Skycoin node.`,
+		RunE: distributeGenesisHandler,
+	}
+
+	cmd.Flags().StringP("genesis-seckey", "s", "", "Genesis address secret key")
+
+	return cmd
+}
+
+func distributeGenesisHandler(c *cobra.Command, args []string) error {
+	sk, err := cipher.SecKeyFromHex(args[0])
+	if err != nil {
+		return errors.New("invalid genesis secret key")
+	}
+
+	// Obtain the genesis uxid from the node
+	uxID, err := getGenesisUxID()
+	if err != nil {
+		return err
+	}
+
+	txn, err := createDistributionTransaction(uxID, sk, params.MainNetDistribution)
+	if err != nil {
+		return err
+	}
+
+	health, err := apiClient.Health()
+	if err != nil {
+		return err
+	}
+
+	// If the node is a block publisher node, we can skip the broadcast and
+	// avoid any broadcast related errors. Otherwise, InjectTransaction would
+	// require that the block publisher node be connected to another peer.
+	// Otherwise, inject the transaction normally, which requires the node
+	// to be connected to peers, or else an error is returned.
+	// This allows the user to use this command against a block publisher node
+	// during setup, or against a local node, after setting up a block publisher
+	// node elsewhere.
+	if health.BlockPublisher {
+		if _, err := apiClient.InjectTransactionNoBroadcast(txn); err != nil {
+			return err
+		}
+	} else {
+		if _, err := apiClient.InjectTransaction(txn); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getGenesisUxID() (string, error) {
+	// Check that the only block is the genesis block
+	bm, err := apiClient.BlockchainMetadata()
+	if err != nil {
+		return "", err
+	}
+	if bm.Head.BkSeq != 0 {
+		return "", errors.New("genesis output has already been distributed")
+	}
+
+	b, err := apiClient.BlockBySeq(0)
+	if err != nil {
+		return "", err
+	}
+
+	// Sanity checks
+	if len(b.Body.Transactions) != 1 {
+		return "", errors.New("genesis block has multiple transactions")
+	}
+	if len(b.Body.Transactions[0].Out) != 1 {
+		return "", errors.New("genesis block has multiple outputs")
+	}
+
+	return b.Body.Transactions[0].Out[0].Hash, nil
+}
+
+func createDistributionTransaction(uxID string, genesisSecKey cipher.SecKey, p params.Distribution) (*coin.Transaction, error) {
+	// Sanity check
+	addrs := p.AddressesDecoded()
+	if p.MaxCoinSupply%uint64(len(addrs)) != 0 {
+		return nil, errors.New("the number of distribution addresses must divide MaxCoinSupply exactly")
+	}
+
+	var txn coin.Transaction
+
+	output, err := cipher.SHA256FromHex(uxID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid uxid")
+	}
+
+	if err := txn.PushInput(output); err != nil {
+		return nil, err
+	}
+
+	coins := (p.MaxCoinSupply / uint64(len(addrs))) * droplet.Multiplier
+	hours := uint64(1000)
+
+	for _, addr := range addrs {
+		if err := txn.PushOutput(addr, coins, hours); err != nil {
+			return nil, err
+		}
+	}
+
+	seckeys := make([]cipher.SecKey, 1)
+	seckey := genesisSecKey.Hex()
+	seckeys[0] = cipher.MustSecKeyFromHex(seckey)
+	txn.SignInputs([]cipher.SecKey{
+		genesisSecKey,
+	})
+
+	if err := txn.UpdateHeader(); err != nil {
+		return nil, err
+	}
+
+	if err := txn.Verify(); err != nil {
+		return nil, err
+	}
+
+	return &txn, nil
+}

--- a/src/cli/generate_addrs.go
+++ b/src/cli/generate_addrs.go
@@ -31,8 +31,7 @@ func walletAddAddressesCmd() *cobra.Command {
     history enabled your wallet encryption password can be recovered from the
     history log. If you do not include the "-p" option you will be prompted to
     enter your password after you enter your command.`,
-		SilenceUsage: true,
-		RunE:         generateAddrs,
+		RunE: generateAddrs,
 	}
 
 	walletAddAddressesCmd.Flags().Uint64P("num", "n", 1, "Number of addresses to generate")

--- a/src/cli/integration/testdata/status-csrf-enabled-header-check-disabled-no-unconfirmed.golden
+++ b/src/cli/integration/testdata/status-csrf-enabled-header-check-disabled-no-unconfirmed.golden
@@ -31,6 +31,7 @@
 		"csp_enabled": true,
 		"wallet_api_enabled": true,
 		"gui_enabled": false,
+		"block_publisher": false,
 		"user_verify_transaction": {
 			"burn_factor": 10,
 			"max_transaction_size": 32768,

--- a/src/cli/integration/testdata/status-csrf-enabled-header-check-disabled.golden
+++ b/src/cli/integration/testdata/status-csrf-enabled-header-check-disabled.golden
@@ -31,6 +31,7 @@
 		"csp_enabled": true,
 		"wallet_api_enabled": true,
 		"gui_enabled": false,
+		"block_publisher": false,
 		"user_verify_transaction": {
 			"burn_factor": 10,
 			"max_transaction_size": 32768,

--- a/src/cli/integration/testdata/status-no-unconfirmed.golden
+++ b/src/cli/integration/testdata/status-no-unconfirmed.golden
@@ -31,6 +31,7 @@
 		"csp_enabled": true,
 		"wallet_api_enabled": true,
 		"gui_enabled": false,
+		"block_publisher": false,
 		"user_verify_transaction": {
 			"burn_factor": 10,
 			"max_transaction_size": 32768,

--- a/src/cli/integration/testdata/status.golden
+++ b/src/cli/integration/testdata/status.golden
@@ -31,6 +31,7 @@
 		"csp_enabled": true,
 		"wallet_api_enabled": true,
 		"gui_enabled": false,
+		"block_publisher": false,
 		"user_verify_transaction": {
 			"burn_factor": 10,
 			"max_transaction_size": 32768,

--- a/src/cli/status.go
+++ b/src/cli/status.go
@@ -20,7 +20,7 @@ type ConfigStatus struct {
 func statusCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:                   "status",
-		Short:                 "Check the status of current skycoin node",
+		Short:                 "Check the status of current Skycoin node",
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
 		Args:                  cobra.NoArgs,

--- a/src/skycoin/skycoin.go
+++ b/src/skycoin/skycoin.go
@@ -507,6 +507,7 @@ func (c *Coin) createGUI(gw *api.Gateway, host string) (*api.Server, error) {
 			},
 			Fiber:           c.config.Node.Fiber,
 			DaemonUserAgent: c.config.Node.userAgent,
+			BlockPublisher:  c.config.Node.RunBlockPublisher,
 		},
 		Username: c.config.Node.WebInterfaceUsername,
 		Password: c.config.Node.WebInterfacePassword,


### PR DESCRIPTION
Changes:
- Add `distributeGenesis` command (formerly, `fiber-init`) to the CLI tool
- Add `no_broadcast` bool flag to `/api/v1/injectTransaction` to disable the txn broadcast. This is to allow transaction injection to a network consisting of a single signing node and no other node type.  Otherwise, broadcast would fail due to a lack of peers.
- Expose `block_publisher` status in `/api/v1/health`

Does this change need to mentioned in CHANGELOG.md?
Yes