### PR TITLE
De-duplicate wallet response construction: move to readable package

### DIFF
--- a/cmd/skycoin-web/commands/root.go
+++ b/cmd/skycoin-web/commands/root.go
@@ -651,7 +651,7 @@ func needsWalletLookup(path, method string) bool {
 
 // handleGetWalletsMulti aggregates wallets from all services
 func handleGetWalletsMulti(c *gin.Context, services []*wallet.Service) {
-	var allWallets []*walletResponse
+	var allWallets []*readable.WalletResponse
 	for _, svc := range services {
 		wlts, err := svc.GetWallets()
 		if err != nil {
@@ -666,7 +666,7 @@ func handleGetWalletsMulti(c *gin.Context, services []*wallet.Service) {
 		}
 	}
 	if allWallets == nil {
-		allWallets = make([]*walletResponse, 0)
+		allWallets = make([]*readable.WalletResponse, 0)
 	}
 	c.JSON(http.StatusOK, allWallets)
 }

--- a/cmd/skycoin-web/commands/wallet_handlers.go
+++ b/cmd/skycoin-web/commands/wallet_handlers.go
@@ -21,104 +21,9 @@ import (
 	"github.com/skycoin/skycoin/src/wallet/bip44wallet"
 )
 
-// walletResponse mirrors api.WalletResponse for the thin client
-type walletResponse struct {
-	Meta     readable.WalletMeta      `json:"meta"`
-	Entries  []readable.WalletEntry   `json:"entries"`
-	Accounts []readable.WalletAccount `json:"accounts,omitempty"`
-}
-
-func newWalletResponse(w wallet.Wallet) (*walletResponse, error) {
-	var wr walletResponse
-
-	wr.Meta.Coin = w.Coin()
-	wr.Meta.Filename = w.Filename()
-	wr.Meta.Label = w.Label()
-	wr.Meta.Type = w.Type()
-	wr.Meta.Version = w.Version()
-	wr.Meta.CryptoType = w.CryptoType()
-	wr.Meta.Encrypted = w.IsEncrypted()
-	wr.Meta.Timestamp = w.Timestamp()
-	wr.Meta.Temp = w.IsTemp()
-
-	var options []wallet.Option
-	switch w.Type() {
-	case wallet.WalletTypeBip44:
-		bip44Coin := w.Bip44Coin()
-		if bip44Coin == nil {
-			return nil, fmt.Errorf("wallet has no Bip44Coin meta data")
-		}
-		wr.Meta.Bip44Coin = bip44Coin
-		options = append(options, wallet.OptionExternal(), wallet.OptionChange())
-
-		// Populate per-account structure
-		accounts := w.Accounts()
-		wr.Accounts = make([]readable.WalletAccount, len(accounts))
-		for ai, acct := range accounts {
-			wa := readable.WalletAccount{
-				Name:  acct.Name,
-				Index: acct.Index,
-			}
-
-			extEntries, err := w.GetEntries(wallet.OptionAccount(acct.Index), wallet.OptionExternal())
-			if err != nil {
-				return nil, fmt.Errorf("failed to get external entries for account %d: %v", acct.Index, err)
-			}
-			wa.ExternalEntries = walletEntriesToReadable(extEntries)
-
-			chgEntries, err := w.GetEntries(wallet.OptionAccount(acct.Index), wallet.OptionChange())
-			if err != nil {
-				return nil, fmt.Errorf("failed to get change entries for account %d: %v", acct.Index, err)
-			}
-			wa.ChangeEntries = walletEntriesToReadable(chgEntries)
-
-			wr.Accounts[ai] = wa
-		}
-	case wallet.WalletTypeXPub:
-		wr.Meta.XPub = w.XPub()
-	}
-
-	entries, err := w.GetEntries(options...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get wallet entries: %v", err)
-	}
-	wr.Entries = make([]readable.WalletEntry, len(entries))
-
-	for i, e := range entries {
-		wr.Entries[i] = readable.WalletEntry{
-			Address: e.Address.String(),
-			Public:  e.Public.Hex(),
-		}
-
-		switch w.Type() {
-		case wallet.WalletTypeBip44:
-			childNumber := e.ChildNumber
-			wr.Entries[i].ChildNumber = &childNumber
-			change := e.Change
-			wr.Entries[i].Change = &change
-		case wallet.WalletTypeXPub:
-			childNumber := e.ChildNumber
-			wr.Entries[i].ChildNumber = &childNumber
-		}
-	}
-
-	return &wr, nil
-}
-
-// walletEntriesToReadable converts wallet entries to readable format with child number info
-func walletEntriesToReadable(entries wallet.Entries) []readable.WalletEntry {
-	result := make([]readable.WalletEntry, len(entries))
-	for i, e := range entries {
-		childNumber := e.ChildNumber
-		change := e.Change
-		result[i] = readable.WalletEntry{
-			Address:     e.Address.String(),
-			Public:      e.Public.Hex(),
-			ChildNumber: &childNumber,
-			Change:      &change,
-		}
-	}
-	return result
+// newWalletResponse creates a wallet response using the shared readable.NewWalletResponse.
+func newWalletResponse(w wallet.Wallet) (*readable.WalletResponse, error) {
+	return readable.NewWalletResponse(w)
 }
 
 // handleWalletAPI handles wallet-related API requests locally when --wallet-dir is set.
@@ -475,7 +380,7 @@ func handleGetWallets(c *gin.Context, s *wallet.Service) {
 		return
 	}
 
-	wrs := make([]*walletResponse, 0, len(wlts))
+	wrs := make([]*readable.WalletResponse, 0, len(wlts))
 	for _, wlt := range wlts {
 		wr, err := newWalletResponse(wlt)
 		if err != nil {

--- a/src/api/wallet.go
+++ b/src/api/wallet.go
@@ -4,7 +4,6 @@ package api
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -35,111 +34,13 @@ type BalanceResponse struct {
 	Addresses readable.AddressBalances `json:"addresses"`
 }
 
-// WalletResponse wallet response struct for http apis
-type WalletResponse struct {
-	Meta     readable.WalletMeta      `json:"meta"`
-	Entries  []readable.WalletEntry   `json:"entries"`
-	Accounts []readable.WalletAccount `json:"accounts,omitempty"`
-}
+// WalletResponse is an alias for readable.WalletResponse for API compatibility.
+type WalletResponse = readable.WalletResponse
 
-// NewWalletResponse creates WalletResponse struct from wallet.Wallet
+// NewWalletResponse creates WalletResponse struct from wallet.Wallet.
+// Delegates to readable.NewWalletResponse.
 func NewWalletResponse(w wallet.Wallet) (*WalletResponse, error) {
-	var wr WalletResponse
-
-	wr.Meta.Coin = w.Coin()
-	wr.Meta.Filename = w.Filename()
-	wr.Meta.Label = w.Label()
-	wr.Meta.Type = w.Type()
-	wr.Meta.Version = w.Version()
-	wr.Meta.CryptoType = w.CryptoType()
-	wr.Meta.Encrypted = w.IsEncrypted()
-	wr.Meta.Timestamp = w.Timestamp()
-	wr.Meta.Temp = w.IsTemp()
-
-	var options []wallet.Option
-	switch w.Type() {
-	case wallet.WalletTypeBip44:
-		bip44Coin := w.Bip44Coin()
-		if bip44Coin == nil {
-			return nil, errors.New("Wallet has no Bip44Coin meta data")
-		}
-		wr.Meta.Bip44Coin = bip44Coin
-
-		// get entries on both external and change chains
-		options = append(options, wallet.OptionExternal(), wallet.OptionChange())
-
-		// Populate per-account structure
-		accounts := w.Accounts()
-		wr.Accounts = make([]readable.WalletAccount, len(accounts))
-		for ai, acct := range accounts {
-			wa := readable.WalletAccount{
-				Name:  acct.Name,
-				Index: acct.Index,
-			}
-
-			extEntries, err := w.GetEntries(wallet.OptionAccount(acct.Index), wallet.OptionExternal())
-			if err != nil {
-				return nil, fmt.Errorf("failed to get external entries for account %d: %v", acct.Index, err)
-			}
-			wa.ExternalEntries = walletEntriesToReadable(extEntries)
-
-			chgEntries, err := w.GetEntries(wallet.OptionAccount(acct.Index), wallet.OptionChange())
-			if err != nil {
-				return nil, fmt.Errorf("failed to get change entries for account %d: %v", acct.Index, err)
-			}
-			wa.ChangeEntries = walletEntriesToReadable(chgEntries)
-
-			wr.Accounts[ai] = wa
-		}
-	case wallet.WalletTypeXPub:
-		wr.Meta.XPub = w.XPub()
-	}
-
-	entries, err := w.GetEntries(options...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get wallet entries: %v", err)
-	}
-	wr.Entries = make([]readable.WalletEntry, len(entries))
-
-	for i, e := range entries {
-		wr.Entries[i] = readable.WalletEntry{
-			Address: e.Address.String(),
-			Public:  e.Public.Hex(),
-		}
-
-		switch w.Type() {
-		// Copy these values to another ref to avoid having a pointer
-		// to an element of Entry which could affect GC of the Entry,
-		// which could cause retention/copying of secret data in the Entry.
-		// This is speculative. I don't know if this matters to the go runtime
-		case wallet.WalletTypeBip44:
-			childNumber := e.ChildNumber
-			wr.Entries[i].ChildNumber = &childNumber
-			change := e.Change
-			wr.Entries[i].Change = &change
-		case wallet.WalletTypeXPub:
-			childNumber := e.ChildNumber
-			wr.Entries[i].ChildNumber = &childNumber
-		}
-	}
-
-	return &wr, nil
-}
-
-// walletEntriesToReadable converts wallet entries to readable format with child number info
-func walletEntriesToReadable(entries wallet.Entries) []readable.WalletEntry {
-	result := make([]readable.WalletEntry, len(entries))
-	for i, e := range entries {
-		childNumber := e.ChildNumber
-		change := e.Change
-		result[i] = readable.WalletEntry{
-			Address:     e.Address.String(),
-			Public:      e.Public.Hex(),
-			ChildNumber: &childNumber,
-			Change:      &change,
-		}
-	}
-	return result
+	return readable.NewWalletResponse(w)
 }
 
 // Returns the wallet's balance, both confirmed and predicted.  The predicted

--- a/src/readable/wallet.go
+++ b/src/readable/wallet.go
@@ -1,6 +1,9 @@
 package readable
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/skycoin/skycoin/src/cipher/bip44"
 	"github.com/skycoin/skycoin/src/cipher/crypto"
 	"github.com/skycoin/skycoin/src/wallet"
@@ -75,4 +78,105 @@ type WalletMeta struct {
 	Encrypted  bool              `json:"encrypted"`
 	Bip44Coin  *bip44.CoinType   `json:"bip44_coin,omitempty"` // For bip44
 	XPub       string            `json:"xpub,omitempty"`       // For xpub
+}
+
+// WalletResponse is the common wallet response structure used by both
+// the daemon API and the skycoin-web thin client.
+type WalletResponse struct {
+	Meta     WalletMeta      `json:"meta"`
+	Entries  []WalletEntry   `json:"entries"`
+	Accounts []WalletAccount `json:"accounts,omitempty"`
+}
+
+// NewWalletResponse creates a WalletResponse from a wallet.Wallet interface.
+func NewWalletResponse(w wallet.Wallet) (*WalletResponse, error) {
+	var wr WalletResponse
+
+	wr.Meta.Coin = w.Coin()
+	wr.Meta.Filename = w.Filename()
+	wr.Meta.Label = w.Label()
+	wr.Meta.Type = w.Type()
+	wr.Meta.Version = w.Version()
+	wr.Meta.CryptoType = w.CryptoType()
+	wr.Meta.Encrypted = w.IsEncrypted()
+	wr.Meta.Timestamp = w.Timestamp()
+	wr.Meta.Temp = w.IsTemp()
+
+	var options []wallet.Option
+	switch w.Type() {
+	case wallet.WalletTypeBip44:
+		bip44Coin := w.Bip44Coin()
+		if bip44Coin == nil {
+			return nil, errors.New("wallet has no Bip44Coin meta data")
+		}
+		wr.Meta.Bip44Coin = bip44Coin
+		options = append(options, wallet.OptionExternal(), wallet.OptionChange())
+
+		accounts := w.Accounts()
+		wr.Accounts = make([]WalletAccount, len(accounts))
+		for ai, acct := range accounts {
+			wa := WalletAccount{
+				Name:  acct.Name,
+				Index: acct.Index,
+			}
+
+			extEntries, err := w.GetEntries(wallet.OptionAccount(acct.Index), wallet.OptionExternal())
+			if err != nil {
+				return nil, fmt.Errorf("failed to get external entries for account %d: %v", acct.Index, err)
+			}
+			wa.ExternalEntries = entriesToReadable(extEntries)
+
+			chgEntries, err := w.GetEntries(wallet.OptionAccount(acct.Index), wallet.OptionChange())
+			if err != nil {
+				return nil, fmt.Errorf("failed to get change entries for account %d: %v", acct.Index, err)
+			}
+			wa.ChangeEntries = entriesToReadable(chgEntries)
+
+			wr.Accounts[ai] = wa
+		}
+	case wallet.WalletTypeXPub:
+		wr.Meta.XPub = w.XPub()
+	}
+
+	entries, err := w.GetEntries(options...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get wallet entries: %v", err)
+	}
+	wr.Entries = make([]WalletEntry, len(entries))
+
+	for i, e := range entries {
+		wr.Entries[i] = WalletEntry{
+			Address: e.Address.String(),
+			Public:  e.Public.Hex(),
+		}
+
+		switch w.Type() {
+		case wallet.WalletTypeBip44:
+			childNumber := e.ChildNumber
+			wr.Entries[i].ChildNumber = &childNumber
+			change := e.Change
+			wr.Entries[i].Change = &change
+		case wallet.WalletTypeXPub:
+			childNumber := e.ChildNumber
+			wr.Entries[i].ChildNumber = &childNumber
+		}
+	}
+
+	return &wr, nil
+}
+
+// entriesToReadable converts wallet entries to readable format with child number info.
+func entriesToReadable(entries wallet.Entries) []WalletEntry {
+	result := make([]WalletEntry, len(entries))
+	for i, e := range entries {
+		childNumber := e.ChildNumber
+		change := e.Change
+		result[i] = WalletEntry{
+			Address:     e.Address.String(),
+			Public:      e.Public.Hex(),
+			ChildNumber: &childNumber,
+			Change:      &change,
+		}
+	}
+	return result
 }


### PR DESCRIPTION
NewWalletResponse and entriesToReadable were duplicated between src/api/wallet.go and cmd/skycoin-web/commands/wallet_handlers.go. Moved the shared logic to src/readable/wallet.go which both packages can import without pulling in heavy node dependencies.

api.WalletResponse is now a type alias for readable.WalletResponse. api.NewWalletResponse delegates to readable.NewWalletResponse.
