### PR TITLE
Run GO111MODULE=off explicitly in run-client.sh

### DIFF
--- a/run-client.sh
+++ b/run-client.sh
@@ -14,7 +14,7 @@ GOLDFLAGS="${GOLDFLAGS} -X main.Commit=${COMMIT} -X main.Branch=${BRANCH}"
 
 GORUNFLAGS=${GORUNFLAGS:-}
 
-go run -ldflags "${GOLDFLAGS}" $GORUNFLAGS ./cmd/skycoin/... \
+GO111MODULE=off go run -ldflags "${GOLDFLAGS}" $GORUNFLAGS ./cmd/skycoin/... \
     -gui-dir="${DIR}/src/gui/static/" \
     -launch-browser=true \
     -enable-all-api-sets=true \


### PR DESCRIPTION
Changes:
- Run GO111MODULE=off in run-client.sh explicitly in case people with different go version would behavior differently.

Does this change need to mentioned in CHANGELOG.md?
No.