### PR TITLE
api: stream JSON responses instead of buffering them

### DIFF
--- a/src/api/transaction_test.go
+++ b/src/api/transaction_test.go
@@ -823,9 +823,9 @@ func TestInjectTransaction(t *testing.T) {
 				require.Equal(t, tc.err, strings.TrimSpace(rr.Body.String()), "got `%v`| %d, want `%v`",
 					strings.TrimSpace(rr.Body.String()), status, tc.err)
 			} else {
-				expectedResponse, err := json.MarshalIndent(tc.httpResponse, "", "    ")
+				expectedResponse, err := json.Marshal(tc.httpResponse)
 				require.NoError(t, err)
-				require.Equal(t, string(expectedResponse), rr.Body.String(), tc.name)
+				require.Equal(t, string(expectedResponse), strings.TrimSpace(rr.Body.String()), tc.name)
 			}
 		})
 	}
@@ -1048,9 +1048,9 @@ func TestGetRawTxn(t *testing.T) {
 				require.Equal(t, tc.err, strings.TrimSpace(rr.Body.String()), "got `%v`| %d, want `%v`",
 					strings.TrimSpace(rr.Body.String()), status, tc.err)
 			} else {
-				expectedResponse, err := json.MarshalIndent(tc.httpResponse, "", "    ")
+				expectedResponse, err := json.Marshal(tc.httpResponse)
 				require.NoError(t, err)
-				require.Equal(t, string(expectedResponse), rr.Body.String(), tc.name)
+				require.Equal(t, string(expectedResponse), strings.TrimSpace(rr.Body.String()), tc.name)
 			}
 		})
 	}

--- a/src/api/wallet_test.go
+++ b/src/api/wallet_test.go
@@ -635,7 +635,7 @@ func TestUpdateWalletLabelHandler(t *testing.T) {
 				require.Equal(t, tc.err, strings.TrimSpace(rr.Body.String()), "got `%v`| %d, want `%v`",
 					strings.TrimSpace(rr.Body.String()), status, tc.err)
 			} else {
-				require.Equal(t, tc.responseBody, rr.Body.String(), tc.name)
+				require.Equal(t, tc.responseBody, strings.TrimSpace(rr.Body.String()), tc.name)
 			}
 		})
 	}

--- a/src/util/http/json.go
+++ b/src/util/http/json.go
@@ -15,17 +15,25 @@ import (
 )
 
 // SendJSONOr500 writes an object as JSON, writing a 500 error if it fails
+//
+// The response is streamed directly to the client rather than marshaled into
+// an intermediate buffer. Buffering was expensive for large responses: the
+// verbose transaction history of a busy wallet is tens of megabytes, and
+// json.MarshalIndent materializes it twice (once compact, once indented)
+// before a single byte is written. On memory constrained systems that was
+// enough to get the node OOM-killed while serving the history view.
+//
+// Output is compact for the same reason; indenting a response of that size
+// added roughly 80% to it in whitespace alone.
+//
+// Because encoding happens while writing, the status and headers are already
+// committed by the time an encoding error can be observed, so such an error is
+// logged rather than turned into a 500.
 func SendJSONOr500(log *logging.Logger, w http.ResponseWriter, m interface{}) {
-	out, err := json.MarshalIndent(m, "", "    ")
-	if err != nil {
-		Error500(w, "json.MarshalIndent failed")
-		return
-	}
-
 	w.Header().Add("Content-Type", "application/json")
 
-	if _, err := w.Write(out); err != nil {
-		log.WithError(err).Error("http Write failed")
+	if err := json.NewEncoder(w).Encode(m); err != nil {
+		log.WithError(err).Error("json encode failed")
 	}
 }
 


### PR DESCRIPTION
### Problem

`SendJSONOr500` (used by every v1 JSON endpoint) marshals the entire
response into memory before writing a byte, via `json.MarshalIndent` —
which internally builds a compact buffer **and then** an indented copy of
it.

For small responses this is irrelevant. But the verbose transaction
history of a busy wallet is large: on a node with 1,323 transactions,
`GET /api/v1/transactions?addrs=…&verbose=1` produces a 66 MB response,
and serving one view of it costs ~104 MB of transient buffers on top of
the transactions themselves.

Those transients also prevented memory from being reclaimed. Repeatedly
serving the history caused resident memory to ratchet upward (511 MB →
952 MB in testing) and stay there. On a memory-constrained host this is
enough to get the process OOM-killed — with no panic or log line, because
`SIGKILL` cannot be caught.

### Change

Encode straight to the `ResponseWriter` with `json.NewEncoder(w).Encode`,
and drop the indentation. On a response that size, indentation was ~80%
overhead in whitespace alone.

### Measured (same node, serving the same history repeatedly)

| | Before | After |
|---|---|---|
| Response body | 66 MB | 36 MB |
| Peak RSS | 952 MB | 437 MB |
| RSS over repeated requests | climbs 511→952, stays | holds flat at 437 |

### Trade-offs / notes

- **Encoding errors after headers are sent** can no longer become an HTTP
  500 (the status line is already committed); they are logged instead.
  This is inherent to streaming.
- **Output is now compact** (single line). Semantically identical JSON —
  any parser is unaffected — but tooling that greps/seds the
  pretty-printed body will need updating. Flagging in case pretty output
  is considered part of the API contract; happy to keep `MarshalIndent`'s
  formatting via a streaming `Encoder.SetIndent` if preferred (that keeps
  the ~2× buffering win but not the whitespace win).
- The two unit tests that compared response bodies byte-for-byte are
  updated for the compact encoding; golden-file integration tests
  unmarshal into structs and are unaffected.
- No CHANGELOG entry included — the top section is behind the current
  tags, so I did not want to guess the target version. Happy to add one
  wherever you'd like it.

### Testing

- `go test ./src/api/... ./src/util/http/...` — pass
- `golangci-lint run ./src/util/http/ ./src/api/` — clean
- `go run .` — compiles
