### PR TITLE
explorer: enable strict TypeScript and fix the resulting type errors

### DIFF
--- a/explorer/src/app/app.datatypes.ts
+++ b/explorer/src/app/app.datatypes.ts
@@ -14,51 +14,51 @@ import { BigNumber } from 'bignumber.js';
  */
 
 export class Block {
-  id: number;
-  hash: string;
-  parent_hash: string;
-  timestamp: number;
-  transactions: Transaction[];
-  size: number;
+  id!: number;
+  hash!: string;
+  parent_hash!: string;
+  timestamp!: number;
+  transactions!: Transaction[];
+  size!: number;
 }
 
 export class Blockchain {
-  blocks: number;
+  blocks!: number;
 }
 
 export class Input {
-  owner: string;
-  coins: BigNumber;
-  uxid: string;
-  hours: BigNumber;
-  calculatedHours: BigNumber;
+  owner!: string;
+  coins!: BigNumber;
+  uxid!: string;
+  hours!: BigNumber;
+  calculatedHours!: BigNumber;
 }
 
 export class Output {
-  address: string;
-  coins: BigNumber;
-  hash: string;
-  hours: BigNumber;
+  address!: string;
+  coins!: BigNumber;
+  hash!: string;
+  hours!: BigNumber;
 }
 
 export class Transaction {
-  block: number;
-  id: string;
-  inputs: Input[];
-  outputs: Output[];
-  status: boolean;
-  timestamp: number;
-  balance: BigNumber;
-  initialBalance: BigNumber;
-  finalBalance: BigNumber;
-  length: number;
-  fee: BigNumber;
+  block!: number | null;
+  id!: string;
+  inputs!: Input[];
+  outputs!: Output[];
+  status!: boolean | null;
+  timestamp!: number;
+  balance!: BigNumber | null;
+  initialBalance!: BigNumber | null;
+  finalBalance!: BigNumber | null;
+  length!: number;
+  fee!: BigNumber;
 }
 
 export class RichlistEntry {
-  address: string;
-  coins: string;
-  locked: boolean;
+  address!: string;
+  coins!: string;
+  locked!: boolean;
 }
 
 /**
@@ -66,45 +66,45 @@ export class RichlistEntry {
  */
 
 export class GenericBlockResponse {
-  header: GenericBlockHeaderResponse;
-  body: GenericBlockBodyResponse;
-  size: number;
+  header!: GenericBlockHeaderResponse;
+  body!: GenericBlockBodyResponse;
+  size!: number;
 }
 
 class GenericBlockHeaderResponse {
-  block_hash: string;
-  previous_block_hash: string;
-  seq: number;
-  timestamp: number;
+  block_hash!: string;
+  previous_block_hash!: string;
+  seq!: number;
+  timestamp!: number;
 }
 
 class GenericBlockBodyResponse {
-  txns: GenericTransactionResponse[];
+  txns!: GenericTransactionResponse[];
 }
 
 export class GenericTransactionResponse {
-  inputs: GenericTransactionInputResponse[];
-  outputs: GenericTransactionOutputResponse[];
+  inputs!: GenericTransactionInputResponse[];
+  outputs!: GenericTransactionOutputResponse[];
   status: any;
-  timestamp: number;
-  txid: string;
-  length: number;
-  fee: number;
+  timestamp!: number;
+  txid!: string;
+  length!: number;
+  fee!: number;
 }
 
 class GenericTransactionInputResponse {
-  uxid: string;
-  owner: string;
-  coins: string;
-  hours: number;
-  calculated_hours: number;
+  uxid!: string;
+  owner!: string;
+  coins!: string;
+  hours!: number;
+  calculated_hours!: number;
 }
 
 class GenericTransactionOutputResponse {
-  coins: string;
-  dst: string;
-  hours: number;
-  uxid: string;
+  coins!: string;
+  dst!: string;
+  hours!: number;
+  uxid!: string;
 }
 
 export function parseGenericBlock(block: GenericBlockResponse): Block {
@@ -118,8 +118,8 @@ export function parseGenericBlock(block: GenericBlockResponse): Block {
   };
 }
 
