### PR TITLE
docs: add MkDocs documentation site (GitHub Pages)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,97 @@
+name: Docs
+
+# Builds the MkDocs site from sources spread across the repo (docs/,
+# top-level guides, src/api, cmd/skycoin-cli and selected package/client
+# READMEs) and deploys it to the gh-pages branch, which GitHub Pages
+# serves at https://skycoin.github.io/skycoin/.
+#
+# Triggers:
+#   - push to develop: build + deploy
+#   - pull_request:    build only (catches broken config / staging errors
+#                      before merge; doesn't touch gh-pages)
+#   - workflow_dispatch: manual rebuild button
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'scripts/docs-prepare.sh'
+      - 'scripts/docs-prepare.py'
+      - '.github/workflows/docs.yml'
+      - 'INSTALLATION.md'
+      - 'INTEGRATION.md'
+      - 'DEVELOPMENT.md'
+      - 'DOCKER.md'
+      - 'FIBERCOIN-CONFIG.md'
+      - 'RELEASE.md'
+      - 'CHANGELOG.md'
+      - 'src/api/README.md'
+      - 'cmd/skycoin-cli/README.md'
+      - 'src/cipher/**/README.md'
+      - 'src/daemon/**/README.md'
+      - 'src/gui/static/README.md'
+      - 'src/skycoin-web/README.md'
+      - 'src/skycoin-lite/README.md'
+      - 'explorer/README.md'
+      - 'electron/README.md'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'scripts/docs-prepare.sh'
+      - 'scripts/docs-prepare.py'
+      - '.github/workflows/docs.yml'
+      - 'INSTALLATION.md'
+      - 'INTEGRATION.md'
+      - 'DEVELOPMENT.md'
+      - 'DOCKER.md'
+      - 'FIBERCOIN-CONFIG.md'
+      - 'RELEASE.md'
+      - 'CHANGELOG.md'
+      - 'src/api/README.md'
+      - 'cmd/skycoin-cli/README.md'
+      - 'src/cipher/**/README.md'
+      - 'src/daemon/**/README.md'
+      - 'src/gui/static/README.md'
+      - 'src/skycoin-web/README.md'
+      - 'src/skycoin-lite/README.md'
+      - 'explorer/README.md'
+      - 'electron/README.md'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - name: Install MkDocs + plugins
+        run: pip install -r docs/requirements.txt
+
+      - name: Stage doc sources under docs/
+        run: bash scripts/docs-prepare.sh
+
+      - name: Build
+        # No --strict: mkdocs.yml sets strict: false because a few of the
+        # staged READMEs contain relative links that assume their original
+        # in-tree location. Warnings are still printed to the build log so
+        # a content-cleanup follow-up can address them.
+        run: mkdocs build
+
+      - name: Deploy to gh-pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          mkdocs gh-deploy --force --message "Deploy docs from {sha}"

--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ genesis.json
 
 # Claude
 CLAUDE.md
+
+# MkDocs build output (`make docs-build`)
+/site/

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@
 .PHONY: check-newcoin-templates check-release-nocgo
 .PHONY: update-dep sync-upstream-develop
 .PHONY: install-linters format release clean-release clean-coverage dep-github-release
+.PHONY: docs-install docs-serve docs-build
 .PHONY: install-deps-ui build-ui build-ui help newcoin merge-coverage
 .PHONY: build build-skycoin build-skyhw build-skyhw-static
 .PHONY: test-skyhw test-skyhw-race lint-skyhw check-skyhw
@@ -189,6 +190,17 @@ install-linters: ## Install linters
 format: ## Formats the code. Must have goimports installed (use make install-linters).
 	goimports -w -local github.com/skycoin/skycoin ./cmd
 	goimports -w -local github.com/skycoin/skycoin ./src
+
+docs-install: ## Install the MkDocs toolchain used to build the documentation site
+	pip install -r docs/requirements.txt
+
+docs-serve: ## Stage doc sources and serve the documentation site locally at http://127.0.0.1:8000
+	bash scripts/docs-prepare.sh
+	mkdocs serve
+
+docs-build: ## Stage doc sources and build the static documentation site into site/
+	bash scripts/docs-prepare.sh
+	mkdocs build
 
 install-deps-ui:  ## Install the UI dependencies
 	cd $(GUI_STATIC_DIR) && npm ci

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,25 @@
+# Pages staged at build time by scripts/docs-prepare.sh from markdown that
+# lives elsewhere in the tree. Their canonical source is the original file
+# (top-level guides, src/api, cmd/skycoin-cli, package READMEs); do not
+# commit the staged copies.
+/guides/installation.md
+/guides/integration.md
+/guides/development.md
+/guides/docker.md
+/guides/fibercoin-config.md
+/guides/release.md
+/guides/changelog.md
+/api/index.md
+/cli/index.md
+/packages/cipher-bip32.md
+/packages/cipher-bip39.md
+/packages/cipher-base58.md
+/packages/cipher-encoder.md
+/packages/cipher-secp256k1.md
+/packages/daemon-pex.md
+/packages/daemon-gnet.md
+/clients/desktop.md
+/clients/web.md
+/clients/lite.md
+/clients/explorer.md
+/clients/electron.md

