### PR TITLE
Include change addresses for /api/v1/wallet endpoint for bip44 wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     * Add flag `scan` to scan ahead addresses in the wallet that have history transactions.
 - CLI command walletKeyExport -p flag is replaced with --path, and -p will be used as a shorthand of --password.
 - CLI command `encryptWallet/decryptWallet` will only return none-sensitive data. Data like the seed, secrets and private keys will no longer be returned.
+- Include change addresses for a bip44 wallet of the endpoint `/api/v1/wallet`.
+
 ### Removed
 
 ## [0.27.0] - 2019-11-26

--- a/src/api/gateway.go
+++ b/src/api/gateway.go
@@ -104,7 +104,7 @@ type Walleter interface {
 	DecryptWallet(wltID string, password []byte) (wallet.Wallet, error)
 	GetWalletSeed(wltID string, password []byte) (string, string, error)
 	CreateWallet(wltName string, options wallet.Options) (wallet.Wallet, error)
-	RecoverWallet(wltID, seed, seedPassphrase string, password []byte, options ...wallet.Option) (wallet.Wallet, error)
+	RecoverWallet(wltID, seed, seedPassphrase string, password []byte) (wallet.Wallet, error)
 	NewAddresses(wltID string, password []byte, n uint64, options ...wallet.Option) ([]cipher.Address, error)
 	ScanAddresses(wltID string, password []byte, n uint64, tf wallet.TransactionsFinder) ([]cipher.Address, error)
 	GetWallet(wltID string) (wallet.Wallet, error)

--- a/src/api/http.go
+++ b/src/api/http.go
@@ -468,179 +468,179 @@ func newServerMux(c muxConfig, gateway Gatewayer) *http.ServeMux {
 	// Status endpoints
 	webHandlerV1("/version", versionHandler(c.health.BuildInfo), nil) // version is always available, regardless of the API set
 	webHandlerV1("/health", healthHandler(c, gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead, EndpointsStatus},
+		http.MethodGet: {EndpointsRead, EndpointsStatus},
 	})
 
 	// Wallet endpoints
 	webHandlerV1("/wallet", walletHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsWallet},
+		http.MethodGet: {EndpointsWallet},
 	})
 	webHandlerV1("/wallet/create", walletCreateHandler(gateway), map[string][]string{
-		http.MethodPost: []string{EndpointsWallet},
+		http.MethodPost: {EndpointsWallet},
 	})
 	webHandlerV1("/wallet/newAddress", walletNewAddressesHandler(gateway), map[string][]string{
-		http.MethodPost: []string{EndpointsWallet},
+		http.MethodPost: {EndpointsWallet},
 	})
 	webHandlerV1("/wallet/scan", walletScanAddressesHandler(gateway), map[string][]string{
-		http.MethodPost: []string{EndpointsWallet},
+		http.MethodPost: {EndpointsWallet},
 	})
 	webHandlerV1("/wallet/balance", walletBalanceHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsWallet},
+		http.MethodGet: {EndpointsWallet},
 	})
 	webHandlerV1("/wallet/transaction", walletCreateTransactionHandler(gateway), map[string][]string{
-		http.MethodPost: []string{EndpointsWallet},
+		http.MethodPost: {EndpointsWallet},
 	})
 	webHandlerV2("/wallet/transaction/sign", walletSignTransactionHandler(gateway), map[string][]string{
-		http.MethodPost: []string{EndpointsWallet},
+		http.MethodPost: {EndpointsWallet},
 	})
 	webHandlerV1("/wallet/transactions", walletTransactionsHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsWallet},
+		http.MethodGet: {EndpointsWallet},
 	})
 	webHandlerV1("/wallet/update", walletUpdateHandler(gateway), map[string][]string{
-		http.MethodPost: []string{EndpointsWallet},
+		http.MethodPost: {EndpointsWallet},
 	})
 	webHandlerV1("/wallets", walletsHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsWallet},
+		http.MethodGet: {EndpointsWallet},
 	})
 	webHandlerV1("/wallets/folderName", walletFolderHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsWallet},
+		http.MethodGet: {EndpointsWallet},
 	})
 	webHandlerV1("/wallet/newSeed", newSeedHandler(), map[string][]string{
-		http.MethodGet: []string{EndpointsWallet},
+		http.MethodGet: {EndpointsWallet},
 	})
 	webHandlerV1("/wallet/seed", walletSeedHandler(gateway), map[string][]string{
-		http.MethodPost: []string{EndpointsInsecureWalletSeed},
+		http.MethodPost: {EndpointsInsecureWalletSeed},
 	})
 	webHandlerV2("/wallet/seed/verify", http.HandlerFunc(walletVerifySeedHandler), map[string][]string{
-		http.MethodPost: []string{EndpointsWallet},
+		http.MethodPost: {EndpointsWallet},
 	})
 
 	webHandlerV1("/wallet/unload", walletUnloadHandler(gateway), map[string][]string{
-		http.MethodPost: []string{EndpointsWallet},
+		http.MethodPost: {EndpointsWallet},
 	})
 	webHandlerV1("/wallet/encrypt", walletEncryptHandler(gateway), map[string][]string{
-		http.MethodPost: []string{EndpointsWallet},
+		http.MethodPost: {EndpointsWallet},
 	})
 	webHandlerV1("/wallet/decrypt", walletDecryptHandler(gateway), map[string][]string{
-		http.MethodPost: []string{EndpointsWallet},
+		http.MethodPost: {EndpointsWallet},
 	})
 	webHandlerV2("/wallet/recover", walletRecoverHandler(gateway), map[string][]string{
-		http.MethodPost: []string{EndpointsWallet},
+		http.MethodPost: {EndpointsWallet},
 	})
 
 	// Blockchain interface
 	webHandlerV1("/blockchain/metadata", blockchainMetadataHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead, EndpointsStatus},
