### PR TITLE
Get the uri prefix from the api

### DIFF
--- a/src/gui/static/src/app/app.config.ts
+++ b/src/gui/static/src/app/app.config.ts
@@ -8,15 +8,6 @@ export const AppConfig = {
   urlForVersionChecking: 'https://version.skycoin.com/skycoin/version.txt',
   walletDownloadUrl: 'https://www.skycoin.com/downloads/',
 
-  priceApiId: 'sky-skycoin',
-
-  /**
-   * This wallet uses the Skycoin URI Specification (based on BIP-21) when creating QR codes and
-   * requesting coins. This variable defines the prefix that will be used for creating QR codes
-   * and URLs. IT MUST BE UNIQUE FOR EACH COIN.
-   */
-  uriSpecificatioPrefix: 'skycoin',
-
   languages: [{
       code: 'en',
       name: 'English',

--- a/src/gui/static/src/app/app.config.ts
+++ b/src/gui/static/src/app/app.config.ts
@@ -8,6 +8,8 @@ export const AppConfig = {
   urlForVersionChecking: 'https://version.skycoin.com/skycoin/version.txt',
   walletDownloadUrl: 'https://www.skycoin.com/downloads/',
 
+  priceApiId: 'sky-skycoin',
+
   languages: [{
       code: 'en',
       name: 'English',

--- a/src/gui/static/src/app/components/layout/qr-code/qr-code.component.ts
+++ b/src/gui/static/src/app/components/layout/qr-code/qr-code.component.ts
@@ -134,7 +134,7 @@ export class QrCodeComponent implements OnInit, OnDestroy {
     }
 
     // Add the BIP21 prefix.
-    this.currentQrContent = AppConfig.uriSpecificatioPrefix.toLowerCase() + ':' + this.data.address;
+    this.currentQrContent = this.appService.uriSpecificatioPrefix.toLowerCase() + ':' + this.data.address;
 
     this.invalidCoins = false;
     this.invalidHours = false;

--- a/src/gui/static/src/app/services/app.service.ts
+++ b/src/gui/static/src/app/services/app.service.ts
@@ -102,6 +102,16 @@ export class AppService {
   }
   private lastestVersionInternal = '';
 
+  /**
+   * This wallet uses the Skycoin URI Specification (based on BIP-21) when creating QR codes and
+   * requesting coins. This variable defines the prefix that will be used for creating QR codes
+   * and URLs. IT MUST BE UNIQUE FOR EACH COIN.
+   */
+  get uriSpecificatioPrefix(): string {
+    return this.uriSpecificatioPrefixInternal;
+  }
+  private uriSpecificatioPrefixInternal = '';
+
   constructor(
     private apiService: ApiService,
     private http: HttpClient,
@@ -124,6 +134,7 @@ export class AppService {
       this.hoursNameInternal = response.fiber.coin_hours_display_name;
       this.hoursNameSingularInternal = response.fiber.coin_hours_display_name_singular;
       this.explorerUrlInternal = response.fiber.explorer_url;
+      this.uriSpecificatioPrefixInternal = response.fiber.qr_uri_prefix;
 
       if (this.explorerUrlInternal.endsWith('/')) {
         this.explorerUrlInternal = this.explorerUrlInternal.substr(0, this.explorerUrl.length - 1);


### PR DESCRIPTION
Changes:
- Now the UI gets the URI prefix for the QR codes from the API.

Does this change need to mentioned in CHANGELOG.md?
No