### PR TITLE
Fix incorrect CLI doc about creating unsigned raw transaction

### DIFF
--- a/cmd/skycoin-cli/README.md
+++ b/cmd/skycoin-cli/README.md
@@ -738,7 +738,7 @@ $ skycoin-cli createRawTransaction $WALLET_FILE $RECIPIENT_ADDRESS $AMOUNT -a $F
 ### Create an unsigned raw transaction
 
 ```bash
-$ skycoin-cli createRawTransactionV2 [wallet] [to address] [amount] [flags]
+$ skycoin-cli createRawTransactionV2 [wallet] [to address] [amount] --unsign
 ```
 
 ### Example


### PR DESCRIPTION
Fixes

The CLI document about creating an unsigned raw transction would create a signed raw transaction instead. It missed the `--unsign` flag.

Does this change need to mentioned in CHANGELOG.md?
No.