+		http.MethodGet: {EndpointsRead, EndpointsStatus},
 	})
 	webHandlerV1("/blockchain/progress", blockchainProgressHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead, EndpointsStatus},
+		http.MethodGet: {EndpointsRead, EndpointsStatus},
 	})
 	webHandlerV1("/block", blockHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead},
+		http.MethodGet: {EndpointsRead},
 	})
 	webHandlerV1("/blocks", blocksHandler(gateway), map[string][]string{
-		http.MethodGet:  []string{EndpointsRead},
-		http.MethodPost: []string{EndpointsRead},
+		http.MethodGet:  {EndpointsRead},
+		http.MethodPost: {EndpointsRead},
 	})
 	webHandlerV1("/last_blocks", lastBlocksHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead},
+		http.MethodGet: {EndpointsRead},
 	})
 
 	// Network stats endpoints
 	webHandlerV1("/network/connection", connectionHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead, EndpointsStatus},
+		http.MethodGet: {EndpointsRead, EndpointsStatus},
 	})
 	webHandlerV1("/network/connections", connectionsHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead, EndpointsStatus},
+		http.MethodGet: {EndpointsRead, EndpointsStatus},
 	})
 	webHandlerV1("/network/defaultConnections", defaultConnectionsHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead, EndpointsStatus},
+		http.MethodGet: {EndpointsRead, EndpointsStatus},
 	})
 	webHandlerV1("/network/connections/trust", trustConnectionsHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead, EndpointsStatus},
+		http.MethodGet: {EndpointsRead, EndpointsStatus},
 	})
 	webHandlerV1("/network/connections/exchange", exchgConnectionsHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead, EndpointsStatus},
+		http.MethodGet: {EndpointsRead, EndpointsStatus},
 	})
 
 	// Network admin endpoints
 	webHandlerV1("/network/connection/disconnect", disconnectHandler(gateway), map[string][]string{
-		http.MethodPost: []string{EndpointsNetCtrl},
+		http.MethodPost: {EndpointsNetCtrl},
 	})
 
 	// Transaction related endpoints
 	webHandlerV1("/pendingTxs", pendingTxnsHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead},
+		http.MethodGet: {EndpointsRead},
 	})
 	webHandlerV1("/transaction", transactionHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead},
+		http.MethodGet: {EndpointsRead},
 	})
 	webHandlerV2("/transaction", transactionHandlerV2(gateway), map[string][]string{
 		// http.MethodGet:  []string{EndpointsRead},
-		http.MethodPost: []string{EndpointsTransaction},
+		http.MethodPost: {EndpointsTransaction},
 	})
 	webHandlerV2("/transaction/verify", verifyTxnHandler(gateway), map[string][]string{
-		http.MethodPost: []string{EndpointsRead},
+		http.MethodPost: {EndpointsRead},
 	})
 	webHandlerV1("/transactions", transactionsHandler(gateway), map[string][]string{
-		http.MethodGet:  []string{EndpointsRead},
-		http.MethodPost: []string{EndpointsRead},
+		http.MethodGet:  {EndpointsRead},
+		http.MethodPost: {EndpointsRead},
 	})
 	webHandlerV2("/transactions", transactionsHandlerV2(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead},
+		http.MethodGet: {EndpointsRead},
 	})
 	webHandlerV1("/injectTransaction", injectTransactionHandler(gateway), map[string][]string{
-		http.MethodPost: []string{EndpointsTransaction, EndpointsWallet},
+		http.MethodPost: {EndpointsTransaction, EndpointsWallet},
 	})
 	webHandlerV1("/resendUnconfirmedTxns", resendUnconfirmedTxnsHandler(gateway), map[string][]string{
-		http.MethodPost: []string{EndpointsTransaction, EndpointsWallet},
+		http.MethodPost: {EndpointsTransaction, EndpointsWallet},
 	})
 	webHandlerV1("/rawtx", rawTxnHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead},
+		http.MethodGet: {EndpointsRead},
 	})
 
 	// Unspent output related endpoints
 	webHandlerV1("/outputs", outputsHandler(gateway), map[string][]string{
-		http.MethodGet:  []string{EndpointsRead},
-		http.MethodPost: []string{EndpointsRead},
+		http.MethodGet:  {EndpointsRead},
+		http.MethodPost: {EndpointsRead},
 	})
 	webHandlerV1("/balance", balanceHandler(gateway), map[string][]string{
-		http.MethodGet:  []string{EndpointsRead},
-		http.MethodPost: []string{EndpointsRead},
+		http.MethodGet:  {EndpointsRead},
+		http.MethodPost: {EndpointsRead},
 	})
 	webHandlerV1("/uxout", uxOutHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead},
+		http.MethodGet: {EndpointsRead},
 	})
 	webHandlerV1("/address_uxouts", addrUxOutsHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead},
+		http.MethodGet: {EndpointsRead},
 	})
 
 	// golang process internal metrics for Prometheus
 	webHandlerV2("/metrics", metricsHandler(c, gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsPrometheus},
+		http.MethodGet: {EndpointsPrometheus},
 	})
 
 	// Address related endpoints
 	webHandlerV2("/address/verify", http.HandlerFunc(addressVerifyHandler), map[string][]string{
-		http.MethodPost: []string{EndpointsRead},
+		http.MethodPost: {EndpointsRead},
 	})
 
 	// Explorer endpoints
 	webHandlerV1("/coinSupply", coinSupplyHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead},
+		http.MethodGet: {EndpointsRead},
 	})
 	webHandlerV1("/richlist", richlistHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead},
