### PR TITLE
chore(frontend): share one ESLint base and align tsconfig strictness

### DIFF
--- a/eslint.base.config.js
+++ b/eslint.base.config.js
@@ -1,0 +1,122 @@
+// @ts-check
+//
+// Shared ESLint flat-config base for the Angular front-ends: /explorer,
+// /src/gui/static and /src/skycoin-web.
+//
+// The three projects had drifted into three different rule sets, so the same
+// code could be clean in one and rejected in another. This file holds the rules
+// that should hold everywhere; each project's eslint.config.js passes in only
+// what is genuinely local to it.
+//
+// It is a factory rather than a plain config object because ESLint plugins are
+// installed per project. Each project requires its own copies of @eslint/js,
+// typescript-eslint and angular-eslint and hands them in, which keeps this file
+// dependency-free and avoids a repository-root node_modules.
+//
+// Usage, from a project's eslint.config.js:
+//
+//   const eslint = require("@eslint/js");
+//   const tseslint = require("typescript-eslint");
+//   const angular = require("angular-eslint");
+//   const createConfig = require("<relative path>/eslint.base.config.js");
+//
+//   module.exports = createConfig({ eslint, tseslint, angular });
+
+/**
+ * @param {object} options
+ * @param {any} options.eslint                     `@eslint/js`
+ * @param {any} options.tseslint                   `typescript-eslint`
+ * @param {any} options.angular                    `angular-eslint`
+ * @param {string|string[]} [options.directiveSelectorPrefix]
+ *   Attribute-selector prefix(es) accepted for directives. Defaults to "app".
+ * @param {Record<string, any>} [options.legacyRules]
+ *   Per-project opt-outs. These are pre-existing debt, not policy: each entry
+ *   marks a rule the project's code cannot satisfy yet. Deleting entries here
+ *   (and fixing the code) is the direction of travel.
+ * @param {Record<string, any>} [options.templateRules]
+ *   Per-project overrides for the HTML template block.
+ */
+module.exports = function createAngularEslintConfig({
+  eslint,
+  tseslint,
+  angular,
+  directiveSelectorPrefix = "app",
+  legacyRules = {},
+  templateRules = {},
+}) {
+  return tseslint.config(
+    {
+      files: ["**/*.ts"],
+      extends: [
+        eslint.configs.recommended,
+        ...tseslint.configs.recommended,
+        ...angular.configs.tsRecommended,
+      ],
+      processor: angular.processInlineTemplates,
+      languageOptions: {
+        parserOptions: {
+          project: ["tsconfig.json"],
+        },
+      },
+      rules: {
+        // --- Angular conventions -------------------------------------------
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            type: "element",
+            prefix: "app",
+            style: "kebab-case",
+          },
+        ],
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            type: "attribute",
+            prefix: directiveSelectorPrefix,
+            style: "camelCase",
+          },
+        ],
+
+        // --- Opinionated angular-eslint rules this codebase does not follow --
+        // inject() vs constructor injection, and standalone components, are
+        // both migrations these NgModule-based apps have not made.
+        "@angular-eslint/prefer-inject": "off",
+        "@angular-eslint/prefer-standalone": "off",
+        // Angular 22 made OnPush the framework default and renamed the previous
+        // default strategy to Eager. All three projects declare Eager
+        // explicitly to keep their pre-22 behaviour, which this rule reports as
+        // opting out of the default. Adopting OnPush is worth doing, but it is
+        // a behavioural change needing per-component review of
+        // markForCheck/async-pipe usage.
+        "@angular-eslint/prefer-on-push-component-change-detection": "off",
+
+        // --- Style and correctness held in common ---------------------------
+        "max-len": ["error", { code: 200 }],
+        "no-underscore-dangle": "off",
+        "prefer-const": "error",
+        curly: "error",
+        eqeqeq: ["error", "always", { null: "ignore" }],
+        "valid-typeof": "error",
+        "@typescript-eslint/consistent-type-definitions": "error",
+
+        // --- Deliberately relaxed everywhere --------------------------------
+        // These fire throughout code that predates the current toolchain and
+        // would be noise rather than signal.
+        "no-constant-binary-expression": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unused-vars": "off",
+        "@typescript-eslint/no-empty-function": "off",
+
+        // --- Per-project debt ------------------------------------------------
+        ...legacyRules,
+      },
+    },
+    {
+      files: ["**/*.html"],
+      extends: [...angular.configs.templateRecommended],
+      rules: {
+        ...templateRules,
+      },
+    }
+  );
+};

--- a/explorer/eslint.config.js
+++ b/explorer/eslint.config.js
@@ -2,76 +2,23 @@
 const eslint = require("@eslint/js");
 const tseslint = require("typescript-eslint");
 const angular = require("angular-eslint");
+const createAngularEslintConfig = require("../eslint.base.config.js");
 
