### PR TITLE
Emergency wipe option for the Skywallet

### DIFF
--- a/src/gui/static/src/app/app.module.ts
+++ b/src/gui/static/src/app/app.module.ts
@@ -127,6 +127,7 @@ import { HistoryService } from './services/wallet-operations/history.service';
 import { FormFieldErrorDirective } from './directives/form-field-error.directive';
 import { EnterLinkComponent } from './components/pages/send-skycoin/enter-link/enter-link.component';
 import { DestinationToolsComponent } from './components/pages/send-skycoin/form-parts/form-destination/destination-tools/destination-tools.component';
+import { ForceSkywalletWipeComponent } from './components/pages/force-skywallet-wipe/force-skywallet-wipe.component';
 
 
 const ROUTES = [
@@ -193,6 +194,10 @@ const ROUTES = [
   {
     path: 'reset/:id',
     component: ResetPasswordComponent,
+  },
+  {
+    path: 'skywallet-wipe',
+    component: ForceSkywalletWipeComponent,
   },
 ];
 
@@ -277,6 +282,7 @@ const ROUTES = [
     FormFieldErrorDirective,
     EnterLinkComponent,
     DestinationToolsComponent,
+    ForceSkywalletWipeComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-dialog-base.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-dialog-base.component.ts
@@ -22,6 +22,16 @@ export class ResultData {
    */
   link?: String;
   /**
+   * Text to show for the link, in case the raw value set in the "link" var is not what the
+   * UI must show. If not set, the value of the "link" var is used.
+   */
+  linkText?: String;
+  /**
+   * If true, the route set in the "link" var is used as an internal link, so it is not openned
+   * in a new tab.
+   */
+  linkIsInternal?: boolean;
+  /**
    * Icon to show.
    */
   icon: MessageIcons;
@@ -138,6 +148,15 @@ export class HwDialogBaseComponent<T> implements OnDestroy {
       if (result.text === 'hardware-wallet.errors.daemon-connection' || result.text.indexOf('Problem connecting to the Skywallet Daemon') !== -1) {
         result.text = 'hardware-wallet.errors.daemon-connection-with-configurable-link';
         result.link = AppConfig.hwWalletDaemonDownloadUrl;
+      }
+
+      // If the operation was cancelled for inactivity, a link to open the page for wiping the
+      // Skywallet is added.
+      if (result.text === 'hardware-wallet.errors.timeout') {
+        result.text = 'hardware-wallet.errors.timeout-with-configurable-link';
+        result.linkText = 'force-skywallet-wipe.title';
+        result.link = '#/skywallet-wipe';
+        result.linkIsInternal = true;
       }
 
       this.currentState = States.ShowingResult;

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-message/hw-message.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-message/hw-message.component.html
@@ -15,8 +15,9 @@
       <span class="big-text">{{ upperBigText }}</span>
     </div>
     <span *ngIf="text">{{ text }}</span>
-    <span *ngIf="linkText && !linkIsUrl" class="link" (click)="activateLink()">{{ linkText }}</span>
-    <span *ngIf="linkText && linkIsUrl"><a class="link" [href]="linkText" target="_blank" rel="noreferrer nofollow noopener">{{ linkText }}</a></span>
+    <span *ngIf="link && !linkIsUrl" class="link" (click)="activateLink()">{{ linkText ? linkText : link }}</span>
+    <span *ngIf="link && linkIsUrl && !linkIsInternal"><a class="link" [href]="link" target="_blank" rel="noreferrer nofollow noopener">{{ linkText ? linkText : link }}</a></span>
+    <span *ngIf="link && linkIsUrl && linkIsInternal"><a class="link" [href]="link">{{ linkText ? linkText : link }}</a></span>
     <div *ngIf="outputsList" class="list">
       <div *ngFor="let output of outputsList" class="list-element">
         <span>• {{ output.coins.toString() | amount }}</span>

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-message/hw-message.component.ts
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-message/hw-message.component.ts
@@ -31,7 +31,11 @@ export class HwMessageComponent {
   // Text to show.
   @Input() text: string;
   // Link to show after the main text.
+  @Input() link: string;
+  // Text to show in the UI for the link (optional).
   @Input() linkText: string;
+  // If true, the link is not openned in a new tab.
+  @Input() linkIsInternal: boolean;
   // URL for the link. If no URL is set, the linkClicked event is dispatched when the user
   // clicks the link.
   @Input() linkIsUrl = false;

--- a/src/gui/static/src/app/components/layout/hardware-wallet/hw-options-dialog/hw-options-dialog.component.html
+++ b/src/gui/static/src/app/components/layout/hardware-wallet/hw-options-dialog/hw-options-dialog.component.html
@@ -1,8 +1,10 @@
 <app-modal [headline]="'wallet.hardware-wallet-button' | translate" [dialog]="dialogRef">
   <app-hw-message *ngIf="currentState === states.ShowingResult"
     [text]="result.text | translate"
-    [linkText]="result.link"
+    [linkText]="result.linkText ? (result.linkText | translate) : null"
+    [link]="result.link"
     [linkIsUrl]="true"
+    [linkIsInternal]="result.linkIsInternal"
     [icon]="result.icon"
   ></app-hw-message>
 

--- a/src/gui/static/src/app/components/pages/force-skywallet-wipe/force-skywallet-wipe.component.html
+++ b/src/gui/static/src/app/components/pages/force-skywallet-wipe/force-skywallet-wipe.component.html
@@ -1,0 +1,19 @@
+<app-header [headline]="'force-skywallet-wipe.title' | translate"></app-header>
+<div class="container">
+  <div class="paper">
+    <div class="text-center">
+      <mat-icon class="icon yellow-text" [inline]="true">warning</mat-icon>
+    </div>
+    <div class="text-center">
+      {{ 'force-skywallet-wipe.operation-warning' | translate }}
+    </div>
+    <div class="text-center">
+      <app-button (action)="back()">
+        {{ 'common.back-button' | translate }}
+      </app-button>
+      <app-button (action)="proceed()" class="primary-button">
+        {{ 'force-skywallet-wipe.proceed-button' | translate }}
+      </app-button>
+    </div>
+  </div>
+</div>

--- a/src/gui/static/src/app/components/pages/force-skywallet-wipe/force-skywallet-wipe.component.scss
+++ b/src/gui/static/src/app/components/pages/force-skywallet-wipe/force-skywallet-wipe.component.scss
@@ -1,0 +1,4 @@
+.icon {
+  font-size: 40px !important;
+  margin-bottom: 10px !important;
+}

--- a/src/gui/static/src/app/components/pages/force-skywallet-wipe/force-skywallet-wipe.component.ts
+++ b/src/gui/static/src/app/components/pages/force-skywallet-wipe/force-skywallet-wipe.component.ts
@@ -1,0 +1,48 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { FormBuilder } from '@angular/forms';
+import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
+
+import { ChildHwDialogParams } from '../../layout/hardware-wallet/hw-options-dialog/hw-options-dialog.component';
+import { HwWipeDialogComponent } from '../../layout/hardware-wallet/hw-wipe-dialog/hw-wipe-dialog.component';
+
+/**
+ * Allows wipe a Skywallet. It is mainly for restoring the device when the user is not able to
+ * use it because the operations are always cancelled for inactivity.
+ */
+@Component({
+  selector: 'app-force-skywallet-wipe',
+  templateUrl: './force-skywallet-wipe.component.html',
+  styleUrls: ['./force-skywallet-wipe.component.scss'],
+})
+export class ForceSkywalletWipeComponent {
+  constructor(
+    public formBuilder: FormBuilder,
+    private router: Router,
+    private dialog: MatDialog,
+  ) { }
+
+  proceed() {
+    const config = new MatDialogConfig();
+    config.width = '450px';
+    config.autoFocus = false;
+
+    // Data for the modal window.
+    config.data = <ChildHwDialogParams> {
+      wallet: null,
+      requestOptionsComponentRefresh: ((error: string = null, recheckSecurityOnly: boolean = false) => {
+        if (!error) {
+          // Return to the wallet list after the operation is done.
+          this.router.navigate([''], {replaceUrl: true});
+        }
+      }),
+    };
+
+    this.dialog.open(HwWipeDialogComponent, config);
+  }
+
+  back() {
+    // Return to the wallet list.
+    this.router.navigate(['']);
+  }
+}

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -511,6 +511,12 @@
     }
   },
 
+  "force-skywallet-wipe": {
+    "title": "Forced Skywallet Wipe",
+    "operation-warning": "This option is designed only as a last resort for cases where the device cannot be used with the normal options. All data on the device will be erased, so you will need your seed to recover the funds.",
+    "proceed-button": "Proceed"
+  },
+
   "hardware-wallet": {
     "general" : {
       "default-wallet-name": "New Skywallet",
@@ -530,6 +536,7 @@
       "daemon-connection": "Problem connecting to the Skywallet Daemon, please make sure it is running and try again. You can download it from www.skycoin.com/downloads",
       "daemon-connection-with-configurable-link": "Problem connecting to the Skywallet Daemon, please make sure it is running and try again. You can download it from ",
       "timeout": "The operation was canceled due to inactivity. Please try again.",
+      "timeout-with-configurable-link": "The operation was canceled due to inactivity. Please try again. If this issue prevents the device from being usable, you can use the following option:",
       "invalid-address-generated": "There was a problem with the address generator and the operation had to be canceled.",
       "invalid-address": "Invalid address.",
       "not-in-bootloader-mode": "To use this option the Skywallet must be in bootloader mode."

--- a/src/gui/static/src/assets/i18n/es.json
+++ b/src/gui/static/src/assets/i18n/es.json
@@ -511,6 +511,12 @@
     }
   },
 
+  "force-skywallet-wipe": {
+    "title": "Borrado Forzado de Skywallet",
+    "operation-warning": "Esta opción está diseñada sólo como último recurso para los casos en los que el dispositivo no se puede utilizar con las opciones normales. Se borrarán todos los datos del dispositivo, por lo que necesitará la semilla para recuperar los fondos.",
+    "proceed-button": "Proceder"
+  },
+
   "hardware-wallet": {
     "general" : {
       "default-wallet-name": "Nueva Skywallet",
@@ -530,6 +536,7 @@
       "daemon-connection": "Problema para conectarse al Skywallet Daemon, por favor asegúrese de que se esté ejecutando e inténtelo nuevamente. Usted puede descargarlo desde www.skycoin.com/downloads",
       "daemon-connection-with-configurable-link": "Problema para conectarse al Skywallet Daemon, por favor asegúrese de que se esté ejecutando e inténtelo nuevamente. Usted puede descargarlo desde ",
       "timeout": "La operación se canceló por inactividad. Por favor inténtelo de nuevo.",
+      "timeout-with-configurable-link": "La operación se canceló por inactividad. Por favor inténtelo de nuevo. Si este problema impide que el dispositivo sea utilizable, puede utilizar la siguiente opción:",
       "invalid-address-generated": "Hubo un problema con el generador de direcciones y la operación tuvo que ser cancelada.",
       "invalid-address": "Dirección inválida.",
       "not-in-bootloader-mode": "Para usar esta opción la Skywallet debe estar en modo bootloader."

--- a/src/gui/static/src/assets/i18n/es_base.json
+++ b/src/gui/static/src/assets/i18n/es_base.json
@@ -511,6 +511,12 @@
     }
   },
 
+  "force-skywallet-wipe": {
+    "title": "Forced Skywallet Wipe",
+    "operation-warning": "This option is designed only as a last resort for cases where the device cannot be used with the normal options. All data on the device will be erased, so you will need your seed to recover the funds.",
+    "proceed-button": "Proceed"
+  },
+
   "hardware-wallet": {
     "general" : {
       "default-wallet-name": "New Skywallet",
@@ -530,6 +536,7 @@
       "daemon-connection": "Problem connecting to the Skywallet Daemon, please make sure it is running and try again. You can download it from www.skycoin.com/downloads",
       "daemon-connection-with-configurable-link": "Problem connecting to the Skywallet Daemon, please make sure it is running and try again. You can download it from ",
       "timeout": "The operation was canceled due to inactivity. Please try again.",
+      "timeout-with-configurable-link": "The operation was canceled due to inactivity. Please try again. If this issue prevents the device from being usable, you can use the following option:",
       "invalid-address-generated": "There was a problem with the address generator and the operation had to be canceled.",
       "invalid-address": "Invalid address.",
       "not-in-bootloader-mode": "To use this option the Skywallet must be in bootloader mode."


### PR DESCRIPTION
Fixes #2579

Changes:
- A page for wiping the a Skywallet without having to perform for the normal procedure was added. In includes a warning for the user.

- A link for opening the new page when a inactivity error is found was added to the UI.

Does this change need to mentioned in CHANGELOG.md?
No