-export function parseGenericTransaction(raw: GenericTransactionResponse, address: string = null): Transaction {
-  let balance = null;
+export function parseGenericTransaction(raw: GenericTransactionResponse, address: string | null = null): Transaction {
+  let balance: BigNumber | null = null;
   if (address) {
     balance = new BigNumber('0');
     for (const input of raw.inputs) {
@@ -134,7 +134,7 @@ export function parseGenericTransaction(raw: GenericTransactionResponse, address
     }
   }
 
-  const response = {
+  const response: Transaction = {
     block: null,
     id: raw.txid,
     timestamp: raw.timestamp,
@@ -185,9 +185,9 @@ function parseGenericTransactionOutput(raw: GenericTransactionOutputResponse): O
  */
 
 export class GetUnconfirmedTransactionResponse {
-  transaction: GenericTransactionResponse;
-  received: string;
-  is_valid: boolean;
+  transaction!: GenericTransactionResponse;
+  received!: string;
+  is_valid!: boolean;
 }
 
 export function parseGetUnconfirmedTransaction(raw: GetUnconfirmedTransactionResponse): Transaction {
@@ -198,61 +198,61 @@ export function parseGetUnconfirmedTransaction(raw: GetUnconfirmedTransactionRes
 }
 
 export class GetBlocksResponse {
-  blocks: GenericBlockResponse[];
+  blocks!: GenericBlockResponse[];
 }
 
 export class GetBlockchainMetadataResponse {
-  head: GetBlockchainMetadataResponseHead;
+  head!: GetBlockchainMetadataResponseHead;
 }
 
 class GetBlockchainMetadataResponseHead {
-  seq: number;
+  seq!: number;
 }
 
 export class GetBalanceResponse {
-  confirmed: GetBalanceResponseElement;
-  predicted: GetBalanceResponseElement;
+  confirmed!: GetBalanceResponseElement;
+  predicted!: GetBalanceResponseElement;
 }
 
 class GetBalanceResponseElement {
-  coins: number;
-  hours: number;
+  coins!: number;
+  hours!: number;
 }
 
 export class GetCurrentBalanceResponse {
-  head_outputs: GetCurrentBalanceResponseOutput[];
+  head_outputs!: GetCurrentBalanceResponseOutput[];
 }
 
 class GetCurrentBalanceResponseOutput {
-  hash: string;
-  src_tx: string;
-  address: string;
-  coins: string;
-  hours: number;
-  calculated_hours: number;
+  hash!: string;
+  src_tx!: string;
+  address!: string;
+  coins!: string;
+  hours!: number;
+  calculated_hours!: number;
 }
 
 export class GetTransactionResponse {
   status: any;
-  time: number;
-  txn: GenericTransactionResponse;
+  time!: number;
+  txn!: GenericTransactionResponse;
 }
 
 export class GetSyncStateResponse {
-  current: number;
-  highest: number;
+  current!: number;
+  highest!: number;
 }
 
-export function parseGetTransaction(raw: GetTransactionResponse, address: string = null): Transaction {
+export function parseGetTransaction(raw: GetTransactionResponse, address: string | null = null): Transaction {
   raw.txn.status = raw.status;
   return parseGenericTransaction(raw.txn, address);
 }
 
 export class GetUxoutResponse {
-  coins: number;
-  hours: number;
-  owner_address: string;
-  uxid: string;
+  coins!: number;
+  hours!: number;
+  owner_address!: string;
+  uxid!: string;
 }
 
 export function parseGetUxout(raw: GetUxoutResponse): Output {

--- a/explorer/src/app/app.reuse-strategy.ts
+++ b/explorer/src/app/app.reuse-strategy.ts
@@ -18,7 +18,7 @@ export class AppReuseStrategy implements RouteReuseStrategy {
     return false;
   }
 
-  retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle {
+  retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle | null {
     return null;
   }
 

--- a/explorer/src/app/components/layout/copy-button/copy-button.component.ts
+++ b/explorer/src/app/components/layout/copy-button/copy-button.component.ts
@@ -58,7 +58,7 @@ export class CopyButtonComponent {
   /**
    * Text to be copied when clicking this button.
    */
-  @Input() text: string;
+  @Input() text!: string;
 
   /**
    * Function for copying the text.

--- a/explorer/src/app/components/layout/date-formatter/date-formatter.component.ts
+++ b/explorer/src/app/components/layout/date-formatter/date-formatter.component.ts
@@ -14,7 +14,7 @@ export class DateFormatterComponent {
   /**
    * Date to be displayed. It should expresed in time since the epoch.
    */
-  @Input()date;
+  @Input() date!: number;
 
   /**
    * Number with which the value of "date" must be multiplied to convert it into milliseconds since

--- a/explorer/src/app/components/layout/header/header.component.ts
+++ b/explorer/src/app/components/layout/header/header.component.ts
@@ -17,7 +17,7 @@ export class HeaderComponent implements OnInit {
   /**
    * If the window is too small, indicates if the menu must me shown.
    */
-  menuVisible: boolean;
+  menuVisible!: boolean;
   /**
    * Data for building the navigation menu.
    */
@@ -63,7 +63,7 @@ export class HeaderComponent implements OnInit {
    *
    * @param item Submenu that was clicked.
    */
-  onClickMenuDropdown(item) {
+  onClickMenuDropdown(item: any) {
     item.open = !item.open;
   }
 }

--- a/explorer/src/app/components/layout/language-selection/language-selection.component.ts
+++ b/explorer/src/app/components/layout/language-selection/language-selection.component.ts
@@ -21,7 +21,7 @@ export class LanguageSelectionComponent implements OnDestroy {
   /**
    * Currently selected language.
    */
-  currentLanguage: LanguageData;
+  currentLanguage!: LanguageData;
   /**
    * If the language selection menu should be visible.
    */

--- a/explorer/src/app/components/layout/loading/loading.component.ts
+++ b/explorer/src/app/components/layout/loading/loading.component.ts
@@ -18,5 +18,5 @@ export class LoadingComponent {
   /**
    * Message to show in case of error. If set, the loading animation is removed.
    */
-  @Input() longErrorMsg: string;
+  @Input() longErrorMsg!: string;
 }

--- a/explorer/src/app/components/layout/qr-code/qr-code.component.ts
+++ b/explorer/src/app/components/layout/qr-code/qr-code.component.ts
@@ -24,9 +24,9 @@ export class QrCodeComponent implements OnInit {
     this.stringInternal = val;
     this.updateQR();
   }
-  private stringInternal: string;
+  private stringInternal!: string;
 
-  @ViewChild('qr', { static: true }) qr: ElementRef;
+  @ViewChild('qr', { static: true }) qr!: ElementRef;
 
   // Size in pixels.
   size = 130;

--- a/explorer/src/app/components/layout/search-bar/search-bar.component.ts
+++ b/explorer/src/app/components/layout/search-bar/search-bar.component.ts
@@ -21,7 +21,7 @@ export class SearchBarComponent implements OnDestroy {
   /**
    * Search field.
    */
-  @ViewChild('input', { static: true }) input: ElementRef;
+  @ViewChild('input', { static: true }) input!: ElementRef;
 
   /**
    * If true, it is not possible to start another search and the UI is shown busy.
@@ -33,8 +33,8 @@ export class SearchBarComponent implements OnDestroy {
   showSyncWarning = false;
 
   private nodeUrlSubscription: Subscription;
-  private syncSubscription: Subscription;
-  private operationSubscription: Subscription;
+  private syncSubscription!: Subscription;
+  private operationSubscription!: Subscription;
 
   constructor(
     public searchService: SearchService,

--- a/explorer/src/app/components/pages/address-detail/address-detail.component.ts
+++ b/explorer/src/app/components/pages/address-detail/address-detail.component.ts
@@ -18,19 +18,19 @@ export class CachedAddressDetails {
   /**
    * Address the data belongs to.
    */
-  address: string;
+  address!: string;
   /**
    * Response obtained when the address transactions were requested.
    */
-  transactionsResponse: AddressTransactionsResponse;
+  transactionsResponse!: AddressTransactionsResponse;
   /**
    * Response obtained when the address balance was requested.
    */
-  balanceResponse: GetBalanceResponse;
+  balanceResponse!: GetBalanceResponse;
   /**
    * Response obtained when the unconfirmed transactions were requested.
    */
-  unconfirmedResponse: GetUnconfirmedTransactionResponse[];
+  unconfirmedResponse!: GetUnconfirmedTransactionResponse[];
 }
 
 /**
@@ -63,7 +63,7 @@ export class AddressDetailComponent extends PageBaseComponent implements OnInit,
   /**
    * Current address.
    */
-  address: string;
+  address!: string;
   /**
    * Indicates if the data has been loaded.
    */
@@ -71,43 +71,43 @@ export class AddressDetailComponent extends PageBaseComponent implements OnInit,
   /**
    * How many transactions the address has.
    */
-  totalTransactionsCount: number;
+  totalTransactionsCount!: number;
   /**
    * Total amount of coins received by the address.
    */
-  totalReceived: BigNumber;
+  totalReceived!: BigNumber;
   /**
    * Total amount of coins sent from the address.
    */
-  totalSent: BigNumber;
+  totalSent!: BigNumber;
   /**
    * Current address coin balance.
    */
-  balance: BigNumber;
+  balance!: BigNumber;
   /**
    * Current address coin hour balance.
    */
-  hoursBalance: BigNumber;
+  hoursBalance!: BigNumber;
   /**
    * How many incoming coins are in unconfirmed transactions.
    */
-  pendingIncomingCoins: BigNumber;
+  pendingIncomingCoins!: BigNumber;
   /**
    * How many outgoing coins are in unconfirmed transactions.
    */
-  pendingOutgoingCoins: BigNumber;
+  pendingOutgoingCoins!: BigNumber;
   /**
    * Total amount of pending coins (pendingIncomingCoins - pendingOutgoingCoins).
    */
-  pendingCoins: BigNumber;
+  pendingCoins!: BigNumber;
   /**
    * Total amount of pending coin hours.
    */
-  pendingHours: BigNumber;
+  pendingHours!: BigNumber;
   /**
    * Transactions to be shown in the current page.
    */
-  pageTransactions: any[];
+  pageTransactions!: any[];
   /**
    * Current page.
    */
@@ -128,7 +128,7 @@ export class AddressDetailComponent extends PageBaseComponent implements OnInit,
   /**
    * Error message to be shown in the loading control if there is a problem.
    */
-  longErrorMsg: string;
+  longErrorMsg!: string;
   /**
    * If true, the address has few transactions and all of them are stored in memory. If false,
    * only the transactions of the current page are in memory and no information about how
@@ -137,8 +137,8 @@ export class AddressDetailComponent extends PageBaseComponent implements OnInit,
   hasManyTransactions = false;
 
   // Subscriptions that will be cleaned when closing the page.
-  private navParamsSubscription: Subscription;
-  private operationSubscription: Subscription;
+  private navParamsSubscription!: Subscription;
+  private operationSubscription!: Subscription;
 
   constructor(
     private api: ApiService,
@@ -234,10 +234,10 @@ export class AddressDetailComponent extends PageBaseComponent implements OnInit,
         // Calculate the number of received and sent coins (counting the confirmed
         // transactions only).
         this.totalReceived = new BigNumber(0);
-        response.recoveredTransactions.map(tx => this.totalReceived = this.totalReceived.plus(tx.balance.isGreaterThan(0) && tx.status ? tx.balance : 0));
+        response.recoveredTransactions.map(tx => this.totalReceived = this.totalReceived.plus(tx.balance!.isGreaterThan(0) && tx.status ? tx.balance! : 0));
 
         this.totalSent = new BigNumber(0);
-        response.recoveredTransactions.map(tx => this.totalSent = this.totalSent.plus(tx.balance.isLessThan(0) && tx.status ? tx.balance : 0));
+        response.recoveredTransactions.map(tx => this.totalSent = this.totalSent.plus(tx.balance!.isLessThan(0) && tx.status ? tx.balance! : 0));
         this.totalSent = this.totalSent.negated();
 
         // Update the list of transactions that will be displayed in the UI.

--- a/explorer/src/app/components/pages/block-details/block-details.component.ts
+++ b/explorer/src/app/components/pages/block-details/block-details.component.ts
@@ -27,15 +27,15 @@ export class BlockDetailsComponent extends PageBaseComponent implements OnInit, 
   /**
    * Current block.
    */
-  block: Block;
+  block!: Block;
   /**
    * Total number of coins sent in all the outputs of all transactions in the block.
    */
-  totalAmount: BigNumber;
+  totalAmount!: BigNumber;
   /**
    * How many blocks the blockchain currently has.
    */
-  blockCount: number;
+  blockCount!: number;
   /**
    * ID (sequence number) of the current block.
    */
@@ -48,7 +48,7 @@ export class BlockDetailsComponent extends PageBaseComponent implements OnInit, 
   /**
    * Error message to be shown in the loading control if there is a problem.
    */
-  longErrorMsg: string;
+  longErrorMsg!: string;
 
   /**
    * Observable subscriptions that will be cleaned when closing the page.
@@ -103,7 +103,7 @@ export class BlockDetailsComponent extends PageBaseComponent implements OnInit, 
   private loadBlockData(checkSavedData: boolean) {
     let oldSavedDataUsed = false;
 
-    let savedData;
+    let savedData: any;
 
     // Get the URL params.
     this.pageSubscriptions.push(this.route.params.pipe(filter(params => +params['id'] !== null),

--- a/explorer/src/app/components/pages/blocks/blocks.component.html
+++ b/explorer/src/app/components/pages/blocks/blocks.component.html
@@ -55,7 +55,7 @@
           The "mouseOver" var helps keep track of those events. -->
           <div class="-xs-only" (mouseenter)="mouseOver = block.id" (mouseleave)="mouseOver === block.id ? mouseOver = -1 : null">
             <span class="-gray"><span class="timezone-icon" [ngClass]="{'timezone-icon-opaque': mouseOver === block.id}" >&#xf0ac;</span>{{ block.timestamp * 1000 | date:'yyyy' }}</span><br/>
-            <span class="-small-font">{{ (block.timestamp * 1000 | date:'MMM dd').toUpperCase() }}</span><br/>
+            <span class="-small-font">{{ (block.timestamp * 1000 | date:'MMM dd')?.toUpperCase() }}</span><br/>
             <span class="-small-font">{{ block.timestamp * 1000 | date:'HH:mm' }}</span>
             @if (mouseOver === block.id) {
               <div class="timezone-container">

--- a/explorer/src/app/components/pages/blocks/blocks.component.ts
+++ b/explorer/src/app/components/pages/blocks/blocks.component.ts
@@ -30,19 +30,19 @@ export class BlocksComponent extends PageBaseComponent implements OnInit, OnDest
   /**
    * Current coin supply.
    */
-  currentSupply: number;
+  currentSupply!: number;
   /**
    * Max coin supply.
    */
-  totalSupply: number;
+  totalSupply!: number;
   /**
    * Current hour coin supply.
    */
-  currentCoinhourSupply: number;
+  currentCoinhourSupply!: number;
   /**
    * Max coin hour supply.
    */
-  totalCoinhourSupply: number;
+  totalCoinhourSupply!: number;
   /**
    * How many blocks the blockchain currently has.
    */
@@ -68,7 +68,7 @@ export class BlocksComponent extends PageBaseComponent implements OnInit, OnDest
   /**
    * Error message to be shown in the loading control if there is a problem.
    */
-  longErrorMsg: string;
+  longErrorMsg!: string;
   /**
    * If the app is using a local node as backend.
    */
@@ -136,7 +136,7 @@ export class BlocksComponent extends PageBaseComponent implements OnInit, OnDest
       return this.route.paramMap.pipe(first());
     }), switchMap(params => {
       // Calculate the values of the current page.
-      this.pageIndex = parseInt(params.get('page'), 10) - 1;
+      this.pageIndex = parseInt(params.get('page')!, 10) - 1;
       const end = this.blockCount - (this.pageIndex * this.pageSize);
       const begin = end - this.pageSize + 1;
 

--- a/explorer/src/app/components/pages/node-url.component.ts
+++ b/explorer/src/app/components/pages/node-url.component.ts
@@ -18,7 +18,7 @@ import { ExplorerService } from 'app/services/explorer/explorer.service';
 })
 export class NodeUrlComponent implements OnInit, OnDestroy {
   // Subscriptions that will be cleaned when closing the page.
-  private navParamsSubscription: Subscription;
+  private navParamsSubscription!: Subscription;
 
   constructor(
     private route: ActivatedRoute,
@@ -30,10 +30,10 @@ export class NodeUrlComponent implements OnInit, OnDestroy {
   ngOnInit() {
     // Check the URL params to detect the URL of the local node.
     this.navParamsSubscription = this.route.params.subscribe(params => {
-      let nodeUrl: string = params['url'];
+      let nodeUrl: string | null = params['url'];
 
       // If the url is "null", convert the value to a real null.
-      if (nodeUrl.toUpperCase() === 'null'.toUpperCase()) {
+      if (nodeUrl && nodeUrl.toUpperCase() === 'null'.toUpperCase()) {
         nodeUrl = null;
       }
 

--- a/explorer/src/app/components/pages/page-base.ts
+++ b/explorer/src/app/components/pages/page-base.ts
@@ -12,7 +12,7 @@ export class LocalValueData {
    * Moment in which the value was updated for the last time. It is the value
    * of new Date().getTime().
    */
-  date: number;
+  date!: number;
 }
 
 /**

--- a/explorer/src/app/components/pages/richlist/richlist.component.ts
+++ b/explorer/src/app/components/pages/richlist/richlist.component.ts
@@ -27,7 +27,7 @@ export class RichlistComponent extends PageBaseComponent implements OnInit, OnDe
   /**
    * Error message to be shown in the loading control if there is a problem.
    */
-  longErrorMsg: string;
+  longErrorMsg!: string;
 
   /**
    * Observable subscriptions that will be cleaned when closing the page.

--- a/explorer/src/app/components/pages/search/search.component.ts
+++ b/explorer/src/app/components/pages/search/search.component.ts
@@ -21,7 +21,7 @@ export class SearchComponent implements OnInit, OnDestroy {
    * Error text that must be shown if there is a problem trying to find were the user must be
    * redirected to.
    */
-  errorMsg: string;
+  errorMsg!: string;
 
   /**
    * Observable subscriptions that will be cleaned when closing the page.

--- a/explorer/src/app/components/pages/transaction-detail/transaction-detail.component.html
+++ b/explorer/src/app/components/pages/transaction-detail/transaction-detail.component.html
@@ -9,7 +9,7 @@
       <div class="-row"><span>{{ 'transactionDetail.block' | translate }}</span><br class="-xs-only" /><div> @if (transaction) {
       <a [routerLink]="'/app/block/' + transaction.block" class="-link -copy-button-margin">{{ transaction.block }}</a>
       } @if (transaction) {
-      <app-copy-button [text]="transaction.block"></app-copy-button>
+      <app-copy-button [text]="transaction.block + ''"></app-copy-button>
       } @if (!transaction) {
       <span>{{ loadingMsg | translate }}</span>
     } </div></div>

--- a/explorer/src/app/components/pages/transaction-detail/transaction-detail.component.ts
+++ b/explorer/src/app/components/pages/transaction-detail/transaction-detail.component.ts
@@ -24,7 +24,7 @@ export class TransactionDetailComponent extends PageBaseComponent implements OnI
   /**
    * Current transaction.
    */
-  transaction: Transaction;
+  transaction!: Transaction;
   /**
    * Small text to be shown in variaous parts (not in the loading control) while loading the data.
    * It may also contain small error messages.
@@ -33,7 +33,7 @@ export class TransactionDetailComponent extends PageBaseComponent implements OnI
   /**
    * Error message to be shown in the loading control if there is a problem.
    */
-  longErrorMsg: string;
+  longErrorMsg!: string;
 
   /**
    * Observable subscriptions that will be cleaned when closing the page.
@@ -72,7 +72,7 @@ export class TransactionDetailComponent extends PageBaseComponent implements OnI
   private loadData(checkSavedData: boolean) {
     let oldSavedDataUsed = false;
 
-    let savedData;
+    let savedData: any;
 
     // Get the URL params and request the data.
     this.pageSubscriptions.push(this.route.params.pipe(

--- a/explorer/src/app/components/pages/unconfirmed-transactions/unconfirmed-transactions.component.ts
+++ b/explorer/src/app/components/pages/unconfirmed-transactions/unconfirmed-transactions.component.ts
@@ -22,19 +22,19 @@ export class UnconfirmedTransactionsComponent extends PageBaseComponent implemen
   /**
    * Transactions list.
    */
-  transactions: Transaction[];
+  transactions!: Transaction[];
   /**
    * Date of the oldest unconfirmed transaction.
    */
-  leastRecent: number;
+  leastRecent!: number;
   /**
    * Date of the most recent unconfirmed transaction.
    */
-  mostRecent: number;
+  mostRecent!: number;
   /**
    * Combined size (in bytes) of all unconfirmed transactions.
    */
-  totalSize: number;
+  totalSize!: number;
   /**
    * Small text to be shown in variaous parts (not in the loading control) while loading the data.
    * It may also contain small error messages.
@@ -43,7 +43,7 @@ export class UnconfirmedTransactionsComponent extends PageBaseComponent implemen
   /**
    * Error message to be shown in the loading control if there is a problem.
    */
-  longErrorMsg: string;
+  longErrorMsg!: string;
 
   /**
    * Observable subscriptions that will be cleaned when closing the page.
@@ -79,15 +79,15 @@ export class UnconfirmedTransactionsComponent extends PageBaseComponent implemen
         this.saveLocalValue(this.persistentServerUnconfirmedTxsResponseKey, transactions);
       }
 
-      transactions = transactions.map(rawTx => parseGetUnconfirmedTransaction(rawTx));
+      transactions = transactions.map((rawTx: any) => parseGetUnconfirmedTransaction(rawTx));
       this.transactions = transactions;
       //this.transactions = transactions.map(rawTx => parseGetUnconfirmedTransaction(rawTx))
       // If there are unconfirmed transactions, calculate the values to be shown in the UI.
       if (transactions.length > 0) {
-        const orderedList = transactions.sort((a, b) => b.timestamp - a.timestamp);
+        const orderedList = transactions.sort((a: Transaction, b: Transaction) => b.timestamp - a.timestamp);
         this.mostRecent = orderedList[0].timestamp;
         this.leastRecent = orderedList[orderedList.length - 1].timestamp;
-        this.totalSize = orderedList.map(tx => tx.length).reduce((sum, current) => sum + current);
+        this.totalSize = orderedList.map((tx: Transaction) => tx.length).reduce((sum: number, current: number) => sum + current);
       }
 
       // If old saved data was used, repeat the operation, ignoring the saved data.

--- a/explorer/src/app/components/pages/unspent-outputs/unspent-outputs.component.ts
+++ b/explorer/src/app/components/pages/unspent-outputs/unspent-outputs.component.ts
@@ -67,11 +67,11 @@ export class UnspentOutputsComponent extends PageBaseComponent implements OnInit
   /**
    * Current address.
    */
-  address: string;
+  address!: string;
   /**
    * Unspent outputs of the current address.
    */
-  outputs: GetCurrentBalanceResponse;
+  outputs!: GetCurrentBalanceResponse;
   /**
    * Outputs that will be shown in the UI.
    */
@@ -79,11 +79,11 @@ export class UnspentOutputsComponent extends PageBaseComponent implements OnInit
   /**
    * Total number of coins in the unspent outputs.
    */
-  coins: BigNumber = null;
+  coins: BigNumber | null = null;
   /**
    * Total number of hours in the unspent outputs.
    */
-  hours: BigNumber = null;
+  hours: BigNumber | null = null;
   /**
    * Small text to be shown in variaous parts (not in the loading control) while loading the data.
    * It may also contain small error messages.
@@ -92,7 +92,7 @@ export class UnspentOutputsComponent extends PageBaseComponent implements OnInit
   /**
    * Error message to be shown in the loading control if there is a problem.
    */
-  longErrorMsg: string;
+  longErrorMsg!: string;
 
   /**
    * Observable subscriptions that will be cleaned when closing the page.
@@ -116,7 +116,7 @@ export class UnspentOutputsComponent extends PageBaseComponent implements OnInit
   private loadData(checkSavedData: boolean) {
     let oldSavedDataUsed = false;
 
-    let savedData;
+    let savedData: any;
 
     // Get the URL params.
     this.pageSubscriptions.push(this.route.params.pipe(switchMap((params: Params) => {
@@ -143,9 +143,9 @@ export class UnspentOutputsComponent extends PageBaseComponent implements OnInit
       // Calculate the total number of coins and hours.
       this.coins = new BigNumber(0);
       this.hours = new BigNumber(0);
-      response.head_outputs.map(o => {
-        this.coins = this.coins.plus(o.coins);
-        this.hours = this.hours.plus(o.calculated_hours);
+      response.head_outputs.map((o: any) => {
+        this.coins = this.coins!.plus(o.coins);
+        this.hours = this.hours!.plus(o.calculated_hours);
       });
 
       if (this.outputs.head_outputs.length > this.maxInitialElements) {

--- a/explorer/src/app/pipes/amount.pipe.ts
+++ b/explorer/src/app/pipes/amount.pipe.ts
@@ -45,7 +45,7 @@ export class AmountPipe implements PipeTransform {
     if (partToReturn !== 'last') {
       // Use the standard decimalPipe for limiting the decimal places. The max number of decimal
       // places for the coins is obtained from the node. Coin hours never have decimal places.
-      firstPart = this.decimalPipe.transform(value, showingCoins ? ('1.0-' + this.explorerService.maxDecimals) : '1.0-0');
+      firstPart = this.decimalPipe.transform(value, showingCoins ? ('1.0-' + this.explorerService.maxDecimals) : '1.0-0') ?? '';
       response = firstPart;
       if (partToReturn !== 'first') {
         response += ' ';

--- a/explorer/src/app/services/api/api.service.ts
+++ b/explorer/src/app/services/api/api.service.ts
@@ -30,7 +30,7 @@ export class ApiService {
   /**
    * Subject for emitting every time the local node URL is changed or removed.
    */
-  private localNodeUrlSubject: ReplaySubject<string> = new ReplaySubject<string>(1);
+  private localNodeUrlSubject: ReplaySubject<string | null> = new ReplaySubject<string | null>(1);
 
   constructor(
     private http: HttpClient
@@ -43,7 +43,7 @@ export class ApiService {
     // Get the URL of the local node that must be used as backend, if an URL was saved before.
     const localNodeUrl = localStorage.getItem(ApiService.localNodeUrlKey);
     if (localNodeUrl) {
-      window[ApiService.localNodeUrlKey] = localNodeUrl;
+      (window as any)[ApiService.localNodeUrlKey] = localNodeUrl;
     }
 
     this.localNodeUrlSubject.next(localNodeUrl);
@@ -53,8 +53,8 @@ export class ApiService {
    * Sets the URL of the local node that must be used as backend. If the URL is null, any
    * previously saved URL is removed.
    */
-  setNodeUrl(url: string) {
-    window[ApiService.localNodeUrlKey] = url;
+  setNodeUrl(url: string | null) {
+    (window as any)[ApiService.localNodeUrlKey] = url;
 
     if (url) {
       localStorage.setItem(ApiService.localNodeUrlKey, url);
@@ -68,7 +68,7 @@ export class ApiService {
   /**
    * Emits every time the local node URL is changed or removed.
    */
-  get localNodeUrl(): Observable<string> {
+  get localNodeUrl(): Observable<string | null> {
     return this.localNodeUrlSubject.asObservable();
   }
 
@@ -227,7 +227,7 @@ export class ApiService {
    * @param url URL segment (the URL of the API endpont after the "/api/" part).
    * @param options Arguments to send as URL params.
    */
-  private get(url: string, options: object = null): any {
+  private get(url: string, options: object | null = null): any {
     return this.http.get(this.getUrl(url, options)).pipe(
       catchError((error: any) => observableThrowError(error || 'Server error'))
     );
@@ -239,13 +239,13 @@ export class ApiService {
    *
    * @param parameters Object with params and values to build the querystring.
    */
-  private getQueryString(parameters: object = null): string {
+  private getQueryString(parameters: object | null = null): string {
     if (!parameters) {
       return '';
     }
 
-    return Object.keys(parameters).reduce((array, key) => {
-      array.push(key + '=' + encodeURIComponent(parameters[key]));
+    return Object.keys(parameters).reduce((array: string[], key) => {
+      array.push(key + '=' + encodeURIComponent((parameters as { [key: string]: any })[key]));
       return array;
     }, []).join('&');
   }
@@ -256,7 +256,7 @@ export class ApiService {
    * @param url URL segment (the URL of the API endpont after the "/api/" part).
    * @param options Arguments to send as URL params.
    */
-  private getUrl(url: string, options: object = null): string {
+  private getUrl(url: string, options: object | null = null): string {
     // Ensure that there is no a '/' at the beginning.
     if (url.startsWith('/')) {
       url = url.substr(1, url.length - 1);
@@ -275,6 +275,6 @@ export class ApiService {
    * valid value, the explorer must use as backend the Go intermediate server included with it.
    */
   private nodeUrl() {
-    return window[ApiService.localNodeUrlKey];
+    return (window as any)[ApiService.localNodeUrlKey];
   }
 }

--- a/explorer/src/app/services/explorer/explorer.service.ts
+++ b/explorer/src/app/services/explorer/explorer.service.ts
@@ -57,8 +57,8 @@ export class ExplorerService {
     return this.internalMaxDecimals;
   }
 
-  private nodeUrlSubscription: Subscription;
-  private initializationSubscription: Subscription;
+  private nodeUrlSubscription!: Subscription;
+  private initializationSubscription!: Subscription;
 
   constructor(
     private api: ApiService,
@@ -213,18 +213,18 @@ export class ExplorerService {
 
   processTransactionListFromServer(transactionList: any, address: string, hasManyTransactions: boolean): Transaction[] {
     // Sort to get the lastest transactions last (it will be reversed below).
-    let response = transactionList.sort((a, b) => a.txn.timestamp - b.txn.timestamp);
+    let response = transactionList.sort((a: any, b: any) => a.txn.timestamp - b.txn.timestamp);
 
     // Process the response.
     let currentBalance = new BigNumber('0');
-    response = response.map(rawTx => {
+    response = response.map((rawTx: any) => {
       const parsedTx = parseGetTransaction(rawTx, address);
 
       // Calculate the balance variation after every transaction, if all transactions
       // are in memory.
       if (!hasManyTransactions) {
         parsedTx.initialBalance = currentBalance;
-        currentBalance = currentBalance.plus(parsedTx.balance);
+        currentBalance = currentBalance.plus(parsedTx.balance!);
         parsedTx.finalBalance = currentBalance;
       }
 

--- a/explorer/src/app/services/language/language.service.ts
+++ b/explorer/src/app/services/language/language.service.ts
@@ -11,18 +11,18 @@ export class LanguageData {
   /**
    * Language code, for TranslateService (ngx-translate).
    */
-  code: string;
+  code!: string;
   /**
    * Languege name (written in the language itself).
    */
-  name: string;
+  name!: string;
   /**
    * Name of the file with the icon flag, with the file extension. The file must be inside
    * the assets/img/lang folder.
    */
-  iconName: string;
+  iconName!: string;
 
-  constructor(langObj) {
+  constructor(langObj: any) {
     Object.assign(this, langObj);
   }
 }
@@ -104,7 +104,7 @@ export class LanguageService {
    */
   private onLanguageChanged(event: LangChangeEvent) {
     // Update the currently selected language and save it in localStorage.
-    this.currentLanguageInternal.next(this.languages.find(val => val.code === event.lang));
+    this.currentLanguageInternal.next(this.languages.find(val => val.code === event.lang)!);
     localStorage.setItem(this.storageKey, event.lang);
   }
 }

--- a/explorer/src/app/services/search/search.service.ts
+++ b/explorer/src/app/services/search/search.service.ts
@@ -13,11 +13,11 @@ export class ResultNavCommandsResponse {
    * Observable for getting the navigation commands needed by Router.navigate for sending the
    * user to the page with the requested data. This Observable may fail due to different reasons.
    */
-  resultNavCommands: Observable<string[]>;
+  resultNavCommands!: Observable<string[]>;
   /**
    * Error returned if the function was not able to process the search term.
    */
-  error: SearchError;
+  error!: SearchError;
 }
 
 /**

--- a/explorer/tsconfig.json
+++ b/explorer/tsconfig.json
@@ -14,10 +14,10 @@
       "node_modules/@types"
     ],
     "useDefineForClassFields": false,
-    "strict": false
+    "strict": true
   },
   "angularCompilerOptions": {
-    "strictTemplates": false,
-    "strictInjectionParameters": false
+    "strictTemplates": true,
+    "strictInjectionParameters": true
   }
 }


### PR DESCRIPTION
Follow-up to the dependency work that made explorer build under Angular 22 /
TypeScript 6 (#2965): re-enable strict TypeScript and fix the resulting type
errors, as its own PR.

### Context
The explorer had **never** type-checked under `strict` — it never compiled
at all until the Angular-22/TS-6 alignment landed, so ~183 latent strict
errors were sitting dormant. #2965 relaxed `strict` to get a first green
build; this PR turns it (and Angular's `strictTemplates` /
`strictInjectionParameters`) back on and fixes everything it surfaces.

### Nature of the changes (type-level only, no runtime behaviour change)
- **app.datatypes.ts**: definite-assignment `!` on JSON-populated DTO fields;
  `Transaction.block/status/balance/initialBalance/finalBalance` typed
  `| null` to match the parsers that assign null; `parse*` `address` params
  `string | null`.
- **Components / services / pipes**: definite-assignment on Angular-injected
  fields; explicit types on implicit-any callback params and closure-scoped
  `savedData`; null-guards / non-null assertions where a value is guaranteed
  set; `(window as any)[key]` for string-indexed window access; the
  localNodeUrl subject/getter and `setNodeUrl` typed `string | null`.
- **Templates**: optional-chaining on a nullable date-pipe result; coerce the
  now-nullable block number to string for the copy-button input.

### Verification
- `ng build --configuration production` — clean under full strict (0 errors,
  down from 183).
- `npm ci` — resolves.

The committed `explorer/dist` is intentionally left untouched; the UI rebuilds
(gui, skydex-client, explorer, skycoin-web) are handled separately.