-module.exports = tseslint.config(
-  {
-    files: ["**/*.ts"],
-    extends: [
-      eslint.configs.recommended,
-      ...tseslint.configs.recommended,
-      ...angular.configs.tsRecommended,
-    ],
-    processor: angular.processInlineTemplates,
-    languageOptions: {
-      parserOptions: {
-        project: ["tsconfig.json"],
+module.exports = createAngularEslintConfig({
+  eslint,
+  tseslint,
+  angular,
+  // Pre-existing debt, not policy. Each entry is a rule this project's code
+  // cannot satisfy yet; fixing the code and deleting the entry is the goal.
+  legacyRules: {
+    "@typescript-eslint/dot-notation": "off",
+    "@typescript-eslint/member-ordering": "off",
+    "@typescript-eslint/explicit-member-accessibility": [
+      "off",
+      {
+        accessibility: "explicit",
       },
-    },
-    rules: {
-      "@angular-eslint/component-selector": [
-        "error",
-        {
-          type: "element",
-          prefix: "app",
-          style: "kebab-case",
-        },
-      ],
-      "@angular-eslint/directive-selector": [
-        "error",
-        {
-          type: "attribute",
-          prefix: "app",
-          style: "camelCase",
-        },
-      ],
-      "@angular-eslint/prefer-inject": "off",
-      "@angular-eslint/prefer-standalone": "off",
-      // Angular 22 made OnPush the framework default and renamed the previous
-      // default strategy to Eager. These components declare Eager explicitly so
-      // they keep the behaviour they had before Angular 22, which this rule
-      // reports as opting out of the default. Adopting OnPush is worth doing,
-      // but it is a behavioural change that has to be reviewed and tested
-      // component by component.
-      "@angular-eslint/prefer-on-push-component-change-detection": "off",
-      "no-constant-binary-expression": "off",
-      "@typescript-eslint/consistent-type-definitions": "error",
-      "@typescript-eslint/dot-notation": "off",
-      "@typescript-eslint/explicit-member-accessibility": [
-        "off",
-        {
-          accessibility: "explicit",
-        },
-      ],
-      "max-len": [
-        "error",
-        {
-          code: 200,
-        },
-      ],
-      "no-underscore-dangle": "off",
-      "valid-typeof": "error",
-      "@typescript-eslint/member-ordering": "off",
-      "object-shorthand": "off",
-      "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-unused-vars": "off",
-      "@typescript-eslint/no-empty-function": "off",
-    },
-  },
-  {
-    files: ["**/*.html"],
-    extends: [
-      ...angular.configs.templateRecommended,
     ],
-    rules: {},
-  }
-);
+    "object-shorthand": "off",
+  },
+});

--- a/src/gui/static/eslint.config.js
+++ b/src/gui/static/eslint.config.js
@@ -2,75 +2,26 @@
 const eslint = require("@eslint/js");
 const tseslint = require("typescript-eslint");
 const angular = require("angular-eslint");
+const createAngularEslintConfig = require("../../../eslint.base.config.js");
 
-module.exports = tseslint.config(
-  {
-    files: ["**/*.ts"],
-    extends: [
-      eslint.configs.recommended,
-      ...tseslint.configs.recommended,
-      ...angular.configs.tsRecommended,
-    ],
-    processor: angular.processInlineTemplates,
-    languageOptions: {
-      parserOptions: {
-        project: ["tsconfig.json"],
-      },
-    },
-    rules: {
-      "@angular-eslint/component-selector": [
-        "error",
-        {
-          type: "element",
-          prefix: "app",
-          style: "kebab-case",
-        },
-      ],
-      "@angular-eslint/directive-selector": [
-        "error",
-        {
-          type: "attribute",
-          prefix: "app",
-          style: "camelCase",
-        },
-      ],
-      "@angular-eslint/prefer-inject": "off",
-      "@angular-eslint/prefer-standalone": "off",
-      // Angular 22 made OnPush the framework default and renamed the previous
-      // default strategy to Eager. The v22 upgrade migration added an explicit
-      // `ChangeDetectionStrategy.Eager` to every component here specifically to
-      // preserve the pre-22 behaviour, which this rule then reports as opting
-      // out of the default. Adopting OnPush is worth doing, but it is a
-      // behavioural change that has to be reviewed and tested component by
-      // component rather than carried along by a dependency bump.
-      "@angular-eslint/prefer-on-push-component-change-detection": "off",
-      "no-constant-binary-expression": "off",
-      "no-useless-assignment": "off",
-      "no-empty": "off",
-      "no-var": "off",
-      "no-self-assign": "off",
-      "@angular-eslint/no-output-on-prefix": "off",
-      "@typescript-eslint/no-wrapper-object-types": "off",
-      "@typescript-eslint/no-unused-expressions": "off",
-      "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-unused-vars": "off",
-      "@typescript-eslint/no-empty-function": "off",
-      "@typescript-eslint/no-empty-object-type": "off",
-      "@typescript-eslint/no-require-imports": "off",
-      "max-len": ["error", { code: 200 }],
-      "no-underscore-dangle": "off",
-      "prefer-const": "error",
-      curly: "error",
-      eqeqeq: ["error", "always", { null: "ignore" }],
-    },
+module.exports = createAngularEslintConfig({
+  eslint,
+  tseslint,
+  angular,
+  // Pre-existing debt, not policy. Each entry is a rule this project's code
+  // cannot satisfy yet; fixing the code and deleting the entry is the goal.
+  legacyRules: {
+    "@angular-eslint/no-output-on-prefix": "off",
+    "@typescript-eslint/no-wrapper-object-types": "off",
+    "@typescript-eslint/no-unused-expressions": "off",
+    "@typescript-eslint/no-empty-object-type": "off",
+    "@typescript-eslint/no-require-imports": "off",
+    "no-useless-assignment": "off",
+    "no-empty": "off",
+    "no-var": "off",
+    "no-self-assign": "off",
   },
-  {
-    files: ["**/*.html"],
-    extends: [
-      ...angular.configs.templateRecommended,
-    ],
-    rules: {
-      "@angular-eslint/template/eqeqeq": "off",
-    },
-  }
-);
+  templateRules: {
+    "@angular-eslint/template/eqeqeq": "off",
+  },
+});

--- a/src/gui/static/src/tsconfig.app.json
+++ b/src/gui/static/src/tsconfig.app.json
@@ -11,8 +11,5 @@
   ],
   "include": [
     "src/**/*.d.ts"
-  ],
-  "angularCompilerOptions": {
-    "strictTemplates": true
-  }
+  ]
 }

