### PR TITLE
Add collection wallet API support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add param `private-keys` to CLI commands `walletCreate` and `walletCreateTemp`.
-- Add param `private-keys` to APIs `/api/v1/wallet/create` and `/api/v1/wallet/createTemp`. 
+- Add param `private-keys` to CLI commands `walletCreate`, `walletCreateTemp`, and `walletNewAddresses`.
+- Add param `private-keys` to APIs `/api/v1/wallet/create`, `/api/v1/wallet/createTemp`, and `/api/v1/wallet/newAddress`. 
 - Add `CLI walletCreateTemp` command to create a temporary wallet.
 - Add `POST /api/v1/wallet/createTemp` API to create a temporary wallet. Warning: The temporary wallet would not be
   persisted after restarting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add param `private-keys` to CLI commands `walletCreate` and `walletCreateTemp`.
+- Add param `private-keys` to APIs `/api/v1/wallet/create` and `/api/v1/wallet/createTemp`. 
 - Add `CLI walletCreateTemp` command to create a temporary wallet.
 - Add `POST /api/v1/wallet/createTemp` API to create a temporary wallet. Warning: The temporary wallet would not be
   persisted after restarting.

--- a/src/api/client.go
+++ b/src/api/client.go
@@ -640,15 +640,16 @@ func (c *Client) Wallets() ([]WalletResponse, error) {
 
 // CreateWalletOptions are the options for creating a wallet
 type CreateWalletOptions struct {
-	Type           string
-	Seed           string
-	SeedPassphrase string
-	Label          string
-	Password       string
-	ScanN          uint64
-	XPub           string
-	Encrypt        bool
-	Bip44Coin      *bip44.CoinType
+	Type                  string
+	Seed                  string
+	SeedPassphrase        string
+	Label                 string
+	Password              string
+	ScanN                 uint64
+	XPub                  string
+	Encrypt               bool
+	Bip44Coin             *bip44.CoinType
+	CollectionPrivateKeys string
 }
 
 // CreateWallet makes a request to POST /api/v1/wallet/create and creates a wallet.
@@ -680,6 +681,10 @@ func (c *Client) CreateWallet(o CreateWalletOptions) (*WalletResponse, error) {
 		v.Add("xpub", o.XPub)
 	}
 
+	if o.CollectionPrivateKeys != "" {
+		v.Add("private-keys", o.CollectionPrivateKeys)
+	}
+
 	var w WalletResponse
 	if err := c.PostForm("/api/v1/wallet/create", strings.NewReader(v.Encode()), &w); err != nil {
 		return nil, err
@@ -706,6 +711,10 @@ func (c *Client) CreateWalletTemp(o CreateWalletOptions) (*WalletResponse, error
 
 	if o.XPub != "" {
 		v.Add("xpub", o.XPub)
+	}
+
+	if o.CollectionPrivateKeys != "" {
+		v.Add("private-keys", o.CollectionPrivateKeys)
 	}
 
 	var w WalletResponse

--- a/src/api/client.go
+++ b/src/api/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/skycoin/skycoin/src/daemon"
 	"github.com/skycoin/skycoin/src/kvstorage"
 	"github.com/skycoin/skycoin/src/readable"
+	"github.com/skycoin/skycoin/src/wallet"
 )
 
 const (
@@ -726,14 +727,29 @@ func (c *Client) CreateWalletTemp(o CreateWalletOptions) (*WalletResponse, error
 
 // NewWalletAddress makes a request to POST /api/v1/wallet/newAddress
 // if n is <= 0, defaults to 1
-func (c *Client) NewWalletAddress(id string, n int, password string) ([]string, error) {
+func (c *Client) NewWalletAddress(id string, password string, options ...wallet.Option) ([]string, error) {
 	v := url.Values{}
 	v.Add("id", id)
-	if n > 0 {
-		v.Add("num", fmt.Sprint(n))
+	if len(password) > 0 {
+		v.Add("password", password)
 	}
 
-	v.Add("password", password)
+	var opts wallet.AdvancedOptions
+	for _, f := range options {
+		f(&opts)
+	}
+
+	if opts.GenerateN > 0 {
+		v.Add("num", fmt.Sprint(opts.GenerateN))
+	}
+
+	if len(opts.PrivateKeys) > 0 {
+		keys := make([]string, 0, len(opts.PrivateKeys))
+		for _, k := range opts.PrivateKeys {
+			keys = append(keys, k.Hex())
+		}
+		v.Add("private-keys", strings.Join(keys, ","))
+	}
 
 	var obj struct {
 		Addresses []string `json:"addresses"`

--- a/src/api/gateway.go
+++ b/src/api/gateway.go
@@ -104,7 +104,7 @@ type Walleter interface {
 	GetWalletSeed(wltID string, password []byte) (string, string, error)
 	CreateWallet(wltName string, options wallet.Options) (wallet.Wallet, error)
 	RecoverWallet(wltID, seed, seedPassphrase string, password []byte) (wallet.Wallet, error)
-	NewAddresses(wltID string, password []byte, n uint64, options ...wallet.Option) ([]cipher.Address, error)
+	NewAddresses(wltID string, password []byte, options ...wallet.Option) ([]cipher.Address, error)
 	ScanAddresses(wltID string, password []byte, n uint64, tf wallet.TransactionsFinder) ([]cipher.Address, error)
 	GetWallet(wltID string) (wallet.Wallet, error)
 	GetWallets() (wallet.Wallets, error)

--- a/src/api/gateway.go
+++ b/src/api/gateway.go
@@ -104,7 +104,7 @@ type Walleter interface {
 	DecryptWallet(wltID string, password []byte) (wallet.Wallet, error)
 	GetWalletSeed(wltID string, password []byte) (string, string, error)
 	CreateWallet(wltName string, options wallet.Options) (wallet.Wallet, error)
-	RecoverWallet(wltID, seed, seedPassphrase string, password []byte) (wallet.Wallet, error)
+	RecoverWallet(wltID, seed, seedPassphrase string, password []byte, tf wallet.TransactionsFinder) (wallet.Wallet, error)
 	NewAddresses(wltID string, password []byte, n uint64, options ...wallet.Option) ([]cipher.Address, error)
 	ScanAddresses(wltID string, password []byte, n uint64, tf wallet.TransactionsFinder) ([]cipher.Address, error)
 	GetWallet(wltID string) (wallet.Wallet, error)

--- a/src/api/gateway.go
+++ b/src/api/gateway.go
@@ -13,8 +13,6 @@ import (
 	"github.com/skycoin/skycoin/src/wallet"
 )
 
-//go:generate mockery -name Gatewayer -case underscore -inpkg -testonly
-
 // Gateway bundles daemon.Daemon, Visor, wallet.Service and kvstorage.Manager into a single object
 type Gateway struct {
 	*daemon.Daemon
@@ -32,6 +30,8 @@ func NewGateway(d *daemon.Daemon, v *visor.Visor, w *wallet.Service, m *kvstorag
 		Manager: m,
 	}
 }
+
+//go:generate mockery -name Gatewayer -case underscore -inpkg -testonly
 
 // Gatewayer interface for Gateway methods
 type Gatewayer interface {
@@ -78,7 +78,6 @@ type Visorer interface {
 	AddressCount() (uint64, error)
 	GetUxOutByID(id cipher.SHA256) (*historydb.UxOut, uint64, error)
 	GetSpentOutputsForAddresses(addr []cipher.Address) ([][]historydb.UxOut, uint64, error)
-	// GetVerboseTransactionsForAddress(a cipher.Address) ([]visor.Transaction, [][]visor.TransactionInput, error)
 	GetRichlist(includeDistribution bool) (visor.Richlist, error)
 	GetAllUnconfirmedTransactions() ([]visor.UnconfirmedTransaction, error)
 	GetAllUnconfirmedTransactionsVerbose() ([]visor.UnconfirmedTransaction, [][]visor.TransactionInput, error)
@@ -104,7 +103,7 @@ type Walleter interface {
 	DecryptWallet(wltID string, password []byte) (wallet.Wallet, error)
 	GetWalletSeed(wltID string, password []byte) (string, string, error)
 	CreateWallet(wltName string, options wallet.Options) (wallet.Wallet, error)
-	RecoverWallet(wltID, seed, seedPassphrase string, password []byte, tf wallet.TransactionsFinder) (wallet.Wallet, error)
+	RecoverWallet(wltID, seed, seedPassphrase string, password []byte) (wallet.Wallet, error)
 	NewAddresses(wltID string, password []byte, n uint64, options ...wallet.Option) ([]cipher.Address, error)
 	ScanAddresses(wltID string, password []byte, n uint64, tf wallet.TransactionsFinder) ([]cipher.Address, error)
 	GetWallet(wltID string) (wallet.Wallet, error)

--- a/src/api/integration/wallet_test.go
+++ b/src/api/integration/wallet_test.go
@@ -390,7 +390,7 @@ func TestWalletNewAddress(t *testing.T) {
 					tc.postWalletHandle(t, c, w.Meta.Filename)
 				}
 
-				addrs, err := c.NewWalletAddress(w.Meta.Filename, i, password)
+				addrs, err := c.NewWalletAddress(w.Meta.Filename, password, wallet.OptionGenerateN(uint64(i)))
 				require.Equal(t, tc.expectErr, err)
 
 				// Confirms no intermediate tmp file exists
@@ -838,7 +838,7 @@ func TestRecoverWallet(t *testing.T) {
 			})
 			defer clean()
 
-			_, err = c.NewWalletAddress(w.Meta.Filename, 10, "")
+			_, err = c.NewWalletAddress(w.Meta.Filename, "", wallet.OptionGenerateN(10))
 			require.NoError(t, err)
 
 			w, err = c.Wallet(w.Meta.Filename)
@@ -1076,7 +1076,7 @@ func prepareAndCheckWallet(t *testing.T, c *api.Client, minCoins, minCoinHours u
 	require.NoError(t, err)
 
 	if wl < 2 {
-		_, err := c.NewWalletAddress(w.Filename(), 2-wl, password)
+		_, err := c.NewWalletAddress(w.Filename(), password, wallet.OptionGenerateN(uint64(2-wl)))
 		if err != nil {
 			t.Fatalf("New wallet address failed: %v", err)
 		}

--- a/src/api/mock_gatewayer_test.go
+++ b/src/api/mock_gatewayer_test.go
@@ -1167,20 +1167,20 @@ func (_m *MockGatewayer) InjectTransaction(txn coin.Transaction) error {
 	return r0
 }
 
-// NewAddresses provides a mock function with given fields: wltID, password, n, options
-func (_m *MockGatewayer) NewAddresses(wltID string, password []byte, n uint64, options ...wallet.Option) ([]cipher.Address, error) {
+// NewAddresses provides a mock function with given fields: wltID, password, options
+func (_m *MockGatewayer) NewAddresses(wltID string, password []byte, options ...wallet.Option) ([]cipher.Address, error) {
 	_va := make([]interface{}, len(options))
 	for _i := range options {
 		_va[_i] = options[_i]
 	}
 	var _ca []interface{}
-	_ca = append(_ca, wltID, password, n)
+	_ca = append(_ca, wltID, password)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
 	var r0 []cipher.Address
-	if rf, ok := ret.Get(0).(func(string, []byte, uint64, ...wallet.Option) []cipher.Address); ok {
-		r0 = rf(wltID, password, n, options...)
+	if rf, ok := ret.Get(0).(func(string, []byte, ...wallet.Option) []cipher.Address); ok {
+		r0 = rf(wltID, password, options...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]cipher.Address)
@@ -1188,8 +1188,8 @@ func (_m *MockGatewayer) NewAddresses(wltID string, password []byte, n uint64, o
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, []byte, uint64, ...wallet.Option) error); ok {
-		r1 = rf(wltID, password, n, options...)
+	if rf, ok := ret.Get(1).(func(string, []byte, ...wallet.Option) error); ok {
+		r1 = rf(wltID, password, options...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/src/api/wallet.go
+++ b/src/api/wallet.go
@@ -1131,8 +1131,7 @@ func walletRecoverHandler(gateway Gatewayer) http.HandlerFunc {
 			password = nil
 		}()
 
-		wlt, err := gateway.RecoverWallet(req.ID, req.Seed, req.SeedPassphrase,
-			password, gateway.TransactionsFinder())
+		wlt, err := gateway.RecoverWallet(req.ID, req.Seed, req.SeedPassphrase, password)
 		if err != nil {
 			var resp HTTPResponse
 			switch err.(type) {

--- a/src/api/wallet.go
+++ b/src/api/wallet.go
@@ -1131,7 +1131,8 @@ func walletRecoverHandler(gateway Gatewayer) http.HandlerFunc {
 			password = nil
 		}()
 
-		wlt, err := gateway.RecoverWallet(req.ID, req.Seed, req.SeedPassphrase, password)
+		wlt, err := gateway.RecoverWallet(req.ID, req.Seed, req.SeedPassphrase,
+			password, gateway.TransactionsFinder())
 		if err != nil {
 			var resp HTTPResponse
 			switch err.(type) {

--- a/src/api/wallet_test.go
+++ b/src/api/wallet_test.go
@@ -970,31 +970,6 @@ func TestWalletCreateHandler(t *testing.T) {
 			wltName: "foo",
 		},
 		{
-			name:   "400 - scan num must be > 0",
-			method: http.MethodPost,
-			body: &httpBody{
-				Type:  wallet.WalletTypeDeterministic,
-				Seed:  "foo",
-				Label: "bar",
-				ScanN: "0",
-			},
-			options: wallet.Options{
-				Type:     wallet.WalletTypeDeterministic,
-				Seed:     "foo",
-				Label:    "bar",
-				ScanN:    0,
-				Password: []byte{},
-			},
-			gatewayCreateWalletErr: wallet.NewError(errors.New("scan num must be > 0")),
-			gatewayCreateWalletResult: func(_ string, _ wallet.Options) wallet.Wallet {
-				var p *deterministic.Wallet
-				return p
-			},
-			status:  http.StatusBadRequest,
-			err:     "400 Bad Request - scan num must be > 0",
-			wltName: "foo",
-		},
-		{
 			name:   "400 - invalid bip44 coin",
 			method: http.MethodPost,
 			body: &httpBody{

--- a/src/api/wallet_test.go
+++ b/src/api/wallet_test.go
@@ -14,6 +14,7 @@ import (
 
 	"encoding/json"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/skycoin/skycoin/src/cipher"
@@ -1969,8 +1970,13 @@ func TestWalletNewAddressesHandler(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
+			mb := mock.MatchedBy(func(option wallet.Option) bool {
+				n := wallet.GetGenerateNFromOptions(option)
+				return tc.n == n
+			})
 			gateway := &MockGatewayer{}
-			gateway.On("NewAddresses", tc.walletID, []byte(tc.password), tc.n).Return(tc.gatewayNewAddressesResult, tc.gatewayNewAddressesErr)
+			gateway.On("NewAddresses", tc.walletID,
+				[]byte(tc.password), mb).Return(tc.gatewayNewAddressesResult, tc.gatewayNewAddressesErr)
 
 			endpoint := "/api/v1/wallet/newAddress"
 

--- a/src/api/wallet_test.go
+++ b/src/api/wallet_test.go
@@ -915,9 +915,20 @@ func TestWalletCreateHandler(t *testing.T) {
 			name:   "400 - missing seed",
 			method: http.MethodPost,
 			body: &httpBody{
-				Type: wallet.WalletTypeDeterministic,
+				Type:  wallet.WalletTypeDeterministic,
+				ScanN: "1",
 			},
-			status:  http.StatusBadRequest,
+			options: wallet.Options{
+				Type:     wallet.WalletTypeDeterministic,
+				Password: []byte{},
+				ScanN:    1,
+			},
+			status:                 http.StatusBadRequest,
+			gatewayCreateWalletErr: wallet.ErrMissingSeed,
+			gatewayCreateWalletResult: func(_ string, _ wallet.Options) wallet.Wallet {
+				var p *deterministic.Wallet
+				return p
+			},
 			err:     "400 Bad Request - missing seed",
 			wltName: "foo",
 		},
@@ -925,10 +936,23 @@ func TestWalletCreateHandler(t *testing.T) {
 			name:   "400 - missing label",
 			method: http.MethodPost,
 			body: &httpBody{
-				Type: wallet.WalletTypeDeterministic,
-				Seed: "foo",
+				Type:  wallet.WalletTypeDeterministic,
+				Seed:  "foo",
+				ScanN: "1",
 			},
-			status:  http.StatusBadRequest,
+			options: wallet.Options{
+				Type:     wallet.WalletTypeDeterministic,
+				Seed:     "foo",
+				Password: []byte{},
+				ScanN:    1,
+			},
+			status: http.StatusBadRequest,
+
+			gatewayCreateWalletErr: wallet.ErrMissingLabel,
+			gatewayCreateWalletResult: func(_ string, _ wallet.Options) wallet.Wallet {
+				var p *deterministic.Wallet
+				return p
+			},
 			err:     "400 Bad Request - missing label",
 			wltName: "foo",
 		},
@@ -946,7 +970,7 @@ func TestWalletCreateHandler(t *testing.T) {
 			wltName: "foo",
 		},
 		{
-			name:   "400 - scan must be > 0",
+			name:   "400 - scan num must be > 0",
 			method: http.MethodPost,
 			body: &httpBody{
 				Type:  wallet.WalletTypeDeterministic,
@@ -954,8 +978,20 @@ func TestWalletCreateHandler(t *testing.T) {
 				Label: "bar",
 				ScanN: "0",
 			},
+			options: wallet.Options{
+				Type:     wallet.WalletTypeDeterministic,
+				Seed:     "foo",
+				Label:    "bar",
+				ScanN:    0,
+				Password: []byte{},
+			},
+			gatewayCreateWalletErr: wallet.NewError(errors.New("scan num must be > 0")),
+			gatewayCreateWalletResult: func(_ string, _ wallet.Options) wallet.Wallet {
+				var p *deterministic.Wallet
+				return p
+			},
 			status:  http.StatusBadRequest,
-			err:     "400 Bad Request - scan must be > 0",
+			err:     "400 Bad Request - scan num must be > 0",
 			wltName: "foo",
 		},
 		{
@@ -1015,6 +1051,7 @@ func TestWalletCreateHandler(t *testing.T) {
 				Type:     wallet.WalletTypeDeterministic,
 				Label:    "bar",
 				Seed:     "foo",
+				ScanN:    1,
 				Password: []byte{},
 			},
 			gatewayCreateWalletErr: wallet.ErrSeedUsed,
@@ -1038,6 +1075,7 @@ func TestWalletCreateHandler(t *testing.T) {
 				Type:     wallet.WalletTypeDeterministic,
 				Label:    "bar",
 				Seed:     "foo",
+				ScanN:    1,
 				Password: []byte{},
 			},
 			gatewayCreateWalletErr: errors.New("gateway.CreateWallet error"),
@@ -1093,7 +1131,7 @@ func TestWalletCreateHandler(t *testing.T) {
 			gatewayCreateWalletResult: func(_ string, _ wallet.Options) wallet.Wallet {
 				w, err := deterministic.NewWallet(
 					"filename",
-					"",
+					"test",
 					"seed",
 					wallet.OptionGenerateN(5),
 				)
@@ -1104,6 +1142,7 @@ func TestWalletCreateHandler(t *testing.T) {
 			responseBody: WalletResponse{
 				Meta: readable.WalletMeta{
 					Coin:       "skycoin",
+					Label:      "test",
 					Filename:   "filename",
 					Type:       "deterministic",
 					Version:    "0.4",
@@ -1136,7 +1175,7 @@ func TestWalletCreateHandler(t *testing.T) {
 			gatewayCreateWalletResult: func(_ string, _ wallet.Options) wallet.Wallet {
 				w, err := deterministic.NewWallet(
 					"filename",
-					"",
+					"test",
 					"seed",
 					wallet.OptionGenerateN(5),
 				)
@@ -1147,6 +1186,7 @@ func TestWalletCreateHandler(t *testing.T) {
 			responseBody: WalletResponse{
 				Meta: readable.WalletMeta{
 					Coin:       "skycoin",
+					Label:      "test",
 					Filename:   "filename",
 					Type:       "deterministic",
 					Version:    "0.4",
@@ -1177,7 +1217,7 @@ func TestWalletCreateHandler(t *testing.T) {
 			gatewayCreateWalletResult: func(_ string, _ wallet.Options) wallet.Wallet {
 				w, err := deterministic.NewWallet(
 					"filename",
-					"",
+					"test",
 					"seed",
 					wallet.OptionGenerateN(5),
 				)
@@ -1188,6 +1228,7 @@ func TestWalletCreateHandler(t *testing.T) {
 			responseBody: WalletResponse{
 				Meta: readable.WalletMeta{
 					Coin:       "skycoin",
+					Label:      "test",
 					Filename:   "filename",
 					Type:       "deterministic",
 					Version:    "0.4",
@@ -1289,9 +1330,6 @@ func TestWalletCreateHandler(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &MockGatewayer{}
-			if tc.options.ScanN == 0 {
-				tc.options.ScanN = 1
-			}
 			gateway.On("TransactionsFinder").Return(&visor.TransactionsFinder{})
 			tc.options.TF = gateway.TransactionsFinder()
 			gateway.On("CreateWallet", "", tc.options).Return(tc.gatewayCreateWalletResult, tc.gatewayCreateWalletErr)
@@ -2284,7 +2322,7 @@ func TestGetWalletFolderHandler(t *testing.T) {
 }
 
 func TestNewWallet(t *testing.T) {
-	w, err := deterministic.NewWallet("filename", "", "seed", wallet.OptionGenerateN(1))
+	w, err := deterministic.NewWallet("filename", "test", "seed", wallet.OptionGenerateN(1))
 	require.NoError(t, err)
 	es, err := w.GetEntries()
 	require.NoError(t, err)
@@ -2623,7 +2661,7 @@ func TestEncryptWallet(t *testing.T) {
 				w: func() wallet.Wallet {
 					wlt, err := deterministic.NewWallet(
 						"wallet.wlt",
-						"",
+						"test",
 						"seed",
 						wallet.OptionPassword([]byte("pwd")),
 						wallet.OptionGenerateN(5),
@@ -2638,6 +2676,7 @@ func TestEncryptWallet(t *testing.T) {
 				Meta: readable.WalletMeta{
 					Coin:       "skycoin",
 					Filename:   "wallet.wlt",
+					Label:      "test",
 					Type:       "deterministic",
 					Version:    "0.4",
 					CryptoType: "scrypt-chacha20poly1305",
@@ -2966,6 +3005,13 @@ func makeEntries(seed []byte, n int) ([]wallet.Entry, []readable.WalletEntry) { 
 	return entries, responseEntries
 }
 
+type mockTxnsFinder struct {
+}
+
+func (tf *mockTxnsFinder) AddressesActivity(addrs []cipher.Addresser) ([]bool, error) {
+	return nil, nil
+}
+
 func TestWalletRecover(t *testing.T) {
 	type gatewayReturnPair struct {
 		w   wallet.Wallet
@@ -2980,6 +3026,7 @@ func TestWalletRecover(t *testing.T) {
 			Type:      wallet.WalletTypeDeterministic,
 			Coin:      wallet.CoinTypeSkycoin,
 			GenerateN: 10,
+			TF:        &mockTxnsFinder{},
 		})
 	require.NoError(t, err)
 	okWalletUnencryptedResponse, err := NewWalletResponse(okWalletUnencrypted)
@@ -2996,6 +3043,7 @@ func TestWalletRecover(t *testing.T) {
 			Password:   []byte("foopassword"),
 			CryptoType: crypto.CryptoTypeScryptChacha20poly1305Insecure,
 			GenerateN:  10,
+			TF:         &mockTxnsFinder{},
 		})
 	require.NoError(t, err)
 	okWalletEncryptedResponse, err := NewWalletResponse(okWalletEncrypted)

--- a/src/cli/address_gen.go
+++ b/src/cli/address_gen.go
@@ -52,9 +52,13 @@ func addressGenCmd() *cobra.Command {
 				return nil
 			}
 
+			// default label
 			label, err := c.Flags().GetString("label")
 			if err != nil {
 				return nil
+			}
+			if label == "" {
+				label = "default"
 			}
 
 			hideSecrets, err := c.Flags().GetBool("hide-secrets")

--- a/src/cli/generate_addrs.go
+++ b/src/cli/generate_addrs.go
@@ -116,7 +116,7 @@ func GenerateAddressesInFile(walletFile string, num uint64, pr PasswordReader) (
 	}
 
 	genAddrsInWallet := func(w wallet.Wallet, n uint64) ([]cipher.Addresser, error) {
-		return w.GenerateAddresses(n)
+		return w.GenerateAddresses(wallet.OptionGenerateN(n))
 	}
 
 	if wlt.IsEncrypted() {
@@ -129,7 +129,7 @@ func GenerateAddressesInFile(walletFile string, num uint64, pr PasswordReader) (
 			var addrs []cipher.Addresser
 			if err := wallet.GuardUpdate(w, password, func(wlt wallet.Wallet) error {
 				var err error
-				addrs, err = wlt.GenerateAddresses(n)
+				addrs, err = wlt.GenerateAddresses(wallet.OptionGenerateN(n))
 				return err
 			}); err != nil {
 				return nil, err

--- a/src/cli/generate_wallet.go
+++ b/src/cli/generate_wallet.go
@@ -191,9 +191,9 @@ func generateWalletHandler(c *cobra.Command, _ []string) error {
 		return err
 	}
 
-	pr := NewPasswordReader([]byte(c.Flag("password").Value.String()))
 	var password []byte
 	if encrypt {
+		pr := NewPasswordReader([]byte(c.Flag("password").Value.String()))
 		var err error
 		password, err = pr.Password()
 		if err != nil {

--- a/src/cli/generate_wallet.go
+++ b/src/cli/generate_wallet.go
@@ -233,7 +233,7 @@ func generateWalletHandler(c *cobra.Command, _ []string) error {
 
 	n := num - uint64(addrN)
 	if n > 0 {
-		_, err := apiClient.NewWalletAddress(id, int(n), string(password))
+		_, err := apiClient.NewWalletAddress(id, string(password), wallet.OptionGenerateN(n))
 		if err != nil {
 			return err
 		}
@@ -422,7 +422,7 @@ func generateWalletTempHandler(c *cobra.Command, _ []string) error {
 
 	n := num - uint64(addrN)
 	if n > 0 {
-		_, err := apiClient.NewWalletAddress(id, int(n), "")
+		_, err := apiClient.NewWalletAddress(id, "", wallet.OptionGenerateN(n))
 		if err != nil {
 			return err
 		}

--- a/src/cli/generate_wallet.go
+++ b/src/cli/generate_wallet.go
@@ -49,7 +49,7 @@ func walletCreateCmd() *cobra.Command {
 	walletCreateCmd.Flags().BoolP("encrypt", "e", true, "Create encrypted wallet.")
 	walletCreateCmd.Flags().StringP("password", "p", "", "Wallet password")
 	walletCreateCmd.Flags().StringP("xpub", "", "", "xpub key for \"xpub\" type wallets")
-	walletCreateCmd.Flags().StringP("private-keys", "pks", "", "Collection private keys")
+	walletCreateCmd.Flags().StringP("private-keys", "", "", "Collection private keys")
 
 	return walletCreateCmd
 }
@@ -268,7 +268,7 @@ func walletCreateTempCmd() *cobra.Command {
 	walletCreateTempCmd.Flags().Uint64P("scan", "", 1, `Number of addresses to scan ahead for balances.`)
 	walletCreateTempCmd.Flags().StringP("type", "t", wallet.WalletTypeDeterministic, "Wallet type. Types are \"collection\", \"deterministic\", \"bip44\" or \"xpub\"")
 	walletCreateTempCmd.Flags().StringP("xpub", "", "", "xpub key for \"xpub\" type wallets")
-	walletCreateTempCmd.Flags().StringP("private-keys", "pks", "", "Collection private keys")
+	walletCreateTempCmd.Flags().StringP("private-keys", "", "", "Collection private keys")
 
 	return walletCreateTempCmd
 }

--- a/src/cli/integration/integration_test.go
+++ b/src/cli/integration/integration_test.go
@@ -2789,7 +2789,7 @@ func prepareAndCheckWallet(t *testing.T, miniCoins, miniCoinHours uint64) (walle
 
 	if el < 3 {
 		// Generates addresses
-		_, err = w.GenerateAddresses(uint64(3 - el))
+		_, err = w.GenerateAddresses(wallet.OptionGenerateN(uint64(3 - el)))
 		if err != nil {
 			t.Fatalf("Wallet generateAddress failed: %v", err)
 		}

--- a/src/cli/integration/integration_test.go
+++ b/src/cli/integration/integration_test.go
@@ -1019,7 +1019,7 @@ func TestAddressGen(t *testing.T) {
 				require.Error(t, err)
 				require.Equal(t, tc.err.Error(), err.Error())
 			} else {
-				require.NoError(t, err)
+				require.NoError(t, err, string(output))
 			}
 
 			tc.check(t, output)

--- a/src/cli/integration/testdata/create-wallet-bip44-encrypt.golden
+++ b/src/cli/integration/testdata/create-wallet-bip44-encrypt.golden
@@ -1,0 +1,28 @@
+{
+	"meta": {
+		"coin": "skycoin",
+		"filename": "",
+		"label": "test",
+		"type": "bip44",
+		"version": "0.4",
+		"crypto_type": "scrypt-chacha20poly1305",
+		"timestamp": 0,
+		"temp": false,
+		"encrypted": true,
+		"bip44_coin": 8000
+	},
+	"entries": [
+		{
+			"address": "TsZ2kmfWR8GMXZN37RqyyqpHrAnVaPxPvn",
+			"public_key": "0388471b5e033beaa27e06b60918d10f924591ae32b382e402d9ff9611621a3523",
+			"child_number": 0,
+			"change": 0
+		},
+		{
+			"address": "2HtJ6pDjWt7HKewcWhqRk3nza6hTfuo6wyQ",
+			"public_key": "03d8814e972fa63078b946887c4855b7eeafbe937bab95cd29ba1c7e7fc75b770c",
+			"child_number": 0,
+			"change": 1
+		}
+	]
+}

--- a/src/cli/integration/testdata/create-wallet-bip44-with-passphrase.golden
+++ b/src/cli/integration/testdata/create-wallet-bip44-with-passphrase.golden
@@ -1,0 +1,28 @@
+{
+	"meta": {
+		"coin": "skycoin",
+		"filename": "",
+		"label": "test",
+		"type": "bip44",
+		"version": "0.4",
+		"crypto_type": "scrypt-chacha20poly1305",
+		"timestamp": 0,
+		"temp": false,
+		"encrypted": true,
+		"bip44_coin": 8000
+	},
+	"entries": [
+		{
+			"address": "cswW3EQMf1uWHzTgx2752AiNfyqtK5UWM3",
+			"public_key": "02691fbb52956156494674614aaa08633571b394586932e6cbfc80d19a41d3b2bb",
+			"child_number": 0,
+			"change": 0
+		},
+		{
+			"address": "2A4XhpdPhP4pZds8uzuu7TsGtiCBAodr33H",
+			"public_key": "02a10fffae18852e9454a6d0e06fea13405a9e844bffb8a526c587c6b2e9fb50dc",
+			"child_number": 0,
+			"change": 1
+		}
+	]
+}

--- a/src/cli/integration/testdata/create-wallet-bip44.golden
+++ b/src/cli/integration/testdata/create-wallet-bip44.golden
@@ -1,0 +1,28 @@
+{
+	"meta": {
+		"coin": "skycoin",
+		"filename": "",
+		"label": "test",
+		"type": "bip44",
+		"version": "0.4",
+		"crypto_type": "scrypt-chacha20poly1305",
+		"timestamp": 0,
+		"temp": false,
+		"encrypted": false,
+		"bip44_coin": 8000
+	},
+	"entries": [
+		{
+			"address": "JX9hhYztxUKj1WH7oTquN6YRTLVnZPUe9V",
+			"public_key": "0374404d53ddfb1866952acea512cacd099f64f09df6c6522d915d380919ae5f0a",
+			"child_number": 0,
+			"change": 0
+		},
+		{
+			"address": "7g9m8trJdzNfFXPZjS1HjcvdE4Ldu6NiPB",
+			"public_key": "033eeedbbaa01f8cb4602b0eb19e772e3577b09170836db8521b4daa5de058d65a",
+			"child_number": 0,
+			"change": 1
+		}
+	]
+}

--- a/src/cli/integration/testdata/create-wallet-collection-1.golden
+++ b/src/cli/integration/testdata/create-wallet-collection-1.golden
@@ -1,0 +1,19 @@
+{
+	"meta": {
+		"coin": "skycoin",
+		"filename": "",
+		"label": "test",
+		"type": "collection",
+		"version": "0.4",
+		"crypto_type": "scrypt-chacha20poly1305",
+		"timestamp": 0,
+		"temp": false,
+		"encrypted": false
+	},
+	"entries": [
+		{
+			"address": "n1BRLU9pn8UbBWUy1o5JfLLvYDMRNrZK2M",
+			"public_key": "0201cb9dd390ee3e84642b7769d56f7f14b8b72be669886dfe586fb13b981a2500"
+		}
+	]
+}

--- a/src/cli/integration/testdata/create-wallet-collection-2.golden
+++ b/src/cli/integration/testdata/create-wallet-collection-2.golden
@@ -1,0 +1,23 @@
+{
+	"meta": {
+		"coin": "skycoin",
+		"filename": "",
+		"label": "test",
+		"type": "collection",
+		"version": "0.4",
+		"crypto_type": "scrypt-chacha20poly1305",
+		"timestamp": 0,
+		"temp": false,
+		"encrypted": false
+	},
+	"entries": [
+		{
+			"address": "n1BRLU9pn8UbBWUy1o5JfLLvYDMRNrZK2M",
+			"public_key": "0201cb9dd390ee3e84642b7769d56f7f14b8b72be669886dfe586fb13b981a2500"
+		},
+		{
+			"address": "2goC8Txe4cpdyHYgMhZQrrs66FjCKCxajpj",
+			"public_key": "02eda796c03ef237e1f79af98507b8d07e4439392e623394b7288d12fb9b36170a"
+		}
+	]
+}

--- a/src/cli/integration/testdata/create-wallet-collection-empty.golden
+++ b/src/cli/integration/testdata/create-wallet-collection-empty.golden
@@ -1,0 +1,14 @@
+{
+	"meta": {
+		"coin": "skycoin",
+		"filename": "",
+		"label": "test",
+		"type": "collection",
+		"version": "0.4",
+		"crypto_type": "scrypt-chacha20poly1305",
+		"timestamp": 0,
+		"temp": false,
+		"encrypted": false
+	},
+	"entries": []
+}

--- a/src/cli/integration/testdata/create-wallet-collection-encrypt.golden
+++ b/src/cli/integration/testdata/create-wallet-collection-encrypt.golden
@@ -1,0 +1,23 @@
+{
+	"meta": {
+		"coin": "skycoin",
+		"filename": "",
+		"label": "test",
+		"type": "collection",
+		"version": "0.4",
+		"crypto_type": "scrypt-chacha20poly1305",
+		"timestamp": 0,
+		"temp": false,
+		"encrypted": true
+	},
+	"entries": [
+		{
+			"address": "n1BRLU9pn8UbBWUy1o5JfLLvYDMRNrZK2M",
+			"public_key": "0201cb9dd390ee3e84642b7769d56f7f14b8b72be669886dfe586fb13b981a2500"
+		},
+		{
+			"address": "2goC8Txe4cpdyHYgMhZQrrs66FjCKCxajpj",
+			"public_key": "02eda796c03ef237e1f79af98507b8d07e4439392e623394b7288d12fb9b36170a"
+		}
+	]
+}

--- a/src/cli/integration/testdata/create-wallet-deterministic-encrypt.golden
+++ b/src/cli/integration/testdata/create-wallet-deterministic-encrypt.golden
@@ -1,0 +1,19 @@
+{
+	"meta": {
+		"coin": "skycoin",
+		"filename": "",
+		"label": "test",
+		"type": "deterministic",
+		"version": "0.4",
+		"crypto_type": "scrypt-chacha20poly1305",
+		"timestamp": 0,
+		"temp": false,
+		"encrypted": true
+	},
+	"entries": [
+		{
+			"address": "NShuSbRQHGvp55STq7rJeuxW3KBKNpYBek",
+			"public_key": "03388ef6208b91c5970b6d40798270c13928aa48ba4d9e6759d0e779bef72b12cc"
+		}
+	]
+}

--- a/src/cli/integration/testdata/create-wallet-deterministic-n-2.golden
+++ b/src/cli/integration/testdata/create-wallet-deterministic-n-2.golden
@@ -1,0 +1,23 @@
+{
+	"meta": {
+		"coin": "skycoin",
+		"filename": "",
+		"label": "test",
+		"type": "deterministic",
+		"version": "0.4",
+		"crypto_type": "scrypt-chacha20poly1305",
+		"timestamp": 0,
+		"temp": false,
+		"encrypted": false
+	},
+	"entries": [
+		{
+			"address": "YyDoexYiuZvz3DmuonL2nFzZA9Gq7WvbE2",
+			"public_key": "02a47d0f0a2d0de27f3b2643931c879f72c79aa35821818f81797922d4cddcecc5"
+		},
+		{
+			"address": "P1N4MA7cdqnwsWpsUitG9KusvLSMtqFs1x",
+			"public_key": "02b9b01c08c7ac58cd95123ad86f366955a80e009f03cd6a1a8ea5051cc4a4e442"
+		}
+	]
+}

--- a/src/cli/integration/testdata/create-wallet-deterministic.golden
+++ b/src/cli/integration/testdata/create-wallet-deterministic.golden
@@ -1,0 +1,19 @@
+{
+	"meta": {
+		"coin": "skycoin",
+		"filename": "",
+		"label": "test",
+		"type": "deterministic",
+		"version": "0.4",
+		"crypto_type": "scrypt-chacha20poly1305",
+		"timestamp": 0,
+		"temp": false,
+		"encrypted": false
+	},
+	"entries": [
+		{
+			"address": "qEdmRtEBtqfJ8EBtcgVazMsYeqRfUfmQbw",
+			"public_key": "034f15a79c06735c6ce828cf37065c52bf0ad3b95c96589c30e3339842d254c99e"
+		}
+	]
+}

--- a/src/cli/integration/testdata/create-wallet-xpub.golden
+++ b/src/cli/integration/testdata/create-wallet-xpub.golden
@@ -1,0 +1,21 @@
+{
+	"meta": {
+		"coin": "skycoin",
+		"filename": "",
+		"label": "test",
+		"type": "xpub",
+		"version": "0.4",
+		"crypto_type": "",
+		"timestamp": 0,
+		"temp": false,
+		"encrypted": false,
+		"xpub": "xpub6EHXAfAY5dgRXDQSKr8X3wQFN3AAo4TAHka9TocHCBU6WjtCvMeb6Q2UFggNPvVdWXk1tQDLvxUVQJNADxNuHEWtWiPAMBmqWn4w3DnTAJC"
+	},
+	"entries": [
+		{
+			"address": "2WBK19nu2uubTKremS9kYFUMfvVQV6HDMpK",
+			"public_key": "036ec0df9c2cfe5c8fddab321a89ed8f6d194523a440b76da798cc1a2779e32956",
+			"child_number": 0
+		}
+	]
+}

--- a/src/cli/integration/testdata/generate-address-collection.golden
+++ b/src/cli/integration/testdata/generate-address-collection.golden
@@ -1,0 +1,6 @@
+{
+	"Addresses": [
+		"utZBndddJYEGHBV9QQZ7xcwFNLJRSK8PES",
+		"EC4mckF5fhQz5NvDYNiYpZ1Ad3ypL5i2Ce"
+	]
+}

--- a/src/visor/wallet_test.go
+++ b/src/visor/wallet_test.go
@@ -906,6 +906,7 @@ func TestWalletCreateTransaction(t *testing.T) {
 			}
 
 			_, err = ws.CreateWallet(tc.walletID, wallet.Options{
+				Label:      "test",
 				Coin:       wallet.CoinTypeSkycoin,
 				Encrypt:    len(tc.password) != 0,
 				Password:   tc.password,

--- a/src/wallet/bip44wallet/wallet.go
+++ b/src/wallet/bip44wallet/wallet.go
@@ -96,6 +96,14 @@ type ChainEntry struct {
 // NewWallet create a bip44 wallet with options
 // also, a default address will be generated
 func NewWallet(filename, label, seed, seedPassphrase string, options ...wallet.Option) (*Wallet, error) {
+	if label == "" {
+		return nil, wallet.ErrMissingLabel
+	}
+
+	if seed == "" {
+		return nil, wallet.ErrMissingSeed
+	}
+
 	wlt := &Wallet{
 		Meta: wallet.Meta{
 			wallet.MetaFilename:       filename,
@@ -163,6 +171,9 @@ func NewWallet(filename, label, seed, seedPassphrase string, options ...wallet.O
 	}
 
 	scanN := advOpts.ScanN
+	if scanN == 0 {
+		return nil, errors.New("scan num must be > 0")
+	}
 	// scans addresses if options.ScanN > 0
 	if scanN > 0 {
 		if advOpts.TF == nil {
@@ -877,10 +888,14 @@ func convertOptions(options wallet.Options) []wallet.Option {
 		opts = append(opts, wallet.OptionGenerateN(options.GenerateN))
 	}
 
-	if options.ScanN > 0 {
-		opts = append(opts, wallet.OptionScanN(options.ScanN))
-		opts = append(opts, wallet.OptionTransactionsFinder(options.TF))
+	scanN := options.ScanN
+	if scanN == 0 {
+		// set default scan to 1
+		scanN = 1
 	}
+
+	opts = append(opts, wallet.OptionScanN(scanN))
+	opts = append(opts, wallet.OptionTransactionsFinder(options.TF))
 
 	if options.Temp {
 		opts = append(opts, wallet.OptionTemp(true))

--- a/src/wallet/bip44wallet/wallet.go
+++ b/src/wallet/bip44wallet/wallet.go
@@ -122,7 +122,7 @@ func NewWallet(filename, label, seed, seedPassphrase string, options ...wallet.O
 	}
 
 	advOpts := wallet.AdvancedOptions{}
-	// applies options to wallet and AdvancedOptions
+	// apply options to wallet and AdvancedOptions
 	for _, opt := range options {
 		opt(wlt)
 		opt(&advOpts)
@@ -171,10 +171,6 @@ func NewWallet(filename, label, seed, seedPassphrase string, options ...wallet.O
 	}
 
 	scanN := advOpts.ScanN
-	if scanN == 0 {
-		return nil, errors.New("scan num must be > 0")
-	}
-	// scans addresses if options.ScanN > 0
 	if scanN > 0 {
 		if advOpts.TF == nil {
 			return nil, errors.New("missing transaction finder for scanning addresses")
@@ -888,14 +884,10 @@ func convertOptions(options wallet.Options) []wallet.Option {
 		opts = append(opts, wallet.OptionGenerateN(options.GenerateN))
 	}
 
-	scanN := options.ScanN
-	if scanN == 0 {
-		// set default scan to 1
-		scanN = 1
+	if options.ScanN > 0 {
+		opts = append(opts, wallet.OptionScanN(options.ScanN))
+		opts = append(opts, wallet.OptionTransactionsFinder(options.TF))
 	}
-
-	opts = append(opts, wallet.OptionScanN(scanN))
-	opts = append(opts, wallet.OptionTransactionsFinder(options.TF))
 
 	if options.Temp {
 		opts = append(opts, wallet.OptionTemp(true))

--- a/src/wallet/bip44wallet/wallet.go
+++ b/src/wallet/bip44wallet/wallet.go
@@ -161,12 +161,12 @@ func NewWallet(filename, label, seed, seedPassphrase string, options ...wallet.O
 		generateN = 1
 	}
 
-	if _, err := wlt.GenerateAddresses(generateN); err != nil {
+	if _, err := wlt.GenerateAddresses(wallet.OptionGenerateN(generateN)); err != nil {
 		return nil, err
 	}
 
 	// Generate a default change address
-	if _, err := wlt.GenerateAddresses(1, wallet.OptionChange()); err != nil {
+	if _, err := wlt.GenerateAddresses(wallet.OptionGenerateN(1), wallet.OptionChange()); err != nil {
 		return nil, err
 	}
 
@@ -687,7 +687,8 @@ func (w *Wallet) GetAddresses(options ...wallet.Option) ([]cipher.Addresser, err
 
 // GenerateAddresses generates addresses on selected account and chain,
 // if no options are provided, addresses will be generated on external chain of account 0.
-func (w *Wallet) GenerateAddresses(num uint64, options ...wallet.Option) ([]cipher.Addresser, error) {
+func (w *Wallet) GenerateAddresses(options ...wallet.Option) ([]cipher.Addresser, error) {
+	num := wallet.GetGenerateNFromOptions(options...)
 	opts := getBip44Options(options...)
 	switch opts.ChainMode {
 	case wallet.DefaultChain, wallet.ExternalChain:
@@ -787,7 +788,7 @@ func (w *Wallet) PeekChangeAddress(tf wallet.TransactionsFinder) (cipher.Address
 
 	if len(entries) == 0 {
 		// generate a new address and return
-		addrs, err := w.GenerateAddresses(1, onChangeChain)
+		addrs, err := w.GenerateAddresses(wallet.OptionGenerateN(1), onChangeChain)
 		if err != nil {
 			return nil, err
 		}
@@ -807,7 +808,7 @@ func (w *Wallet) PeekChangeAddress(tf wallet.TransactionsFinder) (cipher.Address
 	}
 
 	// generate a new address and return it
-	addrs, err := w.GenerateAddresses(1, onChangeChain)
+	addrs, err := w.GenerateAddresses(wallet.OptionGenerateN(1), onChangeChain)
 	if err != nil {
 		return nil, err
 	}

--- a/src/wallet/bip44wallet/wallet_test.go
+++ b/src/wallet/bip44wallet/wallet_test.go
@@ -498,10 +498,10 @@ func TestWalletLock(t *testing.T) {
 
 				if !w.IsEncrypted() {
 					// Generates 2 addresses
-					_, err = w.GenerateAddresses(2)
+					_, err = w.GenerateAddresses(wallet.OptionGenerateN(2))
 					require.NoError(t, err)
 
-					_, err = w.GenerateAddresses(2, wallet.OptionChange())
+					_, err = w.GenerateAddresses(wallet.OptionGenerateN(2), wallet.OptionChange())
 					require.NoError(t, err)
 				}
 
@@ -623,7 +623,7 @@ func TestLockAndUnLock(t *testing.T) {
 	for _, ct := range crypto.TypesInsecure() {
 		w, err := NewWallet("wallet.wlt", "test", testSeed, testSeedPassphrase, wallet.OptionCryptoType(ct))
 		require.NoError(t, err)
-		_, err = w.GenerateAddresses(9)
+		_, err = w.GenerateAddresses(wallet.OptionGenerateN(9))
 		require.NoError(t, err)
 		el, err := w.EntriesLen()
 		require.NoError(t, err)
@@ -754,14 +754,14 @@ func TestWalletGenerateAddress(t *testing.T) {
 
 				// generate address
 				if !tc.oneAddressEachTime {
-					_, err := w.GenerateAddresses(tc.num)
+					_, err := w.GenerateAddresses(wallet.OptionGenerateN(tc.num))
 					require.NoError(t, err)
 					if err != nil {
 						return
 					}
 				} else {
 					for i := uint64(0); i < tc.num; i++ {
-						_, err := w.GenerateAddresses(1)
+						_, err := w.GenerateAddresses(wallet.OptionGenerateN(1))
 						require.Equal(t, tc.err, err)
 						if err != nil {
 							return

--- a/src/wallet/collection/wallet_test.go
+++ b/src/wallet/collection/wallet_test.go
@@ -82,10 +82,10 @@ func TestNewWallet(t *testing.T) {
 		{
 			name:    "ok all defaults",
 			wltName: "test.wlt",
-			label:   "",
+			label:   "test",
 			expect: expect{
 				meta: map[string]string{
-					"label":    "",
+					"label":    "test",
 					"filename": "test.wlt",
 					"coin":     string(wallet.CoinTypeSkycoin),
 					"type":     wallet.WalletTypeCollection,
@@ -161,13 +161,13 @@ func TestNewWallet(t *testing.T) {
 		{
 			name:    "temp wallet",
 			wltName: "test.wlt",
-			label:   "",
+			label:   "temp",
 			opts: []wallet.Option{
 				wallet.OptionTemp(true),
 			},
 			expect: expect{
 				meta: map[string]string{
-					"label":    "",
+					"label":    "temp",
 					"filename": "test.wlt",
 					"coin":     string(wallet.CoinTypeSkycoin),
 					"type":     wallet.WalletTypeCollection,

--- a/src/wallet/collection/wallet_test.go
+++ b/src/wallet/collection/wallet_test.go
@@ -44,9 +44,32 @@ var (
 )
 
 func TestNewWallet(t *testing.T) {
+	privateKeysStr := []string{
+		"a0cc94e7b48f48637b908a773cd5d22d21d5e701ec192ffe5fc6ea9dfbb67c55",
+		"30109ea31d9aab6f21a14d39f2cd48f6bba162d629474a163f8f2e1dd11c22de",
+	}
+
+	entries := make([]wallet.Entry, 0, len(privateKeysStr))
+	sks := make([]cipher.SecKey, 0, len(privateKeysStr))
+	for _, s := range privateKeysStr {
+		sk, err := cipher.SecKeyFromHex(s)
+		require.NoError(t, err)
+		sks = append(sks, sk)
+
+		pk, err := cipher.PubKeyFromSecKey(sk)
+		require.NoError(t, err)
+
+		entries = append(entries, wallet.Entry{
+			Address: cipher.AddressFromPubKey(pk),
+			Public:  pk,
+			Secret:  sk,
+		})
+	}
+
 	type expect struct {
-		meta map[string]string
-		err  error
+		meta    map[string]string
+		entries []wallet.Entry
+		err     error
 	}
 
 	tt := []struct {
@@ -152,6 +175,44 @@ func TestNewWallet(t *testing.T) {
 					"temp":     "true",
 				},
 				err: nil,
+			},
+		},
+		{
+			name:    "wallet with one private key",
+			wltName: "test.wlt",
+			label:   "test",
+			opts: []wallet.Option{
+				wallet.OptionCollectionPrivateKeys(sks[:1]),
+			},
+			expect: expect{
+				meta: map[string]string{
+					"label":    "test",
+					"filename": "test.wlt",
+					"coin":     string(wallet.CoinTypeSkycoin),
+					"type":     wallet.WalletTypeCollection,
+					"version":  wallet.Version,
+				},
+				entries: entries[:1],
+				err:     nil,
+			},
+		},
+		{
+			name:    "wallet with two private key",
+			wltName: "test.wlt",
+			label:   "test",
+			opts: []wallet.Option{
+				wallet.OptionCollectionPrivateKeys(sks[:2]),
+			},
+			expect: expect{
+				meta: map[string]string{
+					"label":    "test",
+					"filename": "test.wlt",
+					"coin":     string(wallet.CoinTypeSkycoin),
+					"type":     wallet.WalletTypeCollection,
+					"version":  wallet.Version,
+				},
+				entries: entries[:2],
+				err:     nil,
 			},
 		},
 	}

--- a/src/wallet/deterministic/wallet.go
+++ b/src/wallet/deterministic/wallet.go
@@ -39,6 +39,14 @@ type Wallet struct {
 
 // NewWallet creates a deterministic wallet
 func NewWallet(filename, label, seed string, options ...wallet.Option) (*Wallet, error) {
+	if label == "" {
+		return nil, wallet.ErrMissingLabel
+	}
+
+	if seed == "" {
+		return nil, wallet.ErrMissingSeed
+	}
+
 	var wlt = &Wallet{
 		Meta: wallet.Meta{
 			wallet.MetaFilename:   filename,
@@ -539,10 +547,14 @@ func convertOptions(options wallet.Options) []wallet.Option {
 		opts = append(opts, wallet.OptionGenerateN(options.GenerateN))
 	}
 
-	if options.ScanN > 0 {
-		opts = append(opts, wallet.OptionScanN(options.ScanN))
-		opts = append(opts, wallet.OptionTransactionsFinder(options.TF))
+	scanN := options.ScanN
+	if scanN == 0 {
+		// set default scan to 1
+		scanN = 1
 	}
+
+	opts = append(opts, wallet.OptionScanN(scanN))
+	opts = append(opts, wallet.OptionTransactionsFinder(options.TF))
 
 	if options.Temp {
 		opts = append(opts, wallet.OptionTemp(true))

--- a/src/wallet/deterministic/wallet.go
+++ b/src/wallet/deterministic/wallet.go
@@ -547,14 +547,10 @@ func convertOptions(options wallet.Options) []wallet.Option {
 		opts = append(opts, wallet.OptionGenerateN(options.GenerateN))
 	}
 
-	scanN := options.ScanN
-	if scanN == 0 {
-		// set default scan to 1
-		scanN = 1
+	if options.ScanN > 0 {
+		opts = append(opts, wallet.OptionScanN(options.ScanN))
+		opts = append(opts, wallet.OptionTransactionsFinder(options.TF))
 	}
-
-	opts = append(opts, wallet.OptionScanN(scanN))
-	opts = append(opts, wallet.OptionTransactionsFinder(options.TF))
 
 	if options.Temp {
 		opts = append(opts, wallet.OptionTemp(true))

--- a/src/wallet/deterministic/wallet.go
+++ b/src/wallet/deterministic/wallet.go
@@ -77,7 +77,7 @@ func NewWallet(filename, label, seed string, options ...wallet.Option) (*Wallet,
 
 	generateN := advOpts.GenerateN
 	if generateN > 0 {
-		_, err := wlt.GenerateAddresses(generateN)
+		_, err := wlt.GenerateAddresses(wallet.OptionGenerateN(generateN))
 		if err != nil {
 			return nil, err
 		}
@@ -383,7 +383,7 @@ func (w *Wallet) ScanAddresses(scanN uint64, tf wallet.TransactionsFinder) ([]ci
 	nExistingAddrs := uint64(len(w2.entries))
 
 	// Generate the addresses to scan
-	addrs, err := w2.GenerateAddresses(scanN)
+	addrs, err := w2.GenerateAddresses(wallet.OptionGenerateN(scanN))
 	if err != nil {
 		return nil, err
 	}
@@ -410,7 +410,7 @@ func (w *Wallet) ScanAddresses(scanN uint64, tf wallet.TransactionsFinder) ([]ci
 	//	return nil, err
 	//}
 
-	if _, err := w2.GenerateAddresses(nExistingAddrs + keepNum); err != nil {
+	if _, err := w2.GenerateAddresses(wallet.OptionGenerateN(nExistingAddrs + keepNum)); err != nil {
 		return nil, err
 	}
 
@@ -420,11 +420,12 @@ func (w *Wallet) ScanAddresses(scanN uint64, tf wallet.TransactionsFinder) ([]ci
 }
 
 // GenerateAddresses generates N addresses
-func (w *Wallet) GenerateAddresses(num uint64, _ ...wallet.Option) ([]cipher.Addresser, error) {
+func (w *Wallet) GenerateAddresses(options ...wallet.Option) ([]cipher.Addresser, error) {
 	if w.Meta.IsEncrypted() {
 		return nil, wallet.ErrWalletEncrypted
 	}
 
+	num := wallet.GetGenerateNFromOptions(options...)
 	if num == 0 {
 		return nil, nil
 	}

--- a/src/wallet/deterministic/wallet_test.go
+++ b/src/wallet/deterministic/wallet_test.go
@@ -85,11 +85,11 @@ func TestNewWallet(t *testing.T) {
 		{
 			name:    "ok all defaults",
 			wltName: "test.wlt",
-			label:   "",
+			label:   "test",
 			seed:    "testseed123",
 			expect: expect{
 				meta: map[string]string{
-					"label":    "",
+					"label":    "test",
 					"filename": "test.wlt",
 					"coin":     string(wallet.CoinTypeSkycoin),
 					"type":     wallet.WalletTypeDeterministic,
@@ -189,14 +189,14 @@ func TestNewWallet(t *testing.T) {
 		{
 			name:    "ok all defaults",
 			wltName: "test.wlt",
-			label:   "",
+			label:   "test",
 			seed:    "testseed123",
 			opts: []wallet.Option{
 				wallet.OptionTemp(true),
 			},
 			expect: expect{
 				meta: map[string]string{
-					"label":    "",
+					"label":    "test",
 					"filename": "test.wlt",
 					"coin":     string(wallet.CoinTypeSkycoin),
 					"type":     wallet.WalletTypeDeterministic,
@@ -286,7 +286,7 @@ func TestWalletLock(t *testing.T) {
 
 				if !w.IsEncrypted() {
 					// Generates 2 addresses
-					_, err = w.GenerateAddresses(2)
+					_, err = w.GenerateAddresses(wallet.OptionGenerateN(2))
 					require.NoError(t, err)
 				}
 
@@ -414,7 +414,7 @@ func TestLockAndUnLock(t *testing.T) {
 		t.Run(fmt.Sprintf("crypto=%v", ct), func(t *testing.T) {
 			w, err := NewWallet("wallet.wlt", "test", bip39.MustNewDefaultMnemonic(), wallet.OptionCryptoType(ct))
 			require.NoError(t, err)
-			_, err = w.GenerateAddresses(9)
+			_, err = w.GenerateAddresses(wallet.OptionGenerateN(9))
 			require.NoError(t, err)
 			el, err := w.EntriesLen()
 			require.NoError(t, err)
@@ -498,14 +498,14 @@ func TestWalletGenerateAddress(t *testing.T) {
 
 				// generate addresses
 				if !tc.oneAddressEachTime {
-					_, err = w.GenerateAddresses(tc.num)
+					_, err = w.GenerateAddresses(wallet.OptionGenerateN(tc.num))
 					require.Equal(t, tc.err, err)
 					if err != nil {
 						return
 					}
 				} else {
 					for i := uint64(0); i < tc.num; i++ {
-						_, err := w.GenerateAddresses(1)
+						_, err := w.GenerateAddresses(wallet.OptionGenerateN(1))
 						require.Equal(t, tc.err, err)
 						if err != nil {
 							return
@@ -718,7 +718,7 @@ func TestWalletSerialize(t *testing.T) {
 	w, err := NewWallet("test.wlt", "test", "test123")
 	require.NoError(t, err)
 
-	_, err = w.GenerateAddresses(5)
+	_, err = w.GenerateAddresses(wallet.OptionGenerateN(5))
 	require.NoError(t, err)
 
 	w.SetTimestamp(0)

--- a/src/wallet/mock_wallet_test.go
+++ b/src/wallet/mock_wallet_test.go
@@ -171,20 +171,19 @@ func (_m *MockWallet) Fingerprint() string {
 	return r0
 }
 
-// GenerateAddresses provides a mock function with given fields: num, options
-func (_m *MockWallet) GenerateAddresses(num uint64, options ...Option) ([]cipher.Addresser, error) {
+// GenerateAddresses provides a mock function with given fields: options
+func (_m *MockWallet) GenerateAddresses(options ...Option) ([]cipher.Addresser, error) {
 	_va := make([]interface{}, len(options))
 	for _i := range options {
 		_va[_i] = options[_i]
 	}
 	var _ca []interface{}
-	_ca = append(_ca, num)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
 	var r0 []cipher.Addresser
-	if rf, ok := ret.Get(0).(func(uint64, ...Option) []cipher.Addresser); ok {
-		r0 = rf(num, options...)
+	if rf, ok := ret.Get(0).(func(...Option) []cipher.Addresser); ok {
+		r0 = rf(options...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]cipher.Addresser)
@@ -192,8 +191,8 @@ func (_m *MockWallet) GenerateAddresses(num uint64, options ...Option) ([]cipher
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(uint64, ...Option) error); ok {
-		r1 = rf(num, options...)
+	if rf, ok := ret.Get(1).(func(...Option) error); ok {
+		r1 = rf(options...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -345,6 +344,20 @@ func (_m *MockWallet) HasEntry(addr cipher.Addresser, options ...Option) (bool, 
 
 // IsEncrypted provides a mock function with given fields:
 func (_m *MockWallet) IsEncrypted() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// IsTemp provides a mock function with given fields:
+func (_m *MockWallet) IsTemp() bool {
 	ret := _m.Called()
 
 	var r0 bool
@@ -515,6 +528,11 @@ func (_m *MockWallet) SetFilename(_a0 string) {
 // SetLabel provides a mock function with given fields: _a0
 func (_m *MockWallet) SetLabel(_a0 string) {
 	_m.Called(_a0)
+}
+
+// SetTemp provides a mock function with given fields: temp
+func (_m *MockWallet) SetTemp(temp bool) {
+	_m.Called(temp)
 }
 
 // SetTimestamp provides a mock function with given fields: _a0

--- a/src/wallet/options.go
+++ b/src/wallet/options.go
@@ -1,6 +1,7 @@
 package wallet
 
 import (
+	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/cipher/bip44"
 	"github.com/skycoin/skycoin/src/cipher/crypto"
 )
@@ -115,6 +116,7 @@ type AdvancedOptions struct {
 	GenerateN               uint64
 	ScanN                   uint64
 	TF                      TransactionsFinder
+	PrivateKeys             []cipher.SecKey // private keys of collection wallet
 }
 
 // advancedOptionFunc is a helper function that assert the
@@ -170,5 +172,12 @@ func OptionTransactionsFinder(tf TransactionsFinder) Option {
 func OptionGenerateN(n uint64) Option {
 	return advancedOptionFunc(func(opts *AdvancedOptions) {
 		opts.GenerateN = n
+	})
+}
+
+// OptionCollectionPrivateKeys can be used to set the private keys when creating a collection wallet
+func OptionCollectionPrivateKeys(keys []cipher.SecKey) Option {
+	return advancedOptionFunc(func(opts *AdvancedOptions) {
+		opts.PrivateKeys = keys
 	})
 }

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -771,7 +771,7 @@ func (serv *Service) View(wltID string, f func(Wallet) error) error {
 // RecoverWallet recovers an encrypted wallet from seed.
 // The recovered wallet will be encrypted with the new password, if provided.
 func (serv *Service) RecoverWallet(wltName, seed, seedPassphrase string,
-	password []byte, tf TransactionsFinder) (Wallet, error) {
+	password []byte) (Wallet, error) {
 	serv.Lock()
 	defer serv.Unlock()
 	if !serv.config.EnableWalletAPI {
@@ -802,7 +802,6 @@ func (serv *Service) RecoverWallet(wltName, seed, seedPassphrase string,
 		Seed:           seed,
 		SeedPassphrase: seedPassphrase,
 		GenerateN:      1,
-		TF:             tf,
 	})
 	if err != nil {
 		err = NewError(fmt.Errorf("RecoverWallet failed to create temporary wallet for fingerprint comparison: %v", err))
@@ -836,7 +835,6 @@ func (serv *Service) RecoverWallet(wltName, seed, seedPassphrase string,
 		CryptoType:     w.CryptoType(),
 		Bip44Coin:      w.Bip44Coin(),
 		GenerateN:      uint64(l),
-		TF:             tf,
 	})
 	if err != nil {
 		return nil, err

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -198,7 +198,6 @@ func (serv *Service) CreateWallet(wltName string, options Options) (Wallet, erro
 		wltName = serv.generateUniqueWalletFilename()
 	}
 
-	options = serv.updateOptions(options)
 	return serv.loadWallet(wltName, options)
 }
 

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -384,7 +384,7 @@ func (serv *Service) DecryptWallet(wltID string, password []byte) (Wallet, error
 // }
 
 // NewAddresses generate addresses
-func (serv *Service) NewAddresses(wltID string, password []byte, num uint64, options ...Option) ([]cipher.Address, error) {
+func (serv *Service) NewAddresses(wltID string, password []byte, options ...Option) ([]cipher.Address, error) {
 	serv.Lock()
 	defer serv.Unlock()
 
@@ -400,7 +400,7 @@ func (serv *Service) NewAddresses(wltID string, password []byte, num uint64, opt
 	var addrs []cipher.Addresser
 	f := func(w Wallet) error {
 		var err error
-		addrs, err = w.GenerateAddresses(num, options...)
+		addrs, err = w.GenerateAddresses(options...)
 		return err
 	}
 
@@ -849,7 +849,7 @@ func (serv *Service) RecoverWallet(wltName, seed, seedPassphrase string,
 
 		// regenerate the change addresses
 		if cl > 1 {
-			_, err := w3.GenerateAddresses(uint64(cl-1), OptionChange())
+			_, err := w3.GenerateAddresses(OptionGenerateN(uint64(cl-1)), OptionChange())
 			if err != nil {
 				return nil, err
 			}

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -770,7 +770,8 @@ func (serv *Service) View(wltID string, f func(Wallet) error) error {
 
 // RecoverWallet recovers an encrypted wallet from seed.
 // The recovered wallet will be encrypted with the new password, if provided.
-func (serv *Service) RecoverWallet(wltName, seed, seedPassphrase string, password []byte) (Wallet, error) {
+func (serv *Service) RecoverWallet(wltName, seed, seedPassphrase string,
+	password []byte, tf TransactionsFinder) (Wallet, error) {
 	serv.Lock()
 	defer serv.Unlock()
 	if !serv.config.EnableWalletAPI {
@@ -797,9 +798,11 @@ func (serv *Service) RecoverWallet(wltName, seed, seedPassphrase string, passwor
 		Type:           w.Type(),
 		Coin:           w.Coin(),
 		Bip44Coin:      w.Bip44Coin(),
+		Label:          w.Label(),
 		Seed:           seed,
 		SeedPassphrase: seedPassphrase,
 		GenerateN:      1,
+		TF:             tf,
 	})
 	if err != nil {
 		err = NewError(fmt.Errorf("RecoverWallet failed to create temporary wallet for fingerprint comparison: %v", err))
@@ -833,6 +836,7 @@ func (serv *Service) RecoverWallet(wltName, seed, seedPassphrase string, passwor
 		CryptoType:     w.CryptoType(),
 		Bip44Coin:      w.Bip44Coin(),
 		GenerateN:      uint64(l),
+		TF:             tf,
 	})
 	if err != nil {
 		return nil, err

--- a/src/wallet/service_test.go
+++ b/src/wallet/service_test.go
@@ -209,6 +209,7 @@ func TestServiceCreateWallet(t *testing.T) {
 				require.NoError(t, err)
 
 				w, err := s.CreateWallet(tc.filename, wallet.Options{
+					Label:    "test",
 					Seed:     tc.seed,
 					Encrypt:  tc.encrypt,
 					Password: tc.password,
@@ -254,9 +255,10 @@ func TestServiceCreateWallet(t *testing.T) {
 				}
 
 				_, err = s.CreateWallet(tc.filename, wallet.Options{
-					Seed: otherSeed,
-					Type: tc.walletType,
-					XPub: otherXPub,
+					Label: "test",
+					Seed:  otherSeed,
+					Type:  tc.walletType,
+					XPub:  otherXPub,
 				})
 				require.Equal(t, err, wallet.ErrWalletNameConflict)
 
@@ -266,9 +268,10 @@ func TestServiceCreateWallet(t *testing.T) {
 					// create wallet with dup seed or xpub key
 					dupWlt := "dup_wallet.wlt"
 					_, err = s.CreateWallet(dupWlt, wallet.Options{
-						Seed: tc.seed,
-						XPub: tc.xpub,
-						Type: tc.walletType,
+						Label: "test",
+						Seed:  tc.seed,
+						XPub:  tc.xpub,
+						Type:  tc.walletType,
 					})
 					require.Equal(t, wallet.NewError(fmt.Errorf("fingerprint conflict for %q wallet", tc.walletType)), err)
 
@@ -849,7 +852,7 @@ func TestServiceNewAddresses(t *testing.T) {
 					checkNoSensitiveData(t, w)
 				}
 
-				naddrs, err := s.NewAddresses(w.Filename(), tc.pwd, tc.n)
+				naddrs, err := s.NewAddresses(w.Filename(), tc.pwd, wallet.OptionGenerateN(tc.n))
 				require.Equal(t, tc.expectErr, err)
 
 				// Confirms that no intermediate tmp file exists
@@ -915,7 +918,7 @@ func TestServiceNewAddresses(t *testing.T) {
 				}
 
 				// Wallet doesn't exist
-				_, err = s.NewAddresses("wallet_not_exist.wlt", tc.pwd, 1)
+				_, err = s.NewAddresses("wallet_not_exist.wlt", tc.pwd, wallet.OptionGenerateN(1))
 				require.Equal(t, wallet.ErrWalletNotExist, err)
 			})
 		}
@@ -1282,6 +1285,7 @@ func TestServiceEncryptWallet(t *testing.T) {
 
 				// Create a new wallet
 				opts := tc.opts
+				opts.Label = "test"
 				opts.CryptoType = ct
 				w, err := s.CreateWallet(tc.wltName, opts)
 				require.NoError(t, err)
@@ -1579,6 +1583,7 @@ func TestServiceDecryptWallet(t *testing.T) {
 					return
 				}
 
+				tc.opts.Label = "test"
 				_, err = s.CreateWallet(tc.wltName, tc.opts)
 				require.NoError(t, err)
 
@@ -1726,6 +1731,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 
 	type exp struct {
 		err      error
+		label    string
 		seed     string
 		lastSeed string
 		xpub     string
@@ -1742,12 +1748,14 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "no coins and scan 0, unencrypted",
 			opts: wallet.Options{
-				Seed: seed,
-				Type: wallet.WalletTypeDeterministic,
-				TF:   tf,
+				Label: "test",
+				Seed:  seed,
+				Type:  wallet.WalletTypeDeterministic,
+				TF:    tf,
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     seed,
 				lastSeed: childSeeds[0],
 				entryNum: 1,
@@ -1757,6 +1765,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "no coins and scan 0, encrypted",
 			opts: wallet.Options{
+				Label:    "test",
 				Seed:     seed,
 				Encrypt:  true,
 				Password: []byte("pwd"),
@@ -1765,6 +1774,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     seed,
 				lastSeed: childSeeds[0],
 				entryNum: 1,
@@ -1774,6 +1784,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "no coins and scan 1, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				Seed:  seed,
 				ScanN: 1,
 				Type:  wallet.WalletTypeDeterministic,
@@ -1781,6 +1792,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     seed,
 				lastSeed: childSeeds[0],
 				entryNum: 1,
@@ -1790,6 +1802,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "no coins and scan 1, encrypted",
 			opts: wallet.Options{
+				Label:    "test",
 				Seed:     seed,
 				Encrypt:  true,
 				Password: []byte("pwd"),
@@ -1799,6 +1812,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     seed,
 				lastSeed: childSeeds[0],
 				entryNum: 1,
@@ -1808,6 +1822,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "no coins and scan 10, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				Seed:  seed,
 				ScanN: 10,
 				Type:  wallet.WalletTypeDeterministic,
@@ -1815,6 +1830,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     seed,
 				lastSeed: childSeeds[0],
 				entryNum: 1,
@@ -1824,6 +1840,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "scan 1 get 1, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				Seed:  seed,
 				ScanN: 1,
 				Type:  wallet.WalletTypeDeterministic,
@@ -1833,6 +1850,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     seed,
 				lastSeed: childSeeds[0],
 				entryNum: 1,
@@ -1842,6 +1860,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "scan 5 get 5, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				Seed:  seed,
 				ScanN: 5,
 				Type:  wallet.WalletTypeDeterministic,
@@ -1851,6 +1870,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     seed,
 				lastSeed: childSeeds[4],
 				entryNum: 5,
@@ -1860,6 +1880,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "scan 5 get 1, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				Seed:  seed,
 				ScanN: 5,
 				Type:  wallet.WalletTypeDeterministic,
@@ -1869,6 +1890,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     seed,
 				lastSeed: childSeeds[0],
 				entryNum: 1,
@@ -1878,6 +1900,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "scan 5 get 2, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				Seed:  seed,
 				ScanN: 5,
 				Type:  wallet.WalletTypeDeterministic,
@@ -1887,6 +1910,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     seed,
 				lastSeed: childSeeds[1],
 				entryNum: 2,
@@ -1897,6 +1921,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "scan 5 get 3, encrypted",
 			opts: wallet.Options{
+				Label:    "test",
 				Seed:     seed,
 				Encrypt:  true,
 				Password: []byte("pwd"),
@@ -1908,6 +1933,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     seed,
 				lastSeed: childSeeds[2],
 				entryNum: 3,
@@ -1917,6 +1943,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "scan 5 get 4, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				Seed:  seed,
 				ScanN: 5,
 				Type:  wallet.WalletTypeDeterministic,
@@ -1927,6 +1954,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     seed,
 				lastSeed: childSeeds[3],
 				entryNum: 4,
@@ -1936,6 +1964,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "scan 5 get 5, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				Seed:  seed,
 				ScanN: 5,
 				Type:  wallet.WalletTypeDeterministic,
@@ -1946,6 +1975,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     seed,
 				lastSeed: childSeeds[4],
 				entryNum: 5,
@@ -1955,6 +1985,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "scan 0 get 1, encrypted",
 			opts: wallet.Options{
+				Label:    "test",
 				Seed:     seed,
 				Encrypt:  true,
 				Password: []byte("pwd"),
@@ -1964,6 +1995,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     seed,
 				lastSeed: childSeeds[0],
 				entryNum: 1,
@@ -1973,6 +2005,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "scan 1 get 1, encrypted",
 			opts: wallet.Options{
+				Label:    "test",
 				Seed:     seed,
 				Encrypt:  true,
 				Password: []byte("pwd"),
@@ -1984,6 +2017,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     seed,
 				lastSeed: childSeeds[0],
 				entryNum: 1,
@@ -1993,6 +2027,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "scan 2 get 1, encrypted",
 			opts: wallet.Options{
+				Label:    "test",
 				Seed:     seed,
 				Encrypt:  true,
 				Password: []byte("pwd"),
@@ -2002,6 +2037,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     seed,
 				lastSeed: childSeeds[0],
 				entryNum: 1,
@@ -2011,6 +2047,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "scan 2 get 2, encrypted",
 			opts: wallet.Options{
+				Label:    "test",
 				Seed:     seed,
 				Encrypt:  true,
 				Password: []byte("pwd"),
@@ -2022,6 +2059,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     seed,
 				lastSeed: childSeeds[1],
 				entryNum: 2,
@@ -2031,6 +2069,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "scan 5 get 5, encrypted",
 			opts: wallet.Options{
+				Label:    "test",
 				Seed:     seed,
 				Encrypt:  true,
 				Password: []byte("pwd"),
@@ -2043,6 +2082,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     seed,
 				lastSeed: childSeeds[4],
 				entryNum: 5,
@@ -2052,12 +2092,14 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "bip44 no coins and scan 0, unencrypted",
 			opts: wallet.Options{
-				Seed: bip44Seed,
-				Type: wallet.WalletTypeBip44,
-				TF:   tf,
+				Label: "test",
+				Seed:  bip44Seed,
+				Type:  wallet.WalletTypeBip44,
+				TF:    tf,
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     bip44Seed,
 				entryNum: 2,
 				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
@@ -2066,6 +2108,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "bip44 no coins and scan 0, encrypted",
 			opts: wallet.Options{
+				Label:    "test",
 				Seed:     bip44Seed,
 				Encrypt:  true,
 				Password: []byte("pwd"),
@@ -2074,6 +2117,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     bip44Seed,
 				entryNum: 2,
 				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
@@ -2082,6 +2126,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "bip44 no coins and scan 1, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				Seed:  bip44Seed,
 				ScanN: 1,
 				Type:  wallet.WalletTypeBip44,
@@ -2089,6 +2134,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     bip44Seed,
 				entryNum: 2,
 				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
@@ -2097,6 +2143,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "bip44 no coins and scan 1, encrypted",
 			opts: wallet.Options{
+				Label:    "test",
 				Seed:     bip44Seed,
 				Encrypt:  true,
 				Password: []byte("pwd"),
@@ -2106,6 +2153,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     bip44Seed,
 				entryNum: 2,
 				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
@@ -2114,6 +2162,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "bip44 no coins and scan 10, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				Seed:  bip44Seed,
 				ScanN: 10,
 				Type:  wallet.WalletTypeBip44,
@@ -2121,6 +2170,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     bip44Seed,
 				entryNum: 2,
 				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
@@ -2129,6 +2179,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "bip44 scan 0 get 1, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				Seed:  bip44Seed,
 				ScanN: 1,
 				Type:  wallet.WalletTypeBip44,
@@ -2138,6 +2189,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     bip44Seed,
 				entryNum: 2,
 				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
@@ -2146,6 +2198,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "bip44 scan 0 get 1, encrypted",
 			opts: wallet.Options{
+				Label:    "test",
 				Seed:     bip44Seed,
 				ScanN:    1,
 				Type:     wallet.WalletTypeBip44,
@@ -2157,6 +2210,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     bip44Seed,
 				entryNum: 2,
 				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
@@ -2165,6 +2219,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "bip44 scan 1 get 1, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				Seed:  bip44Seed,
 				ScanN: 1,
 				Type:  wallet.WalletTypeBip44,
@@ -2174,6 +2229,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     bip44Seed,
 				entryNum: 2,
 				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
@@ -2182,6 +2238,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "bip44 scan 1 get 1, encrypted",
 			opts: wallet.Options{
+				Label:    "test",
 				Seed:     bip44Seed,
 				ScanN:    1,
 				Type:     wallet.WalletTypeBip44,
@@ -2193,6 +2250,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     bip44Seed,
 				entryNum: 2,
 				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
@@ -2201,6 +2259,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "bip44 scan 2 get 2, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				Seed:  bip44Seed,
 				ScanN: 2,
 				Type:  wallet.WalletTypeBip44,
@@ -2211,6 +2270,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     bip44Seed,
 				entryNum: 3,
 				addrs:    combineAddrs(bip44Addrs[:2], bip44ChangeAddrs[:1]),
@@ -2219,6 +2279,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "bip44 scan 2 get 2, encrypted",
 			opts: wallet.Options{
+				Label:    "test",
 				Seed:     bip44Seed,
 				ScanN:    2,
 				Type:     wallet.WalletTypeBip44,
@@ -2231,6 +2292,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     bip44Seed,
 				entryNum: 3,
 				addrs:    combineAddrs(bip44Addrs[:2], bip44ChangeAddrs[:1]),
@@ -2239,6 +2301,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "bip44 scan 5 get 1, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				Seed:  bip44Seed,
 				ScanN: 5,
 				Type:  wallet.WalletTypeBip44,
@@ -2248,6 +2311,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     bip44Seed,
 				entryNum: 2,
 				addrs:    combineAddrs(bip44Addrs[:1], bip44ChangeAddrs[:1]),
@@ -2256,6 +2320,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "bip44 scan 5 get 2, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				Seed:  bip44Seed,
 				ScanN: 5,
 				Type:  wallet.WalletTypeBip44,
@@ -2265,6 +2330,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     bip44Seed,
 				entryNum: 3,
 				addrs:    combineAddrs(bip44Addrs[:2], bip44ChangeAddrs[:1]),
@@ -2273,6 +2339,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "bip44 scan 5 get 5, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				Seed:  bip44Seed,
 				ScanN: 5,
 				Type:  wallet.WalletTypeBip44,
@@ -2282,6 +2349,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     bip44Seed,
 				entryNum: 6,
 				addrs:    combineAddrs(bip44Addrs[:5], bip44ChangeAddrs[:1]),
@@ -2290,6 +2358,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "bip44 scan 5 get 5, encrypted",
 			opts: wallet.Options{
+				Label:    "test",
 				Seed:     bip44Seed,
 				Encrypt:  true,
 				Password: []byte("pwd"),
@@ -2302,6 +2371,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				seed:     bip44Seed,
 				entryNum: 6,
 				addrs:    combineAddrs(bip44Addrs[:5], bip44ChangeAddrs[:1]),
@@ -2310,12 +2380,14 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "xpub no coins and scan 0, unencrypted",
 			opts: wallet.Options{
-				XPub: xpub,
-				Type: wallet.WalletTypeXPub,
-				TF:   tf,
+				Label: "test",
+				XPub:  xpub,
+				Type:  wallet.WalletTypeXPub,
+				TF:    tf,
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				xpub:     xpub,
 				entryNum: 1,
 				addrs:    xpubAddrs,
@@ -2324,12 +2396,14 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "xpub no coins and scan 0",
 			opts: wallet.Options{
-				XPub: xpub,
-				Type: wallet.WalletTypeXPub,
-				TF:   tf,
+				Label: "test",
+				XPub:  xpub,
+				Type:  wallet.WalletTypeXPub,
+				TF:    tf,
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				xpub:     xpub,
 				entryNum: 1,
 				addrs:    xpubAddrs,
@@ -2338,6 +2412,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "xpub no coins and scan 1, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				XPub:  xpub,
 				ScanN: 1,
 				Type:  wallet.WalletTypeXPub,
@@ -2345,6 +2420,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				xpub:     xpub,
 				entryNum: 1,
 				addrs:    xpubAddrs,
@@ -2353,6 +2429,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "xpub no coins and scan 1",
 			opts: wallet.Options{
+				Label: "test",
 				XPub:  xpub,
 				ScanN: 1,
 				Type:  wallet.WalletTypeXPub,
@@ -2360,6 +2437,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				xpub:     xpub,
 				entryNum: 1,
 				addrs:    xpubAddrs,
@@ -2368,6 +2446,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "xpub no coins and scan 10, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				XPub:  xpub,
 				ScanN: 10,
 				Type:  wallet.WalletTypeXPub,
@@ -2375,6 +2454,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				xpub:     xpub,
 				entryNum: 1,
 				addrs:    xpubAddrs,
@@ -2383,6 +2463,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "xpub scan 0 get 1, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				XPub:  xpub,
 				ScanN: 0,
 				Type:  wallet.WalletTypeXPub,
@@ -2392,6 +2473,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				xpub:     xpub,
 				entryNum: 1,
 				addrs:    xpubAddrs,
@@ -2400,6 +2482,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "xpub scan 0 get 1",
 			opts: wallet.Options{
+				Label: "test",
 				XPub:  xpub,
 				ScanN: 0,
 				Type:  wallet.WalletTypeXPub,
@@ -2409,6 +2492,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				xpub:     xpub,
 				entryNum: 1,
 				addrs:    xpubAddrs,
@@ -2417,6 +2501,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "xpub scan 1 get 1, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				XPub:  xpub,
 				ScanN: 1,
 				Type:  wallet.WalletTypeXPub,
@@ -2426,6 +2511,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				xpub:     xpub,
 				entryNum: 1,
 				addrs:    xpubAddrs,
@@ -2434,6 +2520,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "xpub scan 1 get 1",
 			opts: wallet.Options{
+				Label: "test",
 				XPub:  xpub,
 				ScanN: 1,
 				Type:  wallet.WalletTypeXPub,
@@ -2443,6 +2530,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				xpub:     xpub,
 				entryNum: 1,
 				addrs:    xpubAddrs,
@@ -2451,6 +2539,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "xpub scan 2 get 1, unencrypted",
 			opts: wallet.Options{
+				Label: "test",
 				XPub:  xpub,
 				ScanN: 2,
 				Type:  wallet.WalletTypeXPub,
@@ -2460,6 +2549,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				xpub:     xpub,
 				entryNum: 1,
 				addrs:    xpubAddrs,
@@ -2468,6 +2558,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 		{
 			name: "xpub scan 2 get 1",
 			opts: wallet.Options{
+				Label: "test",
 				XPub:  xpub,
 				ScanN: 2,
 				Type:  wallet.WalletTypeXPub,
@@ -2477,6 +2568,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				xpub:     xpub,
 				entryNum: 1,
 				addrs:    xpubAddrs,
@@ -2486,6 +2578,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			name: "xpub scan 2 get 2, unencrypted",
 			opts: wallet.Options{
 				XPub:  xpub,
+				Label: "test",
 				ScanN: 2,
 				Type:  wallet.WalletTypeXPub,
 				TF: mockTxnsFinder{
@@ -2495,6 +2588,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			expect: exp{
 				err:      nil,
 				xpub:     xpub,
+				label:    "test",
 				entryNum: 2,
 				addrs:    xpubAddrs,
 			},
@@ -2504,6 +2598,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			opts: wallet.Options{
 				XPub:  xpub,
 				ScanN: 2,
+				Label: "test",
 				Type:  wallet.WalletTypeXPub,
 				TF: mockTxnsFinder{
 					xpubAddrs[1]: true,
@@ -2513,6 +2608,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 				err:      nil,
 				xpub:     xpub,
 				entryNum: 2,
+				label:    "test",
 				addrs:    xpubAddrs,
 			},
 		},
@@ -2522,6 +2618,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 				XPub:  xpub,
 				ScanN: 5,
 				Type:  wallet.WalletTypeXPub,
+				Label: "test",
 				TF: mockTxnsFinder{
 					xpubAddrs[4]: true,
 				},
@@ -2531,6 +2628,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 				xpub:     xpub,
 				entryNum: 5,
 				addrs:    xpubAddrs,
+				label:    "test",
 			},
 		},
 		{
@@ -2538,6 +2636,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			opts: wallet.Options{
 				XPub:  xpub,
 				ScanN: 5,
+				Label: "test",
 				Type:  wallet.WalletTypeXPub,
 				TF: mockTxnsFinder{
 					xpubAddrs[1]: true,
@@ -2547,6 +2646,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			expect: exp{
 				err:      nil,
 				xpub:     xpub,
+				label:    "test",
 				entryNum: 4,
 				addrs:    xpubAddrs,
 			},
@@ -2557,6 +2657,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 				XPub:  xpub,
 				ScanN: 5,
 				Type:  wallet.WalletTypeXPub,
+				Label: "test",
 				TF: mockTxnsFinder{
 					xpubAddrs[1]: true,
 					xpubAddrs[2]: true,
@@ -2566,6 +2667,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 				err:      nil,
 				xpub:     xpub,
 				entryNum: 3,
+				label:    "test",
 				addrs:    xpubAddrs,
 			},
 		},
@@ -2574,6 +2676,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			opts: wallet.Options{
 				XPub:  xpub,
 				ScanN: 5,
+				Label: "test",
 				Type:  wallet.WalletTypeXPub,
 				TF: mockTxnsFinder{
 					xpubAddrs[1]: true,
@@ -2583,6 +2686,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 				err:      nil,
 				xpub:     xpub,
 				entryNum: 2,
+				label:    "test",
 				addrs:    xpubAddrs,
 			},
 		},
@@ -2592,6 +2696,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 				XPub:  xpub,
 				ScanN: 5,
 				Type:  wallet.WalletTypeXPub,
+				Label: "test",
 				TF: mockTxnsFinder{
 					xpubAddrs[0]: true,
 				},
@@ -2601,6 +2706,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 				xpub:     xpub,
 				entryNum: 1,
 				addrs:    xpubAddrs,
+				label:    "test",
 			},
 		},
 
@@ -2609,6 +2715,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			opts: wallet.Options{
 				XPub:  xpub,
 				ScanN: 5,
+				Label: "test",
 				Type:  wallet.WalletTypeXPub,
 				TF: mockTxnsFinder{
 					xpubAddrs[1]: true,
@@ -2618,6 +2725,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 				err:      nil,
 				xpub:     xpub,
 				entryNum: 2,
+				label:    "test",
 				addrs:    xpubAddrs,
 			},
 		},
@@ -2625,6 +2733,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			name: "xpub scan 5 get 5",
 			opts: wallet.Options{
 				XPub:  xpub,
+				Label: "test",
 				ScanN: 5,
 				Type:  wallet.WalletTypeXPub,
 				TF: mockTxnsFinder{
@@ -2634,6 +2743,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			},
 			expect: exp{
 				err:      nil,
+				label:    "test",
 				xpub:     xpub,
 				entryNum: 5,
 				addrs:    xpubAddrs,
@@ -2643,6 +2753,7 @@ func TestServiceCreateWalletWithScan(t *testing.T) {
 			name: "wallet api disabled",
 			opts: wallet.Options{
 				Seed:     seed,
+				Label:    "test",
 				Encrypt:  true,
 				Password: []byte("pwd"),
 				ScanN:    5,
@@ -3728,7 +3839,7 @@ func TestServiceUpdate(t *testing.T) {
 
 					// The wallet is encrypted so it cannot generate more addresses
 					// TODO: bip44 wallet can generate address without decrypting
-					_, err := w.GenerateAddresses(1)
+					_, err := w.GenerateAddresses(wallet.OptionGenerateN(1))
 					require.Equal(t, wallet.ErrWalletEncrypted, err)
 
 					return nil
@@ -3765,7 +3876,7 @@ func TestServiceUpdate(t *testing.T) {
 
 					// The wallet is encrypted so it cannot generate more addresses
 					// TODO: bip44 wallet can generate address without decrypting
-					_, err := w.GenerateAddresses(1)
+					_, err := w.GenerateAddresses(wallet.OptionGenerateN(1))
 					require.NoError(t, err)
 
 					return nil
@@ -3800,8 +3911,8 @@ func TestServiceUpdate(t *testing.T) {
 					w.SetLabel(w.Label() + "foo")
 
 					// The wallet is encrypted so it cannot generate more addresses
-					_, err := w.GenerateAddresses(1)
-					require.Equal(t, wallet.NewError(errors.New("A collection wallet does not implement GenerateAddresses")), err)
+					_, err := w.GenerateAddresses(wallet.OptionGenerateN(1))
+					require.NoError(t, err)
 
 					return nil
 				}
@@ -3834,7 +3945,7 @@ func TestServiceUpdate(t *testing.T) {
 					w.SetLabel(w.Label() + "foo")
 
 					// The wallet is encrypted so it cannot generate more addresses
-					_, err := w.GenerateAddresses(1)
+					_, err := w.GenerateAddresses(wallet.OptionGenerateN(1))
 					require.NoError(t, err)
 
 					return nil
@@ -3985,7 +4096,7 @@ func TestServiceUpdateSecrets(t *testing.T) {
 
 					// Modify the wallet pointer in order to check that the wallet gets saved
 					w.SetLabel(w.Label() + "foo")
-					_, err := w.GenerateAddresses(1)
+					_, err := w.GenerateAddresses(wallet.OptionGenerateN(1))
 					require.NoError(t, err)
 
 					return nil
@@ -4019,7 +4130,7 @@ func TestServiceUpdateSecrets(t *testing.T) {
 
 					// Modify the wallet pointer in order to check that the wallet gets saved
 					w.SetLabel(w.Label() + "foo")
-					_, err := w.GenerateAddresses(1)
+					_, err := w.GenerateAddresses(wallet.OptionGenerateN(1))
 					require.NoError(t, err)
 
 					return nil
@@ -4058,7 +4169,7 @@ func TestServiceUpdateSecrets(t *testing.T) {
 
 					// Modify the wallet pointer in order to check that the wallet gets saved
 					w.SetLabel(w.Label() + "foo")
-					_, err := w.GenerateAddresses(1)
+					_, err := w.GenerateAddresses(wallet.OptionGenerateN(1))
 					require.NoError(t, err)
 
 					return nil
@@ -4092,7 +4203,7 @@ func TestServiceUpdateSecrets(t *testing.T) {
 
 					// Modify the wallet pointer in order to check that the wallet gets saved
 					w.SetLabel(w.Label() + "foo")
-					_, err := w.GenerateAddresses(1)
+					_, err := w.GenerateAddresses(wallet.OptionGenerateN(1))
 					require.NoError(t, err)
 
 					return nil
@@ -4127,7 +4238,7 @@ func TestServiceUpdateSecrets(t *testing.T) {
 
 					// Modify the wallet pointer in order to check that the wallet gets saved
 					w.SetLabel(w.Label() + "foo")
-					_, err := w.GenerateAddresses(1)
+					_, err := w.GenerateAddresses(wallet.OptionGenerateN(1))
 					require.NoError(t, err)
 
 					return nil

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -65,6 +65,8 @@ var (
 	ErrInvalidPassword = NewError(errors.New("invalid password"))
 	// ErrMissingSeed is returned when trying to create wallet without a seed
 	ErrMissingSeed = NewError(errors.New("missing seed"))
+	// ErrMissingLabel is returned when trying to create wallet without label
+	ErrMissingLabel = NewError(errors.New("missing label"))
 	// ErrMissingAuthenticated is returned if try to decrypt a scrypt chacha20poly1305 encrypted wallet, and find no authenticated metadata.
 	ErrMissingAuthenticated = NewError(errors.New("missing authenticated metadata"))
 	// ErrMissingXPub is returned if try to create a XPub wallet without providing xpub key
@@ -141,22 +143,23 @@ func NewWalletFilename() string {
 
 // Options options that could be used when creating a wallet
 type Options struct {
-	Version        string
-	Type           string            // wallet type: deterministic, collection. Refers to which key generation mechanism is used.
-	Coin           CoinType          // coin type: skycoin, bitcoin, etc. Refers to which pubkey2addr method is used.
-	Bip44Coin      *bip44.CoinType   // bip44 path coin type
-	Label          string            // wallet label
-	Seed           string            // wallet seed
-	SeedPassphrase string            // wallet seed passphrase (bip44 wallets only)
-	Encrypt        bool              // whether the wallet need to be encrypted.
-	Password       []byte            // password that would be used for encryption, and would only be used when 'Encrypt' is true.
-	CryptoType     crypto.CryptoType // wallet encryption type, scrypt-chacha20poly1305 or sha256-xor.
-	ScanN          uint64            // number of addresses that're going to be scanned for a balance. The highest address with a balance will be used.
-	GenerateN      uint64            // number of addresses to generate, regardless of balance
-	XPub           string            // xpub key (xpub wallets only)
-	Decoder        Decoder
-	TF             TransactionsFinder
-	Temp           bool // whether the wallet is created temporary in memory.
+	Version               string
+	Type                  string            // wallet type: deterministic, collection. Refers to which key generation mechanism is used.
+	Coin                  CoinType          // coin type: skycoin, bitcoin, etc. Refers to which pubkey2addr method is used.
+	Bip44Coin             *bip44.CoinType   // bip44 path coin type
+	Label                 string            // wallet label
+	Seed                  string            // wallet seed
+	SeedPassphrase        string            // wallet seed passphrase (bip44 wallets only)
+	Encrypt               bool              // whether the wallet need to be encrypted.
+	Password              []byte            // password that would be used for encryption, and would only be used when 'Encrypt' is true.
+	CryptoType            crypto.CryptoType // wallet encryption type, scrypt-chacha20poly1305 or sha256-xor.
+	ScanN                 uint64            // number of addresses that're going to be scanned for a balance. The highest address with a balance will be used.
+	GenerateN             uint64            // number of addresses to generate, regardless of balance
+	XPub                  string            // xpub key (xpub wallets only)
+	Decoder               Decoder
+	TF                    TransactionsFinder
+	Temp                  bool            // whether the wallet is created temporary in memory.
+	CollectionPrivateKeys []cipher.SecKey // private keys for collection wallet
 }
 
 func (opts Options) Validate() error {

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -99,6 +99,8 @@ var (
 	ErrWalletTypeNotRecoverable = NewError(errors.New("wallet type is not recoverable"))
 	// ErrWalletPermission is returned when updating a wallet without writing permission
 	ErrWalletPermission = NewError(errors.New("saving wallet permission denied"))
+	// ErrInvalidPrivateKeys is returned when creating a collection wallet with invalid private keys
+	ErrInvalidPrivateKeys = NewError(errors.New("invalid private keys"))
 
 	// ErrEntryNotFound is returned by GetEntry is the wallet does not contains the entry
 	ErrEntryNotFound = errors.New("entry not found")
@@ -572,4 +574,26 @@ func SkycoinAddresses(addrs []cipher.Addresser) []cipher.Address {
 		skyAddrs[i] = a.(cipher.Address)
 	}
 	return skyAddrs
+}
+
+// ParsePrivateKeys parse private keys from a string
+// keys must be joined with commas
+func ParsePrivateKeys(keys string) ([]cipher.SecKey, error) {
+	if keys == "" {
+		return nil, nil
+	}
+
+	ss := strings.Split(keys, ",")
+	secKeys := make([]cipher.SecKey, 0, len(ss))
+	for _, s := range ss {
+		v := strings.TrimSpace(s)
+		if len(v) > 0 {
+			sk, err := cipher.SecKeyFromHex(v)
+			if err != nil {
+				return nil, fmt.Errorf("invalid private key: %v", err)
+			}
+			secKeys = append(secKeys, sk)
+		}
+	}
+	return secKeys, nil
 }

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -225,8 +225,8 @@ type Wallet interface {
 	// GenerateAddresses generates N addresses,
 	// for bip44 wallet, if no options are specified, addresses will be generated
 	// on external chain of account with index 0.
-	GenerateAddresses(num uint64, options ...Option) ([]cipher.Addresser, error)
-	// Entries returns entries,
+	GenerateAddresses(options ...Option) ([]cipher.Addresser, error)
+	// GetEntries returns entries,
 	// for bip44 wallet if no options are used, entries on external chain of account
 	// with index 0 will be returned.
 	GetEntries(options ...Option) (Entries, error)
@@ -596,4 +596,23 @@ func ParsePrivateKeys(keys string) ([]cipher.SecKey, error) {
 		}
 	}
 	return secKeys, nil
+}
+
+func applyAdvancedOptions(options ...Option) *AdvancedOptions {
+	var advOpts AdvancedOptions
+	for _, f := range options {
+		f(&advOpts)
+	}
+
+	return &advOpts
+}
+
+// GetGenerateNFromOptions gets generateN from options
+func GetGenerateNFromOptions(options ...Option) uint64 {
+	return applyAdvancedOptions(options...).GenerateN
+}
+
+// GetPrivateKeysFromOptions gets private keys from options
+func GetPrivateKeysFromOptions(options ...Option) []cipher.SecKey {
+	return applyAdvancedOptions(options...).PrivateKeys
 }

--- a/src/wallet/xpubwallet/wallet.go
+++ b/src/wallet/xpubwallet/wallet.go
@@ -457,10 +457,14 @@ func convertOptions(options wallet.Options) []wallet.Option {
 		opts = append(opts, wallet.OptionGenerateN(options.GenerateN))
 	}
 
-	if options.ScanN > 0 {
-		opts = append(opts, wallet.OptionScanN(options.ScanN))
-		opts = append(opts, wallet.OptionTransactionsFinder(options.TF))
+	scanN := options.ScanN
+	if scanN == 0 {
+		// set default scan to 1
+		scanN = 1
 	}
+
+	opts = append(opts, wallet.OptionScanN(scanN))
+	opts = append(opts, wallet.OptionTransactionsFinder(options.TF))
 
 	if options.Temp {
 		opts = append(opts, wallet.OptionTemp(true))

--- a/src/wallet/xpubwallet/wallet.go
+++ b/src/wallet/xpubwallet/wallet.go
@@ -79,7 +79,7 @@ func NewWallet(filename, label, xPub string, options ...wallet.Option) (*Wallet,
 
 	generateN := advOpts.GenerateN
 	if generateN > 0 {
-		_, err := wlt.GenerateAddresses(generateN)
+		_, err := wlt.GenerateAddresses(wallet.OptionGenerateN(generateN))
 		if err != nil {
 			return nil, err
 		}
@@ -290,7 +290,7 @@ func (w *Wallet) ScanAddresses(scanN uint64, tf wallet.TransactionsFinder) ([]ci
 	nExistingAddrs := uint64(len(w2.entries))
 
 	// Generate the addresses to scan
-	addrs, err := w2.GenerateAddresses(scanN)
+	addrs, err := w2.GenerateAddresses(wallet.OptionGenerateN(scanN))
 	if err != nil {
 		return nil, err
 	}
@@ -311,7 +311,7 @@ func (w *Wallet) ScanAddresses(scanN uint64, tf wallet.TransactionsFinder) ([]ci
 	}
 
 	w2.reset()
-	if _, err := w2.GenerateAddresses(nExistingAddrs + keepNum); err != nil {
+	if _, err := w2.GenerateAddresses(wallet.OptionGenerateN(nExistingAddrs + keepNum)); err != nil {
 		return nil, err
 	}
 
@@ -326,7 +326,8 @@ func (w *Wallet) GetAddresses(_ ...wallet.Option) ([]cipher.Addresser, error) {
 }
 
 // GenerateAddresses generates addresses for the external chain, and appends them to the wallet's entries array
-func (w *Wallet) GenerateAddresses(num uint64, _ ...wallet.Option) ([]cipher.Addresser, error) {
+func (w *Wallet) GenerateAddresses(options ...wallet.Option) ([]cipher.Addresser, error) {
+	num := wallet.GetGenerateNFromOptions(options...)
 	if num > math.MaxUint32 {
 		return nil, wallet.NewError(errors.New("XPubWallet.GenerateAddresses num too large"))
 	}

--- a/src/wallet/xpubwallet/wallet.go
+++ b/src/wallet/xpubwallet/wallet.go
@@ -457,14 +457,10 @@ func convertOptions(options wallet.Options) []wallet.Option {
 		opts = append(opts, wallet.OptionGenerateN(options.GenerateN))
 	}
 
-	scanN := options.ScanN
-	if scanN == 0 {
-		// set default scan to 1
-		scanN = 1
+	if options.ScanN > 0 {
+		opts = append(opts, wallet.OptionScanN(options.ScanN))
+		opts = append(opts, wallet.OptionTransactionsFinder(options.TF))
 	}
-
-	opts = append(opts, wallet.OptionScanN(scanN))
-	opts = append(opts, wallet.OptionTransactionsFinder(options.TF))
 
 	if options.Temp {
 		opts = append(opts, wallet.OptionTemp(true))

--- a/src/wallet/xpubwallet/wallet_test.go
+++ b/src/wallet/xpubwallet/wallet_test.go
@@ -216,7 +216,7 @@ func TestWalletGenerateAddresses(t *testing.T) {
 			// generate address
 			var addrs []cipher.Addresser
 			if !tc.oneAddressEachTime {
-				addrs, err = w.GenerateAddresses(tc.num)
+				addrs, err = w.GenerateAddresses(wallet.OptionGenerateN(tc.num))
 				require.Equal(t, tc.err, err, fmt.Sprintf("want: %v; got: %v", tc.err, err))
 				if err != nil {
 					return
@@ -224,7 +224,7 @@ func TestWalletGenerateAddresses(t *testing.T) {
 
 			} else {
 				for i := uint64(0); i < tc.num; i++ {
-					addr, err := w.GenerateAddresses(1)
+					addr, err := w.GenerateAddresses(wallet.OptionGenerateN(1))
 					require.Equal(t, tc.err, err)
 					if err != nil {
 						return
@@ -264,7 +264,7 @@ func TestWalletGetEntry(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			w, err := NewWallet("test.wlt", "test", testXPub)
 			require.NoError(t, err)
-			_, err = w.GenerateAddresses(3)
+			_, err = w.GenerateAddresses(wallet.OptionGenerateN(3))
 			require.NoError(t, err)
 
 			e, err := w.GetEntry(tc.address)
@@ -283,7 +283,7 @@ func TestWalletSerialize(t *testing.T) {
 	w, err := NewWallet("test.wlt", "test", testXPub)
 	require.NoError(t, err)
 
-	_, err = w.GenerateAddresses(5)
+	_, err = w.GenerateAddresses(wallet.OptionGenerateN(5))
 	require.NoError(t, err)
 
 	w.SetTimestamp(0)


### PR DESCRIPTION
Fixes #2435 

Changes:
- Add `-private-keys` param to collection wallet create API
- Add `-private-keys` param to `walletCreate` CLI command for `collection` wallet
- Refactor wallet create code to make the some params checking to different wallet type's own package, as different wallet type has different requirements of the params. 
- Update related unit tests and add integration tests for `walletCreate` CLI command

Does this change need to mentioned in CHANGELOG.md?
Yes. 