### PR TITLE
Update to use github.com/skycoin/gox

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
             - name: Check out code into the Go module directory
               uses: actions/checkout@v2
             - name: Set up Gox
-              run: GO111MODULE=off go get github.com/mitchellh/gox
+              run: GO111MODULE=off go get github.com/skycoin/gox
             - uses: actions/cache@v2
               with:
                 path: |


### PR DESCRIPTION
Fixes #2560

Changes:
- Update to use github.com/skycoin/gox

Does this change need to mentioned in CHANGELOG.md?
No.