### PR TITLE
gnet: stop sendLoop busy-spinning on a closed WriteQueue

### DIFF
--- a/src/daemon/gnet/pool.go
+++ b/src/daemon/gnet/pool.go
@@ -666,7 +666,14 @@ func (pool *ConnectionPool) sendLoop(conn *Connection, timeout time.Duration, ma
 			return nil
 		case <-qc:
 			return nil
-		case m := <-conn.WriteQueue:
+		case m, ok := <-conn.WriteQueue:
+			if !ok {
+				// conn.Close() closed WriteQueue; the connection is shutting
+				// down. Return instead of busy-looping: a closed channel case
+				// is always ready in a select, so without this the loop would
+				// spin at 100% CPU until qc/pool.quit is also closed.
+				return nil
+			}
 			elapser.Register(fmt.Sprintf("conn.WriteQueue address=%s", conn.Addr()))
 			if m == nil {
 				continue


### PR DESCRIPTION
Deliberate follow-up to the audit's LOW finding on gnet.

When `Connection.Close()` closes `conn.WriteQueue`, that closed channel case in `sendLoop`'s select is always ready and yields a nil `Message`; the `if m == nil { continue }` looped it back to the select. Until `qc`/`pool.quit` were also closed, no other case was ready, so the loop span on the closed channel at **100% CPU** — a window that widens under attacker-driven disconnect/reconnect churn (the disconnect callback can block when the event buffer is full).

**Fix:** use the two-value receive and `return` when the channel is closed. Senders (`pool.go:955,995`) never enqueue a nil `Message`, so `m == nil` only ever meant "closed"; the defensive nil skip is kept anyway.

Verified: `go test ./src/daemon/gnet/` passes; `go run .` compiles.

Note: gnet has a **separate, pre-existing** data race under `go test -race` (present on develop without this change) — out of scope here; flagging it for a future dedicated pass.