### PR TITLE
Add cmd/release with integrated hardware wallet utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ Thumbs.db
 *.orig
 
 .cache
-release
+/release
 .bin
 
 .skycoin

--- a/.goreleaser-darwin-amd64.yml
+++ b/.goreleaser-darwin-amd64.yml
@@ -1,5 +1,5 @@
 # GoReleaser configuration for macOS Intel builds
-# Builds skycoin and skyhw binaries for macOS amd64
+# Builds skycoin binary with hardware wallet utilities for macOS amd64
 
 version: 2
 
@@ -21,21 +21,10 @@ builds:
     goarch:
       - amd64
     env:
-      - CGO_ENABLED=0
-    main: ./
-    ldflags: -s -w -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
-
-  - id: skyhw
-    binary: skyhw
-    goos:
-      - darwin
-    goarch:
-      - amd64
-    env:
       - CGO_ENABLED=1
       - CGO_CFLAGS=-I/usr/local/include
       - CGO_LDFLAGS=-L/usr/local/lib
-    main: ./cmd/hardware-wallet/
+    main: ./cmd/release/
     ldflags: -s -w -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
 archives:
@@ -45,7 +34,6 @@ archives:
     name_template: 'skycoin-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     ids:
       - skycoin
-      - skyhw
     files:
       - none*
 

--- a/.goreleaser-darwin-arm64.yml
+++ b/.goreleaser-darwin-arm64.yml
@@ -1,5 +1,5 @@
 # GoReleaser configuration for macOS ARM builds
-# Builds skycoin and skyhw binaries for macOS arm64
+# Builds skycoin binary with hardware wallet utilities for macOS arm64
 
 version: 2
 
@@ -21,21 +21,10 @@ builds:
     goarch:
       - arm64
     env:
-      - CGO_ENABLED=0
-    main: ./
-    ldflags: -s -w -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
-
-  - id: skyhw
-    binary: skyhw
-    goos:
-      - darwin
-    goarch:
-      - arm64
-    env:
       - CGO_ENABLED=1
       - CGO_CFLAGS=-I/opt/homebrew/include
       - CGO_LDFLAGS=-L/opt/homebrew/lib
-    main: ./cmd/hardware-wallet/
+    main: ./cmd/release/
     ldflags: -s -w -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
 archives:
@@ -45,7 +34,6 @@ archives:
     name_template: 'skycoin-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     ids:
       - skycoin
-      - skyhw
     files:
       - none*
 

--- a/.goreleaser-darwin.yml
+++ b/.goreleaser-darwin.yml
@@ -1,5 +1,5 @@
 # GoReleaser configuration for macOS builds
-# Builds skycoin and skyhw binaries for macOS
+# Builds skycoin binary with hardware wallet utilities for macOS
 
 version: 2
 
@@ -22,22 +22,10 @@ builds:
       - amd64
       - arm64
     env:
-      - CGO_ENABLED=0
-    main: ./
-    ldflags: -s -w -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
-
-  - id: skyhw
-    binary: skyhw
-    goos:
-      - darwin
-    goarch:
-      - amd64
-      - arm64
-    env:
       - CGO_ENABLED=1
       - CGO_CFLAGS=-I/usr/local/include
       - CGO_LDFLAGS=-L/usr/local/lib
-    main: ./cmd/hardware-wallet/
+    main: ./cmd/release/
     ldflags: -s -w -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
 archives:
@@ -46,7 +34,6 @@ archives:
     name_template: 'skycoin-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     builds:
       - skycoin
-      - skyhw
     files:
       - none*
 
@@ -55,7 +42,6 @@ nfpms:
     package_name: skycoin
     builds:
       - skycoin
-      - skyhw
     vendor: Skycoin
     homepage: https://skycoin.com
     maintainer: Skycoin Team
@@ -67,8 +53,6 @@ nfpms:
     contents:
       - src: ./dist/skycoin_{{ .Os }}_{{ .Arch }}*/skycoin
         dst: /usr/local/bin/skycoin
-      - src: ./dist/skyhw_{{ .Os }}_{{ .Arch }}*/skyhw
-        dst: /usr/local/bin/skyhw
 
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser-linux.yml
+++ b/.goreleaser-linux.yml
@@ -1,5 +1,6 @@
 # GoReleaser configuration for Linux builds