--- a/docs/clients/index.md
+++ b/docs/clients/index.md
@@ -1,0 +1,10 @@
+# Clients
+
+Skycoin ships with several clients and supporting tools for interacting with
+the node and the blockchain.
+
+- [Desktop (GUI)](desktop.md) — the Angular desktop wallet bundled with the node.
+- [Web client](web.md) — the browser-based wallet.
+- [Lite client](lite.md) — a lightweight client.
+- [Explorer](explorer.md) — the Skycoin block explorer.
+- [Electron build](electron.md) — the Electron packaging/build system for the desktop client.

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -1,0 +1,12 @@
+# Dependency Graph
+
+The Go package dependency graph for the Skycoin node, made with
+[goda](https://github.com/loov/goda).
+
+Regenerate with:
+
+```bash
+go run github.com/loov/goda@latest graph github.com/skycoin/skycoin/... | dot -Tsvg -o docs/skycoin-goda-graph.svg
+```
+
+![Skycoin dependency graph](skycoin-goda-graph.svg){ loading=lazy }

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,11 @@
+# Guides
+
+Practical guides for running, integrating with and developing Skycoin.
+
+- [Installation](installation.md) — install Go and build/run the node.
+- [Exchange Integration](integration.md) — integrate Skycoin into an exchange.
+- [Development](development.md) — development environment and workflow.
+- [Docker](docker.md) — official Docker images and usage.
+- [Custom Fibercoins](fibercoin-config.md) — run a custom coin from a config file.
+- [Release Process](release.md) — how releases are cut and published.
+- [Changelog](changelog.md) — notable changes across releases.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,78 @@
+# Skycoin
+
+![Skycoin logo](https://user-images.githubusercontent.com/26845312/32426705-d95cb988-c281-11e7-9463-a3fce8076a72.png){ width="320" }
+
+Skycoin is a next-generation cryptocurrency and the settlement layer of the
+Skycoin ecosystem. The node implemented in this repository runs the Skycoin
+blockchain, exposes a REST API and CLI, and ships with desktop, web and
+hardware-wallet clients.
+
+[:material-rocket-launch: Install Skycoin](guides/installation.md){ .md-button .md-button--primary }
+[:material-api: REST API](api/index.md){ .md-button }
+[:material-console: CLI](cli/index.md){ .md-button }
+
+## Documentation map
+
+<div class="grid cards" markdown>
+
+-   :material-book-open-variant: __Guides__
+
+    Installation, exchange integration, development workflow, Docker
+    images, custom fibercoins and the release process.
+
+    [:octicons-arrow-right-24: Browse guides](guides/index.md)
+
+-   :material-api: __REST API__
+
+    The HTTP API exposed by the node — endpoints for the blockchain,
+    wallets, transactions and network.
+
+    [:octicons-arrow-right-24: API reference](api/index.md)
+
+-   :material-console-line: __CLI__
+
+    `skycoin-cli` — command-line wallet and node interaction.
+
+    [:octicons-arrow-right-24: CLI reference](cli/index.md)
+
+-   :material-package-variant: __Packages__
+
+    In-tree library documentation: cipher primitives (bip32/bip39/
+    base58/secp256k1) and the peer-exchange / networking layers.
+
+    [:octicons-arrow-right-24: Package docs](packages/index.md)
+
+-   :material-monitor-cellphone: __Clients__
+
+    Desktop GUI, web client, lite client, the block explorer and the
+    Electron build system.
+
+    [:octicons-arrow-right-24: Clients](clients/index.md)
+
+-   :material-graph-outline: __Dependency graph__
+
+    The Go package dependency graph for the node.
+
+    [:octicons-arrow-right-24: View graph](dependency-graph.md)
+
+</div>
+
+## Quick start
+
+```bash
+# Build and run the node from the repository root
+go run . daemon
+
+# Or with the desktop client configuration
+go run . gui
+```
+
+See the [Installation guide](guides/installation.md) for prerequisites and
+platform-specific instructions.
+
+## Resources
+
+- Source: [github.com/skycoin/skycoin](https://github.com/skycoin/skycoin)
+- API reference: [REST API](api/index.md)
+- CLI reference: [skycoin-cli](cli/index.md)
+- Community: [Telegram](https://t.me/skycoin)

--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -1,0 +1,18 @@
+# Packages
+
+Documentation for selected in-tree Go packages. These pages are rendered
+from each package's `README.md`; the authoritative source lives alongside
+the code under [`src/`](https://github.com/skycoin/skycoin/tree/develop/src).
+
+## Cipher
+
+- [cipher/bip32](cipher-bip32.md) — hierarchical deterministic keys (BIP32).
+- [cipher/bip39](cipher-bip39.md) — mnemonic seed phrases (BIP39).
+- [cipher/base58](cipher-base58.md) — fast Base58 encoding.
+- [cipher/encoder](cipher-encoder.md) — deterministic binary serialization.
+- [cipher/secp256k1-go](cipher-secp256k1.md) — secp256k1 elliptic curve.
+
+## Daemon
+
+- [daemon/pex](daemon-pex.md) — peer exchange.
+- [daemon/gnet](daemon-gnet.md) — the networking layer.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+# Python toolchain for building the documentation site (mkdocs.yml).
+# Used by .github/workflows/docs.yml and `make docs-install`.
+mkdocs-material==9.5.*
+mkdocs-awesome-pages-plugin==2.9.*
+pymdown-extensions==10.*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,138 @@
+# MkDocs configuration for the Skycoin documentation site.
+#
+# Hand-written source markdown lives in docs/ on the develop branch.
+# Additional pages are assembled at build time from markdown that
+# already lives elsewhere in the tree (top-level guides, src/api,
+# cmd/skycoin-cli, and a handful of package READMEs) by
+# scripts/docs-prepare.sh, which copies them under docs/ where they
+# are gitignored. This keeps each file's canonical location intact
+# while letting MkDocs render everything as one unified site.
+#
+# The site is built by .github/workflows/docs.yml on every push to
+# develop and deployed to the gh-pages branch, which GitHub Pages
+# serves at https://skycoin.github.io/skycoin/.
+#
+# Local preview: `make docs-serve` (runs the prepare step + mkdocs
+# serve). Open http://127.0.0.1:8000.
+
+site_name: Skycoin
+site_description: Skycoin — a next-generation cryptocurrency and distributed network platform
+site_url: https://skycoin.github.io/skycoin/
+repo_url: https://github.com/skycoin/skycoin
+repo_name: skycoin/skycoin
+edit_uri: edit/develop/docs/
+copyright: Copyright &copy; Skycoin
+
+docs_dir: docs
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - navigation.indexes
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.action.edit
+    - toc.follow
+  palette:
+    # Auto light/dark toggle via system preference, then manual override.
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  icon:
+    repo: fontawesome/brands/github
+
+# Top-level nav. The leaf pages under api/, cli/, guides/ and the
+# package/client sections are copied into place by docs-prepare.sh at
+# build time (gitignored), so they only exist after that script runs.
+nav:
+  - Home: index.md
+  - Guides:
+      - Overview: guides/index.md
+      - Installation: guides/installation.md
+      - Exchange Integration: guides/integration.md
+      - Development: guides/development.md
+      - Docker: guides/docker.md
+      - Custom Fibercoins: guides/fibercoin-config.md
+      - Release Process: guides/release.md
+      - Changelog: guides/changelog.md
+  - REST API: api/index.md
+  - CLI: cli/index.md
+  - Packages:
+      - Overview: packages/index.md
+      - cipher/bip32: packages/cipher-bip32.md
+      - cipher/bip39: packages/cipher-bip39.md
+      - cipher/base58: packages/cipher-base58.md
+      - cipher/encoder: packages/cipher-encoder.md
+      - cipher/secp256k1-go: packages/cipher-secp256k1.md
+      - daemon/pex: packages/daemon-pex.md
+      - daemon/gnet: packages/daemon-gnet.md
+  - Clients:
+      - Overview: clients/index.md
+      - Desktop (GUI): clients/desktop.md
+      - Web client: clients/web.md
+      - Lite client: clients/lite.md
+      - Explorer: clients/explorer.md
+      - Electron build: clients/electron.md
+  - Dependency Graph: dependency-graph.md
+
+plugins:
+  - search
+  - awesome-pages
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+      permalink_title: Permalink
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/skycoin/skycoin
+      name: skycoin/skycoin on GitHub
+    - icon: fontawesome/brands/telegram
+      link: https://t.me/skycoin
+      name: Skycoin on Telegram
+
+# Strict mode fails the build on broken internal links. scripts/docs-prepare.py
+# rewrites the imported READMEs' relative links to either in-site pages or
+# absolute github.com URLs, so the only remaining notes are INFO-level
+# (package-relative absolute links and a few dangling anchors in upstream
+# source), which do not fail strict.
+strict: true

--- a/scripts/docs-prepare.py
+++ b/scripts/docs-prepare.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Stage markdown from across the repo under docs/ for the MkDocs build.
+
+MkDocs requires every source file to live under a single docs_dir. A lot of
+Skycoin's documentation, however, lives next to the code it documents (the
+top-level guides, src/api, cmd/skycoin-cli and assorted package/client
+READMEs). This script copies those files into docs/ at build time and
+rewrites their relative links so they resolve inside the rendered site.
+
+The staged copies are gitignored (see docs/.gitignore) — the canonical copy
+stays in its original location. Idempotent; safe to re-run before every
+`mkdocs serve` / `mkdocs build`.
+
+Link rewriting, per staged file (links are resolved against the file's
+ORIGINAL location, then):
+  - a link to another staged source -> a site-relative path to that page;
+  - a link to any other file that exists in the repo, or any relative link
+    we can't resolve in-site -> an absolute github.com/blob/develop URL;
+  - root-absolute ("/path") links to existing repo files -> a github URL;
+    otherwise left untouched;
+  - http(s)/mailto/anchor-only links -> left untouched.
+
+Used by scripts/docs-prepare.sh (CI + `make docs-serve` / `make docs-build`).
+"""
+
+import os
+import posixpath
+import re
+import shutil
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DOCS_DIR = os.path.join(REPO_ROOT, "docs")
+GITHUB_BLOB = "https://github.com/skycoin/skycoin/blob/develop/"
+
+# original repo path -> destination path relative to docs/
+MAPPING = {
+    # Guides (top-level docs)
+    "INSTALLATION.md": "guides/installation.md",
+    "INTEGRATION.md": "guides/integration.md",
+    "DEVELOPMENT.md": "guides/development.md",
+    "DOCKER.md": "guides/docker.md",
+    "FIBERCOIN-CONFIG.md": "guides/fibercoin-config.md",
+    "RELEASE.md": "guides/release.md",
+    "CHANGELOG.md": "guides/changelog.md",
+    # REST API & CLI
+    "src/api/README.md": "api/index.md",
+    "cmd/skycoin-cli/README.md": "cli/index.md",
+    # Packages
+    "src/cipher/bip32/README.md": "packages/cipher-bip32.md",
+    "src/cipher/bip39/README.md": "packages/cipher-bip39.md",
+    "src/cipher/base58/README.md": "packages/cipher-base58.md",
+    "src/cipher/encoder/README.md": "packages/cipher-encoder.md",
+    "src/cipher/secp256k1-go/README.md": "packages/cipher-secp256k1.md",
+    "src/daemon/pex/README.md": "packages/daemon-pex.md",
+    "src/daemon/gnet/README.md": "packages/daemon-gnet.md",
+    # Clients
+    "src/gui/static/README.md": "clients/desktop.md",
+    "src/skycoin-web/README.md": "clients/web.md",
+    "src/skycoin-lite/README.md": "clients/lite.md",
+    "explorer/README.md": "clients/explorer.md",
+    "electron/README.md": "clients/electron.md",
+}
+
+# Matches markdown inline link / image targets: ](url) or ](<url> "title").
+LINK_RE = re.compile(r"\]\(\s*(<[^>]+>|[^)\s]+)(\s+\"[^\"]*\")?\s*\)")
+
+SKIP_PREFIXES = ("http://", "https://", "mailto:", "tel:", "#")
+
+
+def repo_exists(path):
+    return os.path.isfile(os.path.join(REPO_ROOT, path))
+
+
+def rewrite_links(text, src_repo_path, dest_rel):
+    src_dir = posixpath.dirname(src_repo_path)
+    dest_dir = posixpath.dirname(dest_rel)
+
+    def repl(m):
+        raw = m.group(1)
+        title = m.group(2) or ""
+        url = raw[1:-1] if raw.startswith("<") and raw.endswith(">") else raw
+
+        if url.startswith(SKIP_PREFIXES) or not url:
+            return m.group(0)
+
+        path, _, anchor = url.partition("#")
+        anchor = ("#" + anchor) if anchor else ""
+        if not path:  # pure anchor
+            return m.group(0)
+
+        root_absolute = path.startswith("/")
+        candidate = path[1:] if root_absolute else posixpath.normpath(
+            posixpath.join(src_dir, path)
+        )
+
+        if candidate in MAPPING:
+            new = posixpath.relpath(MAPPING[candidate], dest_dir or ".") + anchor
+        elif repo_exists(candidate):
+            new = GITHUB_BLOB + candidate + anchor
+        elif root_absolute:
+            return m.group(0)  # unknown absolute link — leave as-is
+        else:
+            # Unresolved relative link (dangling in the source too). Point at
+            # where it would live on GitHub so the site has no dead in-tree
+            # links; harmless if the target is also missing upstream.
+            new = GITHUB_BLOB + candidate + anchor
+
+        return "](" + new + title + ")"
+
+    return LINK_RE.sub(repl, text)
+
+
+def main():
+    staged = []
+    for src_rel, dest_rel in MAPPING.items():
+        src = os.path.join(REPO_ROOT, src_rel)
+        if not os.path.isfile(src):
+            print(f"docs-prepare: WARNING: missing source {src_rel} "
+                  f"(skipping {dest_rel})", file=sys.stderr)
+            continue
+        dest = os.path.join(DOCS_DIR, dest_rel)
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        with open(src, encoding="utf-8") as fh:
+            text = fh.read()
+        text = rewrite_links(text, src_rel, dest_rel)
+        with open(dest, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        staged.append(dest_rel)
+
+    print(f"docs-prepare: staged {len(staged)} pages under docs/ "
+          "(guides, api, cli, packages, clients)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/docs-prepare.sh
+++ b/scripts/docs-prepare.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# scripts/docs-prepare.sh — entry point for staging documentation sources
+# under docs/ before an MkDocs build. The actual copy + link-rewriting logic
+# lives in scripts/docs-prepare.py (Python is always present: it runs MkDocs).
+#
+# Used by .github/workflows/docs.yml (CI) and `make docs-serve` /
+# `make docs-build` (local preview).
+set -euo pipefail
+exec python3 "$(dirname "$0")/docs-prepare.py"


### PR DESCRIPTION
Adds a MkDocs Material documentation site, served by GitHub Pages at **https://skycoin.github.io/skycoin/**, mirroring the setup used by [skycoin/skywire](https://skycoin.github.io/skywire/).

## How it works
- `mkdocs.yml` — site config, Material theme, navigation. `strict: true`.
- `docs/` — hand-written **Home**, section landing pages (Guides / Packages / Clients), and a **Dependency Graph** page that embeds the existing `docs/skycoin-goda-graph.svg`.
- `scripts/docs-prepare.py` — at build time, stages markdown that already lives elsewhere in the tree under `docs/` so MkDocs can render it as one site, and rewrites each file's relative links to either in-site pages or absolute `github.com` URLs (resolved against the file's original location). Sources: the top-level guides (`INSTALLATION`, `INTEGRATION`, `DEVELOPMENT`, `DOCKER`, `FIBERCOIN-CONFIG`, `RELEASE`, `CHANGELOG`), `src/api/README.md`, `cmd/skycoin-cli/README.md`, selected `cipher`/`daemon` package READMEs, and the client READMEs (desktop GUI, web, lite, explorer, electron). Staged copies are gitignored — each file's canonical location stays put. `scripts/docs-prepare.sh` is a thin wrapper around the Python script.
- `docs/requirements.txt` — pinned MkDocs toolchain (mkdocs-material, awesome-pages, pymdown-extensions), used by both CI and `make docs-install`.
- `.github/workflows/docs.yml` — builds the site on PRs (validation only) and, on push to `develop`, deploys to the `gh-pages` branch via `mkdocs gh-deploy`.
- `Makefile` — `docs-install` / `docs-serve` / `docs-build` for local preview.

## Deployment / required setup
The `gh-pages` branch is created and maintained automatically by the workflow on the first push to `develop` — no manual branch creation needed. **One repo-admin action is required once:** enable GitHub Pages in **Settings → Pages → Source: `gh-pages` branch (root)**.

## Local preview
```bash
make docs-install   # one-time: installs from docs/requirements.txt
make docs-serve     # http://127.0.0.1:8000
```

## Notes
- Built and verified locally and in CI with `mkdocs build` under `strict: true` — 0 warnings; all nav pages render and the goda SVG is bundled.
- The link rewriter resolves each imported README's relative links against its original in-tree path, so cross-references (e.g. INTEGRATION → API/CLI) become in-site links and references to code/other files become `github.com` URLs. The only remaining notes are INFO-level (a few package-relative absolute links and dangling anchors that exist in the upstream source), which do not fail strict.