### PR TITLE
docs: add SECURITY.md, remove stale disclosure section, align README badges with skywire

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 # Skycoin
 
 [![Go](https://github.com/skycoin/skycoin/workflows/Go/badge.svg)](https://github.com/skycoin/skycoin/actions)
-[![GoDoc](https://godoc.org/github.com/skycoin/skycoin?status.svg)](https://godoc.org/github.com/skycoin/skycoin)
-[![Go Report Card](https://goreportcard.com/badge/github.com/skycoin/skycoin)](https://goreportcard.com/report/github.com/skycoin/skycoin)
+[![GitHub release](https://img.shields.io/github/release/skycoin/skycoin.svg)](https://github.com/skycoin/skycoin/releases/)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/skycoin/skycoin/badge)](https://api.securityscorecards.dev/projects/github.com/skycoin/skycoin)
+[![go.mod](https://img.shields.io/github/go-mod/go-version/skycoin/skycoin.svg)](https://github.com/skycoin/skycoin)
+[![Telegram](https://img.shields.io/badge/Join-Telegram-blue?logo=telegram)](https://t.me/skycoin)
 
 Skycoin is a next-generation cryptocurrency.
 
@@ -123,7 +125,6 @@ This multi-chain architecture allows:
 		- [Pre-release testing](#pre-release-testing)
 		- [Creating release builds](#creating-release-builds)
 		- [Release signing](#release-signing)
-- [Responsible Disclosure](#responsible-disclosure)
 
 <!-- /MarkdownTOC -->
 
@@ -442,46 +443,6 @@ $ ./caddy
 You will be prompted to enter an email address to receive the notifications from let's Encrypt.
 That's all about the deployment, check the https://apitest.skycoin.com/api/v1/version to see if
 the Skycoin API node is working correctly.
-
-## Responsible Disclosure
-
-Security flaws in skycoin source or infrastructure can be sent to security@skycoin.com.
-Bounties are available for accepted critical bug reports.
-
-PGP Key for signing:
-
-```
------BEGIN PGP PUBLIC KEY BLOCK-----
-
-mDMEXYCYPxYJKwYBBAHaRw8BAQdAeDPi3n9xLv5xGsxbcbwZjfV4h772W+GPZ3Mz
-RS17STm0L2lrZXRoZWFkb3JlIHNreWNvaW4gPGx1eGFpcmxha2VAcHJvdG9ubWFp
-bC5jb20+iJYEExYIAD4WIQSY+TTwT5M0uB36M5iRO71SBrGWIAUCXYCYPwIbAwUJ
-B4TOAAULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRCRO71SBrGWID0NAP0VRiNA
-2Kq2uakPMqV29HY39DVhc9QgxJfMIwXWtFxKAwEAn0NqGRV/iKXNf+qxqAtMWa5X
-F2S36hkEfDHO5W44DwC4OARdgJg/EgorBgEEAZdVAQUBAQdAeiEz/tUmCgOA67Rq
-ANmHmX2vrdZp/SfJ9KOI2ANCCm8DAQgHiH4EGBYIACYWIQSY+TTwT5M0uB36M5iR
-O71SBrGWIAUCXYCYPwIbDAUJB4TOAAAKCRCRO71SBrGWIJOJAQDTaqxpcLtAw5kH
-Hp2jWvUnLudIONeqeUTCmkLJhcNv1wD+PFJZWMKD1btIG4pkXRW9YoA7M7t5by5O
-x5I+LywZNww=
-=p6Gq
------END PGP PUBLIC KEY BLOCK-----
-```
-
-
-Key ID: [0x913BBD5206B19620](https://pgp.mit.edu/pks/lookup?search=0x913BBD5206B19620&op=index)
-
-The fingerprint for this key is:
-
-```
-pub   ed25519 2019-09-17 [SC] [expires: 2023-09-16]
-      98F934F04F9334B81DFA3398913BBD5206B19620
-uid           [ultimate] iketheadore skycoin <luxairlake@protonmail.com>
-sub   cv25519 2019-09-17 [E] [expires: 2023-09-16]
-```
-
-Keybase.io account: https://keybase.io/iketheadore
-
-
 
 ## Dependency Graph
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security issue in Skycoin, please report it through either of
+these channels:
+
+- **Telegram** — reach the maintainers on the dedicated technical channel
+  [**@skywire**](https://t.me/skywire). This is the fastest way to reach the
+  people who work on the code, and the right place for anything sensitive.
+- **GitHub issue** — open an issue at
+  <https://github.com/skycoin/skycoin/issues>.
+
+We monitor both. When reporting, please include enough detail to understand and
+reproduce the issue — the affected version or commit, the relevant
+configuration, and the steps that trigger it.


### PR DESCRIPTION
Two README-housekeeping changes, aligning skycoin with skywire.

### Security policy
- Add `SECURITY.md` — reports go to the dedicated technical Telegram channel [**@skywire**](https://t.me/skywire) and/or a [GitHub issue](https://github.com/skycoin/skycoin/issues). GitHub surfaces this in the **Security** tab and the "Report a vulnerability" flow.
- Remove the README **Responsible Disclosure** section (and its TOC entry): it directed reports to `security@skycoin.com` (no longer monitored) and shipped a PGP key that **expired 2023-09-16**, for a maintainer no longer involved.

### Badge alignment
Match the skywire README badge set:
- **Remove** the retired **Go Report Card** badge (goreportcard.com is being sunset → renders "retired") and the **GoDoc** badge (godoc.org is shut down; and with no license, pkg.go.dev shows no docs either).
- **Add** GitHub release, **OpenSSF Scorecard**, go.mod version, and Telegram badges — mirroring skywire.

The matching security policy is being added to `skycoin/skywire` in parallel (SECURITY.md + workflow hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)