-# Builds skycoin-wallet binaries for multiple Linux architectures
+# Builds skycoin binaries for multiple Linux architectures
+# Non-386 builds include hardware wallet utilities as a subcommand
 
 version: 2
 
@@ -27,23 +28,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/runner/work/skycoin/skycoin/musl-data/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
       - PKG_CONFIG_PATH=/home/runner/work/skycoin/skycoin/musl-data/x86_64-linux-musl-cross/x86_64-linux-musl/lib/pkgconfig
-    main: ./
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
-
-  - id: skyhw-amd64
-    binary: skyhw
-    goos:
-      - linux
-    goarch:
-      - amd64
-    flags:
-      - -tags=cgo
-      - -trimpath
-    env:
-      - CGO_ENABLED=1
-      - CC=/home/runner/work/skycoin/skycoin/musl-data/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
-      - PKG_CONFIG_PATH=/home/runner/work/skycoin/skycoin/musl-data/x86_64-linux-musl-cross/x86_64-linux-musl/lib/pkgconfig
-    main: ./cmd/hardware-wallet/
+    main: ./cmd/release/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: skycoin-386
@@ -59,23 +44,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/runner/work/skycoin/skycoin/musl-data/i686-linux-musl-cross/bin/i686-linux-musl-gcc
       - PKG_CONFIG_PATH=/home/runner/work/skycoin/skycoin/musl-data/i686-linux-musl-cross/i686-linux-musl/lib/pkgconfig
-    main: ./
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
-
-  - id: skyhw-386
-    binary: skyhw
-    goos:
-      - linux
-    goarch:
-      - 386
-    flags:
-      - -tags=cgo
-      - -trimpath
-    env:
-      - CGO_ENABLED=1
-      - CC=/home/runner/work/skycoin/skycoin/musl-data/i686-linux-musl-cross/bin/i686-linux-musl-gcc
-      - PKG_CONFIG_PATH=/home/runner/work/skycoin/skycoin/musl-data/i686-linux-musl-cross/i686-linux-musl/lib/pkgconfig
-    main: ./cmd/hardware-wallet/
+    main: ./cmd/release/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: skycoin-arm64
@@ -91,23 +60,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/runner/work/skycoin/skycoin/musl-data/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
       - PKG_CONFIG_PATH=/home/runner/work/skycoin/skycoin/musl-data/aarch64-linux-musl-cross/aarch64-linux-musl/lib/pkgconfig
-    main: ./
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
-
-  - id: skyhw-arm64
-    binary: skyhw
-    goos:
-      - linux
-    goarch:
-      - arm64
-    flags:
-      - -tags=cgo
-      - -trimpath
-    env:
-      - CGO_ENABLED=1
-      - CC=/home/runner/work/skycoin/skycoin/musl-data/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
-      - PKG_CONFIG_PATH=/home/runner/work/skycoin/skycoin/musl-data/aarch64-linux-musl-cross/aarch64-linux-musl/lib/pkgconfig
-    main: ./cmd/hardware-wallet/
+    main: ./cmd/release/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: skycoin-arm
@@ -125,25 +78,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/runner/work/skycoin/skycoin/musl-data/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
       - PKG_CONFIG_PATH=/home/runner/work/skycoin/skycoin/musl-data/arm-linux-musleabi-cross/arm-linux-musleabi/lib/pkgconfig
-    main: ./
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
-
-  - id: skyhw-arm
-    binary: skyhw
-    goos:
-      - linux
-    goarch:
-      - arm
-    goarm:
-      - 6
-    flags:
-      - -tags=cgo
-      - -trimpath
-    env:
-      - CGO_ENABLED=1
-      - CC=/home/runner/work/skycoin/skycoin/musl-data/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
-      - PKG_CONFIG_PATH=/home/runner/work/skycoin/skycoin/musl-data/arm-linux-musleabi-cross/arm-linux-musleabi/lib/pkgconfig
-    main: ./cmd/hardware-wallet/
+    main: ./cmd/release/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: skycoin-armhf
@@ -161,25 +96,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/runner/work/skycoin/skycoin/musl-data/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
       - PKG_CONFIG_PATH=/home/runner/work/skycoin/skycoin/musl-data/arm-linux-musleabihf-cross/arm-linux-musleabihf/lib/pkgconfig
