### PR TITLE
docs: describe the release process that actually runs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -329,9 +329,6 @@ To disable CSRF:
 $ ./run-daemon.sh -disable-csrf
 ```
 
-#### Electron Desktop Client Mode
-This mode configures itself via electron-main.js
-
 #### Standalone Desktop Client Mode
 This mode is configured by compiling with `STANDALONE_CLIENT` build tag.
 The configuration is handled in `cmd/skycoin/skycoin.go`
@@ -355,7 +352,7 @@ You can find information about how to work with translation files in the [Transl
 0. If the `master` branch has commits that are not in `develop` (e.g. due to a hotfix applied to `master`), merge `master` into `develop`
 0. Make sure the translations are up to date. See the [i18n README](./src/gui/static/src/assets/i18n/README.md) for instructions on how to update translations and how to check if they are up to date.
 0. Compile the `src/gui/static/dist/` to make sure that it is up to date (see [Wallet GUI Development README](src/gui/static/README.md))
-0. Update version strings to the new version in the following files: `electron/package-lock.json`, `electron/package.json`, `electron/skycoin/current-skycoin.json`, `src/cli/cli.go`, `src/gui/static/src/current-skycoin.json`, `src/cli/integration/testdata/status*.golden`, `template/coin.template`, `README.md` files .
+0. Update version strings to the new version in the following files: `src/cli/cli.go`, `src/gui/static/src/current-skycoin.json`, `src/cli/integration/testdata/status*.golden`, `template/coin.template`, `README.md` files .
 0. If changes require a new database verification on the next upgrade, update `src/skycoin/skycoin.go`'s `DBVerifyCheckpointVersion` value
 0. Update `CHANGELOG.md`: move the "unreleased" changes to the version and add the date
 0. Update the files in https://github.com/skycoin/repo-info by following the [metadata update procedure](https://github.com/skycoin/repo-info/#updating-skycoin-repository-metadate),
@@ -367,7 +364,7 @@ You can find information about how to work with translation files in the [Transl
     Sign the tag. If you have your GPG key in github, creating a release on the Github website will automatically tag the release.
     It can be tagged from the command line with `git tag -as v0.20.0 $COMMIT_ID`, but Github will not recognize it as a "release".
 0. Make sure that the client runs properly from the `master` branch
-0. Release builds are created and uploaded by travis. To do it manually, checkout the `master` branch and follow the [create release builds](electron/README.md) instructions.
+0. Push the tag. [.github/workflows/release.yml](.github/workflows/release.yml) runs on any tag starting with `v`: it creates the GitHub release, builds each platform in a matrix, cross-compiles the hardware wallet utility against musl, and uploads each archive together with its `.sha256` checksum.
 
 If there are problems discovered after merging to `master`, start over, and increment the 3rd version number.
 For example, `v0.20.0` becomes `v0.20.1`, for minor fixes.
@@ -400,7 +397,12 @@ Performs these actions before releasing:
 
 #### Creating release builds
 
-[Create Release builds](electron/README.md).
+There is no manual build step. Pushing a tag that starts with `v` runs
+[.github/workflows/release.yml](.github/workflows/release.yml), which produces
+every artifact and uploads it to the GitHub release.
+
+Release archives are built with `go install <module>@<tag>`, so the sources come
+from the tag through the module proxy rather than from a working copy.
 
 #### Release signing
 


### PR DESCRIPTION
`DEVELOPMENT.md` is the source for `docs/guides/development.md`, which is staged
at build time and gitignored. The earlier pass in #3016 fixed the mkdocs link
failures but edited the **generated copy**, so the text itself was never
corrected — the original still said:

> Release builds are created and uploaded by travis. To do it manually, checkout
> the `master` branch and follow the [create release builds](electron/README.md)
> instructions.

Neither half is true. Releases are built by
[`.github/workflows/release.yml`](.github/workflows/release.yml), which runs on
any tag starting with `v`: it creates the GitHub release, builds each platform
in a matrix, cross-compiles the hardware-wallet utility against musl, and uploads
each archive with its `.sha256`. There is no manual build step, and `electron/`
was removed in #3016.

Also removed:

- the electron package files from the list of version strings to bump at release time
- the "Electron Desktop Client Mode" section

Worth noting for future doc edits: several pages under `docs/` are generated by
`scripts/docs-prepare.py` from sources elsewhere in the tree and are listed in
`docs/.gitignore`. Editing the staged copy looks like it works and then silently
disappears.