### PR TITLE
fix(gnet): invoke Connect/DisconnectCallback outside the strand + dependabot bumps

### DIFF
--- a/electron/app/package-lock.json
+++ b/electron/app/package-lock.json
@@ -211,9 +211,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/electron/app/package-lock.json
+++ b/electron/app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.27.1",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.15.0",
+        "axios": "^1.15.2",
         "electron-context-menu": "^0.9.1",
         "electron-debug": "^1.5.0",
         "rxjs": "^5.5.12"
@@ -22,9 +22,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/electron/app/package.json
+++ b/electron/app/package.json
@@ -7,7 +7,7 @@
   "description": "Specific Electron code for the skycoin wallet",
   "private": true,
   "dependencies": {
-    "axios": "^1.15.0",
+    "axios": "^1.15.2",
     "electron-context-menu": "^0.9.1",
     "electron-debug": "^1.5.0",
     "rxjs": "^5.5.12"

--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -11892,9 +11892,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -11903,7 +11903,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -21374,6 +21375,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {

--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -11875,9 +11875,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -27,7 +27,7 @@
         "bootstrap": "^5.3.8",
         "disable-scroll": "^0.6.0",
         "fast-xml-parser": "^5.7.1",
-        "hono": "^4.12.14",
+        "hono": "^4.12.18",
         "rxjs": "^7.8.2",
         "strip-ansi": "^7.2.0",
         "tslib": "^2.8.1",
@@ -12583,9 +12583,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -22,7 +22,7 @@
         "@popperjs/core": "^2.11.8",
         "@wdio/logger": "^9.18.0",
         "ansi-regex": "^6.2.2",
-        "basic-ftp": "^5.3.0",
+        "basic-ftp": "^5.3.1",
         "bignumber.js": "^10.0.2",
         "bootstrap": "^5.3.8",
         "disable-scroll": "^0.6.0",
@@ -4818,9 +4818,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4838,9 +4835,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4858,9 +4852,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4878,9 +4869,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4898,9 +4886,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4918,9 +4903,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4938,9 +4920,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5508,9 +5487,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5532,9 +5508,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5556,9 +5529,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5580,9 +5550,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5604,9 +5571,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5628,9 +5592,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6163,9 +6124,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6183,9 +6141,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6203,9 +6158,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6223,9 +6175,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6402,9 +6351,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6419,9 +6365,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6436,9 +6379,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6453,9 +6393,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6470,9 +6407,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6487,9 +6421,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6504,9 +6435,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6521,9 +6449,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6538,9 +6463,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6555,9 +6477,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6572,9 +6491,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6589,9 +6505,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6606,9 +6519,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9091,9 +9001,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -27,7 +27,7 @@
     "@popperjs/core": "^2.11.8",
     "@wdio/logger": "^9.18.0",
     "ansi-regex": "^6.2.2",
-    "basic-ftp": "^5.3.0",
+    "basic-ftp": "^5.3.1",
     "bignumber.js": "^10.0.2",
     "bootstrap": "^5.3.8",
     "disable-scroll": "^0.6.0",

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -32,7 +32,7 @@
     "bootstrap": "^5.3.8",
     "disable-scroll": "^0.6.0",
     "fast-xml-parser": "^5.7.1",
-    "hono": "^4.12.14",
+    "hono": "^4.12.18",
     "rxjs": "^7.8.2",
     "strip-ansi": "^7.2.0",
     "tslib": "^2.8.1",

--- a/src/daemon/gnet/pool.go
+++ b/src/daemon/gnet/pool.go
@@ -497,19 +497,18 @@ func (pool *ConnectionPool) handleConnection(conn net.Conn, solicited bool) erro
 		err = pool.strand("handleConnection", func() error {
 			var err error
 			c, err = pool.newConnection(conn, solicited)
-			if err != nil {
-				return err
-			}
-
-			if pool.Config.ConnectCallback != nil {
-				pool.Config.ConnectCallback(c.Addr(), c.ID, solicited)
-			}
-
-			return nil
+			return err
 		})
 
 		return c, err
 	}()
+
+	// ConnectCallback is invoked outside the strand so that callbacks which
+	// block on downstream channels (e.g. daemon.events) cannot deadlock the
+	// strand worker.
+	if err == nil && pool.Config.ConnectCallback != nil {
+		pool.Config.ConnectCallback(c.Addr(), c.ID, solicited)
+	}
 
 	// TODO -- this error is not fully propagated back to a caller of Connect() so the daemon state
 	// can get stuck in pending
@@ -845,9 +844,12 @@ func (pool *ConnectionPool) Connect(address string) error {
 	return nil
 }
 
-// Disconnect removes a connection from the pool by address and invokes DisconnectCallback
+// Disconnect removes a connection from the pool by address and invokes DisconnectCallback.
+// The DisconnectCallback is invoked outside the strand so that callbacks which block on
+// downstream channels (e.g. daemon.events) cannot deadlock the strand worker.
 func (pool *ConnectionPool) Disconnect(addr string, r DisconnectReason) error {
-	return pool.strand("Disconnect", func() error {
+	var conn *Connection
+	err := pool.strand("Disconnect", func() error {
 		logger.WithFields(logrus.Fields{
 			"addr":   addr,
 			"reason": r,
@@ -861,7 +863,7 @@ func (pool *ConnectionPool) Disconnect(addr string, r DisconnectReason) error {
 			}
 		}
 
-		conn := pool.disconnect(addr, r)
+		conn = pool.disconnect(addr, r)
 
 		if conn == nil {
 			return errors.New("Disconnect: connection does not exist")
@@ -872,12 +874,17 @@ func (pool *ConnectionPool) Disconnect(addr string, r DisconnectReason) error {
 			logger.Debugf("%d/%d default connections in use", l, pool.Config.MaxDefaultPeerOutgoingConnections)
 		}
 
-		if pool.Config.DisconnectCallback != nil {
-			pool.Config.DisconnectCallback(addr, conn.ID, r)
-		}
-
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	if pool.Config.DisconnectCallback != nil {
+		pool.Config.DisconnectCallback(addr, conn.ID, r)
+	}
+
+	return nil
 }
 
 func (pool *ConnectionPool) disconnect(addr string, r DisconnectReason) *Connection {

--- a/src/gui/static/package-lock.json
+++ b/src/gui/static/package-lock.json
@@ -3146,9 +3146,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/gui/static/package-lock.json
+++ b/src/gui/static/package-lock.json
@@ -10809,13 +10809,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
-      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -11946,9 +11946,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/gui/static/package-lock.json
+++ b/src/gui/static/package-lock.json
@@ -11068,9 +11068,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/src/gui/static/package-lock.json
+++ b/src/gui/static/package-lock.json
@@ -26,7 +26,7 @@
         "buffer": "^6.0.3",
         "follow-redirects": "^1.16.0",
         "font-awesome": "^4.7.0",
-        "hono": "^4.12.14",
+        "hono": "^4.12.18",
         "moment": "^2.30.1",
         "rxjs": "^7.8.2",
         "tslib": "^2.8.1",
@@ -5648,9 +5648,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5668,9 +5665,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5688,9 +5682,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5708,9 +5699,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5728,9 +5716,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6296,9 +6281,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6320,9 +6302,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6344,9 +6323,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6368,9 +6344,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6752,9 +6725,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6772,9 +6742,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6985,9 +6952,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7002,9 +6966,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7019,9 +6980,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7036,9 +6994,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7053,9 +7008,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7070,9 +7022,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7087,9 +7036,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7104,9 +7050,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7121,9 +7064,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7138,9 +7078,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7155,9 +7092,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11576,9 +11510,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/src/gui/static/package.json
+++ b/src/gui/static/package.json
@@ -29,7 +29,7 @@
     "buffer": "^6.0.3",
     "follow-redirects": "^1.16.0",
     "font-awesome": "^4.7.0",
-    "hono": "^4.12.14",
+    "hono": "^4.12.18",
     "moment": "^2.30.1",
     "rxjs": "^7.8.2",
     "tslib": "^2.8.1",

--- a/src/skycoin-web/package-lock.json
+++ b/src/skycoin-web/package-lock.json
@@ -28,7 +28,7 @@
         "bootstrap": "^5.3.8",
         "enhanced-resolve": "5.20.0",
         "font-awesome": "^4.7.0",
-        "hono": "^4.12.14",
+        "hono": "^4.12.18",
         "immutable": "^5.1.5",
         "js-yaml": "^4.1.1",
         "lodash": "^4.17.23",
@@ -11708,9 +11708,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/src/skycoin-web/package-lock.json
+++ b/src/skycoin-web/package-lock.json
@@ -11136,9 +11136,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/src/skycoin-web/package-lock.json
+++ b/src/skycoin-web/package-lock.json
@@ -19,11 +19,10 @@
         "@angular/platform-browser": "^21.2.4",
         "@angular/platform-browser-dynamic": "^21.2.4",
         "@angular/router": "^21.2.4",
-        "@hono/node-server": "^1.19.14",
         "@ngx-translate/core": "^17.0.0",
         "@ngx-translate/http-loader": "^17.0.0",
         "@popperjs/core": "^2.11.8",
-        "axios": "^1.15.0",
+        "axios": "^1.15.2",
         "bignumber.js": "^10.0.2",
         "bip39": "^3.1.0",
         "bootstrap": "^5.3.8",
@@ -4300,6 +4299,7 @@
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -5615,9 +5615,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5635,9 +5632,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5655,9 +5649,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5675,9 +5666,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5695,9 +5683,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6285,9 +6270,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6309,9 +6291,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6333,9 +6312,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6357,9 +6333,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6748,9 +6721,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6768,9 +6738,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6981,9 +6948,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6998,9 +6962,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7015,9 +6976,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7032,9 +6990,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7049,9 +7004,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7066,9 +7018,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7083,9 +7032,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7100,9 +7046,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7117,9 +7060,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7134,9 +7074,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7151,9 +7088,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8620,9 +8554,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/src/skycoin-web/package.json
+++ b/src/skycoin-web/package.json
@@ -37,7 +37,7 @@
     "bootstrap": "^5.3.8",
     "enhanced-resolve": "5.20.0",
     "font-awesome": "^4.7.0",
-    "hono": "^4.12.14",
+    "hono": "^4.12.18",
     "immutable": "^5.1.5",
     "js-yaml": "^4.1.1",
     "lodash": "^4.17.23",

--- a/src/skycoin-web/package.json
+++ b/src/skycoin-web/package.json
@@ -31,7 +31,7 @@
     "@ngx-translate/core": "^17.0.0",
     "@ngx-translate/http-loader": "^17.0.0",
     "@popperjs/core": "^2.11.8",
-    "axios": "^1.15.0",
+    "axios": "^1.15.2",
     "bignumber.js": "^10.0.2",
     "bip39": "^3.1.0",
     "bootstrap": "^5.3.8",


### PR DESCRIPTION
## Summary

### Primary fix: gnet callback deadlock (`src/daemon/gnet/pool.go`)

Field reports of a Skycoin daemon spiking to ~160% CPU after long uptime, with `gnet` warnings reporting goroutines waiting **4–11 hours** to write to the strand request channel:

```
WARN [gnet]: Waited 7h41m54s while trying to write daemon.gnet.ConnectionPool.handleConnection to the strand request channel
WARN [gnet]: Waited 10h45m31s ...
```

A SIGQUIT goroutine dump from a stuck daemon (39-day uptime) showed 12 goroutines parked in `[chan send, 682 minutes]` at `daemon.go:1023` — `dm.events <- DisconnectEvent{...}` inside `onGnetDisconnect`, called from inside the strand worker.

#### Cycle

```
Run loop (single goroutine, daemon.go:399)
  case <-blocksRequestTicker.C
    -> dm.requestBlocks()
    -> dm.broadcastMessage()
    -> pool.Pool.BroadcastMessage()
    -> pool.strand("BroadcastMessage", ...)        <-- Run blocked waiting for strand
                                                       |
strand worker is busy executing                        |
  Disconnect.func5 (pool.go:876)                       |
    -> pool.Config.DisconnectCallback                  |
    -> dm.onGnetDisconnect                             |
    -> dm.events <- DisconnectEvent{...}    <-- blocked, channel full
                                                       |
dm.events has only one reader, at daemon.go:454        |
  case r := <-dm.events  (the same Run loop) <---------+
```

Three-way circular wait. Once `dm.events` saturated, every subsequent `handleConnection` enqueue on the strand piled up behind the stuck disconnect callback. Network-facing API endpoints (`/network/connections`, `/health`) hung; mempool/blockchain endpoints continued to work because they don't enter the strand.

#### Fix

The strand exists to serialize `ConnectionPool` state mutations. The callbacks (`ConnectCallback`, `DisconnectCallback`) don't read or write pool state — they only notify the daemon with primitives. Move the callback invocations out of the strand callback in two places:

- `Disconnect()` — capture `conn` inside the strand block, then invoke `DisconnectCallback` after `pool.strand(...)` returns.
- `handleConnection()` — keep `newConnection` inside the strand block, invoke `ConnectCallback` after the inner anonymous function returns. Existing error path (deferred `conn.Close`, `ConnectFailureCallback`) is unchanged.

Per-connection ordering (Connect-before-Disconnect) is preserved: both callbacks fire on the same `handleConnection` goroutine sequentially. A theoretical cross-goroutine race where an external `dm.Disconnect(addr)` fires `DisconnectCallback` before the in-flight `ConnectCallback` for the same addr is benign — `dm.connections.remove` would log and return.

### Bundled: open dependabot bumps

To avoid a stack of separate PRs against the same lockfiles, replicating the open dependabot PRs in one place:

| PR | Bump |
|---|---|
| #2855 | follow-redirects 1.15.11 → 1.16.0 in /electron/app |
| #2857 | axios 1.15.0 → 1.15.2 in /electron/app |
| #2858 | axios 1.15.0 → 1.15.2 in /src/skycoin-web |
| #2859 | basic-ftp 5.3.0 → 5.3.1 in /explorer |
| #2860, #2861, #2862 | hono 4.12.14 → 4.12.18 in /src/gui/static, /src/skycoin-web, /explorer |
| #2863 | fast-xml-builder 1.1.5 → 1.2.0 in /explorer |
| #2864, #2865, #2866 | fast-uri 3.1.0 → 3.1.2 in /src/skycoin-web, /explorer, /src/gui/static |
| #2867 | @babel/plugin-transform-modules-systemjs 7.29.0 → 7.29.4 in /src/gui/static |
| #2856 | ip-address & express-rate-limit in /src/gui/static |

## Test plan

- [x] `go vet ./src/daemon/gnet/...` — clean
- [x] `go build ./src/daemon/gnet/...` — clean
- [x] `go test -short ./src/daemon/gnet/...` — pass (17s)
- [ ] CI: full test suite + JS build for the bumped subdirs
- [ ] Soak test: run a long-uptime daemon with `--http-prof` and confirm the multi-hour `gnet` strand-wait warnings do not reappear