### PR TITLE
Scan addresses from last to first

### DIFF
--- a/src/api/gateway.go
+++ b/src/api/gateway.go
@@ -94,6 +94,7 @@ type Visorer interface {
 	WalletCreateTransaction(wltID string, p transaction.Params, wp visor.CreateTransactionParams) (*coin.Transaction, []visor.TransactionInput, error)
 	WalletCreateTransactionSigned(wltID string, password []byte, p transaction.Params, wp visor.CreateTransactionParams) (*coin.Transaction, []visor.TransactionInput, error)
 	WalletSignTransaction(wltID string, password []byte, txn *coin.Transaction, signIndexes []int) (*coin.Transaction, []visor.TransactionInput, error)
+	ScanWalletAddresses(wltID string, password []byte, num uint64) ([]cipher.Address, error)
 }
 
 // Walleter interface for wallet.Service methods used by the API

--- a/src/api/gateway.go
+++ b/src/api/gateway.go
@@ -86,7 +86,6 @@ type Visorer interface {
 	GetTransactionWithInputs(txid cipher.SHA256) (*visor.Transaction, []visor.TransactionInput, error)
 	GetTransactions(flts []visor.TxFilter, order visor.SortOrder, page *visor.PageIndex) ([]visor.Transaction, uint64, error)
 	GetTransactionsWithInputs(flts []visor.TxFilter, order visor.SortOrder, page *visor.PageIndex) ([]visor.Transaction, [][]visor.TransactionInput, uint64, error)
-	AddressesActivity(addrs []cipher.Addresser) ([]bool, error)
 	GetWalletUnconfirmedTransactions(wltID string) ([]visor.UnconfirmedTransaction, error)
 	GetWalletUnconfirmedTransactionsVerbose(wltID string) ([]visor.UnconfirmedTransaction, [][]visor.TransactionInput, error)
 	GetWalletBalance(wltID string) (wallet.BalancePair, wallet.AddressBalances, error)
@@ -95,6 +94,7 @@ type Visorer interface {
 	WalletCreateTransactionSigned(wltID string, password []byte, p transaction.Params, wp visor.CreateTransactionParams) (*coin.Transaction, []visor.TransactionInput, error)
 	WalletSignTransaction(wltID string, password []byte, txn *coin.Transaction, signIndexes []int) (*coin.Transaction, []visor.TransactionInput, error)
 	ScanWalletAddresses(wltID string, password []byte, num uint64) ([]cipher.Address, error)
+	TransactionsFinder() wallet.TransactionsFinder
 }
 
 // Walleter interface for wallet.Service methods used by the API

--- a/src/api/mock_gatewayer_test.go
+++ b/src/api/mock_gatewayer_test.go
@@ -1310,6 +1310,29 @@ func (_m *MockGatewayer) ScanAddresses(wltID string, password []byte, n uint64, 
 	return r0, r1
 }
 
+// ScanWalletAddresses provides a mock function with given fields: wltID, password, num
+func (_m *MockGatewayer) ScanWalletAddresses(wltID string, password []byte, num uint64) ([]cipher.Address, error) {
+	ret := _m.Called(wltID, password, num)
+
+	var r0 []cipher.Address
+	if rf, ok := ret.Get(0).(func(string, []byte, uint64) []cipher.Address); ok {
+		r0 = rf(wltID, password, num)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]cipher.Address)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, []byte, uint64) error); ok {
+		r1 = rf(wltID, password, num)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // StartedAt provides a mock function with given fields:
 func (_m *MockGatewayer) StartedAt() time.Time {
 	ret := _m.Called()

--- a/src/api/mock_gatewayer_test.go
+++ b/src/api/mock_gatewayer_test.go
@@ -63,29 +63,6 @@ func (_m *MockGatewayer) AddressCount() (uint64, error) {
 	return r0, r1
 }
 
-// AddressesActivity provides a mock function with given fields: addrs
-func (_m *MockGatewayer) AddressesActivity(addrs []cipher.Addresser) ([]bool, error) {
-	ret := _m.Called(addrs)
-
-	var r0 []bool
-	if rf, ok := ret.Get(0).(func([]cipher.Addresser) []bool); ok {
-		r0 = rf(addrs)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]bool)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func([]cipher.Addresser) error); ok {
-		r1 = rf(addrs)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // CreateTransaction provides a mock function with given fields: p, wp
 func (_m *MockGatewayer) CreateTransaction(p transaction.Params, wp visor.CreateTransactionParams) (*coin.Transaction, []visor.TransactionInput, error) {
 	ret := _m.Called(p, wp)
@@ -1342,6 +1319,22 @@ func (_m *MockGatewayer) StartedAt() time.Time {
 		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(time.Time)
+	}
+
+	return r0
+}
+
+// TransactionsFinder provides a mock function with given fields:
+func (_m *MockGatewayer) TransactionsFinder() wallet.TransactionsFinder {
+	ret := _m.Called()
+
+	var r0 wallet.TransactionsFinder
+	if rf, ok := ret.Get(0).(func() wallet.TransactionsFinder); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(wallet.TransactionsFinder)
+		}
 	}
 
 	return r0

--- a/src/api/wallet.go
+++ b/src/api/wallet.go
@@ -435,7 +435,7 @@ func walletScanAddressesHandler(gateway Gatewayer) http.HandlerFunc {
 			password = ""
 		}()
 
-		addrs, err := gateway.ScanAddresses(wltID, []byte(password), n, gateway)
+		addrs, err := gateway.ScanWalletAddresses(wltID, []byte(password), n)
 		if err != nil {
 			switch err {
 			case wallet.ErrWalletAPIDisabled:

--- a/src/api/wallet.go
+++ b/src/api/wallet.go
@@ -306,7 +306,7 @@ func walletCreateHandler(gateway Gatewayer) http.HandlerFunc {
 			SeedPassphrase: r.FormValue("seed-passphrase"),
 			Bip44Coin:      bip44Coin,
 			XPub:           r.FormValue("xpub"),
-			TF:             gateway,
+			TF:             gateway.TransactionsFinder(),
 		})
 		if err != nil {
 			switch err.(type) {

--- a/src/api/wallet_test.go
+++ b/src/api/wallet_test.go
@@ -1292,7 +1292,8 @@ func TestWalletCreateHandler(t *testing.T) {
 			if tc.options.ScanN == 0 {
 				tc.options.ScanN = 1
 			}
-			tc.options.TF = gateway
+			gateway.On("TransactionsFinder").Return(&visor.TransactionsFinder{})
+			tc.options.TF = gateway.TransactionsFinder()
 			gateway.On("CreateWallet", "", tc.options).Return(tc.gatewayCreateWalletResult, tc.gatewayCreateWalletErr)
 
 			endpoint := "/api/v1/wallet/create"
@@ -2180,7 +2181,7 @@ func TestWalletScanAddressesHandler(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &MockGatewayer{}
-			gateway.On("ScanAddresses", walletID, []byte(tc.password), tc.scanN, gateway).Return(tc.gatewayScanAddressesResult, tc.gatewayScanAddressesErr)
+			gateway.On("ScanWalletAddresses", walletID, []byte(tc.password), tc.scanN).Return(tc.gatewayScanAddressesResult, tc.gatewayScanAddressesErr)
 
 			c := newHTTPMockClient(gateway, ContentTypeForm, tc.disableCSRF)
 

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -2199,15 +2199,20 @@ func (vs *Visor) ScanWalletAddresses(wltID string, password []byte, num uint64) 
 	return vs.wallets.ScanAddresses(wltID, password, num, vs.tf)
 }
 
-// transactionsFinder implements the wallet.TransactionsFinder interface
-type transactionsFinder struct {
+// TransactionsFinder returns a transactions finder
+func (vs *Visor) TransactionsFinder() wallet.TransactionsFinder {
+	return newTransactionsFinder(vs)
+}
+
+// TransactionsFinder implements the wallet.TransactionsFinder interface
+type TransactionsFinder struct {
 	db          *dbutil.DB
 	history     Historyer
 	unconfirmed UnconfirmedTransactionPooler
 }
 
-func newTransactionsFinder(v *Visor) *transactionsFinder {
-	return &transactionsFinder{
+func newTransactionsFinder(v *Visor) *TransactionsFinder {
+	return &TransactionsFinder{
 		db:          v.db,
 		history:     v.history,
 		unconfirmed: v.unconfirmed,
@@ -2215,7 +2220,7 @@ func newTransactionsFinder(v *Visor) *transactionsFinder {
 }
 
 // AddressesActivity implements the methods of wallet.TransactionsFinder interface
-func (tf *transactionsFinder) AddressesActivity(addrs []cipher.Addresser) ([]bool, error) {
+func (tf *TransactionsFinder) AddressesActivity(addrs []cipher.Addresser) ([]bool, error) {
 	if len(addrs) == 0 {
 		return nil, nil
 	}

--- a/src/visor/visor.go
+++ b/src/visor/visor.go
@@ -119,7 +119,7 @@ func New(c Config, db *dbutil.DB, wltServ *wallet.Service) (*Visor, error) {
 		txns:        &txns,
 	}
 
-	v.tf = &TransactionsFinder{v}
+	v.tf = newTransactionsFinder(v)
 
 	return v, nil
 }
@@ -2194,68 +2194,32 @@ func (vs *Visor) WithUpdateTx(name string, f func(tx *dbutil.Tx) error) error {
 	})
 }
 
-// AddressesActivity returns whether or not each address has any activity on blockchain
-// or in the unconfirmed pool
-func (vs *Visor) AddressesActivity(addrs []cipher.Addresser) ([]bool, error) {
-	skyAddrs := make([]cipher.Address, len(addrs))
-	// convert to skycoin addresses
-	for i, a := range addrs {
-		addr, ok := a.(cipher.Address)
-		if !ok {
-			return nil, errors.New("invalid skycoin address")
-		}
-		skyAddrs[i] = addr
-	}
-
-	active := make([]bool, len(addrs))
-	addrsMap := make(map[cipher.Address]int, len(addrs))
-	for i, a := range skyAddrs {
-		addrsMap[a] = i
-	}
-
-	if len(addrsMap) != len(addrs) {
-		return nil, errors.New("duplicates addresses not allowed")
-	}
-
-	if err := vs.db.View("AddressActivity", func(tx *dbutil.Tx) error {
-		// Check if the addresses appear in the blockchain
-		for i, a := range skyAddrs {
-			ok, err := vs.history.AddressSeen(tx, a)
-			if err != nil {
-				return err
-			}
-
-			if ok {
-				active[i] = true
-			}
-		}
-
-		// Check if the addresses appears in the unconfirmed pool
-		// NOTE: if this needs to be optimized, add an index to the unconfirmed pool
-		return vs.unconfirmed.ForEach(tx, func(h cipher.SHA256, ut UnconfirmedTransaction) error {
-			// Only transaction outputs need to be checked; if the address is associated
-			// with an input, it must have appeared in a transaction in the blockchain history
-			for _, o := range ut.Transaction.Out {
-				if i, ok := addrsMap[o.Address]; ok {
-					active[i] = true
-				}
-			}
-			return nil
-		})
-	}); err != nil {
-		return nil, err
-	}
-
-	return active, nil
+// ScanWalletAddresses scan addresses ahead in a wallet to find addresses with transactions
+func (vs *Visor) ScanWalletAddresses(wltID string, password []byte, num uint64) ([]cipher.Address, error) {
+	return vs.wallets.ScanAddresses(wltID, password, num, vs.tf)
 }
 
-// TransactionsFinder implements the wallet.TransactionsFinder interface
-type TransactionsFinder struct {
-	v *Visor
+// transactionsFinder implements the wallet.TransactionsFinder interface
+type transactionsFinder struct {
+	db          *dbutil.DB
+	history     Historyer
+	unconfirmed UnconfirmedTransactionPooler
+}
+
+func newTransactionsFinder(v *Visor) *transactionsFinder {
+	return &transactionsFinder{
+		db:          v.db,
+		history:     v.history,
+		unconfirmed: v.unconfirmed,
+	}
 }
 
 // AddressesActivity implements the methods of wallet.TransactionsFinder interface
-func (tf *TransactionsFinder) AddressesActivity(addrs []cipher.Addresser) ([]bool, error) {
+func (tf *transactionsFinder) AddressesActivity(addrs []cipher.Addresser) ([]bool, error) {
+	if len(addrs) == 0 {
+		return nil, nil
+	}
+
 	skyAddrs := make([]cipher.Address, len(addrs))
 	// convert to skycoin addresses
 	for i, a := range addrs {
@@ -2276,22 +2240,24 @@ func (tf *TransactionsFinder) AddressesActivity(addrs []cipher.Addresser) ([]boo
 		return nil, errors.New("duplicates addresses not allowed")
 	}
 
-	if err := tf.v.db.View("AddressActivity", func(tx *dbutil.Tx) error {
+	if err := tf.db.View("AddressActivity", func(tx *dbutil.Tx) error {
 		// Check if the addresses appear in the blockchain
-		for i, a := range skyAddrs {
-			ok, err := tf.v.history.AddressSeen(tx, a)
+		// scan from the last to first, break once find an address with transactions.
+		for i := len(skyAddrs) - 1; i >= 0; i-- {
+			ok, err := tf.history.AddressSeen(tx, skyAddrs[i])
 			if err != nil {
 				return err
 			}
 
 			if ok {
 				active[i] = true
+				break
 			}
 		}
 
 		// Check if the addresses appears in the unconfirmed pool
 		// NOTE: if this needs to be optimized, add an index to the unconfirmed pool
-		return tf.v.unconfirmed.ForEach(tx, func(h cipher.SHA256, ut UnconfirmedTransaction) error {
+		return tf.unconfirmed.ForEach(tx, func(h cipher.SHA256, ut UnconfirmedTransaction) error {
 			// Only transaction outputs need to be checked; if the address is associated
 			// with an input, it must have appeared in a transaction in the blockchain history
 			for _, o := range ut.Transaction.Out {

--- a/src/visor/visor_test.go
+++ b/src/visor/visor_test.go
@@ -2913,7 +2913,7 @@ func TestTransactionsFinder(t *testing.T) {
 				addrsInHistory[addr] = struct{}{}
 			}
 
-			tf := transactionsFinder{
+			tf := TransactionsFinder{
 				db:          db,
 				history:     &MockHistoryerAddressSeen{addrsMap: addrsInHistory},
 				unconfirmed: &MockUnconfirmedTransactionPoolerForEach{txns: tc.unconfirmedTxns},

--- a/src/visor/wallet.go
+++ b/src/visor/wallet.go
@@ -276,10 +276,6 @@ func (vs *Visor) WalletCreateTransactionSigned(wltID string, password []byte, p 
 		return nil, nil, err
 	}
 
-	if vs.tf == nil {
-		vs.tf = &TransactionsFinder{vs}
-	}
-
 	if p.ChangeAddress == nil && w.Type() == wallet.WalletTypeBip44 {
 		// TODO: Maybe add the `PeekChangeAddress` to wallet.Wallet interface, and
 		// only bip44 wallet will implement it, all others do nothing. In this way
@@ -324,10 +320,6 @@ func (vs *Visor) WalletCreateTransaction(wltID string, p transaction.Params, wp 
 
 	var txn *coin.Transaction
 	var inputs []TransactionInput
-
-	if vs.tf == nil {
-		vs.tf = &TransactionsFinder{vs}
-	}
 
 	if err := vs.wallets.Update(wltID, func(w wallet.Wallet) error {
 		if p.ChangeAddress == nil && w.Type() == wallet.WalletTypeBip44 {


### PR DESCRIPTION
Fixes #2437 

Changes:
- Scan wallet addresses from the last one to the first, whenever an address was found has transactions related, stop the scanning.
- Added `ScanWalletAddresses` function to `Gatewayer.Visorer` interface, scan addresses through this function instead of `Walletor.ScanAddresses`.

Does this change need to mentioned in CHANGELOG.md?
No