--- a/src/gui/static/src/tsconfig.spec.json
+++ b/src/gui/static/src/tsconfig.spec.json
@@ -15,8 +15,5 @@
   "include": [
     "**/*.spec.ts",
     "**/*.d.ts"
-  ],
-  "angularCompilerOptions": {
-    "strictTemplates": true
-  }
+  ]
 }

--- a/src/gui/static/tsconfig.json
+++ b/src/gui/static/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compileOnSave": false,
   "angularCompilerOptions": {
-    "preserveWhitespaces": true
+    "preserveWhitespaces": true,
+    "strictTemplates": true,
+    "strictInjectionParameters": true
   },
   "compilerOptions": {
     "ignoreDeprecations": "6.0",

--- a/src/skycoin-web/eslint.config.js
+++ b/src/skycoin-web/eslint.config.js
@@ -2,75 +2,28 @@
 const eslint = require("@eslint/js");
 const tseslint = require("typescript-eslint");
 const angular = require("angular-eslint");
+const createAngularEslintConfig = require("../../eslint.base.config.js");
 
-module.exports = tseslint.config(
-  {
-    files: ["**/*.ts"],
-    extends: [
-      eslint.configs.recommended,
-      ...tseslint.configs.recommended,
-      ...angular.configs.tsRecommended,
-    ],
-    processor: angular.processInlineTemplates,
-    languageOptions: {
-      parserOptions: {
-        project: ["tsconfig.json"],
-      },
-    },
-    rules: {
-      "@angular-eslint/component-selector": [
-        "error",
-        {
-          type: "element",
-          prefix: "app",
-          style: "kebab-case",
-        },
-      ],
-      "@angular-eslint/directive-selector": [
-        "error",
-        {
-          type: "attribute",
-          prefix: ["app", "clipboard"],
-          style: "camelCase",
-        },
-      ],
-      "@angular-eslint/prefer-inject": "off",
-      "@angular-eslint/prefer-standalone": "off",
-      // Angular 22 made OnPush the framework default and renamed the previous
-      // default strategy to Eager. The v22 upgrade migration added an explicit
-      // `ChangeDetectionStrategy.Eager` to every component here specifically to
-      // preserve the pre-22 behaviour, which this rule then reports as opting
-      // out of the default. Adopting OnPush is worth doing, but it is a
-      // behavioural change that has to be reviewed and tested component by
-      // component rather than carried along by a dependency bump.
-      "@angular-eslint/prefer-on-push-component-change-detection": "off",
-      "no-constant-binary-expression": "off",
-      "no-useless-assignment": "off",
-      "no-empty": "off",
-      "no-var": "off",
-      "no-self-assign": "off",
-      "@angular-eslint/no-output-on-prefix": "off",
-      "@typescript-eslint/no-wrapper-object-types": "off",
-      "@typescript-eslint/no-unused-expressions": "off",
-      "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-unused-vars": "off",
-      "@typescript-eslint/no-empty-function": "off",
-      "@typescript-eslint/no-empty-object-type": "off",
-      "@typescript-eslint/no-require-imports": "off",
-      "max-len": ["error", { code: 200 }],
-      "no-underscore-dangle": "off",
-      "prefer-const": "error",
-      curly: "error",
-      eqeqeq: ["error", "always", { null: "ignore" }],
-    },
+module.exports = createAngularEslintConfig({
+  eslint,
+  tseslint,
+  angular,
+  // ClipboardDirective is declared with a `clipboard` attribute selector.
+  directiveSelectorPrefix: ["app", "clipboard"],
+  // Pre-existing debt, not policy. Each entry is a rule this project's code
+  // cannot satisfy yet; fixing the code and deleting the entry is the goal.
+  legacyRules: {
+    "@angular-eslint/no-output-on-prefix": "off",
+    "@typescript-eslint/no-wrapper-object-types": "off",
+    "@typescript-eslint/no-unused-expressions": "off",
+    "@typescript-eslint/no-empty-object-type": "off",
+    "@typescript-eslint/no-require-imports": "off",
+    "no-useless-assignment": "off",
+    "no-empty": "off",
+    "no-var": "off",
+    "no-self-assign": "off",
   },
-  {
-    files: ["**/*.html"],
-    extends: [
-      ...angular.configs.templateRecommended,
-    ],
-    rules: {
-      "@angular-eslint/template/eqeqeq": "off",
-    },
-  }
-);
+  templateRules: {
+    "@angular-eslint/template/eqeqeq": "off",
+  },
+});

--- a/src/skycoin-web/src/tsconfig.app.json
+++ b/src/skycoin-web/src/tsconfig.app.json
@@ -10,8 +10,5 @@
     "test.ts",
     "**/*.spec.ts",
     "./app/utils/test-mocks.ts"
-  ],
-  "angularCompilerOptions": {
-    "strictTemplates": true
-  }
+  ]
 }