+		http.MethodGet: {EndpointsRead},
 	})
 	webHandlerV1("/addresscount", addressCountHandler(gateway), map[string][]string{
-		http.MethodGet: []string{EndpointsRead},
+		http.MethodGet: {EndpointsRead},
 	})
 
 	// Storage endpoint
 	webHandlerV2("/data", storageHandler(gateway), map[string][]string{
-		http.MethodGet:    []string{EndpointsStorage},
-		http.MethodPost:   []string{EndpointsStorage},
-		http.MethodDelete: []string{EndpointsStorage},
+		http.MethodGet:    {EndpointsStorage},
+		http.MethodPost:   {EndpointsStorage},
+		http.MethodDelete: {EndpointsStorage},
 	})
 
 	return mux

--- a/src/api/http.go
+++ b/src/api/http.go
@@ -244,8 +244,10 @@ func Create(host string, c Config, gateway Gatewayer) (*Server, error) {
 
 	s, err := create(host, c, gateway)
 	if err != nil {
-		if closeErr := s.listener.Close(); closeErr != nil {
-			logger.WithError(err).Warning("s.listener.Close() error")
+		if s != nil {
+			if closeErr := s.listener.Close(); closeErr != nil {
+				logger.WithError(err).Warning("s.listener.Close() error")
+			}
 		}
 		return nil, err
 	}
@@ -278,8 +280,10 @@ func CreateHTTPS(host string, c Config, gateway Gatewayer, certFile, keyFile str
 
 	s, err := create(host, c, gateway)
 	if err != nil {
-		if closeErr := s.listener.Close(); closeErr != nil {
-			logger.WithError(err).Warning("s.listener.Close() error")
+		if s != nil {
+			if closeErr := s.listener.Close(); closeErr != nil {
+				logger.WithError(err).Warning("s.listener.Close() error")
+			}
 		}
 		return nil, err
 	}

--- a/src/api/integration/testdata/wallet-balance-bip44.golden
+++ b/src/api/integration/testdata/wallet-balance-bip44.golden
@@ -17,6 +17,16 @@
 				"coins": 0,
 				"hours": 0
 			}
+		},
+		"cLkNhXDYteSkhpUHCdNYBtNriSKwhqJGUZ": {
+			"confirmed": {
+				"coins": 0,
+				"hours": 0
+			},
+			"predicted": {
+				"coins": 0,
+				"hours": 0
+			}
 		}
 	}
 }

--- a/src/api/mock_gatewayer_test.go
+++ b/src/api/mock_gatewayer_test.go
@@ -1197,20 +1197,13 @@ func (_m *MockGatewayer) NewAddresses(wltID string, password []byte, n uint64, o
 	return r0, r1
 }
 
