### PR TITLE
Improvements for the Electron build

### DIFF
--- a/electron/app/electron-main.js
+++ b/electron/app/electron-main.js
@@ -111,7 +111,9 @@ function startSkycoin() {
 		  var id = setInterval(function() {
 			// wait till the splash page loading is finished
 			if (splashLoaded) {
-			  app.emit('skycoin-ready', { url: currentURL });
+				if (skycoin) {
+					app.emit('skycoin-ready', { url: currentURL });
+				}
 			  clearInterval(id);
 			}
 		  }, 500);

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -570,9 +570,9 @@
             }
         },
         "core-js": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.7.0.tgz",
-            "integrity": "sha512-NwS7fI5M5B85EwpWuIwJN4i/fbisQUwLwiSNUWeXlkAZ0sbBjLEvLvFLf1uzAUV66PcEPt4xCGCmOZSxVf3xzA==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.1.tgz",
+            "integrity": "sha512-9Id2xHY1W7m8hCl8NkhQn5CufmF/WuR30BTRewvCXc1aZd3kMECwNZ69ndLbekKfakw9Rf2Xyc+QR6E7Gg+obg==",
             "dev": true,
             "optional": true
         },
@@ -716,9 +716,9 @@
             }
         },
         "electron": {
-            "version": "10.1.6",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-10.1.6.tgz",
-            "integrity": "sha512-Wyiq5Fy64KAa51i72m+5zayYKSm9O5lnittUdaElAn3PAzGl3yDifYO2QsXR7k/iKxWVSROOPzf43mXYytL67Q==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-10.2.0.tgz",
+            "integrity": "sha512-GBUyq8dwUqXPkCTkoID+eZ5Pm9GFlLUd2eSoGe8UOaHeW68SgCf5t75/uGHraQ1OIz/0qniyH5M4ebWEHGppyQ==",
             "dev": true,
             "requires": {
                 "@electron/get": "^1.0.1",

--- a/electron/package.json
+++ b/electron/package.json
@@ -72,7 +72,7 @@
         "postinstall": "electron-builder install-app-deps"
     },
     "devDependencies": {
-        "electron": "^10.1.6",
+        "electron": "^10.2.0",
         "electron-builder": "22.9.1"
     },
     "dependencies": {}


### PR DESCRIPTION
Changes:
- Electron was updated to v10.2
- A small bug which made the Electron window go black if the bundled node had a problem just after openning it (like when opening the Electron app when a Skycoin node is already running) was solved.

Does this change need to mentioned in CHANGELOG.md?
No