-    main: ./
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
-
-  - id: skyhw-armhf
-    binary: skyhw
-    goos:
-      - linux
-    goarch:
-      - arm
-    goarm:
-      - 7
-    flags:
-      - -tags=cgo
-      - -trimpath
-    env:
-      - CGO_ENABLED=1
-      - CC=/home/runner/work/skycoin/skycoin/musl-data/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
-      - PKG_CONFIG_PATH=/home/runner/work/skycoin/skycoin/musl-data/arm-linux-musleabihf-cross/arm-linux-musleabihf/lib/pkgconfig
-    main: ./cmd/hardware-wallet/
+    main: ./cmd/release/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: skycoin-riscv64
@@ -195,23 +112,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/runner/work/skycoin/skycoin/musl-data/riscv64-linux-musl-cross/bin/riscv64-linux-musl-gcc
       - PKG_CONFIG_PATH=/home/runner/work/skycoin/skycoin/musl-data/riscv64-linux-musl-cross/riscv64-linux-musl/lib/pkgconfig
-    main: ./
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
-
-  - id: skyhw-riscv64
-    binary: skyhw
-    goos:
-      - linux
-    goarch:
-      - riscv64
-    flags:
-      - -tags=cgo
-      - -trimpath
-    env:
-      - CGO_ENABLED=1
-      - CC=/home/runner/work/skycoin/skycoin/musl-data/riscv64-linux-musl-cross/bin/riscv64-linux-musl-gcc
-      - PKG_CONFIG_PATH=/home/runner/work/skycoin/skycoin/musl-data/riscv64-linux-musl-cross/riscv64-linux-musl/lib/pkgconfig
-    main: ./cmd/hardware-wallet/
+    main: ./cmd/release/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
 archives:
@@ -221,7 +122,6 @@ archives:
     name_template: 'skycoin-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     ids:
       - skycoin-amd64
-      - skyhw-amd64
     files:
       - none*
 
@@ -231,7 +131,6 @@ archives:
     name_template: 'skycoin-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     ids:
       - skycoin-arm64
-      - skyhw-arm64
     files:
       - none*
 
@@ -241,7 +140,6 @@ archives:
     name_template: 'skycoin-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     ids:
       - skycoin-arm
-      - skyhw-arm
     files:
       - none*
 
@@ -251,7 +149,6 @@ archives:
     name_template: 'skycoin-v{{ .Version }}-{{ .Os }}-{{ .Arch }}hf'
     ids:
       - skycoin-armhf
-      - skyhw-armhf
     files:
       - none*
 
@@ -261,7 +158,6 @@ archives:
     name_template: 'skycoin-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     ids:
       - skycoin-386
-      - skyhw-386
     files:
       - none*
 
@@ -271,7 +167,6 @@ archives:
     name_template: 'skycoin-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     ids:
       - skycoin-riscv64
-      - skyhw-riscv64
     files:
       - none*
 

--- a/.goreleaser-windows.yml
+++ b/.goreleaser-windows.yml
@@ -1,5 +1,6 @@
-# GoReleaser configuration for Windows builds  
-# Builds skycoin and skyhw binaries for Windows
+# GoReleaser configuration for Windows builds
+# Builds skycoin binaries for Windows
+# amd64 includes hardware wallet utilities, 386 and arm64 do not
 
 version: 2
 
@@ -23,23 +24,9 @@ builds:
     env:
       - CGO_ENABLED=1
       - PKG_CONFIG_PATH=C:/msys64/mingw64/lib/pkgconfig
-      - CGO_CFLAGS=-IC:/msys64/mingw64/include
-      - CGO_LDFLAGS=-LC:/msys64/mingw64/lib
-    main: ./
-    ldflags: -s -w -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
-
-  - id: skyhw-amd64
-    binary: skyhw
-    goos:
-      - windows
-    goarch:
-      - amd64
-    env:
-      - CGO_ENABLED=1
-      - PKG_CONFIG_PATH=C:/msys64/mingw64/lib/pkgconfig
       - CGO_CFLAGS=-IC:/msys64/mingw64/include -IC:/msys64/mingw64/include/libusb-1.0
       - CGO_LDFLAGS=-LC:/msys64/mingw64/lib
-    main: ./cmd/hardware-wallet/
+    main: ./cmd/release/
     ldflags: -s -w -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: skycoin-386
@@ -50,7 +37,7 @@ builds:
       - 386
     env:
       - CGO_ENABLED=0
-    main: ./
+    main: ./cmd/release/
     ldflags: -s -w -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: skycoin-arm64
@@ -61,7 +48,7 @@ builds:
       - arm64
     env:
       - CGO_ENABLED=0
