### PR TITLE
Add version display and build info flags to main command

### DIFF
--- a/FIBERCOIN-CONFIG.md
+++ b/FIBERCOIN-CONFIG.md
@@ -1,0 +1,123 @@
+# Running Custom Fibercoins with Configuration Files
+
+## Overview
+
+You can now run custom fibercoin nodes without compiling coin-specific binaries by using the `--fiber-config` flag with a custom `fiber.toml` configuration file.
+
+## Usage
+
+### 1. Create a Custom Fiber Configuration
+
+```bash
+cp fiber.toml mycoin.toml
+# Edit mycoin.toml to customize your fibercoin parameters
+```
+
+### 2. Run the Node with Custom Config
+
+```bash
+skycoin daemon --fiber-config mycoin.toml
+```
+
+The daemon will:
+- Load all parameters from `mycoin.toml`
+- Use the custom genesis settings, ticker, display name, etc.
+- Set the data directory from the config file
+
+### 3. Override Individual Parameters
+
+CLI flags take precedence over config file values:
+
+```bash
+skycoin daemon \
+  --fiber-config mycoin.toml \
+  --port 7000 \
+  --ticker MYC \
+  --display-name "My Custom Coin"
+```
+
+## Configuration Precedence
+
+1. **CLI flags** (highest priority)
+2. **fiber.toml values** (from --fiber-config)
+3. **Hardcoded defaults** (lowest priority)
+
+## Available Flags
+
+All fiber coin parameters can now be configured via flags:
+
+### Core Parameters
+- `--coin-name` - Name of the coin
+- `--ticker` - Coin ticker symbol (e.g., SKY)
+- `--display-name` - Display name of the coin
+- `--port` - P2P network port
+- `--web-interface-port` - Web interface port
+- `--data-dir` - Data directory path
+
+### Branding Parameters
+- `--coin-hours-name` - Display name for coin hours
+- `--coin-hours-name-singular` - Singular form
+- `--coin-hours-ticker` - Ticker for coin hours
+- `--qr-uri-prefix` - QR code URI prefix
+- `--explorer-url` - Block explorer URL
+- `--version-url` - Version check URL
+- `--bip44-coin` - BIP44 coin type number
+
+### Blockchain Parameters
+- `--genesis-address` - Genesis address
+- `--genesis-signature` - Genesis block signature
+- `--genesis-timestamp` - Genesis timestamp
+- `--blockchain-public-key` - Blockchain public key
+- `--blockchain-secret-key` - Blockchain secret key (for block publishers)
+
+## Example: Creating a Test Coin
+
+```toml
+# testcoin.toml
+[node]
+genesis_signature_str = "..."
+genesis_address_str = "..."
+blockchain_pubkey_str = "..."
+genesis_timestamp = 1426562704
+genesis_coin_volume = 100000000000000
+port = 7000
+web_interface_port = 7420
+data_directory = "$HOME/.testcoin"
+display_name = "TestCoin"
+ticker = "TST"
+coin_hours_display_name = "Test Hours"
+qr_uri_prefix = "testcoin"
+explorer_url = "https://explorer.testcoin.com"
+bip44_coin = 9000
+
+[params]
+max_coin_supply = 100000000
+distribution_addresses = [
+    "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
+]
+```
+
+Run it:
+```bash
+skycoin daemon --fiber-config testcoin.toml
+```
+
+## Benefits
+
+- **No compilation required** - Use the same `skycoin` binary for multiple coins
+- **Easy configuration** - All parameters in one TOML file
+- **Flexible deployment** - Override specific values via flags when needed
+- **Consistent behavior** - Same code base, different configurations
+
+## Implementation Details
+
+The fiber config is loaded during the command's `PreRun` phase, after flag parsing but before the daemon starts. This ensures:
+
+1. Config file values override hardcoded defaults
+2. CLI flags override config file values
+3. All parameters are properly validated before starting
+
+See the full implementation in:
+- `src/skycoin/config.go` - Config loading logic
+- `cmd/skycoin/commands/root.go` - PreRun hook
+- `template/coin.template` - Template for generated coins

