### PR TITLE
build(deps): sweep the open dependabot updates

### DIFF
--- a/cmd/skydex-client/package-lock.json
+++ b/cmd/skydex-client/package-lock.json
@@ -17,7 +17,7 @@
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "@vitejs/plugin-react": "^6.0.5",
-        "vite": "^8.2.0"
+        "vite": "^8.2.1"
       }
     },
     "node_modules/@emnapi/core": {
@@ -949,16 +949,16 @@
       "optional": true
     },
     "node_modules/vite": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
-      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.23",
-        "rolldown": "~1.2.0",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/cmd/skydex-client/package.json
+++ b/cmd/skydex-client/package.json
@@ -18,6 +18,6 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.0.5",
-    "vite": "^8.2.0"
+    "vite": "^8.2.1"
   }
 }

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -2252,9 +2252,9 @@
             }
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
             "funding": [
                 {


### PR DESCRIPTION
Replicates the two Dependabot pull requests opened since #3000, applied directly
rather than cherry-picked:

| PR | Directory | Update |
|----|-----------|--------|
| #3001 | `/cmd/skydex-client` | `vite` 8.2.0 → 8.2.1 |
| #3002 | `/electron` | `js-yaml` 4.3.0 → 4.3.1 |

`js-yaml` is reached transitively in `/electron`, so that one is a lock file
change only — which is why Dependabot raised it without touching
`package.json`.

Both are patch bumps, and the diff is exactly two resolved versions across the
two lock files with no other churn:

```
-            "version": "4.3.0",      →  +            "version": "4.3.1",
-      "version": "8.2.0",            →  +      "version": "8.2.1",
```

## Verification

The skydex-client UI is embedded into the Go binary, so `make check-skydex-ui`
was run after the vite bump: it rebuilds and compares against the committed
embed, which came out **byte identical**. `go run .` still builds and runs.

Nothing here touches the Angular front-ends — neither package is used by them.

Supersedes #3001 and #3002.