### PR TITLE
Limit blocks number of /api/v1/last_blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Change `POST /api/v1/wallet/encrypt` to encrypt wallet that has no 'cryptoType' field with the default 
   crypto type for `deterministic`, `collection`, `bip44` wallets.
+- Add `-max-last-blocks-count` flag to limit the maximum number of blocks the api `/api/v1/last_blocks` can return.
+    This also fixes the `out of memory` panic. The default maximum number is `256`.
 
 ### Fixed
 

--- a/src/api/blockchain.go
+++ b/src/api/blockchain.go
@@ -341,6 +341,8 @@ func blocksHandler(gateway Gatewayer) http.HandlerFunc {
 // Args:
 //	num [int]
 //  verbose [bool]
+//
+// NOTE: num will be limited to 1000
 func lastBlocksHandler(gateway Gatewayer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -358,6 +360,12 @@ func lastBlocksHandler(gateway Gatewayer) http.HandlerFunc {
 		n, err := strconv.ParseUint(num, 10, 64)
 		if err != nil {
 			wh.Error400(w, fmt.Sprintf("Invalid num value %q", num))
+			return
+		}
+
+		maxLBC := gateway.DaemonConfig().MaxLastBlocksCount
+		if n > maxLBC {
+			wh.Error400(w, fmt.Sprintf("num: %q must < %d", num, maxLBC))
 			return
 		}
 

--- a/src/api/blockchain.go
+++ b/src/api/blockchain.go
@@ -341,8 +341,6 @@ func blocksHandler(gateway Gatewayer) http.HandlerFunc {
 // Args:
 //	num [int]
 //  verbose [bool]
-//
-// NOTE: num will be limited to 1000
 func lastBlocksHandler(gateway Gatewayer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {

--- a/src/api/blockchain_test.go
+++ b/src/api/blockchain_test.go
@@ -1172,6 +1172,7 @@ func TestGetLastBlocks(t *testing.T) {
 			endpoint := "/api/v1/last_blocks"
 			gateway := &MockGatewayer{}
 
+			gateway.On("DaemonConfig").Return(daemon.DaemonConfig{MaxLastBlocksCount: 256})
 			gateway.On("GetLastBlocks", tc.num).Return(tc.gatewayGetLastBlocksResult, tc.gatewayGetLastBlocksError)
 			gateway.On("GetLastBlocksVerbose", tc.num).Return(tc.gatewayGetLastBlocksVerboseResult.Blocks,
 				tc.gatewayGetLastBlocksVerboseResult.Inputs, tc.gatewayGetLastBlocksVerboseError)

--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -221,6 +221,8 @@ type DaemonConfig struct { //nolint:golint
 	MaxOutgoingMessageLength uint64
 	// Maximum total size of transactions in a block
 	MaxBlockTransactionsSize uint32
+	// Maximum number of blocks to response on /api/v1/last_blocks API
+	MaxLastBlocksCount uint64
 }
 
 // NewDaemonConfig creates daemon config

--- a/src/skycoin/config.go
+++ b/src/skycoin/config.go
@@ -95,6 +95,8 @@ type NodeConfig struct {
 	MaxOutgoingMessageLength int
 	// MaxIncomingMessageLength maximum size of incoming messages
 	MaxIncomingMessageLength int
+	// MaxLastBlocksCount maximum number of blocks to response to API /api/v1/last_blocks
+	MaxLastBlocksCount uint64
 	// PeerlistSize represents the maximum number of peers that the pex would maintain
 	PeerlistSize int
 	// Wallet Address Version
@@ -261,6 +263,7 @@ func NewNodeConfig(mode string, node fiber.NodeConfig) NodeConfig {
 		OutgoingConnectionsRate:  time.Second * 5,
 		MaxOutgoingMessageLength: 256 * 1024,
 		MaxIncomingMessageLength: 1024 * 1024,
+		MaxLastBlocksCount:       256,
 		PeerlistSize:             65535,
 		// Wallet Address Version
 		// AddressVersion: "test",
@@ -504,6 +507,10 @@ func (c *Config) postProcess() error {
 		return errors.New("-max-decimals-create-block exceeds MaxUint8")
 	}
 
+	if c.Node.MaxLastBlocksCount > math.MaxUint64 {
+		return fmt.Errorf("-max-last-blocks-count exceeds math.MaxUint64")
+	}
+
 	c.Node.UnconfirmedVerifyTxn.BurnFactor = uint32(c.Node.unconfirmedBurnFactor)
 	c.Node.UnconfirmedVerifyTxn.MaxTransactionSize = uint32(c.Node.maxUnconfirmedTransactionSize)
 	c.Node.UnconfirmedVerifyTxn.MaxDropletPrecision = uint8(c.Node.unconfirmedMaxDropletPrecision)
@@ -706,6 +713,7 @@ func (c *NodeConfig) RegisterFlags() {
 	flag.Uint64Var(&c.createBlockMaxTransactionSize, "max-txn-size-create-block", uint64(c.CreateBlockVerifyTxn.MaxTransactionSize), "maximum size of a transaction applied when creating blocks")
 	flag.Uint64Var(&c.createBlockMaxDropletPrecision, "max-decimals-create-block", uint64(c.CreateBlockVerifyTxn.MaxDropletPrecision), "max number of decimal places applied when creating blocks")
 	flag.Uint64Var(&c.maxBlockSize, "max-block-size", uint64(c.MaxBlockTransactionsSize), "maximum total size of transactions in a block")
+	flag.Uint64Var(&c.MaxLastBlocksCount, "max-last-blocks-count", c.MaxLastBlocksCount, "Maximum number of blocks to response for API /api/v1/last_blocks")
 
 	flag.BoolVar(&c.RunBlockPublisher, "block-publisher", c.RunBlockPublisher, "run the daemon as a block publisher")
 	flag.StringVar(&c.BlockchainPubkeyStr, "blockchain-public-key", c.BlockchainPubkeyStr, "public key of the blockchain")

--- a/src/skycoin/skycoin.go
+++ b/src/skycoin/skycoin.go
@@ -420,6 +420,7 @@ func (c *Coin) ConfigureDaemon() daemon.Config {
 	dc.Daemon.MaxOutgoingMessageLength = uint64(c.config.Node.MaxOutgoingMessageLength)
 	dc.Daemon.MaxIncomingMessageLength = uint64(c.config.Node.MaxIncomingMessageLength)
 	dc.Daemon.MaxBlockTransactionsSize = c.config.Node.MaxBlockTransactionsSize
+	dc.Daemon.MaxLastBlocksCount = c.config.Node.MaxLastBlocksCount
 	dc.Daemon.DefaultConnections = c.config.Node.DefaultConnections
 	dc.Daemon.DisableOutgoingConnections = c.config.Node.DisableOutgoingConnections
 	dc.Daemon.DisableIncomingConnections = c.config.Node.DisableIncomingConnections


### PR DESCRIPTION
Fixes:

There's no limit of blocks number the /api/v1/last_blocks can return, this can lead to the `out of memory` panic if the `num` is very big.

Does this change need to mentioned in CHANGELOG.md?
Yes