--- a/src/skycoin-web/src/tsconfig.spec.json
+++ b/src/skycoin-web/src/tsconfig.spec.json
@@ -16,8 +16,5 @@
     "**/*.spec.ts",
     "**/*.d.ts",
     "./app/utils/test-mocks.ts"
-  ],
-  "angularCompilerOptions": {
-    "strictTemplates": true
-  }
+  ]
 }

--- a/src/skycoin-web/tsconfig.json
+++ b/src/skycoin-web/tsconfig.json
@@ -15,5 +15,9 @@
       "node_modules/@types"
     ],
     "useDefineForClassFields": false
+  },
+  "angularCompilerOptions": {
+    "strictTemplates": true,
+    "strictInjectionParameters": true
   }
 }


### PR DESCRIPTION
Follow-up to #3000. The three Angular front-ends had drifted into three
different rule sets, so the same code could be clean in one project and rejected
in another. `/src/gui/static` and `/src/skycoin-web` differed by a single line,
while `/explorer` disabled four rules the others did not and enabled two the
others lacked.

## Shared ESLint base

Adds `eslint.base.config.js` at the repository root with the rules that should
apply everywhere. It is a factory rather than a plain config because the plugins
are installed per project: each `eslint.config.js` requires its own copies of
`@eslint/js`, `typescript-eslint` and `angular-eslint` and passes them in, so the
shared file needs no dependencies and no repository-root `node_modules`.

Each project supplies only what is genuinely local — skycoin-web's `clipboard`
directive-selector prefix, and a `legacyRules` block naming the rules its code
cannot satisfy yet. Those are labelled as debt rather than policy, so the lists
are meant to shrink.

**Convergence is purely additive.** No rule was removed or weakened anywhere:

| project | gains |
|---|---|
| explorer | `curly`, `eqeqeq`, `prefer-const` |
| gui/static | `valid-typeof`, `@typescript-eslint/consistent-type-definitions` |
| skycoin-web | `valid-typeof`, `@typescript-eslint/consistent-type-definitions` |

All three still pass `npm run lint` with no source changes.

## tsconfig strictness

`/explorer` declared `strictTemplates` and `strictInjectionParameters` in its
root `tsconfig.json`; the other two declared `strictTemplates` in
`src/tsconfig.app.json` and `src/tsconfig.spec.json` and had no
`strictInjectionParameters` at all. Both flags now sit in each project's root
`angularCompilerOptions`, and the duplicated child declarations are removed.

Moving a setting across an `extends` boundary risks silently losing it, so this
was verified rather than assumed. A deliberate `[isLoading]="'a string'"` binding
added to a gui/static template fails the production build with

```
error TS2322: Type 'string' is not assignable to type 'boolean'
```

a strictTemplates-only diagnostic, confirming the setting is genuinely inherited
from the root config. The probe was reverted afterwards.

## Verification

- `make lint-ui`, `make test-ui` and `make check-ui` all pass
- Committed bundles are byte identical — this changes configuration only