### PR TITLE
Encrypt wallet with default crypto type when wallet's 'cryptoType' field is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `-max-incoming-connection` flag to control the maximum allowed incoming connections.
 - Add `qr_uri_prefix` field to `/api/v1/health` endpoint.
 
+### changed
+
+- Change `POST /api/v1/wallet/encrypt` to encrypt wallet that has no 'cryptoType' field with the default 
+  crypto type for `deterministic`, `collection`, `bip44` wallets.
+
 ### Fixed
 
 ### Changed

--- a/src/wallet/bip44wallet/wallet.go
+++ b/src/wallet/bip44wallet/wallet.go
@@ -345,8 +345,9 @@ func (w *Wallet) Lock(password []byte) error {
 
 	cryptoType := wlt.Meta.CryptoType()
 	if cryptoType == "" {
-		return errors.New("crypto type field not set")
+		cryptoType = crypto.DefaultCryptoType
 	}
+
 	cryptor, err := crypto.GetCrypto(cryptoType)
 	if err != nil {
 		return err

--- a/src/wallet/collection/wallet.go
+++ b/src/wallet/collection/wallet.go
@@ -165,7 +165,7 @@ func (w *Wallet) Lock(password []byte) error {
 
 	cryptoType := wlt.CryptoType()
 	if cryptoType == "" {
-		return errors.New("crypto type field not set")
+		cryptoType = crypto.DefaultCryptoType
 	}
 
 	cryptor, err := crypto.GetCrypto(cryptoType)

--- a/src/wallet/deterministic/wallet.go
+++ b/src/wallet/deterministic/wallet.go
@@ -188,7 +188,7 @@ func (w *Wallet) Lock(password []byte) error {
 
 	cryptoType := wlt.CryptoType()
 	if cryptoType == "" {
-		return errors.New("crypto type field not set")
+		cryptoType = crypto.DefaultCryptoType
 	}
 
 	cryptor, err := crypto.GetCrypto(cryptoType)


### PR DESCRIPTION
Fixes #2603 

Changes:
- API `/v1/wallet/encrypt` will encrypt wallet that has no 'cryptoType' field with the default crypto type for `deterministic`, `collection`, `bip44` wallets.

Does this change need to mentioned in CHANGELOG.md?
Yes.