### PR TITLE
Add `/api/v1/wallet/xpub` API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add `/api/v1/wallet/xpub` API endpoint to get xpub key of a bip44 wallet.
 - Add `/api/v1/transactions/num` to get total transactions number
 - Add param `private-keys` to CLI commands `walletCreate`, `walletCreateTemp`, and `walletNewAddresses`.
 - Add param `private-keys` to APIs `/api/v1/wallet/create`, `/api/v1/wallet/createTemp`, and `/api/v1/wallet/newAddress`. 

--- a/src/api/http.go
+++ b/src/api/http.go
@@ -532,6 +532,9 @@ func newServerMux(c muxConfig, gateway Gatewayer) *http.ServeMux {
 	webHandlerV2("/wallet/recover", walletRecoverHandler(gateway), map[string][]string{
 		http.MethodPost: {EndpointsWallet},
 	})
+	webHandlerV1("/wallet/xpub", walletXPubKeyHandler(gateway), map[string][]string{
+		http.MethodGet: {EndpointsWallet},
+	})
 
 	// Blockchain interface
 	webHandlerV1("/blockchain/metadata", blockchainMetadataHandler(gateway), map[string][]string{

--- a/src/wallet/bip44wallet/account.go
+++ b/src/wallet/bip44wallet/account.go
@@ -542,3 +542,16 @@ func (a *bip44Accounts) reset() {
 		act.reset()
 	}
 }
+
+func (a *bip44Accounts) getXPubKey(accountIndex, chainIndex uint32) (string, error) {
+	if int(accountIndex) >= len(a.accounts) {
+		return "", errors.New("account index out of bounds")
+	}
+	act := a.accounts[accountIndex]
+	if int(chainIndex) >= len(act.Chains) {
+		return "", errors.New("chain index out of bounds")
+	}
+
+	c := act.Chains[chainIndex]
+	return c.PubKey.String(), nil
+}

--- a/src/wallet/bip44wallet/account_test.go
+++ b/src/wallet/bip44wallet/account_test.go
@@ -17,6 +17,8 @@ const (
 )
 
 var (
+	testSkycoinExternalXPubKey   = "xpub6EMRsT95ntbCFRR2Z6WppnGss1SijAkarfKoRM8tft66tuJh2nt4aJi13S21hUCLZL4cbFBXgHuxipmsS7dj1DW1s4NRup3hzxWfqUdGYv7"
+	testSkycoinInternalXPubKey   = "xpub6EMRsT95ntbCGrt4gKqcJTx8rFbBLSvPzxFGfq9DVqFyA6UmDYXAoeTNFs3nmuycUhJG1hC1R5rSbEMK1EiSHotne9hYG55pyPLj8kLuutb"
 	testSkycoinExternalAddresses = []string{
 		"2JBfeo6y6FQn2rCiuhdQ8F1E6bj6rpnHo5U",
 		"28Wn9scn3wb5nkScHiTHgNmLjSUS3F2SqAj",

--- a/src/wallet/bip44wallet/wallet_test.go
+++ b/src/wallet/bip44wallet/wallet_test.go
@@ -995,6 +995,44 @@ func TestScanAddresses(t *testing.T) {
 	}
 }
 
+func TestWalletGetXPubKey(t *testing.T) {
+	w, err := NewWallet(
+		"test.wlt",
+		"test",
+		testSeed,
+		testSeedPassphrase,
+		wallet.OptionCoinType(wallet.CoinTypeSkycoin))
+	require.NoError(t, err)
+
+	_, err = w.newExternalAddresses(0, 2)
+	require.NoError(t, err)
+	//require.Equal(t, testSkycoinExternalAddresses[1:3], addrsStr)
+
+	_, err = w.newChangeAddresses(0, 2)
+	require.NoError(t, err)
+	//require.Equal(t, testSkycoinChangeAddresses[1:3], addrsStr)
+
+	k1, err := w.GetXPubKey("0/0")
+	require.Equal(t, k1, testSkycoinExternalXPubKey)
+	k2, err := w.GetXPubKey("0/1")
+	require.Equal(t, k2, testSkycoinInternalXPubKey)
+
+	_, err = w.GetXPubKey("a/0")
+	require.EqualError(t, err, "invalid account index: a, err: strconv.ParseUint: parsing \"a\": invalid syntax")
+
+	_, err = w.GetXPubKey("0/a")
+	require.EqualError(t, err, "invalid chain index: a, err: strconv.ParseUint: parsing \"a\": invalid syntax")
+
+	_, err = w.GetXPubKey("10/0")
+	require.EqualError(t, err, "account index out of bounds")
+
+	_, err = w.GetXPubKey("0/10")
+	require.EqualError(t, err, "chain index out of bounds")
+
+	_, err = w.GetXPubKey("00")
+	require.EqualError(t, err, "invalid path: 00")
+}
+
 func getExternalAddrs(t *testing.T) []cipher.Addresser {
 	return skycoinAddressStringsToAddress(testSkycoinExternalAddresses)
 }


### PR DESCRIPTION
Fixes #2522 

Changes:
- Add API endpoint `/api/v1/wallet/xpub` to get xpub key of bip44 wallets.

Does this change need to mentioned in CHANGELOG.md?
Yes.