### PR TITLE
Do not encrypt temporary wallets

### DIFF
--- a/src/api/wallet.go
+++ b/src/api/wallet.go
@@ -1010,6 +1010,7 @@ func walletEncryptHandler(gateway Gatewayer) http.HandlerFunc {
 			switch err {
 			case wallet.ErrWalletEncrypted,
 				wallet.ErrMissingPassword,
+				wallet.ErrEncryptTempWallet,
 				wallet.ErrInvalidPassword:
 				wh.Error400(w, err.Error())
 			case wallet.ErrWalletAPIDisabled:

--- a/src/cli/encrypt_wallet.go
+++ b/src/cli/encrypt_wallet.go
@@ -41,6 +41,10 @@ func encryptWallet(id string, pr PasswordReader) error {
 		return wallet.ErrWalletEncrypted
 	}
 
+	if wlt.Meta.Temp {
+		return wallet.ErrEncryptTempWallet
+	}
+
 	if pr == nil {
 		return wallet.ErrMissingPassword
 	}

--- a/src/wallet/bip44wallet/wallet.go
+++ b/src/wallet/bip44wallet/wallet.go
@@ -188,6 +188,10 @@ func NewWallet(filename, label, seed, seedPassphrase string, options ...wallet.O
 
 	// encrypts wallet if options.Encrypt is true
 	if advOpts.Encrypt {
+		if wlt.IsTemp() {
+			return nil, wallet.ErrEncryptTempWallet
+		}
+
 		if len(advOpts.Password) == 0 {
 			return nil, errors.New("missing password for encrypting wallet")
 		}
@@ -327,6 +331,10 @@ func (w Wallet) IsEncrypted() bool {
 // Lock encrypts the wallet if it is unencrypted, return false
 // if it is already encrypted.
 func (w *Wallet) Lock(password []byte) error {
+	if w.IsTemp() {
+		return wallet.ErrEncryptTempWallet
+	}
+
 	if len(password) == 0 {
 		return wallet.ErrMissingPassword
 	}

--- a/src/wallet/collection/wallet.go
+++ b/src/wallet/collection/wallet.go
@@ -93,6 +93,10 @@ func NewWallet(filename, label string, options ...wallet.Option) (*Wallet, error
 	}
 
 	if advOpts.Encrypt {
+		if wlt.IsTemp() {
+			return nil, wallet.ErrEncryptTempWallet
+		}
+
 		if len(advOpts.Password) == 0 {
 			return nil, wallet.ErrMissingPassword
 		}
@@ -161,6 +165,10 @@ func (w *Wallet) Deserialize(data []byte) error {
 
 // Lock encrypts the wallet secrets
 func (w *Wallet) Lock(password []byte) error {
+	if w.IsTemp() {
+		return wallet.ErrEncryptTempWallet
+	}
+
 	if len(password) == 0 {
 		return wallet.ErrMissingPassword
 	}

--- a/src/wallet/collection/wallet_test.go
+++ b/src/wallet/collection/wallet_test.go
@@ -178,6 +178,18 @@ func TestNewWallet(t *testing.T) {
 			},
 		},
 		{
+			name:    "temp wallet encrypt",
+			wltName: "test.wlt",
+			label:   "temp",
+			opts: []wallet.Option{
+				wallet.OptionTemp(true),
+				wallet.OptionEncrypt(true),
+			},
+			expect: expect{
+				err: wallet.ErrEncryptTempWallet,
+			},
+		},
+		{
 			name:    "wallet with one private key",
 			wltName: "test.wlt",
 			label:   "test",
@@ -282,6 +294,13 @@ func TestWalletLock(t *testing.T) {
 			},
 			lockPwd: []byte("pwd"),
 			err:     wallet.ErrWalletEncrypted,
+		},
+		{
+			name: "temp wallet encrypt",
+			opts: []wallet.Option{
+				wallet.OptionTemp(true),
+			},
+			err: wallet.ErrEncryptTempWallet,
 		},
 	}
 

--- a/src/wallet/deterministic/wallet.go
+++ b/src/wallet/deterministic/wallet.go
@@ -101,6 +101,10 @@ func NewWallet(filename, label, seed string, options ...wallet.Option) (*Wallet,
 
 	// encrypts wallet if options.Encrypt is true
 	if advOpts.Encrypt {
+		if wlt.IsTemp() {
+			return nil, wallet.ErrEncryptTempWallet
+		}
+
 		if len(advOpts.Password) == 0 {
 			return nil, wallet.ErrMissingPassword
 		}
@@ -171,6 +175,10 @@ func (w *Wallet) Deserialize(data []byte) error {
 
 // Lock encrypts the sensitive data of the wallet
 func (w *Wallet) Lock(password []byte) error {
+	if w.IsTemp() {
+		return wallet.ErrEncryptTempWallet
+	}
+
 	if len(password) == 0 {
 		return wallet.ErrMissingPassword
 	}

--- a/src/wallet/deterministic/wallet_test.go
+++ b/src/wallet/deterministic/wallet_test.go
@@ -187,7 +187,7 @@ func TestNewWallet(t *testing.T) {
 			},
 		},
 		{
-			name:    "ok all defaults",
+			name:    "temp wallet - ok all defaults",
 			wltName: "test.wlt",
 			label:   "test",
 			seed:    "testseed123",
@@ -205,6 +205,19 @@ func TestNewWallet(t *testing.T) {
 					"temp":     "true",
 				},
 				err: nil,
+			},
+		},
+		{
+			name:    "temp wallet - encrypt",
+			wltName: "test.wlt",
+			label:   "test",
+			seed:    "testseed123",
+			opts: []wallet.Option{
+				wallet.OptionTemp(true),
+				wallet.OptionEncrypt(true),
+			},
+			expect: expect{
+				err: wallet.ErrEncryptTempWallet,
 			},
 		},
 	}
@@ -259,9 +272,8 @@ func TestWalletLock(t *testing.T) {
 			lockPwd: []byte("pwd"),
 		},
 		{
-			name:    "password is nil",
-			lockPwd: nil,
-			err:     wallet.ErrMissingPassword,
+			name: "password is nil",
+			err:  wallet.ErrMissingPassword,
 		},
 		{
 			name: "wallet already encrypted",
@@ -271,6 +283,14 @@ func TestWalletLock(t *testing.T) {
 			},
 			lockPwd: []byte("pwd"),
 			err:     wallet.ErrWalletEncrypted,
+		},
+		{
+			name: "temp wallet encrypt",
+			opts: []wallet.Option{
+				wallet.OptionTemp(true),
+			},
+			lockPwd: []byte("pwd"),
+			err:     wallet.ErrEncryptTempWallet,
 		},
 	}
 

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -104,6 +104,8 @@ var (
 
 	// ErrEntryNotFound is returned by GetEntry is the wallet does not contains the entry
 	ErrEntryNotFound = errors.New("entry not found")
+	// ErrEncryptTempWallet is returned when trying to encrypt a temporary wallet
+	ErrEncryptTempWallet = errors.New("temporary wallet does not support encryption")
 )
 
 const (


### PR DESCRIPTION
Fixes #2630 

Changes:
- Update API `/api/v1/wallet/encrypt` and CLI command `walletCreateTemp` to stop encrypt temporary wallets
- Update related unit tests

Does this change need to mentioned in CHANGELOG.md?
No.