### PR TITLE
Solve the travis build problem

### DIFF
--- a/src/gui/static/package-lock.json
+++ b/src/gui/static/package-lock.json
@@ -7429,19 +7429,19 @@
           "dev": true
         },
         "webdriver-manager": {
-          "version": "12.0.6",
-          "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.0.6.tgz",
-          "integrity": "sha1-PfGkgZdwELTL+MnYXHpXeCjA5ws=",
+          "version": "12.1.6",
+          "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.6.tgz",
+          "integrity": "sha512-B1mOycNCrbk7xODw7Jgq/mdD3qzPxMaTsnKIQDy2nXlQoyjTrJTTD0vRpEZI9b8RibPEyQvh9zIZ0M1mpOxS3w==",
           "dev": true,
           "requires": {
-            "adm-zip": "^0.4.7",
+            "adm-zip": "^0.4.9",
             "chalk": "^1.1.1",
             "del": "^2.2.0",
             "glob": "^7.0.3",
             "ini": "^1.3.4",
             "minimist": "^1.2.0",
             "q": "^1.4.1",
-            "request": "^2.78.0",
+            "request": "^2.87.0",
             "rimraf": "^2.5.2",
             "semver": "^5.3.0",
             "xml2js": "^0.4.17"


### PR DESCRIPTION
Changes:
- This PR makes npm to install an updated version of the `webdriver-manager` dependency, as it is currently installing a version that is not compatible with the current version of Google Chrome.

Does this change need to mentioned in CHANGELOG.md?
No