-// RecoverWallet provides a mock function with given fields: wltID, seed, seedPassphrase, password, options
-func (_m *MockGatewayer) RecoverWallet(wltID string, seed string, seedPassphrase string, password []byte, options ...wallet.Option) (wallet.Wallet, error) {
-	_va := make([]interface{}, len(options))
-	for _i := range options {
-		_va[_i] = options[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, wltID, seed, seedPassphrase, password)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+// RecoverWallet provides a mock function with given fields: wltID, seed, seedPassphrase, password
+func (_m *MockGatewayer) RecoverWallet(wltID string, seed string, seedPassphrase string, password []byte) (wallet.Wallet, error) {
+	ret := _m.Called(wltID, seed, seedPassphrase, password)
 
 	var r0 wallet.Wallet
-	if rf, ok := ret.Get(0).(func(string, string, string, []byte, ...wallet.Option) wallet.Wallet); ok {
-		r0 = rf(wltID, seed, seedPassphrase, password, options...)
+	if rf, ok := ret.Get(0).(func(string, string, string, []byte) wallet.Wallet); ok {
+		r0 = rf(wltID, seed, seedPassphrase, password)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(wallet.Wallet)
@@ -1218,8 +1211,8 @@ func (_m *MockGatewayer) RecoverWallet(wltID string, seed string, seedPassphrase
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, string, []byte, ...wallet.Option) error); ok {
-		r1 = rf(wltID, seed, seedPassphrase, password, options...)
+	if rf, ok := ret.Get(1).(func(string, string, string, []byte) error); ok {
+		r1 = rf(wltID, seed, seedPassphrase, password)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/src/api/wallet.go
+++ b/src/api/wallet.go
@@ -52,6 +52,7 @@ func NewWalletResponse(w wallet.Wallet) (*WalletResponse, error) {
 	wr.Meta.Encrypted = w.IsEncrypted()
 	wr.Meta.Timestamp = w.Timestamp()
 
+	var options []wallet.Option
 	switch w.Type() {
 	case wallet.WalletTypeBip44:
 		bip44Coin := w.Bip44Coin()
@@ -59,11 +60,14 @@ func NewWalletResponse(w wallet.Wallet) (*WalletResponse, error) {
 			return nil, errors.New("Wallet has no Bip44Coin meta data")
 		}
 		wr.Meta.Bip44Coin = bip44Coin
+
+		// get entries on both external and change chains
+		options = append(options, wallet.OptionExternal(), wallet.OptionChange())
 	case wallet.WalletTypeXPub:
 		wr.Meta.XPub = w.XPub()
 	}
 
-	entries, err := w.GetEntries()
+	entries, err := w.GetEntries(options...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get wallet entries: %v", err)
 	}

--- a/src/cli/integration/integration_test.go
+++ b/src/cli/integration/integration_test.go
@@ -3126,7 +3126,7 @@ func TestStableWalletCreate(t *testing.T) {
 				// get external entries length
 				extLen, err := w.EntriesLen()
 				require.NoError(t, err)
-				require.Equal(t, extLen, 5)
+				require.Equal(t, 6, extLen) // 5 external, 1 change
 
 				// get change entries length
 				chgLen, err := w.EntriesLen(wallet.OptionChange())

--- a/src/cli/integration/integration_test.go
+++ b/src/cli/integration/integration_test.go
@@ -2975,11 +2975,11 @@ func TestStableWalletCreateXPubFlow(t *testing.T) {
 	args := []string{"walletCreate", "xpub-flow", "-t", "bip44", "-n", "10", "-p", "pwd"}
 	output, err := execCommandCombinedOutput(args...)
 	require.NoError(t, err, fmt.Sprintf("expect no error, got: %s", string(output)))
-	var wrsp api.WalletResponse
-	require.NoError(t, json.Unmarshal(output, &wrsp))
+	var bip44Wlt api.WalletResponse
+	require.NoError(t, json.Unmarshal(output, &bip44Wlt))
 
 	// Export the xpub key from the bip44 wallet subpath 0'/0
-	args = []string{"walletKeyExport", wrsp.Meta.Filename, "-k", "xpub", "--path", "0/0", "-p", "pwd"}
+	args = []string{"walletKeyExport", bip44Wlt.Meta.Filename, "-k", "xpub", "--path", "0/0", "-p", "pwd"}
 	output, err = execCommandCombinedOutput(args...)
 	require.NoError(t, err, fmt.Sprintf("expect no error, got: %s", string(output)))
 
@@ -2987,25 +2987,25 @@ func TestStableWalletCreateXPubFlow(t *testing.T) {
 
 	c := newClient()
 	dir := getWalletDir(t, c)
-	xpubFilename := filepath.Join(dir, wrsp.Meta.Filename)
+	bip44Filename := filepath.Join(dir, bip44Wlt.Meta.Filename)
 
 	// Create an xpub wallet
 	args = []string{"walletCreate", "xpubwallet", "-t", "xpub", "--xpub", xpub, "-n", "10"}
 	output, err = execCommandCombinedOutput(args...)
 	require.NoError(t, err, fmt.Sprintf("expect no error, got: %s", string(output)))
-	var wrsp2 api.WalletResponse
-	require.NoError(t, json.Unmarshal(output, &wrsp2))
+	var xpubWlt api.WalletResponse
+	require.NoError(t, json.Unmarshal(output, &xpubWlt))
 
-	xpubFilename2 := filepath.Join(dir, wrsp2.Meta.Filename)
+	xpubFilename := filepath.Join(dir, xpubWlt.Meta.Filename)
 	// Compare the entries of both wallets: they should match
 
-	w, err := wallet.Load(xpubFilename)
+	w, err := wallet.Load(bip44Filename)
 	require.NoError(t, err)
 
-	w2, err := wallet.Load(xpubFilename2)
+	w2, err := wallet.Load(xpubFilename)
 	require.NoError(t, err)
 
-	entries, err := w.GetEntries()
+	entries, err := w.GetEntries(wallet.OptionExternal())
 	require.NoError(t, err)
 
 	for i, e := range entries {

--- a/src/cli/integration/integration_test.go
+++ b/src/cli/integration/integration_test.go
@@ -3129,7 +3129,7 @@ func TestStableWalletCreate(t *testing.T) {
 				require.Equal(t, extLen, 5)
 
 				// get change entries length
-				chgLen, err := w.EntriesLen(wallet.OptionChange(true))
+				chgLen, err := w.EntriesLen(wallet.OptionChange())
 				require.NoError(t, err)
 				require.Equal(t, chgLen, 1)
 			},

--- a/src/util/http/json_test.go
+++ b/src/util/http/json_test.go
@@ -41,7 +41,7 @@ func TestDurationUnmarshalJSON(t *testing.T) {
 		{
 			name: "invalid duration",
 			s:    "foo",
-			err:  "time: invalid duration foo",
+			err:  "time: invalid duration \"foo\"",
 		},
 	}
 
@@ -51,7 +51,7 @@ func TestDurationUnmarshalJSON(t *testing.T) {
 			err := d.UnmarshalJSON([]byte(fmt.Sprintf(`"%s"`, tc.s)))
 
 			if tc.err != "" {
-				require.Equal(t, errors.New(tc.err), err)
+				require.Contains(t, err.Error(), "time: invalid duration ")
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, d.Duration)

--- a/src/wallet/bip44wallet/account.go
+++ b/src/wallet/bip44wallet/account.go
@@ -195,8 +195,11 @@ func (a *bip44Account) unpackSecrets(ss wallet.Secrets) error {
 func (a bip44Account) entries(chain uint32) (wallet.Entries, error) {
 	switch chain {
 	case bip44.ExternalChainIndex, bip44.ChangeChainIndex:
-		c := a.Chains[chain]
-		return c.Entries.Clone(), nil
+		es := a.Chains[chain].Entries.Clone()
+		for i := range es {
+			es[i].Change = chain
+		}
+		return es, nil
 	default:
 		return nil, fmt.Errorf("invalid chain index: %d", chain)
 	}

--- a/src/wallet/bip44wallet/wallet.go
+++ b/src/wallet/bip44wallet/wallet.go
@@ -508,7 +508,7 @@ func (w *Wallet) GetEntries(options ...wallet.Option) (wallet.Entries, error) {
 
 	var entries wallet.Entries
 	switch opts.ChainMode {
-	case wallet.AllChains:
+	case wallet.DefaultChain, wallet.AllChains:
 		ees, err := w.entries(opts.Account, bip44.ExternalChainIndex)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get external chain, err: %v", err)
@@ -520,7 +520,7 @@ func (w *Wallet) GetEntries(options ...wallet.Option) (wallet.Entries, error) {
 		}
 
 		entries = append(ees, ces...)
-	case wallet.DefaultChain, wallet.ExternalChain:
+	case wallet.ExternalChain:
 		es, err := w.entries(opts.Account, bip44.ExternalChainIndex)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get external chain, err: %v", err)
@@ -694,7 +694,7 @@ func (w *Wallet) GenerateAddresses(num uint64, options ...wallet.Option) ([]ciph
 }
 
 // GetEntryAt returns the entry at specified index of selected chain.
-// If no chain is specified, the entry of append(external chain, change chain)[index] will be returned.
+// If no chain is specified, the entry of append(external, change)[index] will be returned.
 func (w *Wallet) GetEntryAt(i int, options ...wallet.Option) (wallet.Entry, error) {
 	entries, err := w.GetEntries(options...)
 	if err != nil {
@@ -737,18 +737,18 @@ func (w *Wallet) HasEntry(addr cipher.Addresser, options ...wallet.Option) (bool
 }
 
 // EntriesLen returns the entries length of selected account and chain,
-// if no options are provided, entries length of external chain on account 0 will
+// if no options are provided, entries length of all chains will
 // be returned.
 func (w *Wallet) EntriesLen(options ...wallet.Option) (int, error) {
 	opts := getBip44Options(options...)
 	switch opts.ChainMode {
-	case wallet.DefaultChain, wallet.ExternalChain:
+	case wallet.ExternalChain:
 		l, err := w.entriesLen(opts.Account, bip44.ExternalChainIndex)
 		return int(l), err
 	case wallet.ChangeChain:
 		l, err := w.entriesLen(opts.Account, bip44.ChangeChainIndex)
 		return int(l), err
-	case wallet.AllChains:
+	case wallet.DefaultChain, wallet.AllChains:
 		el, err := w.entriesLen(opts.Account, bip44.ExternalChainIndex)
 		if err != nil {
 			return 0, fmt.Errorf("failed to get entries length of external chain, err: %v", err)

--- a/src/wallet/bip44wallet/wallet_test.go
+++ b/src/wallet/bip44wallet/wallet_test.go
@@ -64,7 +64,7 @@ func TestBip44NewWallet(t *testing.T) {
 			expect: expect{
 				wallet.CoinTypeSkycoin,
 				bip44.CoinTypeSkycoin,
-				1,
+				2, // 1 external, 1 change
 				DefaultAccountName,
 			},
 		},
@@ -80,7 +80,7 @@ func TestBip44NewWallet(t *testing.T) {
 			expect: expect{
 				wallet.CoinTypeBitcoin,
 				bip44.CoinTypeBitcoin,
-				1,
+				2, // 1 external, 1 change,
 				DefaultAccountName,
 			},
 		},
@@ -97,7 +97,7 @@ func TestBip44NewWallet(t *testing.T) {
 			expect: expect{
 				wallet.CoinTypeSkycoin,
 				bip44.CoinTypeSkycoin,
-				1,
+				2, // one external, 1 change,
 				DefaultAccountName,
 			},
 		},
@@ -113,7 +113,7 @@ func TestBip44NewWallet(t *testing.T) {
 			expect: expect{
 				wallet.CoinTypeSkycoin,
 				bip44.CoinTypeSkycoin,
-				5,
+				6, // 5 external, 1 change
 				DefaultAccountName,
 			},
 		},
@@ -133,7 +133,7 @@ func TestBip44NewWallet(t *testing.T) {
 			expect: expect{
 				wallet.CoinTypeSkycoin,
 				bip44.CoinTypeSkycoin,
-				3,
+				4, // 3 external, 1 change
 				DefaultAccountName,
 			},
 		},
@@ -153,7 +153,7 @@ func TestBip44NewWallet(t *testing.T) {
 			expect: expect{
 				wallet.CoinTypeSkycoin,
 				bip44.CoinTypeSkycoin,
-				4,
+				5, // 4 external, 1 change
 				DefaultAccountName,
 			},
 		},
@@ -172,7 +172,7 @@ func TestBip44NewWallet(t *testing.T) {
 			expect: expect{
 				wallet.CoinTypeSkycoin,
 				bip44.CoinTypeSkycoin,
-				2,
+				3, // 2 external, one change
 				DefaultAccountName,
 			},
 		},
@@ -191,7 +191,7 @@ func TestBip44NewWallet(t *testing.T) {
 			expect: expect{
 				wallet.CoinTypeSkycoin,
 				bip44.CoinTypeSkycoin,
-				1,
+				2, // 1 external, 1 change
 				DefaultAccountName,
 			},
 		},
@@ -208,7 +208,7 @@ func TestBip44NewWallet(t *testing.T) {
 			expect: expect{
 				wallet.CoinTypeSkycoin,
 				bip44.CoinTypeSkycoin,
-				1,
+				2, // 1 external, 1 change
 				DefaultAccountName,
 			},
 		},
@@ -224,7 +224,7 @@ func TestBip44NewWallet(t *testing.T) {
 			expect: expect{
 				wallet.CoinTypeSkycoin,
 				bip44.CoinTypeSkycoin,
-				1,
+				2, // 1 external, 1 change
 				"marketing",
 			},
 		},
@@ -241,7 +241,7 @@ func TestBip44NewWallet(t *testing.T) {
 			expect: expect{
 				wallet.CoinTypeSkycoin,
 				newBip44Type,
-				1,
+				2, // 1 external, 1 change
 				DefaultAccountName,
 			},
 		},
@@ -264,7 +264,7 @@ func TestBip44NewWallet(t *testing.T) {
 			expect: expect{
 				wallet.CoinTypeSkycoin,
 				bip44.CoinTypeSkycoin,
-				1,
+				2, // 1 external, 1 change
 				DefaultAccountName,
 			},
 		},
@@ -557,7 +557,7 @@ func TestWalletUnlock(t *testing.T) {
 				// Checks the generated external addresses
 				el, err := unlockWlt.EntriesLen()
 				require.NoError(t, err)
-				require.Equal(t, 5, el)
+				require.Equal(t, 6, el)
 
 				// pack the origin wallet's secrets
 				originSS := make(wallet.Secrets)
@@ -596,7 +596,7 @@ func TestLockAndUnLock(t *testing.T) {
 		el, err := w.EntriesLen()
 		require.NoError(t, err)
 		// 1 default address + 9
-		require.Equal(t, 10, el)
+		require.Equal(t, 11, el)
 
 		// clone the wallet
 		cw := w.Clone()
@@ -672,25 +672,30 @@ func TestWalletGenerateAddress(t *testing.T) {
 		name               string
 		opts               []wallet.Option
 		num                uint64
+		expectNum          uint64
 		oneAddressEachTime bool
 		err                error
 	}{
 		{
-			name: "ok with none address",
-			num:  0,
+			name:      "ok with none address",
+			num:       0,
+			expectNum: 2, // 1 external, 1 change
 		},
 		{
-			name: "ok with one address",
-			num:  1,
+			name:      "ok with one address",
+			num:       1,
+			expectNum: 3, // 2 external, 1 change
 		},
 		{
-			name: "ok with two address",
-			num:  1,
+			name:      "ok with two address",
+			num:       2,
+			expectNum: 4, // 3 external, 1 change
 		},
 		{
 			name:               "ok with three address and generate one address each time deterministic",
 			num:                2,
 			oneAddressEachTime: true,
+			expectNum:          4, // 3 external, 1 change
 		},
 		{
 			name: "encrypt wallet",
@@ -700,6 +705,7 @@ func TestWalletGenerateAddress(t *testing.T) {
 			},
 			num:                2,
 			oneAddressEachTime: true,
+			expectNum:          4, // 3 external, 1 change
 		},
 	}
 
@@ -735,16 +741,15 @@ func TestWalletGenerateAddress(t *testing.T) {
 				l, err := w.EntriesLen()
 				require.NoError(t, err)
 				// 1 default address + tc.num = wallet.EntriesLen()
-				require.Equal(t, int(tc.num)+1, l)
+				require.Equal(t, int(tc.expectNum), l)
 
 				addrs, err := w.GetAddresses()
 				require.NoError(t, err)
 
-				if tc.num == 0 {
-					require.Equal(t, skycoinExternalAddrs[:1], addrs)
-				} else {
-					require.Equal(t, skycoinExternalAddrs[:tc.num+1], addrs)
-				}
+				expectAddrs := make([]cipher.Addresser, tc.num+2)
+				copy(expectAddrs, skycoinExternalAddrs[:tc.num+1])
+				copy(expectAddrs[tc.num+1:], skycoinChangeAddrs[:1])
+				require.Equal(t, expectAddrs, addrs)
 			})
 		}
 	}

--- a/src/wallet/bip44wallet/wallet_test.go
+++ b/src/wallet/bip44wallet/wallet_test.go
@@ -469,7 +469,7 @@ func TestWalletLock(t *testing.T) {
 					_, err = w.GenerateAddresses(2)
 					require.NoError(t, err)
 
-					_, err = w.GenerateAddresses(2, wallet.OptionChange(true))
+					_, err = w.GenerateAddresses(2, wallet.OptionChange())
 					require.NoError(t, err)
 				}
 
@@ -936,7 +936,7 @@ func TestScanAddresses(t *testing.T) {
 			require.Equal(t, tc.expectAddrs, addrs)
 
 			// get the change address, as the ScanAddresses function won't return the change addresses
-			changeAddrs, err := w.GetAddresses(wallet.OptionChange(true))
+			changeAddrs, err := w.GetAddresses(wallet.OptionChange())
 			require.NoError(t, err)
 			require.Equal(t, tc.expectAllChangeAddrs, changeAddrs)
 		})

--- a/src/wallet/options.go
+++ b/src/wallet/options.go
@@ -9,7 +9,7 @@ import (
 type ChainMode uint32
 
 const (
-	DefaultChain  ChainMode = 0 // indicates the default chain, usually it is the external chain
+	DefaultChain  ChainMode = 0 // indicates the default chain when no chain is specified.
 	ExternalChain           = 1 // indicates the external chain
 	ChangeChain             = 2 // indicates the change chain
 	AllChains               = 3 // indicates both external and change chains

--- a/src/wallet/options.go
+++ b/src/wallet/options.go
@@ -5,6 +5,16 @@ import (
 	"github.com/skycoin/skycoin/src/wallet/crypto"
 )
 
+// ChainMode represents the bip44 chain mode. AllChains =  ExternalChain | ChangeChain
+type ChainMode uint32
+
+const (
+	DefaultChain  ChainMode = 0 // indicates the default chain, usually it is the external chain
+	ExternalChain           = 1 // indicates the external chain
+	ChangeChain             = 2 // indicates the change chain
+	AllChains               = 3 // indicates both external and change chains
+)
+
 // Option represents the general options, it can be used to set optional
 // parameters while creating a new wallet. Also, can be used to get
 // entries service of a wallet.
@@ -13,8 +23,8 @@ type Option func(interface{})
 // Bip44EntriesOptions represents the options that will be used
 // by bip44 to get entries service
 type Bip44EntriesOptions struct {
-	Account uint32
-	Change  uint32
+	Account   uint32
+	ChainMode ChainMode
 }
 
 // OptionAccount is the option type for specifying a bip44 account
@@ -28,19 +38,27 @@ func OptionAccount(index uint32) Option {
 	}
 }
 
-// OptionChange is the option type for specifying a bip44 chain
-func OptionChange(change bool) Option {
+// OptionChange is the option for selecting the change chain
+func OptionChange() Option {
 	return func(opts interface{}) {
-		bip44, ok := opts.(*Bip44EntriesOptions)
+		o, ok := opts.(*Bip44EntriesOptions)
 		if !ok {
 			return
 		}
 
-		var chain uint32
-		if change {
-			chain = 1
+		o.ChainMode += ChangeChain
+	}
+}
+
+// OptionExternal is the option type for selecting the external chain
+func OptionExternal() Option {
+	return func(opts interface{}) {
+		o, ok := opts.(*Bip44EntriesOptions)
+		if !ok {
+			return
 		}
-		bip44.Change = chain
+
+		o.ChainMode += ExternalChain
 	}
 }
 

--- a/src/wallet/service_test.go
+++ b/src/wallet/service_test.go
@@ -431,7 +431,7 @@ func TestServiceLoadWallet(t *testing.T) {
 				},
 			},
 			err:           nil,
-			expectAddrNum: 1,
+			expectAddrNum: 2,
 			expectAddrs:   bip44Addrs[:1],
 		},
 		{
@@ -446,7 +446,7 @@ func TestServiceLoadWallet(t *testing.T) {
 				},
 			},
 			err:           nil,
-			expectAddrNum: 2,
+			expectAddrNum: 3,
 			expectAddrs:   bip44Addrs[:2],
 		},
 		{
@@ -463,7 +463,7 @@ func TestServiceLoadWallet(t *testing.T) {
 				},
 			},
 			err:           nil,
-			expectAddrNum: 1,
+			expectAddrNum: 2,
 			expectAddrs:   bip44Addrs[:1],
 		},
 		{
@@ -480,7 +480,7 @@ func TestServiceLoadWallet(t *testing.T) {
 				},
 			},
 			err:           nil,
-			expectAddrNum: 2,
+			expectAddrNum: 3,
 			expectAddrs:   bip44Addrs[:2],
 		},
 
@@ -497,7 +497,7 @@ func TestServiceLoadWallet(t *testing.T) {
 				},
 			},
 			err:           nil,
-			expectAddrNum: 1,
+			expectAddrNum: 2,
 			expectAddrs:   bip44SeedPassphraseAddrs[:1],
 		},
 		{
@@ -513,7 +513,7 @@ func TestServiceLoadWallet(t *testing.T) {
 				},
 			},
 			err:           nil,
-			expectAddrNum: 2,
+			expectAddrNum: 3,
 			expectAddrs:   bip44SeedPassphraseAddrs[:2],
 		},
 		{
@@ -531,7 +531,7 @@ func TestServiceLoadWallet(t *testing.T) {
 				},
 			},
 			err:           nil,
-			expectAddrNum: 1,
+			expectAddrNum: 2,
 			expectAddrs:   bip44SeedPassphraseAddrs[:1],
 		},
 		{
@@ -549,7 +549,7 @@ func TestServiceLoadWallet(t *testing.T) {
 				},
 			},
 			err:           nil,
-			expectAddrNum: 2,
+			expectAddrNum: 3,
 			expectAddrs:   bip44SeedPassphraseAddrs[:2],
 		},
 	}
@@ -872,7 +872,11 @@ func TestServiceNewAddresses(t *testing.T) {
 				require.NoError(t, err)
 				el, err := w.EntriesLen()
 				require.NoError(t, err)
-				require.Equal(t, int(tc.n+1), el)
+				if w.Type() == wallet.WalletTypeBip44 {
+					require.Equal(t, int(tc.n+2), el) // bip44 wallet has a change address
+				} else {
+					require.Equal(t, int(tc.n+1), el)
+				}
 
 				addrsInWlt, err := w.GetAddresses()
 				require.NoError(t, err)
@@ -892,7 +896,12 @@ func TestServiceNewAddresses(t *testing.T) {
 				el, err = lw.EntriesLen()
 				require.NoError(t, err)
 
-				require.Equal(t, tc.expectAddrNum+1, el)
+				if w.Type() == wallet.WalletTypeBip44 {
+					require.Equal(t, tc.expectAddrNum+2, el)
+				} else {
+					require.Equal(t, tc.expectAddrNum+1, el)
+				}
+
 				es, err := w.GetEntries()
 				require.NoError(t, err)
 				for i := range es {
@@ -2050,8 +2059,8 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			expect: exp{
 				err:      nil,
 				seed:     bip44Seed,
-				entryNum: 1,
-				addrs:    bip44Addrs,
+				entryNum: 2,
+				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
 			},
 		},
 		{
@@ -2066,8 +2075,8 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			expect: exp{
 				err:      nil,
 				seed:     bip44Seed,
-				entryNum: 1,
-				addrs:    bip44Addrs,
+				entryNum: 2,
+				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
 			},
 		},
 		{
@@ -2081,8 +2090,8 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			expect: exp{
 				err:      nil,
 				seed:     bip44Seed,
-				entryNum: 1,
-				addrs:    bip44Addrs,
+				entryNum: 2,
+				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
 			},
 		},
 		{
@@ -2091,15 +2100,15 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 				Seed:     bip44Seed,
 				Encrypt:  true,
 				Password: []byte("pwd"),
-				ScanN:    1,
+				ScanN:    2,
 				Type:     wallet.WalletTypeBip44,
 				TF:       tf,
 			},
 			expect: exp{
 				err:      nil,
 				seed:     bip44Seed,
-				entryNum: 1,
-				addrs:    bip44Addrs,
+				entryNum: 2,
+				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
 			},
 		},
 		{
@@ -2113,8 +2122,8 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			expect: exp{
 				err:      nil,
 				seed:     bip44Seed,
-				entryNum: 1,
-				addrs:    bip44Addrs,
+				entryNum: 2,
+				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
 			},
 		},
 		{
@@ -2130,8 +2139,8 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			expect: exp{
 				err:      nil,
 				seed:     bip44Seed,
-				entryNum: 1,
-				addrs:    bip44Addrs,
+				entryNum: 2,
+				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
 			},
 		},
 		{
@@ -2149,8 +2158,8 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			expect: exp{
 				err:      nil,
 				seed:     bip44Seed,
-				entryNum: 1,
-				addrs:    bip44Addrs,
+				entryNum: 2,
+				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
 			},
 		},
 		{
@@ -2166,8 +2175,8 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			expect: exp{
 				err:      nil,
 				seed:     bip44Seed,
-				entryNum: 1,
-				addrs:    bip44Addrs,
+				entryNum: 2,
+				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
 			},
 		},
 		{
@@ -2185,8 +2194,8 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			expect: exp{
 				err:      nil,
 				seed:     bip44Seed,
-				entryNum: 1,
-				addrs:    bip44Addrs,
+				entryNum: 2,
+				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
 			},
 		},
 		{
@@ -2203,8 +2212,8 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			expect: exp{
 				err:      nil,
 				seed:     bip44Seed,
-				entryNum: 2,
-				addrs:    bip44Addrs,
+				entryNum: 3,
+				addrs:    combineAddrs(bip44Addrs[:2], bip44ChangeAddrs[:1]),
 			},
 		},
 		{
@@ -2223,8 +2232,8 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			expect: exp{
 				err:      nil,
 				seed:     bip44Seed,
-				entryNum: 2,
-				addrs:    bip44Addrs,
+				entryNum: 3,
+				addrs:    combineAddrs(bip44Addrs[:2], bip44ChangeAddrs[:1]),
 			},
 		},
 		{
@@ -2240,8 +2249,8 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			expect: exp{
 				err:      nil,
 				seed:     bip44Seed,
-				entryNum: 1,
-				addrs:    bip44Addrs,
+				entryNum: 2,
+				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
 			},
 		},
 		{
@@ -2257,8 +2266,8 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			expect: exp{
 				err:      nil,
 				seed:     bip44Seed,
-				entryNum: 2,
-				addrs:    bip44Addrs,
+				entryNum: 3,
+				addrs:    combineAddrs(bip44Addrs[:2], bip44ChangeAddrs[:1]),
 			},
 		},
 		{
@@ -2274,8 +2283,8 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			expect: exp{
 				err:      nil,
 				seed:     bip44Seed,
-				entryNum: 5,
-				addrs:    bip44Addrs,
+				entryNum: 6,
+				addrs:    combineAddrs(bip44Addrs[:5], bip44ChangeAddrs[:1]),
 			},
 		},
 		{
@@ -2294,8 +2303,8 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			expect: exp{
 				err:      nil,
 				seed:     bip44Seed,
-				entryNum: 5,
-				addrs:    bip44Addrs,
+				entryNum: 6,
+				addrs:    combineAddrs(bip44Addrs[:5], bip44ChangeAddrs[:1]),
 			},
 		},
 		{
@@ -3758,7 +3767,6 @@ func TestServiceUpdate(t *testing.T) {
 					// TODO: bip44 wallet can generate address without decrypting
 					_, err := w.GenerateAddresses(1)
 					require.NoError(t, err)
-					//require.Equal(t, wallet.ErrWalletEncrypted, err)
 
 					return nil
 				}
@@ -3767,7 +3775,7 @@ func TestServiceUpdate(t *testing.T) {
 				require.Equal(t, "foowltfoo", w.Label())
 				el, err := w.EntriesLen()
 				require.NoError(t, err)
-				require.Equal(t, 2, el)
+				require.Equal(t, 3, el)
 				checkNoSensitiveData(t, w)
 			},
 		},
@@ -4060,7 +4068,7 @@ func TestServiceUpdateSecrets(t *testing.T) {
 				require.Equal(t, "foowltbip44foo", w.Label())
 				el, err := w.EntriesLen()
 				require.NoError(t, err)
-				require.Equal(t, 2, el)
+				require.Equal(t, 3, el)
 				checkNoSensitiveData(t, w)
 			},
 		},
@@ -4094,7 +4102,7 @@ func TestServiceUpdateSecrets(t *testing.T) {
 				require.Equal(t, "foowltbip44foo", w.Label())
 				el, err := w.EntriesLen()
 				require.NoError(t, err)
-				require.Equal(t, 2, el)
+				require.Equal(t, 3, el)
 				entries, err := w.GetEntries()
 				require.NoError(t, err)
 				require.NotEmpty(t, entries[1].Secret)
@@ -4312,4 +4320,11 @@ func checkNoSensitiveData(t *testing.T, w wallet.Wallet) {
 	for _, e := range entries {
 		require.True(t, e.Secret.Null())
 	}
+}
+
+func combineAddrs(a []cipher.Address, b []cipher.Address) []cipher.Address {
+	addrs := make([]cipher.Address, len(a)+len(b))
+	copy(addrs, a[:])
+	copy(addrs[len(a):], b[:])
+	return addrs
 }


### PR DESCRIPTION
Fixes #2536 

Changes:
- Include change addresses for bip44 wallet for /api/v1/wallet endpoint
- Fix redundant type of `[]string` in http handlers registration
- Do nil check before referencing the variables of the `server` returned by `http.create` function.

Does this change need to mentioned in CHANGELOG.md?
Yes