-    main: ./
+    main: ./cmd/release/
     ldflags: -s -w -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
 archives:
@@ -71,7 +58,6 @@ archives:
     name_template: 'skycoin-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     ids:
       - skycoin-amd64
-      - skyhw-amd64
     files:
       - none*
 

--- a/cmd/hardware-wallet/commands/root_386.go
+++ b/cmd/hardware-wallet/commands/root_386.go
@@ -1,0 +1,29 @@
+//go:build 386
+// +build 386
+
+// Package commands provides a stub for 386 architecture.
+//
+// Hardware wallet support is disabled on 386 architecture due to
+// limitations in the github.com/google/gousb library which lacks proper
+// 32-bit support.
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// RootCmd is a stub for 386 architecture - hardware wallet is not supported
+var RootCmd = &cobra.Command{
+	Use:    "skyhw",
+	Short:  "hardware wallet utilities (not available on 386)",
+	Long:   "Hardware wallet support is not available on 386 architecture",
+	Hidden: true,
+	Run: func(cmd *cobra.Command, _ []string) {
+		cmd.Println("Hardware wallet support is not available on 386 architecture")
+	},
+}
+
+// Execute is a stub for 386 architecture
+func Execute() {
+	// No-op on 386
+}

--- a/cmd/release/README.md
+++ b/cmd/release/README.md
@@ -1,0 +1,36 @@
+# skycoin release
+
+Release binary compilation including all skycoin utilities with hardware wallet support.
+
+This binary includes:
+- `daemon` - skycoin wallet daemon
+- `cli` - skycoin command line interface
+- `web` - skycoin thin client web wallet
+- `explorer` - skycoin blockchain explorer
+- `newcoin` - fibercoin creation tool
+- `skyhw` - skycoin hardware wallet utilities (daemon and cli)
+
+## Build Requirements
+
+Hardware wallet support requires libusb-1.0 for development builds:
+
+```bash
+# Debian/Ubuntu
+sudo apt-get install libusb-1.0-0-dev
+
+# macOS
+brew install libusb
+
+# Fedora
+sudo dnf install libusb1-devel
+```
+
+## Static Compilation (Release Builds)
+
+Release binaries are statically compiled with musl to eliminate runtime dependencies.
+See the goreleaser configuration files for build details.
+
+## Architecture Support
+
+Hardware wallet support is disabled on 386 architecture due to limitations in the
+github.com/google/gousb library.

--- a/cmd/release/commands/root.go
+++ b/cmd/release/commands/root.go
@@ -1,0 +1,99 @@
+// Package commands implements the skycoin release commands with hardware wallet support.
+//
+// Note: On 386 architecture, the hardware wallet subcommand is a stub due to
+// limitations in the github.com/google/gousb library.
+package commands
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo"
+	"github.com/spf13/cobra"
+
+	explorer "github.com/skycoin/skycoin/cmd/explorer/commands"
+	skyhw "github.com/skycoin/skycoin/cmd/hardware-wallet/commands"
+	newcoin "github.com/skycoin/skycoin/cmd/newcoin/commands"
+	cli "github.com/skycoin/skycoin/cmd/skycoin-cli/commands"
+	web "github.com/skycoin/skycoin/cmd/skycoin-web/commands"
+	skycoin "github.com/skycoin/skycoin/cmd/skycoin/commands"
+)
+
+var (
+	bv bool
+	di bool
+)
+
+func init() {
+	RootCmd.AddCommand(
+		skycoin.RootCmd,
+		web.RootCmd,
+		cli.RootCmd,
+		newcoin.RootCmd,
+		explorer.RootCmd,
+		skyhw.RootCmd,
+	)
+	skycoin.RootCmd.Use = "daemon"
+	web.RootCmd.Use = "web"
+	web.RootCmd.Short = "skycoin thin client web wallet"
+	explorer.RootCmd.Use = "explorer"
+	skyhw.RootCmd.Use = "skyhw"
+	skyhw.RootCmd.Short = "skycoin hardware wallet utilities"
+
+	if fmt.Sprintf("%v", buildinfo.DebugBuildInfo()) != "" {
+		RootCmd.Flags().BoolVarP(&di, "info", "d", false, "print runtime/debug.BuildInfo")
+	}
+	if fmt.Sprintf("%v", buildinfo.DBIVersion()) != "" {
+		RootCmd.Flags().BoolVarP(&bv, "bv", "b", false, "print runtime/debug.BuildInfo.Main.Version")
+	}
+}
+
+// RootCmd contains every daemon, cli, newcoin, and hardware wallet utilities
+var RootCmd = &cobra.Command{
+	Use: func() string {
+		return strings.Split(filepath.Base(strings.ReplaceAll(strings.ReplaceAll(fmt.Sprintf("%v", os.Args), "[", ""), "]", "")), " ")[0]
+	}(),
+	Long: func() (ret string) {
+		ret = `
+    ┌─┐┬┌─┬ ┬┌─┐┌─┐┬┌┐┌
+    └─┐├┴┐└┬┘│  │ │││││
+    └─┘┴ ┴ ┴ └─┘└─┘┴┘└┘`
+		if buildinfo.DBIVersion() != "" {
+			ret += fmt.Sprintf("\n%v", buildinfo.DBIVersion())
+		} else {
+			ret += fmt.Sprintf("\nskycoin version %v", buildinfo.Version())
+		}
+		if buildinfo.Go() != "unknown" && buildinfo.Go() != "" {
+			ret += "\nbuilt with " + buildinfo.Go()
+		}
+		return ret
+	}(),
+	SilenceErrors:         true,
+	SilenceUsage:          true,
+	DisableSuggestions:    true,
+	DisableFlagsInUseLine: true,
+	Version:               buildinfo.Version(),
+	Run: func(cmd *cobra.Command, _ []string) {
+		if di {
+			fmt.Printf("%v\n", buildinfo.DebugBuildInfo())
+			return
+		}
+		if bv {
+			fmt.Printf("%v\n", buildinfo.DBIVersion())
+			return
+		}
+		if err := cmd.Help(); err != nil {
+			log.Printf("Failed to print help: %v", err)
+		}
+	},
+}
+
+// Execute executes root CLI command.
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		log.Fatal("Failed to execute command: ", err)
+	}
+}

