### PR TITLE
Make the Swaplab integration work in electron and dev builds

### DIFF
--- a/electron/app/electron-api.js
+++ b/electron/app/electron-api.js
@@ -1,4 +1,4 @@
-// Warning: for this to work the contextIsolation property of the browser window must be set to true.
+// Warning: for this to work the contextIsolation property of the browser window must be set to false.
 
 window.isElectron = true;
 window.ipcRenderer = require('electron').ipcRenderer;

--- a/electron/app/electron-main.js
+++ b/electron/app/electron-main.js
@@ -207,6 +207,52 @@ function createWindow(url) {
     console.log('Cleared the caching of the skycoin wallet.');
   });
 
+  // When an options request to Swaplab using an https endpoint is detected, asume that it is a
+  // cors request and redirect it to an invalid endpoint on the node API.
+  ses.protocol.registerHttpProtocol('https', (request, callback) => {
+    if (request.method.toLowerCase().includes('options') && request.url.toLowerCase().includes('swaplab.cc')) {
+      callback({ url: currentURL + '/api/v1/unused', method: 'get' });
+    } else {
+      callback({ url:request.url });
+    }
+  }, (error) => {
+    if (error) console.error('Failed to register protocol')
+  })
+
+  // Remove the origin headers when connecting to Swaplab.
+  ses.webRequest.onBeforeSendHeaders({
+    urls: ['https://swaplab.cc/*']
+  }, (details, callback) => {
+    details.requestHeaders['origin'] = null;
+    details.requestHeaders['referer'] = null;
+    details.requestHeaders['host'] = null;
+    details.requestHeaders['Origin'] = null;
+    details.requestHeaders['Referer'] = null;
+    details.requestHeaders['Host'] = null;
+
+    callback({ requestHeaders: details.requestHeaders });
+  })
+
+  // Make all connections made to swaplab include permisive cors headers.
+  ses.webRequest.onHeadersReceived({
+    urls: ['https://swaplab.cc/*']
+  }, (details, callback) => {
+    const headers = details.responseHeaders;
+    if (headers) {
+      headers['Access-Control-Allow-Origin'] = '*';
+      headers['Access-Control-Allow-Headers'] = '*';
+    }
+    const response = { responseHeaders: headers };
+
+    // Options request are redirected to an invalid url, so the status must be changed to 200
+    // to simulate a good response.
+    if (details.method.toLowerCase().includes('options')) {
+      response['statusLine'] = '200';
+    }
+
+    callback(response);
+  });
+
   if (url) {
     win.loadURL(url);
   } else {

--- a/src/gui/static/proxy.config.js
+++ b/src/gui/static/proxy.config.js
@@ -8,7 +8,13 @@ const PROXY_CONFIG = {
       req.headers["referer"] = 'http://127.0.0.1:6420';
       req.headers["origin"] = 'http://127.0.0.1:6420';
     }
-},
+  },
+  "/swaplab": {
+    "target": "https://swaplab.cc",
+    "logLevel": "debug",
+    "changeOrigin": true,
+    pathRewrite: {'^/swaplab' : ''}
+  },
   "/teller/*": {
     "target": "http://127.0.0.1:7071",
     "pathRewrite": {

--- a/src/gui/static/src/app/components/pages/exchange/exchange.component.html
+++ b/src/gui/static/src/app/components/pages/exchange/exchange.component.html
@@ -1,6 +1,12 @@
 <app-header [headline]="'exchange.title-and-button' | translate:{coinName: appService.coinName}"></app-header>
 <div class="container">
   <div class="paper">
+    <app-loading-content
+      [isLoading]="false"
+      noDataText="exchange.unavailable"
+      *ngIf="unavailable"
+    ></app-loading-content>
+
     <app-exchange-create
       *ngIf="!currentOrderDetails && !loading"
       (submitted)="showStatus($event)"

--- a/src/gui/static/src/app/components/pages/exchange/exchange.component.ts
+++ b/src/gui/static/src/app/components/pages/exchange/exchange.component.ts
@@ -5,6 +5,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { ExchangeHistoryComponent } from './exchange-history/exchange-history.component';
 import { SubscriptionLike } from 'rxjs';
 import { AppService } from '../../../services/app.service';
+import { environment } from '../../../../environments/environment';
 
 @Component({
   selector: 'app-exchange',
@@ -15,6 +16,7 @@ export class ExchangeComponent implements OnInit, OnDestroy {
   currentOrderDetails: StoredExchangeOrder;
   hasHistory = false;
   loading = true;
+  unavailable = false;
 
   private lastViewedSubscription: SubscriptionLike;
   private historySubscription: SubscriptionLike;
@@ -26,6 +28,12 @@ export class ExchangeComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit() {
+    if (environment.production && navigator.userAgent.toLowerCase().indexOf('electron') === -1) {
+      this.unavailable = true;
+
+      return;
+    }
+
     this.lastViewedSubscription = this.exchangeService.lastViewedOrderLoaded.subscribe(response => {
       if (response) {
         const lastViewedOrder = this.exchangeService.lastViewedOrder;
@@ -42,8 +50,12 @@ export class ExchangeComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.lastViewedSubscription.unsubscribe();
-    this.historySubscription.unsubscribe();
+    if (this.lastViewedSubscription) {
+      this.lastViewedSubscription.unsubscribe();
+    }
+    if (this.historySubscription) {
+      this.historySubscription.unsubscribe();
+    }
   }
 
   showStatus(order) {

--- a/src/gui/static/src/app/services/exchange.service.ts
+++ b/src/gui/static/src/app/services/exchange.service.ts
@@ -15,7 +15,7 @@ import { processServiceError } from '../utils/errors';
 
 @Injectable()
 export class ExchangeService {
-  private readonly API_ENDPOINT = 'https://swaplab.cc/api/v3';
+  private readonly API_ENDPOINT = environment.production ? 'https://swaplab.cc/api/v3' : '/swaplab/api/v3';
   private readonly STORAGE_KEY = 'exchange-orders';
   private readonly LAST_VIEWED_STORAGE_KEY = 'last-viewed-order';
   private readonly API_KEY = environment.swaplab.apiKey;

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -674,6 +674,7 @@
     "label-status": "Status",
     "exchanging": "Exchanging {{from}} for {{to}}",
     "destination-select-from-list-link": "Select",
+    "unavailable": "The exchange service is not available in the portable version",
     "offline": "Exchange is temporarily offline",
     "problem-connecting": "Unable to connect with the service. Please check your Internet connection and try again later",
     "invalid-address-error": "Invalid address.",

--- a/src/gui/static/src/assets/i18n/es.json
+++ b/src/gui/static/src/assets/i18n/es.json
@@ -674,6 +674,7 @@
     "label-status": "Estado",
     "exchanging": "Intercambiando {{from}} por {{to}}",
     "destination-select-from-list-link": "Seleccionar",
+    "unavailable": "El servicio de intercambio no está disponible en la versión portable.",
     "offline": "El servicio está temporalmente offline",
     "problem-connecting": "No se puede conectar con el servicio. Por favor compruebe su conexión a Internet y vuelva a intentarlo más tarde.",
     "invalid-address-error": "Dirección inválida.",

--- a/src/gui/static/src/assets/i18n/es_base.json
+++ b/src/gui/static/src/assets/i18n/es_base.json
@@ -674,6 +674,7 @@
     "label-status": "Status",
     "exchanging": "Exchanging {{from}} for {{to}}",
     "destination-select-from-list-link": "Select",
+    "unavailable": "The exchange service is not available in the portable version",
     "offline": "Exchange is temporarily offline",
     "problem-connecting": "Unable to connect with the service. Please check your Internet connection and try again later",
     "invalid-address-error": "Invalid address.",


### PR DESCRIPTION
Changes:
- The problem with the cors policy while connecting to the Swaplab API was solved in the dev enviroment and the Electron version. In the dev enviroment the dev proxy was modified to use the appropiate headers. For Electron code was created for using something like a "cors response emulator", which includes and removes some headers and redirects some connections to a local URL, to avoid sending unnecessary requests to the backend and make it possible to complete the operations. Also, an error msg indicating that the Swaplab integration is not available in the portable version was added.

Note: adapted from https://github.com/SkycoinProject/skycoin/pull/242#issuecomment-599097810

Does this change need to mentioned in CHANGELOG.md?
No