### PR TITLE
Add token permissions for tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
     pull_request:
         branches: [ master, develop ]
 
+permissions:
+  contents: read
+
 jobs:
     Test:
         name: Do ${{ matrix.test }} tests


### PR DESCRIPTION
GitHub asks users to define workflow permissions, see https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/ and https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token for securing GitHub workflows against supply-chain attacks.

The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. 

This repository has a Scorecards score of 3.9/10 with 10 being the most secure. The `Token-Permissions` category has a score of 0/10.

This file was fixed automatically using the open-source tool https://github.com/step-security/secure-workflows. If you like the changes and merge them, please consider starring the repo. 