--- a/cmd/newcoin/commands/root.go
+++ b/cmd/newcoin/commands/root.go
@@ -2,6 +2,7 @@
 package commands
 
 import (
+	"embed"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,6 +16,9 @@ import (
 	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/skycoin/skycoin/src/util/useragent"
 )
+
+//go:embed templates/*.template
+var templateFS embed.FS
 
 const (
 	// Version is the CLI version
@@ -62,15 +66,6 @@ var createCoinCmd = &cobra.Command{
 	Short: "Create a new coin from a template file",
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if err := validateCoinName(coinName); err != nil {
-			return err
-		}
-		if _, err := os.Stat(filepath.Join(templateDir, coinTemplateFile)); os.IsNotExist(err) {
-			return err
-		}
-		if _, err := os.Stat(filepath.Join(templateDir, coinTestTemplateFile)); os.IsNotExist(err) {
-			return err
-		}
-		if _, err := os.Stat(filepath.Join(templateDir, paramsTemplateFile)); os.IsNotExist(err) {
 			return err
 		}
 		configFilepath := filepath.Join(configDir, configFile)
@@ -122,23 +117,52 @@ var createCoinCmd = &cobra.Command{
 			return err
 		}
 		defer paramsFile.Close() //nolint
-		err = os.Chdir(templateDir)
+
+		// Read embedded template files
+		coinTemplateContent, err := templateFS.ReadFile("templates/" + coinTemplateFile)
 		if err != nil {
-			log.Errorf("failed to change directory to %s", templateDir)
+			log.Errorf("failed to read embedded coin template: %v", err)
 			return err
 		}
-		templateFiles := []string{
-			coinTemplateFile,
-			commandTemplateFile,
-			coinTestTemplateFile,
-			paramsTemplateFile,
+		commandTemplateContent, err := templateFS.ReadFile("templates/" + commandTemplateFile)
+		if err != nil {
+			log.Errorf("failed to read embedded command template: %v", err)
+			return err
 		}
+		coinTestTemplateContent, err := templateFS.ReadFile("templates/" + coinTestTemplateFile)
+		if err != nil {
+			log.Errorf("failed to read embedded coin test template: %v", err)
+			return err
+		}
+		paramsTemplateContent, err := templateFS.ReadFile("templates/" + paramsTemplateFile)
+		if err != nil {
+			log.Errorf("failed to read embedded params template: %v", err)
+			return err
+		}
+
+		// Parse templates from embedded content
 		t := template.New(coinTemplateFile)
-		t, err = t.ParseFiles(templateFiles...)
+		t, err = t.Parse(string(coinTemplateContent))
 		if err != nil {
-			log.Errorf("failed to parse template files: %v", templateFiles)
+			log.Errorf("failed to parse coin template: %v", err)
 			return err
 		}
+		t, err = t.New(commandTemplateFile).Parse(string(commandTemplateContent))
+		if err != nil {
+			log.Errorf("failed to parse command template: %v", err)
+			return err
+		}
+		t, err = t.New(coinTestTemplateFile).Parse(string(coinTestTemplateContent))
+		if err != nil {
+			log.Errorf("failed to parse coin test template: %v", err)
+			return err
+		}
+		t, err = t.New(paramsTemplateFile).Parse(string(paramsTemplateContent))
+		if err != nil {
+			log.Errorf("failed to parse params template: %v", err)
+			return err
+		}
+
 		config.Node.CoinName = coinName
 		config.Node.CoinAscii = asciiFont(coinName)
 		config.Node.DataDirectory = "$HOME/." + coinName

--- a/cmd/newcoin/commands/templates/coin.template
+++ b/cmd/newcoin/commands/templates/coin.template
@@ -1,0 +1,137 @@
+/*
+{{.CoinName}} daemon
+*/
+package commands
+
+/*
+CODE GENERATED AUTOMATICALLY WITH FIBER COIN CREATOR
+AVOID EDITING THIS MANUALLY
+edit the template instead at template/coin.template
+and then run cmd/newcoin
+*/
+
+import (
+	_ "net/http/pprof"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skycoin/src/fiber"
+	"github.com/skycoin/skycoin/src/readable"
+	"github.com/skycoin/skycoin/src/skycoin"
+	"github.com/skycoin/skycoin/src/util/logging"
+
+	// register the supported wallets
+	_ "github.com/skycoin/skycoin/src/wallet/bip44wallet"
+	_ "github.com/skycoin/skycoin/src/wallet/collection"
+	_ "github.com/skycoin/skycoin/src/wallet/deterministic"
+	_ "github.com/skycoin/skycoin/src/wallet/xpubwallet"
+)
+
+var (
+	// DB VERSION - WARNING: CHANGING WILL MAKE THE SYNCED BLOCKCHAIN NOT WORK WITH OLDER SOFTWARE VERSIONS
+	// Version of the node. Can be set by -ldflags
+	Version = "0.27.1"
+	// Commit ID. Can be set by -ldflags
+	Commit = ""
+	// Branch name. Can be set by -ldflags
+	Branch = ""
+	// ConfigMode (possible values are "", "STANDALONE_CLIENT").
+	// This is used to change the default configuration.
+	// Can be set by -ldflags
+	ConfigMode = ""
+
+	logger = logging.MustGetLogger("main")
+
+	// CoinName name of coin
+	CoinName = "{{.CoinName}}"
+
+	// GenesisSignatureStr hex string of genesis signature
+	GenesisSignatureStr = "{{.GenesisSignatureStr}}"
+	// GenesisAddressStr genesis address string
+	GenesisAddressStr = "{{.GenesisAddressStr}}"
+	// BlockchainPubkeyStr pubic key string
+	BlockchainPubkeyStr = "{{.BlockchainPubkeyStr}}"
+	// BlockchainSeckeyStr empty private key string
+	BlockchainSeckeyStr = "{{.BlockchainSeckeyStr}}"
+
+	// GenesisTimestamp genesis block create unix time
+	GenesisTimestamp uint64 = {{.GenesisTimestamp}}
+	// GenesisCoinVolume represents the coin capacity
+	GenesisCoinVolume uint64 = {{.GenesisCoinVolume}}
+
+	// DefaultConnections the default trust node addresses
+	DefaultConnections = []string{
+	{{- range $index, $address := .DefaultConnections}}
+		"{{$address -}}",
+	{{- end}}
+	}
+
+	nodeConfig = skycoin.NewNodeConfig(ConfigMode, fiber.NodeConfig{
+		CoinName:            CoinName,
+		GenesisSignatureStr: GenesisSignatureStr,
+		GenesisAddressStr:   GenesisAddressStr,
+		GenesisCoinVolume:   GenesisCoinVolume,
+		GenesisTimestamp:    GenesisTimestamp,
+		BlockchainPubkeyStr: BlockchainPubkeyStr,
+		BlockchainSeckeyStr: BlockchainSeckeyStr,
+		DefaultConnections:  DefaultConnections,
+		PeerListURL:         "{{.PeerListURL}}",
+		Port:                {{.Port}},
+		WebInterfacePort:    {{.WebInterfacePort}},
+		DataDirectory:       "{{.DataDirectory}}",
+
+		UnconfirmedBurnFactor:          {{.UnconfirmedBurnFactor}},
+		UnconfirmedMaxTransactionSize:  {{.UnconfirmedMaxTransactionSize}},
+		UnconfirmedMaxDropletPrecision: {{.UnconfirmedMaxDropletPrecision}},
+		CreateBlockBurnFactor:          {{.CreateBlockBurnFactor}},
+		CreateBlockMaxTransactionSize:  {{.CreateBlockMaxTransactionSize}},
+		CreateBlockMaxDropletPrecision: {{.CreateBlockMaxDropletPrecision}},
+		MaxBlockTransactionsSize:       {{.MaxBlockTransactionsSize}},
+
+		DisplayName:           "{{.DisplayName}}",
+		Ticker:                "{{.Ticker}}",
+		CoinHoursName:         "{{.CoinHoursName}}",
+		CoinHoursNameSingular: "{{.CoinHoursNameSingular}}",
+		CoinHoursTicker:       "{{.CoinHoursTicker}}",
+		QrURIPrefix:           "{{.QrURIPrefix}}",
+		ExplorerURL:           "{{.ExplorerURL}}",
+		VersionURL:            "{{.VersionURL}}",
+		Bip44Coin:             {{.Bip44Coin}},
+	})
+)
+
+func init() {
+	nodeConfig.RegisterFlags(RootCmd)
+}
+
+// RootCmd is the root command
+var RootCmd = &cobra.Command{
+	Use:   "{{.CoinName}}",
+	Short: "{{.CoinName}} wallet",
+	Long: `
+{{.CoinAscii}}
+	{{.CoinName}} wallet`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// create a new fiber coin instance
+		coin := skycoin.NewCoin(skycoin.Config{
+			Node: nodeConfig,
+			Build: readable.BuildInfo{
+				Version: Version,
+				Commit:  Commit,
+				Branch:  Branch,
+			},
+		}, logger)
+
+		// parse config values
+		if err := coin.ParseConfig(); err != nil {
+			logger.Error(err)
+			os.Exit(1)
+		}
+
+		// run fiber coin node
+		if err := coin.Run(); err != nil {
+			os.Exit(1)
+		}
+	},
+}

--- a/cmd/newcoin/commands/templates/coin_test.template
+++ b/cmd/newcoin/commands/templates/coin_test.template
@@ -1,0 +1,45 @@
+//go:build testrunmain
+// +build testrunmain
+
+/*
+CODE GENERATED AUTOMATICALLY WITH FIBER COIN CREATOR
+AVOID EDITING THIS MANUALLY
+*/
+
+// This file allows us to run the entire program with test coverage enabled, useful for integration tests
+package main
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	"github.com/skycoin/skycoin/cmd/{{.CoinName}}/commands"
+)
+
+func init() {
+	// Merge cobra's command flags into pflag.CommandLine so the test binary recognizes them
+	// This must happen in init() before TestMain runs
+	pflag.CommandLine.AddFlagSet(commands.RootCmd.Flags())
+	pflag.CommandLine.AddFlagSet(commands.RootCmd.PersistentFlags())
+}
+
+// TestMain handles flag parsing for both test and application flags
+func TestMain(m *testing.M) {
+	// Parse flags using pflag which supports both POSIX and GNU styles
+	// This allows the test binary to accept both -test.* flags and application flags like -disable-networking
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
+
+	// Set the parsed flags back to the standard library flag package for the test framework
+	flag.CommandLine.Parse([]string{})
+
+	// Run tests
+	os.Exit(m.Run())
+}
+
+func TestRunMain(t *testing.T) {
+	main()
+}

--- a/cmd/newcoin/commands/templates/command.template
+++ b/cmd/newcoin/commands/templates/command.template
@@ -1,0 +1,25 @@
+/*
+{{.CoinName}} daemon
+*/
+package main
+
+/*
+CODE GENERATED AUTOMATICALLY WITH FIBER COIN CREATOR
+AVOID EDITING THIS MANUALLY
+edit the template instead at: template/command.template
+and then run cmd/newcoin
+*/
+
+import (
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/flags"
+
+	"github.com/skycoin/skycoin/cmd/{{.CoinName}}/commands"
+)
+
+func init() {
+	flags.InitFlags(commands.RootCmd, true)
+}
+
+func main() {
+	commands.RootCmd.Execute()
+}

--- a/cmd/newcoin/commands/templates/params.template
+++ b/cmd/newcoin/commands/templates/params.template
@@ -1,0 +1,31 @@
+package params
+
+/*
+CODE GENERATED AUTOMATICALLY WITH FIBER COIN CREATOR
+AVOID EDITING THIS MANUALLY
+*/
+
+var (
+	// MainNetDistribution Skycoin mainnet coin distribution parameters
+	MainNetDistribution = Distribution{
+		MaxCoinSupply:        {{.MaxCoinSupply}},
+		InitialUnlockedCount: {{.InitialUnlockedCount}},
+		UnlockAddressRate:    {{.UnlockAddressRate}},
+		UnlockTimeInterval:   {{.UnlockTimeInterval}},
+		Addresses: []string{
+		{{- range $index, $address := .DistributionAddresses}}
+			"{{$address -}}",
+		{{- end}}
+		},
+	}
+
+	// UserVerifyTxn transaction verification parameters for user-created transactions
+	UserVerifyTxn = VerifyTxn{
+		// BurnFactor can be overriden with `USER_BURN_FACTOR` env var
+		BurnFactor: {{.UserBurnFactor}},
+		// MaxTransactionSize can be overriden with `USER_MAX_TXN_SIZE` env var
+		MaxTransactionSize: {{.UserMaxTransactionSize}}, // in bytes
+		// MaxDropletPrecision can be overriden with `USER_MAX_DECIMALS` env var
+		MaxDropletPrecision: {{.UserMaxDropletPrecision}},
+	}
+)

--- a/cmd/skycoin-wallet/commands/root.go
+++ b/cmd/skycoin-wallet/commands/root.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/spf13/cobra"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo"
+	"github.com/spf13/cobra"
 
 	explorer "github.com/skycoin/skycoin/cmd/explorer/commands"
 	newcoin "github.com/skycoin/skycoin/cmd/newcoin/commands"

--- a/cmd/skycoin-wallet/commands/root.go
+++ b/cmd/skycoin-wallet/commands/root.go
@@ -9,12 +9,18 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo"
 
 	explorer "github.com/skycoin/skycoin/cmd/explorer/commands"
 	newcoin "github.com/skycoin/skycoin/cmd/newcoin/commands"
 	cli "github.com/skycoin/skycoin/cmd/skycoin-cli/commands"
 	web "github.com/skycoin/skycoin/cmd/skycoin-web/commands"
 	skycoin "github.com/skycoin/skycoin/cmd/skycoin/commands"
+)
+
+var (
+	bv bool
+	di bool
 )
 
 func init() {
@@ -30,6 +36,12 @@ func init() {
 	web.RootCmd.Use = "web"
 	web.RootCmd.Short = "skycoin thin client web wallet"
 	explorer.RootCmd.Use = "explorer"
+	if fmt.Sprintf("%v", buildinfo.DebugBuildInfo()) != "" {
+		RootCmd.Flags().BoolVarP(&di, "info", "d", false, "print runtime/debug.BuildInfo")
+	}
+	if fmt.Sprintf("%v", buildinfo.DBIVersion()) != "" {
+		RootCmd.Flags().BoolVarP(&bv, "bv", "b", false, "print runtime/debug.BuildInfo.Main.Version")
+	}
 }
 
 // RootCmd contains every daemon, cli, & newcoin
@@ -37,13 +49,39 @@ var RootCmd = &cobra.Command{
 	Use: func() string {
 		return strings.Split(filepath.Base(strings.ReplaceAll(strings.ReplaceAll(fmt.Sprintf("%v", os.Args), "[", ""), "]", "")), " ")[0]
 	}(),
-	Long: `
-	┌─┐┬┌─┬ ┬┌─┐┌─┐┬┌┐┌
-	└─┐├┴┐└┬┘│  │ │││││
-	└─┘┴ ┴ ┴ └─┘└─┘┴┘└┘`,
+	Long: func() (ret string) {
+		ret = `
+    ┌─┐┬┌─┬ ┬┌─┐┌─┐┬┌┐┌
+    └─┐├┴┐└┬┘│  │ │││││
+    └─┘┴ ┴ ┴ └─┘└─┘┴┘└┘`
+		if buildinfo.DBIVersion() != "" {
+			ret += fmt.Sprintf("\n%v", buildinfo.DBIVersion())
+		} else {
+			ret += fmt.Sprintf("\nskycoin version %v", buildinfo.Version())
+		}
+		if buildinfo.Go() != "unknown" && buildinfo.Go() != "" {
+			ret += "\nbuilt with " + buildinfo.Go()
+		}
+		return ret
+	}(),
+	SilenceErrors:         true,
 	SilenceUsage:          true,
 	DisableSuggestions:    true,
 	DisableFlagsInUseLine: true,
+	Version:               buildinfo.Version(),
+	Run: func(cmd *cobra.Command, _ []string) {
+		if di {
+			fmt.Printf("%v\n", buildinfo.DebugBuildInfo())
+			return
+		}
+		if bv {
+			fmt.Printf("%v\n", buildinfo.DBIVersion())
+			return
+		}
+		if err := cmd.Help(); err != nil {
+			log.Printf("Failed to print help: %v", err)
+		}
+	},
 }
 
 // Execute executes root CLI command.

--- a/cmd/skycoin/commands/root.go
+++ b/cmd/skycoin/commands/root.go
@@ -11,6 +11,8 @@ and then run cmd/newcoin
 */
 
 import (
+	"fmt"
+	"log"
 	_ "net/http/pprof"
 	"os"
 
@@ -20,6 +22,7 @@ import (
 	"github.com/skycoin/skycoin/src/readable"
 	"github.com/skycoin/skycoin/src/skycoin"
 	"github.com/skycoin/skycoin/src/util/logging"
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo"
 
 	// register the supported wallets
 	_ "github.com/skycoin/skycoin/src/wallet/bip44wallet"
@@ -42,6 +45,9 @@ var (
 	ConfigMode = ""
 
 	logger = logging.MustGetLogger("main")
+
+	bv bool
+	di bool
 
 	// CoinName name of coin
 	CoinName = "skycoin"
@@ -107,18 +113,47 @@ var (
 
 func init() {
 	nodeConfig.RegisterFlags(RootCmd)
+	if fmt.Sprintf("%v", buildinfo.DebugBuildInfo()) != "" {
+		RootCmd.Flags().BoolVarP(&di, "info", "d", false, "print runtime/debug.BuildInfo")
+	}
+	if fmt.Sprintf("%v", buildinfo.DBIVersion()) != "" {
+		RootCmd.Flags().BoolVarP(&bv, "bv", "b", false, "print runtime/debug.BuildInfo.Main.Version")
+	}
 }
 
 // RootCmd is the root command
 var RootCmd = &cobra.Command{
 	Use:   "skycoin",
 	Short: "skycoin wallet",
-	Long: `
-┌─┐┬┌─┬ ┬┌─┐┌─┐┬┌┐┌
-└─┐├┴┐└┬┘│  │ │││││
-└─┘┴ ┴ ┴ └─┘└─┘┴┘└┘
-	skycoin wallet`,
+	Long: func() (ret string) {
+		ret = `
+    ┌─┐┬┌─┬ ┬┌─┐┌─┐┬┌┐┌
+    └─┐├┴┐└┬┘│  │ │││││
+    └─┘┴ ┴ ┴ └─┘└─┘┴┘└┘`
+		if buildinfo.DBIVersion() != "" {
+			ret += fmt.Sprintf("\n%v", buildinfo.DBIVersion())
+		} else {
+			ret += fmt.Sprintf("\nskycoin version %v", buildinfo.Version())
+		}
+		if buildinfo.Go() != "unknown" && buildinfo.Go() != "" {
+			ret += "\nbuilt with " + buildinfo.Go()
+		}
+		return ret
+	}(),
+	SilenceErrors:         true,
+	SilenceUsage:          true,
+	DisableSuggestions:    true,
+	DisableFlagsInUseLine: true,
+	Version:               buildinfo.Version(),
 	Run: func(cmd *cobra.Command, args []string) {
+		if di {
+			fmt.Printf("%v\n", buildinfo.DebugBuildInfo())
+			return
+		}
+		if bv {
+			fmt.Printf("%v\n", buildinfo.DBIVersion())
+			return
+		}
 		// create a new fiber coin instance
 		coin := skycoin.NewCoin(skycoin.Config{
 			Node: nodeConfig,
@@ -137,7 +172,7 @@ var RootCmd = &cobra.Command{
 
 		// run fiber coin node
 		if err := coin.Run(); err != nil {
-			os.Exit(1)
+			log.Fatal("Failed to run coin: ", err)
 		}
 	},
 }

--- a/cmd/skycoin/commands/root.go
+++ b/cmd/skycoin/commands/root.go
@@ -113,6 +113,16 @@ var (
 )
 
 func init() {
+	// Check for FIBER_TOML environment variable to load custom fibercoin config
+	// This sets the default values before flag registration, so CLI flags naturally override
+	if fiberTomlPath := os.Getenv("FIBER_TOML"); fiberTomlPath != "" {
+		if err := nodeConfig.LoadFromFiberConfig(fiberTomlPath); err != nil {
+			logger.Errorf("Failed to load FIBER_TOML config: %v", err)
+			os.Exit(1)
+		}
+		logger.Infof("Loaded fiber config from FIBER_TOML: %s", fiberTomlPath)
+	}
+
 	nodeConfig.RegisterFlags(RootCmd)
 	if fmt.Sprintf("%v", buildinfo.DebugBuildInfo()) != "" {
 		RootCmd.Flags().BoolVarP(&di, "info", "d", false, "print runtime/debug.BuildInfo")

--- a/cmd/skycoin/commands/root.go
+++ b/cmd/skycoin/commands/root.go
@@ -18,11 +18,12 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo"
+
 	"github.com/skycoin/skycoin/src/fiber"
 	"github.com/skycoin/skycoin/src/readable"
 	"github.com/skycoin/skycoin/src/skycoin"
 	"github.com/skycoin/skycoin/src/util/logging"
-	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo"
 
 	// register the supported wallets
 	_ "github.com/skycoin/skycoin/src/wallet/bip44wallet"

--- a/src/skycoin/config.go
+++ b/src/skycoin/config.go
@@ -735,6 +735,18 @@ func (c *NodeConfig) RegisterFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&c.LocalhostOnly, "localhost-only", c.LocalhostOnly, "Run on localhost and only connect to localhost peers")
 	cmd.Flags().StringVar(&c.WalletCryptoType, "wallet-crypto-type", c.WalletCryptoType, "wallet crypto type. Can be sha256-xor or scrypt-chacha20poly1305")
 	cmd.Flags().BoolVar(&c.Version, "version", false, "show node version")
+
+	// Display/Branding flags
+	cmd.Flags().StringVar(&c.Fiber.Name, "coin-name", c.Fiber.Name, "name of the coin")
+	cmd.Flags().StringVar(&c.Fiber.Ticker, "ticker", c.Fiber.Ticker, "coin ticker symbol (e.g., SKY)")
+	cmd.Flags().StringVar(&c.Fiber.DisplayName, "display-name", c.Fiber.DisplayName, "display name of the coin")
+	cmd.Flags().StringVar(&c.Fiber.CoinHoursName, "coin-hours-name", c.Fiber.CoinHoursName, "display name for coin hours")
+	cmd.Flags().StringVar(&c.Fiber.CoinHoursNameSingular, "coin-hours-name-singular", c.Fiber.CoinHoursNameSingular, "singular display name for coin hours")
+	cmd.Flags().StringVar(&c.Fiber.CoinHoursTicker, "coin-hours-ticker", c.Fiber.CoinHoursTicker, "ticker symbol for coin hours")
+	cmd.Flags().StringVar(&c.Fiber.QrURIPrefix, "qr-uri-prefix", c.Fiber.QrURIPrefix, "prefix for QR code URIs")
+	cmd.Flags().StringVar(&c.Fiber.ExplorerURL, "explorer-url", c.Fiber.ExplorerURL, "URL of the block explorer")
+	cmd.Flags().StringVar(&c.Fiber.VersionURL, "version-url", c.Fiber.VersionURL, "URL for version checking")
+	cmd.Flags().Uint32Var((*uint32)(&c.Fiber.Bip44Coin), "bip44-coin", uint32(c.Fiber.Bip44Coin), "BIP44 coin type")
 }
 
 func (c *NodeConfig) applyConfigMode(configMode string) {
@@ -758,6 +770,144 @@ func (c *NodeConfig) applyConfigMode(configMode string) {
 		c.WebInterfacePort = 0 // randomize web interface port
 	default:
 		panic("Invalid ConfigMode")
+	}
+}
+
+// LoadFromFiberConfig loads configuration from a fiber.toml file
+// and overrides the default values in NodeConfig
+func (c *NodeConfig) LoadFromFiberConfig(configPath string) error {
+	if configPath == "" {
+		return nil // No config file specified
+	}
+
+	// Load fiber config
+	fiberCfg, err := fiber.NewConfig(filepath.Base(configPath), filepath.Dir(configPath))
+	if err != nil {
+		return fmt.Errorf("failed to load fiber config: %w", err)
+	}
+
+	// Map fiber.NodeConfig to skycoin.NodeConfig
+	c.applyFiberNodeConfig(fiberCfg.Node)
+
+	return nil
+}
+
+// applyFiberNodeConfig maps fiber.NodeConfig fields to NodeConfig
+func (c *NodeConfig) applyFiberNodeConfig(node fiber.NodeConfig) {
+	// Core blockchain parameters
+	if node.CoinName != "" {
+		c.CoinName = node.CoinName
+		c.Fiber.Name = node.CoinName
+	}
+	if node.Port != 0 {
+		c.Port = node.Port
+	}
+	if node.WebInterfacePort != 0 {
+		c.WebInterfacePort = node.WebInterfacePort
+	}
+	if node.GenesisSignatureStr != "" {
+		c.GenesisSignatureStr = node.GenesisSignatureStr
+	}
+	if node.GenesisAddressStr != "" {
+		c.GenesisAddressStr = node.GenesisAddressStr
+	}
+	if node.BlockchainPubkeyStr != "" {
+		c.BlockchainPubkeyStr = node.BlockchainPubkeyStr
+	}
+	if node.BlockchainSeckeyStr != "" {
+		c.BlockchainSeckeyStr = node.BlockchainSeckeyStr
+	}
+	if node.GenesisTimestamp != 0 {
+		c.GenesisTimestamp = node.GenesisTimestamp
+	}
+	if node.GenesisCoinVolume != 0 {
+		c.GenesisCoinVolume = node.GenesisCoinVolume
+	}
+	if len(node.DefaultConnections) > 0 {
+		c.DefaultConnections = node.DefaultConnections
+	}
+	if node.PeerListURL != "" {
+		c.PeerListURL = node.PeerListURL
+	}
+
+	// Data directory - expand $HOME
+	// If not explicitly set, derive from coin name or display name
+	if node.DataDirectory != "" {
+		dataDir := node.DataDirectory
+		home := file.UserHome()
+		dataDir = replaceHome(dataDir, home)
+		c.DataDirectory = dataDir
+	} else if c.DataDirectory == "$HOME/.skycoin" {
+		// Auto-derive data directory from coin name or display name (matches newcoin behavior)
+		home := file.UserHome()
+		derivedName := ""
+		if node.CoinName != "" {
+			derivedName = node.CoinName
+		} else if node.DisplayName != "" {
+			derivedName = node.DisplayName
+		}
+		if derivedName != "" {
+			c.DataDirectory = replaceHome("$HOME/."+strings.ToLower(derivedName), home)
+		}
+	}
+
+	// Transaction verification params
+	if node.UnconfirmedBurnFactor != 0 {
+		c.UnconfirmedVerifyTxn.BurnFactor = node.UnconfirmedBurnFactor
+		c.unconfirmedBurnFactor = uint64(node.UnconfirmedBurnFactor)
+	}
+	if node.UnconfirmedMaxTransactionSize != 0 {
+		c.UnconfirmedVerifyTxn.MaxTransactionSize = node.UnconfirmedMaxTransactionSize
+		c.maxUnconfirmedTransactionSize = uint64(node.UnconfirmedMaxTransactionSize)
+	}
+	if node.UnconfirmedMaxDropletPrecision != 0 {
+		c.UnconfirmedVerifyTxn.MaxDropletPrecision = node.UnconfirmedMaxDropletPrecision
+		c.unconfirmedMaxDropletPrecision = uint64(node.UnconfirmedMaxDropletPrecision)
+	}
+	if node.CreateBlockBurnFactor != 0 {
+		c.CreateBlockVerifyTxn.BurnFactor = node.CreateBlockBurnFactor
+		c.createBlockBurnFactor = uint64(node.CreateBlockBurnFactor)
+	}
+	if node.CreateBlockMaxTransactionSize != 0 {
+		c.CreateBlockVerifyTxn.MaxTransactionSize = node.CreateBlockMaxTransactionSize
+		c.createBlockMaxTransactionSize = uint64(node.CreateBlockMaxTransactionSize)
+	}
+	if node.CreateBlockMaxDropletPrecision != 0 {
+		c.CreateBlockVerifyTxn.MaxDropletPrecision = node.CreateBlockMaxDropletPrecision
+		c.createBlockMaxDropletPrecision = uint64(node.CreateBlockMaxDropletPrecision)
+	}
+	if node.MaxBlockTransactionsSize != 0 {
+		c.MaxBlockTransactionsSize = node.MaxBlockTransactionsSize
+		c.maxBlockSize = uint64(node.MaxBlockTransactionsSize)
+	}
+
+	// Display/Branding
+	if node.Ticker != "" {
+		c.Fiber.Ticker = node.Ticker
+	}
+	if node.DisplayName != "" {
+		c.Fiber.DisplayName = node.DisplayName
+	}
+	if node.CoinHoursName != "" {
+		c.Fiber.CoinHoursName = node.CoinHoursName
+	}
+	if node.CoinHoursNameSingular != "" {
+		c.Fiber.CoinHoursNameSingular = node.CoinHoursNameSingular
+	}
+	if node.CoinHoursTicker != "" {
+		c.Fiber.CoinHoursTicker = node.CoinHoursTicker
+	}
+	if node.QrURIPrefix != "" {
+		c.Fiber.QrURIPrefix = node.QrURIPrefix
+	}
+	if node.ExplorerURL != "" {
+		c.Fiber.ExplorerURL = node.ExplorerURL
+	}
+	if node.VersionURL != "" {
+		c.Fiber.VersionURL = node.VersionURL
+	}
+	if node.Bip44Coin != 0 {
+		c.Fiber.Bip44Coin = node.Bip44Coin
 	}
 }
 

--- a/template/coin.template
+++ b/template/coin.template
@@ -112,6 +112,16 @@ var RootCmd = &cobra.Command{
 	Long: `
 {{.CoinAscii}}
 	{{.CoinName}} wallet`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		// Load fiber config if specified
+		if nodeConfig.FiberConfigFile != "" {
+			if err := nodeConfig.LoadFromFiberConfig(nodeConfig.FiberConfigFile); err != nil {
+				logger.Errorf("Failed to load fiber config: %v", err)
+				os.Exit(1)
+			}
+			logger.Infof("Loaded fiber config from: %s", nodeConfig.FiberConfigFile)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// create a new fiber coin instance
 		coin := skycoin.NewCoin(skycoin.Config{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -265,6 +265,7 @@ github.com/skycoin/hardware-wallet-protob/go/google/protobuf
 github.com/skycoin/skycoin-lite/liteclient
 # github.com/skycoin/skywire v1.3.32-0.20251008181048-e232456f8799
 ## explicit; go 1.25.1
+github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo
 github.com/skycoin/skywire/pkg/skywire-utilities/pkg/calvin
 github.com/skycoin/skywire/pkg/skywire-utilities/pkg/flags
 # github.com/spf13/afero v1.15.0


### PR DESCRIPTION
Add version information display (BuildInfo version, go compiler) and flags (-b/--bv, -d/--info, -v/--version) to main skycoin command to match skywire's format. Also update daemon subcommand with same features.