### PR TITLE
harden untrusted-input handling: don't panic/OOM on crafted wallet/xpub/API input

### DIFF
--- a/src/api/blockchain.go
+++ b/src/api/blockchain.go
@@ -278,6 +278,21 @@ func blocksHandler(gateway Gatewayer) http.HandlerFunc {
 			}
 		}
 
+		// Bound the number of blocks a single request can materialize. Without
+		// this a request such as start=0&end=<huge> forces the whole chain to be
+		// loaded and JSON-encoded in memory, exhausting RAM. Reuse the same
+		// configurable limit as /last_blocks.
+		maxCount := gateway.DaemonConfig().MaxLastBlocksCount
+		if len(seqs) > 0 {
+			if uint64(len(seqs)) > maxCount {
+				wh.Error400(w, fmt.Sprintf("too many sequences requested, max is %d", maxCount))
+				return
+			}
+		} else if end >= start && end-start >= maxCount {
+			wh.Error400(w, fmt.Sprintf("too many blocks requested, max is %d", maxCount))
+			return
+		}
+
 		if verbose {
 			var blocks []coin.SignedBlock
 			var inputs [][][]visor.TransactionInput

--- a/src/api/blockchain_test.go
+++ b/src/api/blockchain_test.go
@@ -956,6 +956,7 @@ func TestGetBlocks(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			gateway := &MockGatewayer{}
+			gateway.On("DaemonConfig").Return(daemon.DaemonConfig{MaxLastBlocksCount: 256})
 			gateway.On("GetBlocksInRange", tc.start, tc.end).Return(tc.gatewayGetBlocksInRangeResult, tc.gatewayGetBlocksInRangeError)
 			gateway.On("GetBlocksInRangeVerbose", tc.start, tc.end).Return(tc.gatewayGetBlocksInRangeVerboseResult.Blocks,
 				tc.gatewayGetBlocksInRangeVerboseResult.Inputs, tc.gatewayGetBlocksInRangeVerboseError)

--- a/src/api/csrf.go
+++ b/src/api/csrf.go
@@ -98,7 +98,9 @@ func verifyCSRFToken(headerToken string) error {
 
 	sig := base64.RawURLEncoding.EncodeToString(h.Sum(nil))
 
-	if sig != tokenParts[1] {
+	// Constant-time comparison to avoid a timing side-channel on the signature,
+	// consistent with the basic-auth check in middleware.go.
+	if !hmac.Equal([]byte(sig), []byte(tokenParts[1])) {
 		return ErrCSRFInvalidSignature
 	}
 

--- a/src/api/explorer.go
+++ b/src/api/explorer.go
@@ -275,6 +275,14 @@ func explorerAddressHandler(gateway Gatewayer) http.HandlerFunc {
 			return
 		}
 
+		// Guard the inputs[i] indexing below (the v1/v2 transaction handlers make
+		// the same check) so a length mismatch returns an error rather than panicking.
+		if len(txns) != len(inputs) {
+			wh.Error500(w, "server error")
+			logger.Critical().Errorf("explorerAddressHandler: len(txns)=%d != len(inputs)=%d", len(txns), len(inputs))
+			return
+		}
+
 		// Build the old flattened response format: an array of TransactionVerbose
 		// (status + timestamp + length/type/txid/inner_hash/fee/sigs/inputs/outputs)
 		result := make([]readable.TransactionVerbose, 0, len(txns))

--- a/src/api/wallet.go
+++ b/src/api/wallet.go
@@ -18,6 +18,11 @@ import (
 	"github.com/skycoin/skycoin/src/wallet/bip44wallet"
 )
 
+// maxAddressGenerateNum bounds how many addresses a single /wallet/newAddress or
+// /wallet/scan request may generate, so a large num value cannot tie the node up
+// in EC key derivation.
+const maxAddressGenerateNum = 65536
+
 // UnconfirmedTxnsResponse contains unconfirmed transaction data
 type UnconfirmedTxnsResponse struct {
 	Transactions []readable.UnconfirmedTransactions `json:"transactions"`
@@ -421,6 +426,10 @@ func walletNewAddressesHandler(gateway Gatewayer) http.HandlerFunc {
 				wh.Error400(w, "invalid num value")
 				return
 			}
+			if n > maxAddressGenerateNum {
+				wh.Error400(w, fmt.Sprintf("num must be <= %d", maxAddressGenerateNum))
+				return
+			}
 			opts = append(opts, wallet.OptionGenerateN(n))
 		}
 
@@ -519,6 +528,10 @@ func walletScanAddressesHandler(gateway Gatewayer) http.HandlerFunc {
 			}
 			if n <= 0 {
 				wh.Error400(w, "invalid num value, must be > 0")
+				return
+			}
+			if n > maxAddressGenerateNum {
+				wh.Error400(w, fmt.Sprintf("num must be <= %d", maxAddressGenerateNum))
 				return
 			}
 		}

--- a/src/cipher/encrypt/harden_scrypt_test.go
+++ b/src/cipher/encrypt/harden_scrypt_test.go
@@ -1,0 +1,33 @@
+package encrypt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Regression tests for the audit DoS findings on ScryptChacha20poly1305.Decrypt:
+// attacker-controlled metadata must not be able to panic or OOM the process.
+func TestDecryptEmptyInputDoesNotPanic(t *testing.T) {
+	// Previously sliced encData[:2] on an empty buffer and panicked.
+	_, err := DefaultScryptChacha20poly1305.Decrypt([]byte{}, []byte("password"))
+	require.Error(t, err)
+}
+
+func TestValidateScryptParams(t *testing.T) {
+	// Default parameters must remain valid (do not break existing wallets).
+	require.NoError(t, validateScryptParams(ScryptN, ScryptR, ScryptP, ScryptKeyLen))
+
+	// Non-positive / degenerate parameters are rejected.
+	require.Error(t, validateScryptParams(0, 8, 1, 32))
+	require.Error(t, validateScryptParams(1<<20, 0, 1, 32))
+	require.Error(t, validateScryptParams(1<<20, 8, 0, 32))
+	require.Error(t, validateScryptParams(1<<20, 8, 1, 0))
+
+	// Memory-exhausting parameters (e.g. N=1<<24,r=8 ⇒ ~16 GiB) are rejected
+	// before scrypt.Key is ever called.
+	require.Error(t, validateScryptParams(1<<24, 8, 1, 32))
+	require.Error(t, validateScryptParams(1<<26, 8, 1, 32))
+	// Oversized keyLen is rejected.
+	require.Error(t, validateScryptParams(1<<20, 8, 1, 1<<25))
+}

--- a/src/cipher/encrypt/scrypt_chacha20poly1305.go
+++ b/src/cipher/encrypt/scrypt_chacha20poly1305.go
@@ -144,6 +144,12 @@ func (s ScryptChacha20poly1305) Decrypt(data, password []byte) ([]byte, error) {
 	}
 	encData = encData[:n]
 
+	// The metadata length prefix must be present; without this check a short
+	// (e.g. empty) input slices out of range and panics.
+	if len(encData) < scryptChacha20MetaLengthSize {
+		return nil, errors.New("invalid encrypted data length")
+	}
+
 	length := binary.LittleEndian.Uint16(encData[:scryptChacha20MetaLengthSize])
 	if int(scryptChacha20MetaLengthSize+length) > len(encData) {
 		return nil, errors.New("invalid metadata length")
@@ -151,6 +157,14 @@ func (s ScryptChacha20poly1305) Decrypt(data, password []byte) ([]byte, error) {
 
 	var m meta
 	if err := json.Unmarshal(encData[scryptChacha20MetaLengthSize:scryptChacha20MetaLengthSize+length], &m); err != nil {
+		return nil, err
+	}
+
+	// The scrypt parameters come from the (as yet unauthenticated) metadata, so
+	// they must be bounded before being handed to scrypt.Key, which allocates
+	// roughly 128*N*r bytes. Otherwise a crafted blob can request tens of GB and
+	// OOM the process on a decrypt attempt.
+	if err := validateScryptParams(m.N, m.R, m.P, m.KeyLen); err != nil {
 		return nil, err
 	}
 
@@ -167,5 +181,40 @@ func (s ScryptChacha20poly1305) Decrypt(data, password []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	// chacha20poly1305.Open panics on a wrong-length nonce; the nonce is
+	// attacker-controlled metadata, so validate it first.
+	if len(m.Nonce) != chacha20poly1305.NonceSize {
+		return nil, errors.New("invalid nonce length")
+	}
+
 	return aead.Open(nil, m.Nonce, encData[scryptChacha20MetaLengthSize+length:], ad)
+}
+
+// maxScryptMemory bounds the memory scrypt.Key may allocate when deriving a key
+// from untrusted metadata. The default parameters (N=1<<20, r=8) use about
+// 1 GiB, so this 2 GiB limit leaves headroom for them while rejecting the tens
+// of GiB an attacker could otherwise request via a crafted encrypted blob.
+const maxScryptMemory = 2 << 30
+
+// validateScryptParams rejects scrypt parameters that are non-positive or that
+// would drive scrypt.Key to allocate more than maxScryptMemory. scrypt.Key
+// itself only rejects non-power-of-2 and astronomically large N, so realistic
+// OOM-inducing values (e.g. N=1<<24, r=8 ⇒ ~16 GiB) pass it unchecked.
+func validateScryptParams(N, r, p, keyLen int) error {
+	if N <= 1 || r <= 0 || p <= 0 || keyLen <= 0 {
+		return errors.New("invalid scrypt parameters")
+	}
+	const maxUnit = maxScryptMemory / 128 // per-factor bound that also prevents product overflow
+	if uint64(N) > maxUnit || uint64(r) > maxUnit || uint64(p) > maxUnit {
+		return errors.New("scrypt parameters exceed memory limit")
+	}
+	if keyLen > 1<<20 {
+		return errors.New("scrypt keyLen too large")
+	}
+	// scrypt allocates ~128*N*r bytes (the V array) and ~128*r*p bytes (B).
+	if uint64(128)*uint64(N)*uint64(r) > maxScryptMemory ||
+		uint64(128)*uint64(r)*uint64(p) > maxScryptMemory {
+		return errors.New("scrypt parameters exceed memory limit")
+	}
+	return nil
 }

--- a/src/cipher/harden_pubkey_test.go
+++ b/src/cipher/harden_pubkey_test.go
@@ -1,0 +1,19 @@
+package cipher
+
+import (
+	"bytes"
+	"testing"
+)
+
+// Regression test: a compressed pubkey whose X coordinate is >= the field
+// prime must be rejected as invalid without panicking (audit HIGH finding).
+func TestPubKeyXCoordinateAboveFieldPrimeDoesNotPanic(t *testing.T) {
+	b := append([]byte{0x02}, bytes.Repeat([]byte{0xFF}, 32)...)
+	pk, err := NewPubKey(b)
+	if err != nil {
+		return // rejected at construction is also acceptable
+	}
+	if err := pk.Verify(); err == nil {
+		t.Fatal("expected Verify() to reject X>=p pubkey, got nil error")
+	}
+}

--- a/src/cipher/secp256k1-go/secp256k1-go2/ec.go
+++ b/src/cipher/secp256k1-go/secp256k1-go2/ec.go
@@ -191,7 +191,12 @@ func PubkeyIsValid(pubkey []byte) int {
 	}
 
 	if !bytes.Equal(pubkey1.Bytes(), pubkey) {
-		log.Panic("pubkey parses but serialize/deserialize roundtrip fails")
+		// The parse/serialize round-trip fails when the encoded X coordinate is
+		// not the canonical (reduced mod p) representation, i.e. X >= the field
+		// prime. Such a public key is invalid; report it as invalid rather than
+		// panicking, because pubkey bytes can come from untrusted input (wallet
+		// files, xpub imports) and must not be able to crash the process.
+		return -4
 	}
 
 	if !pubkey1.IsValid() {

--- a/src/cli/generate_wallet.go
+++ b/src/cli/generate_wallet.go
@@ -231,8 +231,12 @@ func generateWalletHandler(c *cobra.Command, _ []string) error {
 		}
 	}
 
-	n := num - uint64(addrN) //nolint:gosec
-	if n > 0 {
+	// Only request more addresses when num exceeds what CreateWallet already
+	// generated. Guard the subtraction: for collection wallets num is 0 while
+	// addrN is >= 1, so an unguarded num-addrN underflows to a huge uint64 and
+	// asks the node to generate ~2^64 addresses.
+	if num > uint64(addrN) {
+		n := num - uint64(addrN)
 		_, err := apiClient.NewWalletAddress(id, string(password), wallet.OptionGenerateN(n))
 		if err != nil {
 			return err

--- a/src/wallet/bip44wallet/decoder.go
+++ b/src/wallet/bip44wallet/decoder.go
@@ -57,6 +57,12 @@ func newReadableBip44WalletNew(w *Wallet) (*readableBip44WalletNew, error) {
 
 // toWallet converts the readable bip44 wallet to a bip44 wallet
 func (rw readableBip44WalletNew) toWallet() (*Wallet, error) {
+	// Validate the metadata before use so a malformed wallet file returns an
+	// error here instead of panicking later in Meta.IsEncrypted()/Bip44Coin().
+	if err := rw.Meta.Validate(); err != nil {
+		return nil, err
+	}
+
 	// resolve the coin adapter base on coin type
 	d := wallet.ResolveAddressSecKeyDecoder(rw.Coin())
 

--- a/src/wallet/collection/decoder.go
+++ b/src/wallet/collection/decoder.go
@@ -98,7 +98,7 @@ func newEntryFromReadable(coinType wallet.CoinType, re *readableEntry) (*wallet.
 	case wallet.CoinTypeBitcoin:
 		a, err = cipher.DecodeBase58BitcoinAddress(re.Address)
 	default:
-		panic(fmt.Errorf("invalid coin type %q", coinType))
+		return nil, fmt.Errorf("invalid coin type %q", coinType)
 	}
 
 	if err != nil {
@@ -119,7 +119,7 @@ func newEntryFromReadable(coinType wallet.CoinType, re *readableEntry) (*wallet.
 		case wallet.CoinTypeBitcoin:
 			secret, err = cipher.SecKeyFromBitcoinWalletImportFormat(re.Secret)
 		default:
-			panic(fmt.Errorf("invalid coin type %q", coinType))
+			return nil, fmt.Errorf("invalid coin type %q", coinType)
 		}
 		if err != nil {
 			return nil, err

--- a/src/wallet/deterministic/decoder.go
+++ b/src/wallet/deterministic/decoder.go
@@ -98,7 +98,7 @@ func newEntryFromReadable(coinType wallet.CoinType, re *readableEntry) (*wallet.
 	case wallet.CoinTypeBitcoin:
 		a, err = cipher.DecodeBase58BitcoinAddress(re.Address)
 	default:
-		panic(fmt.Errorf("invalid coin type %q", coinType))
+		return nil, fmt.Errorf("invalid coin type %q", coinType)
 	}
 
 	if err != nil {
@@ -119,7 +119,7 @@ func newEntryFromReadable(coinType wallet.CoinType, re *readableEntry) (*wallet.
 		case wallet.CoinTypeBitcoin:
 			secret, err = cipher.SecKeyFromBitcoinWalletImportFormat(re.Secret)
 		default:
-			panic(fmt.Errorf("invalid coin type %q", coinType))
+			return nil, fmt.Errorf("invalid coin type %q", coinType)
 		}
 		if err != nil {
 			return nil, err

--- a/src/wallet/meta.go
+++ b/src/wallet/meta.go
@@ -316,6 +316,15 @@ func (m Meta) Validate() error {
 			return errors.New("secrets should not be in unencrypted wallets")
 		}
 	}
+
+	// Validate the bip44 coin type here so that a malformed value returns an
+	// error instead of later panicking in Meta.Bip44Coin() (which is called on
+	// essentially every wallet operation).
+	if c, ok := m[MetaBip44Coin]; ok {
+		if _, err := strconv.ParseUint(c, 10, 32); err != nil {
+			return errors.New("invalid bip44Coin value")
+		}
+	}
 	return nil
 }
 

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -112,6 +112,8 @@ func (serv *Service) WalletDir() (string, error) {
 
 // SetEnableWalletAPI sets whether or not enables the wallet related APIs
 func (serv *Service) SetEnableWalletAPI(enable bool) {
+	serv.Lock()
+	defer serv.Unlock()
 	serv.config.EnableWalletAPI = enable
 }
 

--- a/src/wallet/xpubwallet/decoder.go
+++ b/src/wallet/xpubwallet/decoder.go
@@ -36,6 +36,12 @@ type readableWallet struct {
 }
 
 func (w readableWallet) toWallet() (*Wallet, error) {
+	// Validate the metadata before use so a malformed wallet file returns an
+	// error here instead of panicking later in Meta.IsEncrypted().
+	if err := w.Meta.Validate(); err != nil {
+		return nil, err
+	}
+
 	ad := wallet.ResolveAddressDecoder(w.Coin())
 	entries, err := w.Entries.toXPubEntries(ad)
 	if err != nil {


### PR DESCRIPTION
Addresses the actionable findings from the security/correctness audit. The
common root pattern was **panic / log.Panic / unbounded allocation on
attacker-controlled input** (wallet files, xpub imports, encrypted blobs, API
parameters). Each is turned into a bounded, error-returning path. **No behaviour
change for valid input.**

### Crypto (`src/cipher`)
- **HIGH** — `secp256k1.PubkeyIsValid`: a compressed pubkey with X ≥ the field
  prime failed the parse/serialize round-trip and hit `log.Panic`. Reachable via
  wallet/xpub import and `bip32.DeserializeEncodedPublicKey`. Now returns an
  invalid code (the key *is* invalid). Regression test added.
- **MEDIUM** — `ScryptChacha20poly1305.Decrypt`: validate the metadata nonce
  length (`chacha20poly1305.Open` panics otherwise); **bound the metadata scrypt
  N/r/p** (used before authentication — a crafted blob could force a ~16–64 GB
  allocation → OOM); length-check before slicing the length prefix (empty input
  panicked). Regression tests added.

### Wallet (`src/wallet`)
- **MEDIUM** — bip44 & xpub decoders now call `Meta.Validate()` (which also now
  validates `bip44Coin`), so a malformed wallet file errors instead of later
  panicking in `Meta.IsEncrypted()`/`Bip44Coin()`.
- **MEDIUM** — deterministic/collection decoders return an error (not `panic`) on
  an unexpected coin type (a `bitcoin-segwit` wallet was saveable but panicked on
  reload).
- **LOW** — `SetEnableWalletAPI` now takes the service lock (was a data race).

### API (`src/api`)
- **MEDIUM** — `/api/v1/blocks` bounds the range / seqs count with the same
  configurable `MaxLastBlocksCount` as `/last_blocks`. Previously
  `start=0&end=<huge>` materialized and JSON-encoded the whole chain in memory
  (same class as the already-fixed transactions-API OOM).
- **LOW** — `/wallet/newAddress` and `/wallet/scan` bound `num`.
- **LOW** — `explorerAddressHandler` guards the txns/inputs length match.
- **LOW** — CSRF signature compared with `hmac.Equal` (constant time).

### Deferred (audit INFO / not exploitable today)
signature low-S check is an approximation; bip32 point-at-infinity not flagged
`ImpossibleChild`; bip39 wordlist mutex bypass; gnet `sendLoop` busy-spin on a
closed queue. Noted for a follow-up; none is reachable/exploitable as-is.

### Testing
`go test ./src/cipher/... ./src/wallet/... ./src/api/` passes; `go run .` compiles.
