### PR TITLE
Adding json:"qr_uri_prefix" in fiber.go

### DIFF
--- a/src/readable/fiber.go
+++ b/src/readable/fiber.go
@@ -14,4 +14,5 @@ type FiberConfig struct {
 	ExplorerURL           string         `json:"explorer_url"`
 	VersionURL            string         `json:"version_url"`
 	Bip44Coin             bip44.CoinType `json:"bip44_coin"`
+    QrURIPrefix           string         `json:"qr_uri_prefix"`
 }


### PR DESCRIPTION
Fixes #

Changes:
-
Adding `json:"qr_uri_prefix"` to FiberConfig struct in fiber.go

Does this change need to mentioned in CHANGELOG.md?
