### PR TITLE
fix(lint): silence gosec G204 in the cipher wasm linkage test

### DIFF
--- a/cmd/skycoin-web/commands/wasm_test.go
+++ b/cmd/skycoin-web/commands/wasm_test.go
@@ -12,7 +12,9 @@ const cipherWasmBlob = "github.com/skycoin/skycoin/src/skycoin-lite/wasm-go"
 func deps(t *testing.T, pkg string) map[string]bool {
 	t.Helper()
 
-	out, err := exec.Command("go", "list", "-deps", pkg).Output()
+	// pkg is never attacker controlled: both call sites pass a literal, either
+	// "." or one of the four in-repo package paths listed below.
+	out, err := exec.Command("go", "list", "-deps", pkg).Output() //nolint:gosec // G204: package pattern is a literal, not input
 	if err != nil {
 		t.Skipf("go list unavailable: %v", err)
 	}


### PR DESCRIPTION
`golangci-lint` has been failing on `develop` since #3031, which blocks every PR opened against it (including #3035):

```
cmd/skycoin-web/commands/wasm_test.go:15:14: G204: Subprocess launched with variable (gosec)
	out, err := exec.Command("go", "list", "-deps", pkg).Output()
```

The helper shells out to `go list -deps <pkg>` to read a package's dependency graph, which is the whole point of the test — there is no way to ask for that without naming the package in the argument. Neither call site takes input: one passes `"."`, the other iterates four in-repo package path literals.

That makes it the genuine one-off the `.golangci.yml` exclusion block reserves for a per-site `//nolint` with a reason, rather than another blanket path rule.

Verified with `golangci-lint run` at v2.12.2, the version CI pins: 0 issues. `go run .` still builds and `make format` leaves no diff.