### PR TITLE
Add QR URI prefix to /health endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `CLI walletScanAddresses` command to scan wallet addresses ahead.
 - Add `GET /api/v2/transactions` API to get transactions with pagination.
 - Add `-max-incoming-connection` flag to control the maximum allowed incoming connections.
+- Add `qr_uri_prefix` field to `/api/v1/health` endpoint.
 
 ### Fixed
-
 
 ### Changed
 

--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -94,6 +94,7 @@ var (
 		CoinHoursName:         "Coin Hours",
 		CoinHoursNameSingular: "Coin Hour",
 		CoinHoursTicker:       "SCH",
+		QrURIPrefix:           "skycoin",
 		ExplorerURL:           "https://explorer.skycoin.com",
 		VersionURL:            "https://version.skycoin.com/skycoin/version.txt",
 		Bip44Coin:             8000,

--- a/fiber.toml
+++ b/fiber.toml
@@ -32,6 +32,7 @@ peer_list_url = "https://downloads.skycoin.com/blockchain/peers.txt"
 # coin_hours_display_name = "Coin Hours"
 # coin_hours_display_name_singular = "Coin Hour"
 # coin_hours_ticker = "SCH"
+# qr_uri_prefix = "skycoin"
 # explorer_url = "https://explorer.skycoin.com"
 # bip44_coin = 8000
 

--- a/src/cli/integration/testdata/status-csrf-enabled-header-check-disabled.golden
+++ b/src/cli/integration/testdata/status-csrf-enabled-header-check-disabled.golden
@@ -50,6 +50,7 @@
 			"coin_hours_display_name": "Coin Hours",
 			"coin_hours_display_name_singular": "Coin Hour",
 			"coin_hours_ticker": "SCH",
+			"qr_uri_prefix": "skycoin",
 			"explorer_url": "https://explorer.skycoin.com",
 			"version_url": "https://version.skycoin.com/skycoin/version.txt",
 			"bip44_coin": 8000

--- a/src/cli/integration/testdata/status.golden
+++ b/src/cli/integration/testdata/status.golden
@@ -50,6 +50,7 @@
 			"coin_hours_display_name": "Coin Hours",
 			"coin_hours_display_name_singular": "Coin Hour",
 			"coin_hours_ticker": "SCH",
+			"qr_uri_prefix": "skycoin",
 			"explorer_url": "https://explorer.skycoin.com",
 			"version_url": "https://version.skycoin.com/skycoin/version.txt",
 			"bip44_coin": 8000

--- a/src/fiber/config.go
+++ b/src/fiber/config.go
@@ -68,6 +68,8 @@ type NodeConfig struct {
 	CoinHoursNameSingular string `mapstructure:"coin_hours_display_name_singular"`
 	// CoinHoursTicker is the name of the coinhour asset type's price ticker, e.g. SCH (Skycoin Coin Hours)
 	CoinHoursTicker string `mapstructure:"coin_hours_ticker"`
+	// QrURIPrefix is the prefix name of a QR url, e.g. skycoin:[address], the skycoin is the prefix.
+	QrURIPrefix string `mapstructure:"qr_uri_prefix"`
 	// ExplorerURL is the URL of the public explorer
 	ExplorerURL string `mapstructure:"explorer_url"`
 	// VersionURL is the URL for wallet to check the latest version number
@@ -158,6 +160,7 @@ func setDefaults() {
 	viper.SetDefault("node.coin_hours_display_name", "Coin Hours")
 	viper.SetDefault("node.coin_hours_display_name_singular", "Coin Hour")
 	viper.SetDefault("node.coin_hours_ticker", "SCH")
+	viper.SetDefault("node.qr_uri_prefix", "skycoin")
 	viper.SetDefault("node.explorer_url", "https://explorer.skycoin.com")
 	viper.SetDefault("node.version_url", "https://version.skycoin.com/skycoin/version.txt")
 	viper.SetDefault("node.bip44_coin", bip44.CoinTypeSkycoin)

--- a/src/fiber/config_test.go
+++ b/src/fiber/config_test.go
@@ -43,6 +43,7 @@ func TestNewConfig(t *testing.T) {
 			CoinHoursName:                  "Testcoin Hours",
 			CoinHoursNameSingular:          "Testcoin Hour",
 			CoinHoursTicker:                "TCH",
+			QrURIPrefix:                    "skycoin",
 			ExplorerURL:                    "https://explorer.testcoin.com",
 			VersionURL:                     "https://version.testcoin.com/testcoin/version.txt",
 			Bip44Coin:                      bip44.CoinTypeSkycoin,

--- a/src/readable/fiber.go
+++ b/src/readable/fiber.go
@@ -10,6 +10,7 @@ type FiberConfig struct {
 	CoinHoursName         string         `json:"coin_hours_display_name"`
 	CoinHoursNameSingular string         `json:"coin_hours_display_name_singular"`
 	CoinHoursTicker       string         `json:"coin_hours_ticker"`
+	QrURIPrefix           string         `json:"qr_uri_prefix"`
 	ExplorerURL           string         `json:"explorer_url"`
 	VersionURL            string         `json:"version_url"`
 	Bip44Coin             bip44.CoinType `json:"bip44_coin"`

--- a/src/skycoin/config.go
+++ b/src/skycoin/config.go
@@ -339,6 +339,7 @@ func NewNodeConfig(mode string, node fiber.NodeConfig) NodeConfig {
 			CoinHoursName:         node.CoinHoursName,
 			CoinHoursNameSingular: node.CoinHoursNameSingular,
 			CoinHoursTicker:       node.CoinHoursTicker,
+			QrURIPrefix:           node.QrURIPrefix,
 			ExplorerURL:           node.ExplorerURL,
 			VersionURL:            node.VersionURL,
 			Bip44Coin:             node.Bip44Coin,

--- a/template/coin.template
+++ b/template/coin.template
@@ -90,6 +90,7 @@ var (
 		CoinHoursName:         "{{.CoinHoursName}}",
 		CoinHoursNameSingular: "{{.CoinHoursNameSingular}}",
 		CoinHoursTicker:       "{{.CoinHoursTicker}}",
+		QrURIPrefix:           "{{.QrURIPrefix}}",
 		ExplorerURL:           "{{.ExplorerURL}}",
 		VersionURL:            "{{.VersionURL}}",
 		Bip44Coin:             {{.Bip44Coin}},


### PR DESCRIPTION
Fixes #2477 

Changes:
- Add `qr_uri_prefix` to `/health` endpoint.

Does this change need to mentioned in CHANGELOG.md?
Yes.