--- a/cmd/release/skycoin.go
+++ b/cmd/release/skycoin.go
@@ -34,7 +34,7 @@ func main() {
 		NoExtraNewlines: true,
 		NoBottomNewline: true,
 	})
-	commands.RootCmd.Execute() //nolint:errcheck
+	commands.RootCmd.Execute() //nolint:errcheck,gosec
 }
 
 const help = "{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +

--- a/cmd/release/skycoin.go
+++ b/cmd/release/skycoin.go
@@ -1,0 +1,47 @@
+/*
+skycoin release binary with hardware wallet support
+
+Note: On 386 architecture, the hardware wallet subcommand is a stub due to
+limitations in the github.com/google/gousb library.
+*/
+package main
+
+import (
+	cc "github.com/ivanpirog/coloredcobra"
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skycoin/cmd/release/commands"
+)
+
+func init() {
+	var helpflag bool
+	commands.RootCmd.SetUsageTemplate(help)
+	commands.RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help menu")
+	commands.RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
+	commands.RootCmd.PersistentFlags().MarkHidden("help") //nolint
+}
+
+func main() {
+	cc.Init(&cc.Config{
+		RootCmd:         commands.RootCmd,
+		Headings:        cc.HiBlue + cc.Bold,
+		Commands:        cc.HiBlue + cc.Bold,
+		CmdShortDescr:   cc.HiBlue,
+		Example:         cc.HiBlue + cc.Italic,
+		ExecName:        cc.HiBlue + cc.Bold,
+		Flags:           cc.HiBlue + cc.Bold,
+		FlagsDescr:      cc.HiBlue,
+		NoExtraNewlines: true,
+		NoBottomNewline: true,
+	})
+	commands.RootCmd.Execute() //nolint:errcheck
+}
+
+const help = "{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
+	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}" +
+	"Available Commands:{{range .Commands}}  {{if and (ne .Name \"completion\") .IsAvailableCommand}}\r\n  " +
+	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
+	"Flags:\r\n" +
+	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
+	"Global Flags:\r\n" +
+	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"


### PR DESCRIPTION
- Create cmd/release binary that includes skyhw as a subcommand
- Add 386 stub for hardware wallet commands (not supported on 32-bit)
- Update all goreleaser configs to build from cmd/release
- Single binary release now includes: daemon, cli, web, explorer, newcoin, skyhw
- Default compilation (go run .) unchanged - no libusb dependency required
- Release builds use static compilation with musl for no runtime dependencies
