### PR TITLE
Fix the bottom margin

### DIFF
--- a/src/gui/static/src/app/components/pages/exchange/exchange.component.html
+++ b/src/gui/static/src/app/components/pages/exchange/exchange.component.html
@@ -38,4 +38,6 @@
       </span>
     </div>
   </div>
+  <!-- Needed to force Chrome respect any previous bottom margin. -->
+  <div class="final-element"></div>
 </div>

--- a/src/gui/static/src/app/components/pages/reset-password/reset-password.component.html
+++ b/src/gui/static/src/app/components/pages/reset-password/reset-password.component.html
@@ -43,4 +43,6 @@
       </div>
     </div>
   </div>
+  <!-- Needed to force Chrome respect any previous bottom margin. -->
+  <div class="final-element"></div>
 </div>

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-skycoin.component.html
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-skycoin.component.html
@@ -27,4 +27,6 @@
     <span class="separator"> / </span>
     <span class="link" (click)="broadcastTransaction()">{{ 'offline-transactions.broadcast-tx.title' | translate }}</span>
   </div>
+  <!-- Needed to force Chrome respect any previous bottom margin. -->
+  <div class="final-element"></div>
 </div>

--- a/src/gui/static/src/app/components/pages/settings/backup/backup.component.html
+++ b/src/gui/static/src/app/components/pages/settings/backup/backup.component.html
@@ -42,4 +42,6 @@
       </div>
     </div>
   </div>
+  <!-- Needed to force Chrome respect any previous bottom margin. -->
+  <div class="final-element"></div>
 </div>

--- a/src/gui/static/src/app/components/pages/settings/blockchain/blockchain.component.html
+++ b/src/gui/static/src/app/components/pages/settings/blockchain/blockchain.component.html
@@ -51,4 +51,6 @@
       </div>
     </div>
   </div>
+  <!-- Needed to force Chrome respect any previous bottom margin. -->
+  <div class="final-element"></div>
 </div>

--- a/src/gui/static/src/app/components/pages/settings/network/network.component.html
+++ b/src/gui/static/src/app/components/pages/settings/network/network.component.html
@@ -38,4 +38,6 @@
       </div>
     </div>
   </div>
+  <!-- Needed to force Chrome respect any previous bottom margin. -->
+  <div class="final-element"></div>
 </div>

--- a/src/gui/static/src/app/components/pages/settings/outputs/outputs.component.html
+++ b/src/gui/static/src/app/components/pages/settings/outputs/outputs.component.html
@@ -31,4 +31,6 @@
       </div>
     </div>
   </div>
+  <!-- Needed to force Chrome respect any previous bottom margin. -->
+  <div class="final-element"></div>
 </div>

--- a/src/gui/static/src/app/components/pages/settings/pending-transactions/pending-transactions.component.html
+++ b/src/gui/static/src/app/components/pages/settings/pending-transactions/pending-transactions.component.html
@@ -25,4 +25,6 @@
       </div>
     </div>
   </div>
+  <!-- Needed to force Chrome respect any previous bottom margin. -->
+  <div class="final-element"></div>
 </div>

--- a/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.html
+++ b/src/gui/static/src/app/components/pages/transaction-list/transaction-list.component.html
@@ -98,4 +98,6 @@
     </ng-container>
     <div *ngIf="viewingTruncatedList" class="view-all-button" (click)="showAll()">{{ 'history.view-all' | translate:{ number:totalElements } }}</div>
   </div>
+  <!-- Needed to force Chrome respect any previous bottom margin. -->
+  <div class="final-element"></div>
 </div>

--- a/src/gui/static/src/styles.scss
+++ b/src/gui/static/src/styles.scss
@@ -123,3 +123,8 @@ Alerts
 .error-tooltip {
   background-color: $red !important;
 }
+
+.final-element {
+  width: 1px;
+  height: 1px;
+}


### PR DESCRIPTION
Changes:
- When using Chrome, most of the pages of the desktop wallet are not showing the bottom margin needed for the design to look well (this does not happen in Firefox). This PR solves that problem.

Does this change need to mentioned in CHANGELOG.md?
No