### PR TITLE
Improve the double button

### DIFF
--- a/src/gui/static/src/app/components/layout/double-button/double-button.component.scss
+++ b/src/gui/static/src/app/components/layout/double-button/double-button.component.scss
@@ -38,7 +38,7 @@
 
 .light {
   &.-buttons-container {
-    background: #f7f7f7;
+    background: #f1f1f1;
   }
 
   .-toggle ::ng-deep button.enabled {


### PR DESCRIPTION
Changes:
- In some screens it is very difficult to distinguish which option is selected in the small double buttons. This PR makes the background darker to prevent that:

Before:
![c1](https://user-images.githubusercontent.com/34079003/63100184-92051a00-bf44-11e9-86b8-a8af2c9aa281.png)

After:
![c2](https://user-images.githubusercontent.com/34079003/63100206-9cbfaf00-bf44-11e9-8132-591c19b92576.png)


Does this change need to mentioned in CHANGELOG.md?
No