### PR TITLE
Hide the exchange page

### DIFF
--- a/src/gui/static/src/app/app.module.ts
+++ b/src/gui/static/src/app/app.module.ts
@@ -155,11 +155,16 @@ const ROUTES = [
     component: BuyComponent,
     canActivate: [WizardGuardService],
   },
+  /*
+
+  Route for the Swaplab integration. Should be removed if the integration is not restored.
+
   {
     path: 'exchange',
     component: ExchangeComponent,
     canActivate: [WizardGuardService],
   },
+  */
   {
     path: 'settings',
     children: [

--- a/src/gui/static/src/app/components/layout/header/nav-bar/nav-bar.component.html
+++ b/src/gui/static/src/app/components/layout/header/nav-bar/nav-bar.component.html
@@ -13,10 +13,15 @@
       <span>{{ 'history.title-and-button' | translate }}</span>
     </a>
     <div class="flex-fill"></div>
+    <!--
+
+    Link for the Swaplab integration. Should be removed if the integration is not restored.
+
     <a class="-button" routerLink="/exchange" routerLinkActive="full-opacity" *ngIf="exchangeEnabled">
       <img src="assets/img/money-gold.png">
       <span>{{ 'exchange.title-and-button' | translate:{coinName: appService.coinName} }}</span>
     </a>
+    -->
     <a class="-button" *ngIf="otcEnabled">
       <img src="assets/img/money-gold.png">
       <span>{{ 'buy.title-and-button' | translate }}</span>


### PR DESCRIPTION
Changes:
- The exchange page has been disabled, because the Swaplab integration is not working. The code was not removed.

Does this change need to mentioned in CHANGELOG.md?
No